### PR TITLE
Recalculate animation end position if layout changes after start.

### DIFF
--- a/gfx/widgets/gfx_widget_load_content_animation.c
+++ b/gfx/widgets/gfx_widget_load_content_animation.c
@@ -566,6 +566,42 @@ static void gfx_widget_load_content_animation_layout(
          (float)font_regular->line_centre_offset;
    /* > Note: cannot determine state->text_x_end
     *   until text strings are set */
+
+   /* Recalculate end positions if layout changes after start */
+   if (state->status > GFX_WIDGET_LOAD_CONTENT_BEGIN)
+   {
+      int content_name_width;
+      int system_name_width;
+      int text_width;
+
+      /* Get overall text width */
+      content_name_width = font_driver_get_message_width(
+            font_bold->font, state->content_name,
+            strlen(state->content_name), 1.0f);
+      system_name_width = font_driver_get_message_width(
+            font_regular->font, state->system_name,
+            state->system_name_len, 1.0f);
+
+      state->content_name_width = (content_name_width > 0) ?
+            (unsigned)content_name_width : 0;
+      state->system_name_width  = (system_name_width > 0) ?
+            (unsigned)system_name_width : 0;
+
+      text_width = (state->content_name_width > state->system_name_width) ?
+            (int)state->content_name_width : (int)state->system_name_width;
+
+      /* Now we have the text width, can determine
+       * final icon/text x draw positions */
+      state->icon_x_end = ((int)last_video_width - text_width -
+            (int)state->icon_size - (3 * (int)widget_padding)) >> 1;
+      if (state->icon_x_end < (int)widget_padding)
+         state->icon_x_end = widget_padding;
+
+      state->text_x_end = state->icon_x_end +
+            (float)(state->icon_size + widget_padding);
+
+   }
+
 }
 
 /* Widget iterate() */


### PR DESCRIPTION
## Description

Recalculate load content animation if layout changes after animation start.

At some point after 1.15.0, load content animation in case of Wayland started to look weird, content icon and content title became overlapping. 
![load_content_1](https://github.com/libretro/RetroArch/assets/101990835/1b663be0-75cb-413d-a780-9ef8c5c5a18d)

Bisect pointed to [this commit](https://github.com/libretro/RetroArch/commit/402b381c9bd054d22f65ac50159bf9ed596d7f62), it resulted in a layout change after the initial position calculation. As this commit had no direct relation to the animation itself, it was easier to prepare the animation to handle this, by simply reusing the code from gfx_widget_load_content_animation_iterate().
![load_content_2](https://github.com/libretro/RetroArch/assets/101990835/eb7c928c-6e74-47e1-b0db-74a2bd51696a)
