### PR TITLE
Add openal support for emscripten build target

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -758,8 +758,10 @@ ifeq ($(HAVE_EMSCRIPTEN), 1)
    OBJ += frontend/drivers/platform_emscripten.o \
           input/drivers/rwebinput_input.o \
           input/drivers_joypad/rwebpad_joypad.o \
-          audio/drivers/rwebaudio.o \
           camera/drivers/rwebcam.o
+   ifeq ($(HAVE_RWEBAUDIO), 1)
+      OBJ += audio/drivers/rwebaudio.o
+   endif
 endif
 
 ifeq ($(HAVE_BLUETOOTH), 1)

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -46,6 +46,16 @@ HAVE_IBXM = 1
 HAVE_CORE_INFO_CACHE = 1
 HAVE_7ZIP = 1
 HAVE_BSV_MOVIE = 1
+HAVE_AL = 1
+
+
+# WARNING -- READ BEFORE ENABLING
+# The rwebaudio driver is known to have several audio bugs, such as
+#  minor crackling, or the entire page freezing/crashing.
+#  It works perfectly on chrome, but even firefox has really bad audio quality.
+#  I should also note, the driver on iOS is completely broken (crashes the page).
+#  You have been warned.
+HAVE_RWEBAUDIO = 0
 
 ASYNC ?= 0
 ifeq ($(LIBRETRO), mupen64plus)
@@ -70,9 +80,17 @@ OBJDIR := obj-emscripten
 LIBS    := -s USE_ZLIB=1
 LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']" \
            -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
-           --js-library emscripten/library_rwebaudio.js \
-           --js-library emscripten/library_rwebcam.js \
-           --js-library emscripten/library_errno_codes.js
+           --js-library emscripten/library_errno_codes.js \
+           --js-library emscripten/library_rwebcam.js
+
+ifeq ($(HAVE_RWEBAUDIO), 1)
+   LDFLAGS += --js-library emscripten/library_rwebaudio.js
+   DEFINES += -DHAVE_RWEBAUDIO
+endif
+ifeq ($(HAVE_AL), 1)
+   LDFLAGS += -lopenal
+   DEFINES += -DHAVE_AL
+endif
 
 ifneq ($(PTHREAD), 0)
    LDFLAGS += -s WASM_MEM_MAX=1073741824 -pthread -s PTHREAD_POOL_SIZE=$(PTHREAD)

--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -143,7 +143,7 @@ audio_driver_t *audio_drivers[] = {
 #ifdef WIIU
    &audio_ax,
 #endif
-#ifdef EMSCRIPTEN
+#if defined(EMSCRIPTEN) && defined(HAVE_RWEBAUDIO)
    &audio_rwebaudio,
 #endif
 #if defined(PSP) || defined(VITA) || defined(ORBIS)

--- a/audio/drivers/openal.c
+++ b/audio/drivers/openal.c
@@ -237,7 +237,11 @@ static bool al_start(void *data, bool is_shutdown)
 {
    al_t *al = (al_t*)data;
    if (al)
-      al->is_paused = false;
+#ifdef EMSCRIPTEN //NEVER EVER BLOCK THE MAIN THREAD!! Emscripten will handle this for us :)
+      al->nonblock = true;
+#else
+      al->nonblock = state;
+#endif
    return true;
 }
 

--- a/audio/drivers/openal.c
+++ b/audio/drivers/openal.c
@@ -237,7 +237,7 @@ static bool al_start(void *data, bool is_shutdown)
 {
    al_t *al = (al_t*)data;
    if (al)
-      al->nonblock = state;
+      al->is_paused = false;
    return true;
 }
 

--- a/audio/drivers/openal.c
+++ b/audio/drivers/openal.c
@@ -237,11 +237,7 @@ static bool al_start(void *data, bool is_shutdown)
 {
    al_t *al = (al_t*)data;
    if (al)
-#ifdef EMSCRIPTEN //NEVER EVER BLOCK THE MAIN THREAD!! Emscripten will handle this for us :)
-      al->nonblock = true;
-#else
       al->nonblock = state;
-#endif
    return true;
 }
 

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -205,6 +205,9 @@ for f in `ls -v *_${platform}.${EXT}`; do
    whole_archive=
    big_stack=
 
+   if [ $PLATFORM = "emscripten" ]; then
+      async=1 #emscripten needs async to sleep
+   fi
    if [ $name = "nxengine" ] ; then
       echo "Applying whole archive linking..."
       whole_archive="WHOLE_ARCHIVE_LINK=1"

--- a/libretro-common/include/retro_timers.h
+++ b/libretro-common/include/retro_timers.h
@@ -39,6 +39,8 @@
 #include <psp2/kernel/threadmgr.h>
 #elif defined(_3DS)
 #include <3ds.h>
+#elif defined(EMSCRIPTEN)
+#include <emscripten/emscripten.h>
 #else
 #include <time.h>
 #endif
@@ -99,6 +101,8 @@ static int nanosleepDOS(const struct timespec *rqtp, struct timespec *rmtp)
 #define retro_sleep(msec) (usleep(1000 * (msec)))
 #elif defined(WIIU)
 #define retro_sleep(msec) (OSSleepTicks(ms_to_ticks((msec))))
+#elif defined(EMSCRIPTEN)
+#define retro_sleep(msec) (emscripten_sleep(msec))
 #else
 static INLINE void retro_sleep(unsigned msec)
 {

--- a/retroarch.c
+++ b/retroarch.c
@@ -4930,7 +4930,9 @@ int rarch_main(int argc, char *argv[], void *data)
 #if defined(EMSCRIPTEN)
 #include "gfx/common/gl_common.h"
 
+#ifdef HAVE_RWEBAUDIO
 void RWebAudioRecalibrateTime(void);
+#endif
 
 void emscripten_mainloop(void)
 {
@@ -4946,7 +4948,9 @@ void emscripten_mainloop(void)
    bool runloop_is_slowmotion             = runloop_flags & RUNLOOP_FLAG_SLOWMOTION;
    bool runloop_is_paused                 = runloop_flags & RUNLOOP_FLAG_PAUSED;
 
+#ifdef HAVE_RWEBAUDIO
    RWebAudioRecalibrateTime();
+#endif
 
    emscripten_frame_count++;
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Adds openal support for emscripten, and makes it the default emscripten audio driver, since rwebaudio doesn't understand the lack of threading in Javascript, and openal gives us a better audio quality and is more reliable.

The rwebaudio driver works in chrome, is very crackily in Firefox, and crashes on mobile ios webkit

The openal driver just doesn't work on beta ios, the reason is unknown but it's probably because of either Apple or emscripten. Thats an issue for later. It works perfectly on stable

## Related Issues

Related to https://github.com/EmulatorJS/EmulatorJS/issues/416
