### PR TITLE
Fix window title after video reinit

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2392,6 +2392,25 @@ size_t video_driver_get_window_title(char *buf, unsigned len)
    return video_st->window_title_len;
 }
 
+void video_driver_update_title(void *data)
+{
+#ifndef _XBOX
+   const ui_window_t *window      = ui_companion_driver_get_window_ptr();
+   video_driver_state_t *video_st = &video_driver_st;
+   if (     video_st->flags & VIDEO_FLAG_WINDOW_TITLE_UPDATE
+         && window)
+   {
+      if (     video_st->window_title[0]
+            && !string_is_equal(video_st->window_title, video_st->window_title_prev))
+      {
+         window->set_title((void*)video_st->display_userdata, video_st->window_title);
+         strlcpy(video_st->window_title_prev, video_st->window_title, sizeof(video_st->window_title_prev));
+      }
+      video_st->flags &= ~VIDEO_FLAG_WINDOW_TITLE_UPDATE;
+   }
+#endif
+}
+
 void video_driver_build_info(video_frame_info_t *video_info)
 {
    video_viewport_t *custom_vp             = NULL;
@@ -3883,6 +3902,7 @@ void video_driver_reinit(int flags)
    video_driver_state_t *video_st          = &video_driver_st;
    struct retro_hw_render_callback *hwr    =
          VIDEO_DRIVER_GET_HW_CONTEXT_INTERNAL(video_st);
+
    if (hwr->cache_context != false)
       video_st->flags                     |=  VIDEO_FLAG_CACHE_CONTEXT;
    else
@@ -3890,6 +3910,8 @@ void video_driver_reinit(int flags)
    video_st->flags                        &= ~VIDEO_FLAG_CACHE_CONTEXT_ACK;
    video_driver_reinit_context(settings, flags);
    video_st->flags                        &= ~VIDEO_FLAG_CACHE_CONTEXT;
+
+   video_st->window_title_prev[0]          = '\0';
 }
 
 void video_frame_delay_auto(video_driver_state_t *video_st, video_frame_delay_auto_t *vfda)
@@ -4061,25 +4083,5 @@ void video_frame_delay_auto(video_driver_state_t *video_st, video_frame_delay_au
             video_st->frame_time_samples[frame_time_index - 7],
             video_st->frame_time_samples[frame_time_index - 8]
       );
-#endif
-}
-
-void video_driver_update_title(void *data)
-{
-#ifndef _XBOX
-   const ui_window_t *window      = ui_companion_driver_get_window_ptr();
-   video_driver_state_t *video_st = &video_driver_st;
-   if (     video_st->flags & VIDEO_FLAG_WINDOW_TITLE_UPDATE
-         && window)
-   {
-      static char prev_title[128];
-      if (      video_st->window_title[0] 
-            && !string_is_equal(video_st->window_title, prev_title))
-      {
-         window->set_title((void*)video_st->display_userdata, video_st->window_title);
-         strlcpy(prev_title, video_st->window_title, sizeof(prev_title));
-      }
-      video_st->flags &= ~VIDEO_FLAG_WINDOW_TITLE_UPDATE;
-   }
 #endif
 }

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -859,6 +859,7 @@ typedef struct
 
    char cli_shader_path[PATH_MAX_LENGTH];
    char window_title[512];
+   char window_title_prev[512];
    char gpu_device_string[128];
    char gpu_api_version_string[128];
    char title_buf[64];

--- a/runloop.c
+++ b/runloop.c
@@ -4593,16 +4593,24 @@ bool runloop_event_init_core(
          video_st->title_buf,
          msg_hash_to_str(MSG_PROGRAM),
          sizeof(video_st->title_buf));
-   video_st->title_buf[  len] = ' ';
-   video_st->title_buf[++len] = '\0';
-   len += strlcpy(video_st->title_buf + len,
-         sys_info->info.library_name,
-         sizeof(video_st->title_buf)  - len);
-   video_st->title_buf[  len] = ' ';
-   video_st->title_buf[++len] = '\0';
-   strlcpy(video_st->title_buf        + len,
-         sys_info->info.library_version,
-         sizeof(video_st->title_buf)  - len);
+
+   if (!string_is_empty(sys_info->info.library_name))
+   {
+      video_st->title_buf[  len] = ' ';
+      video_st->title_buf[++len] = '\0';
+      len += strlcpy(video_st->title_buf + len,
+            sys_info->info.library_name,
+            sizeof(video_st->title_buf)  - len);
+   }
+
+   if (!string_is_empty(sys_info->info.library_version))
+   {
+      video_st->title_buf[  len] = ' ';
+      video_st->title_buf[++len] = '\0';
+      strlcpy(video_st->title_buf        + len,
+            sys_info->info.library_version,
+            sizeof(video_st->title_buf)  - len);
+   }
 
    strlcpy(sys_info->valid_extensions,
          sys_info->info.valid_extensions ?


### PR DESCRIPTION
## Description

- Fixed window title from resetting to "RetroArch" with a core running when toggling fullscreen etc
- Removed empty spaces from the title when a core is not running
- Moved update title function below get title
