### PR TITLE
(Android) Reduce default menu scale

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1444,6 +1444,8 @@
  * drivers and display widgets */
 #if defined(VITA)
 #define DEFAULT_MENU_SCALE_FACTOR 1.5f
+#elif defined(__ANDROID__)
+#define DEFAULT_MENU_SCALE_FACTOR 0.75f
 #else
 #define DEFAULT_MENU_SCALE_FACTOR 1.0f
 #endif


### PR DESCRIPTION
## Description

The default menu scale is a bit too much for smaller displays.
