### PR TITLE
Improve 'Set Core Association' menu

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2677,23 +2677,28 @@ static void xmb_populate_entries(void *data,
    xmb_system_tab       = xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr);
    xmb_horizontal_type  = (xmb_system_tab == UINT_MAX ? xmb_get_horizontal_selection_type(xmb) : 0);
    /* Determine whether this is a playlist */
-   xmb->is_playlist     = (depth == 1
-                      && ((xmb_system_tab == XMB_SYSTEM_TAB_FAVORITES)
-                      || (xmb_system_tab == XMB_SYSTEM_TAB_HISTORY)
+   xmb->is_playlist     =
+            (depth == 1
+         && (  (xmb_system_tab == XMB_SYSTEM_TAB_FAVORITES)
+            || (xmb_system_tab == XMB_SYSTEM_TAB_HISTORY)
 #ifdef HAVE_IMAGEVIEWER
-                      || (xmb_system_tab == XMB_SYSTEM_TAB_IMAGES)
+            || (xmb_system_tab == XMB_SYSTEM_TAB_IMAGES)
 #endif
-                      || (xmb_system_tab == XMB_SYSTEM_TAB_MUSIC)
+            || (xmb_system_tab == XMB_SYSTEM_TAB_MUSIC)
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
-                      || (xmb_system_tab == XMB_SYSTEM_TAB_VIDEO)
+            || (xmb_system_tab == XMB_SYSTEM_TAB_VIDEO)
 #endif
-                      ))
-                      || (xmb_horizontal_type == FILE_TYPE_PLAYLIST_COLLECTION)
-                      || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST))
-                      || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST))
-                      || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_IMAGES_LIST))
-                      || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_MUSIC_LIST))
-                      || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_VIDEO_LIST));
+         ))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_IMAGES_LIST))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_MUSIC_LIST))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_VIDEO_LIST));
+
+   xmb->is_playlist |=
+            (xmb_system_tab > XMB_SYSTEM_TAB_SETTINGS && depth == 1)
+         || (xmb_system_tab < XMB_SYSTEM_TAB_SETTINGS && depth == 4);
+
    xmb->is_playlist = 
              xmb->is_playlist
          && !string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_INFORMATION))

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2752,6 +2752,10 @@ static void xmb_populate_entries(void *data,
          xmb->is_explore_list = false;
       else if (!xmb->is_quick_menu)
          xmb->skip_thumbnail_reset = true;
+
+      /* 'is_playlist' must be cleared for 'xmb_set_thumbnail_content' */
+      if (xmb->is_explore_list)
+         xmb->is_playlist = false;
    }
 #endif
 
@@ -3763,7 +3767,7 @@ static int xmb_draw_item(
                && (  (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
                   || (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_PENDING)));
 
-      if (     xmb->is_playlist
+      if (     (xmb->is_playlist || xmb->is_explore_list)
             && !xmb->is_playlist_information
             && xmb->use_ps3_layout
             && (  show_right_thumbnail
@@ -3803,7 +3807,7 @@ static int xmb_draw_item(
    }
 
    /* Don't update ticker limit while waiting for thumbnail status */
-   if (     xmb->is_playlist
+   if (     (xmb->is_playlist || xmb->is_explore_list)
          && (  (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
                && xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
             || (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
@@ -5818,7 +5822,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    }
 
    /* Allow browsing playlist in fullscreen thumbnail mode */
-   if (    (xmb->is_playlist || xmb->is_state_slot)
+   if (    (xmb->is_playlist || xmb->is_explore_list || xmb->is_state_slot)
          && xmb->show_fullscreen_thumbnails
          && xmb->fullscreen_thumbnails_available
          && (menu_st->selection_ptr != xmb->fullscreen_thumbnail_selection))

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -7435,7 +7435,7 @@ static void xmb_navigation_pointer_changed(void *data)
 static void xmb_navigation_set(void *data, bool scroll)
 {
    xmb_handle_t  *xmb  = (xmb_handle_t*)data;
-   xmb_selection_pointer_changed(xmb, true);
+   xmb_selection_pointer_changed(xmb, scroll);
 }
 
 static void xmb_navigation_alphabet(void *data, size_t *unused)

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4503,24 +4503,6 @@ static bool menu_displaylist_parse_playlist_manager_settings(
          playlist_path, "_history.lpl", strlen(playlist_path),
          STRLEN_CONST("_history.lpl"));
 
-   /* Default core association
-    * > This is only shown for collection playlists
-    *   (i.e. it is not relevant for history/favourites) */
-   if (   !is_content_history
-       && !string_is_equal(playlist_file, FILE_PATH_CONTENT_FAVORITES))
-      menu_entries_append(list,
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_DEFAULT_CORE),
-            msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_DEFAULT_CORE),
-            MENU_ENUM_LABEL_PLAYLIST_MANAGER_DEFAULT_CORE,
-            MENU_SETTING_PLAYLIST_MANAGER_DEFAULT_CORE, 0, 0, NULL);
-
-   /* Reset core associations */
-   menu_entries_append(list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_RESET_CORES),
-         msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES),
-         MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES,
-         MENU_SETTING_ACTION_PLAYLIST_MANAGER_RESET_CORES, 0, 0, NULL);
-
    /* Label display mode */
    menu_entries_append(list,
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_LABEL_DISPLAY_MODE),
@@ -4577,6 +4559,24 @@ static bool menu_displaylist_parse_playlist_manager_settings(
             msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_SORT_MODE),
             MENU_ENUM_LABEL_PLAYLIST_MANAGER_SORT_MODE,
             MENU_SETTING_PLAYLIST_MANAGER_SORT_MODE, 0, 0, NULL);
+
+   /* Default core association
+    * > This is only shown for collection playlists
+    *   (i.e. it is not relevant for history/favourites) */
+   if (   !is_content_history
+       && !string_is_equal(playlist_file, FILE_PATH_CONTENT_FAVORITES))
+      menu_entries_append(list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_DEFAULT_CORE),
+            msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_DEFAULT_CORE),
+            MENU_ENUM_LABEL_PLAYLIST_MANAGER_DEFAULT_CORE,
+            MENU_SETTING_PLAYLIST_MANAGER_DEFAULT_CORE, 0, 0, NULL);
+
+   /* Reset core associations */
+   menu_entries_append(list,
+         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_RESET_CORES),
+         msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES),
+         MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES,
+         MENU_SETTING_ACTION_PLAYLIST_MANAGER_RESET_CORES, 0, 0, NULL);
 
    /* Refresh playlist */
    if (playlist_scan_refresh_enabled(playlist))


### PR DESCRIPTION
## Description

XMB corrections:
- Stop showing playlist entry index outside of playlists
- Fix menu focus issue when returning from "Set Core Association" if playlist index is greater than the previous menu
- Explore menu corrections:
  - Prevent flashing when browsing fullscreen thumbnails
  - Match label ticker length behavior with playlists

Other:
- Preselect current core in "Set Core Assocation" menu for more carefree usage
- Focus back to "Set Core Association" item after returning from the menu instead of first item
- Replaced hack fix for focusing the first item after returning from core suggestion "Run" menu after association reset
- Fixed setting core association in history/favorites after resetting it and running without setting
- Relocate playlist manager core association options to prevent accidental resets with Start
- Unified `generic_action_ok_displaylist_push()` usage for easier reading
- Removed tabs


## Related Issues

Closes #15420 