### PR TITLE
Enable overlay by default only on mobile + winraw overlay fix

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1468,7 +1468,11 @@ bool config_overlay_enable_default(void)
 {
    if (g_defaults.overlay_set)
       return g_defaults.overlay_enable;
+#if defined(RARCH_MOBILE)
    return true;
+#else
+   return false;
+#endif
 }
 
 static struct config_array_setting *populate_settings_array(settings_t *settings, int *size)

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -414,7 +414,7 @@ static void winraw_update_mouse_state(winraw_input_t *wr,
       {
          settings_t *settings = config_get_ptr();
          if (     settings->bools.input_overlay_enable
-               && settings->bools.input_overlay_show_mouse_cursor)
+               && !string_is_empty(settings->paths.path_overlay))
             getcursorpos = true;
       }
 


### PR DESCRIPTION
## Description

Alleviated the pain with multiple mice winraw + overlay enabled by default by requiring `RARCH_MOBILE` for overlay to be enabled by default, and winraw rather requiring active preset instead of visible overlay mouse cursor, since it won't stop the reading of mouse, thus it still creates incorrect presses.

## Related Issues

Closes #15485
