### PR TITLE
Playlist + Explore corrections + cleanups

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -5839,6 +5839,11 @@ static int action_ok_delete_entry(const char *path,
    menu_entries_pop_stack(&new_selection_ptr, 0, 1);
    menu_st->selection_ptr = new_selection_ptr;
 
+   /* Thumbnail must be refreshed */
+   if (menu_st->driver_ctx && menu_st->driver_ctx->refresh_thumbnail_image)
+      menu_st->driver_ctx->refresh_thumbnail_image(
+            menu_st->userdata, new_selection_ptr);
+
    return 0;
 }
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -3828,6 +3828,20 @@ static int menu_displaylist_parse_horizontal_content_actions(
                break;
          }
 
+         /* Remove 'Remove' from Explore lists for now since it does not work correctly */
+         if (remove_entry_enabled)
+         {
+            struct menu_state *menu_st  = menu_state_get_ptr();
+            menu_list_t *menu_list      = menu_st->entries.list;
+            file_list_t *menu_stack     = MENU_LIST_GET(menu_list, 0);
+            struct item_file *stack_top = menu_stack->list;
+            size_t depth                = menu_stack->size;
+            unsigned current_type       = (depth > 0 ? stack_top[depth - 1].type : 0);
+
+            if (current_type)
+               remove_entry_enabled = false;
+         }
+
          if (remove_entry_enabled)
             menu_entries_append(list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DELETE_ENTRY),

--- a/playlist.c
+++ b/playlist.c
@@ -1195,7 +1195,7 @@ bool playlist_content_path_is_valid(const char *path)
 
 /**
  * playlist_push:
- * @playlist        	   : Playlist handle.
+ * @playlist           : Playlist handle.
  *
  * Push entry to top of playlist.
  **/
@@ -2054,7 +2054,7 @@ void playlist_free(playlist_t *playlist)
 
 /**
  * playlist_clear:
- * @playlist        	   : Playlist handle.
+ * @playlist           : Playlist handle.
  *
  * Clears all playlist entries in playlist.
  **/
@@ -2076,7 +2076,7 @@ void playlist_clear(playlist_t *playlist)
 
 /**
  * playlist_size:
- * @playlist        	   : Playlist handle.
+ * @playlist           : Playlist handle.
  *
  * Gets size of playlist.
  * Returns: size of playlist.
@@ -2090,7 +2090,7 @@ size_t playlist_size(playlist_t *playlist)
 
 /**
  * playlist_capacity:
- * @playlist        	   : Playlist handle.
+ * @playlist           : Playlist handle.
  *
  * Gets maximum capacity of playlist.
  * Returns: maximum capacity of playlist.
@@ -2488,10 +2488,10 @@ static bool playlist_read_file(playlist_t *playlist)
     *   non-whitespace ASCII character */
    do
    {
-	   /* Read error or EOF (end of file) */
+      /* Read error or EOF (end of file) */
       if ((test_char = intfstream_getc(file)) == EOF)
          goto end;
-   }while (!isgraph(test_char) || test_char > 0x7F);
+   } while (!isgraph(test_char) || test_char > 0x7F);
 
    playlist->old_format = (test_char != '{');
 
@@ -2780,7 +2780,7 @@ bool playlist_init_cached(const playlist_config_t *config)
 
 /**
  * playlist_init:
- * @config            	: Playlist configuration object.
+ * @config            : Playlist configuration object.
  *
  * Creates and initializes a playlist.
  *
@@ -3173,8 +3173,8 @@ void playlist_get_db_name(playlist_t *playlist, size_t idx,
           * (i.e. ignore history/favourites) */
          if (
                   !string_is_empty(conf_path_basename)
-               && !string_ends_with_size(conf_path_basename, "_history.lpl",
-                        strlen(conf_path_basename), STRLEN_CONST("_history.lpl"))
+               && !string_is_equal(conf_path_basename,
+                        FILE_PATH_CONTENT_HISTORY)
                && !string_is_equal(conf_path_basename,
                         FILE_PATH_CONTENT_FAVORITES)
             )

--- a/retroarch.c
+++ b/retroarch.c
@@ -3503,7 +3503,7 @@ bool command_event(enum event_command cmd, void *data)
                runloop_msg_queue_push(
                      msg_hash_to_str(MSG_ADD_TO_FAVORITES_FAILED), 1, 180, true, NULL,
                      MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_ERROR);
-               return false;
+               return true;
             }
 
             if (str_list)
@@ -3533,11 +3533,12 @@ bool command_event(enum event_command cmd, void *data)
                         playlist_qsort(g_defaults.content_favorites);
 
                      playlist_write_file(g_defaults.content_favorites);
-                     runloop_msg_queue_push(msg_hash_to_str(MSG_ADDED_TO_FAVORITES), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+                     runloop_msg_queue_push(
+                           msg_hash_to_str(MSG_ADDED_TO_FAVORITES), 1, 180, true, NULL,
+                           MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
                   }
                }
             }
-
             break;
          }
       case CMD_EVENT_RESET_CORE_ASSOCIATION:
@@ -3567,7 +3568,9 @@ bool command_event(enum event_command cmd, void *data)
                      menu_st->userdata, i);
 #endif
 
-            runloop_msg_queue_push(msg_hash_to_str(MSG_RESET_CORE_ASSOCIATION), 1, 180, true, NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+            runloop_msg_queue_push(
+                  msg_hash_to_str(MSG_RESET_CORE_ASSOCIATION), 1, 180, true, NULL,
+                  MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
             break;
          }
       case CMD_EVENT_RESTART_RETROARCH:


### PR DESCRIPTION
## Description

- Fixed thumbnail not refreshing after pressing "Remove" from playlists
- Fixed thumbnail going blank after "Add to Favorites" fails due to size limit
- Fixed XMB from refreshing thumbnails properly when going backwards in menu, such as when removing
- Removed "Remove" from Explore lists for now, since the result is not expected
- Cleanups and tab removals