### PR TITLE
Fix rwebaudio freezing bug

### DIFF
--- a/emscripten/library_rwebaudio.js
+++ b/emscripten/library_rwebaudio.js
@@ -35,6 +35,8 @@ var LibraryRWebAudio = {
                RA.buffers[RA.numBuffers - 1] = buf[0];
                i--;
                RA.bufIndex--;
+            } else if (!RA.startTime) {
+                RA.setStartTime();
             }
          }
       },
@@ -74,7 +76,7 @@ var LibraryRWebAudio = {
       block: function() {
          do {
             RA.process();
-         } while (RA.bufIndex === RA.numBuffers-2);
+         } while (RA.bufIndex === RA.numBuffers);
       }
    },
 
@@ -87,8 +89,6 @@ var LibraryRWebAudio = {
 
       RA.numBuffers = ((latency * RA.context.sampleRate) / (1000 * RA.BUFFER_SIZE))|0;
       if (RA.numBuffers < 2) RA.numBuffers = 2;
-      
-      RA.numBuffers++;
 
       for (var i = 0; i < RA.numBuffers; i++) {
          RA.buffers[i] = RA.context.createBuffer(2, RA.BUFFER_SIZE, RA.context.sampleRate);
@@ -114,7 +114,7 @@ var LibraryRWebAudio = {
       var count = 0;
 
       while (samples) {
-         if (RA.bufIndex === RA.numBuffers-2) {
+         if (RA.bufIndex === RA.numBuffers) {
             if (RA.nonblock) break;
             else RA.block();
          }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This PR fixes the bug thought to be fixed in #15442. Turns out, the issue is actually a race condition. The reason why #15442 seemed to fix the issue was because adding another buffer gave the browser more time to initialize (aka, the whole thing was a race condition) This was simply fixed by calling the function to set the start time if not already set, so the entire page doesn't get stuck in an endless loop (since javascript only has 1 thread).

## Related Issues

See https://github.com/EmulatorJS/EmulatorJS/issues/416

## Related Pull Requests

Originally thought to be fixed in #15442.
