### PR TITLE
Allow adjusting screenshot flash without notification enabled

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -10060,7 +10060,7 @@ unsigned menu_displaylist_build_list(
                         build_list[i].checked = true;
                      break;
                   case MENU_ENUM_LABEL_NOTIFICATION_SHOW_SCREENSHOT_FLASH:
-                     if (widgets_active && notification_show_screenshot)
+                     if (widgets_active)
                         build_list[i].checked = true;
                      break;
 #endif


### PR DESCRIPTION
## Description

Let's remove this requirement, since otherwise notification has to be enabled even though flash and notification work separately.
