### PR TITLE
Remove microphone driver disabled logging

### DIFF
--- a/audio/microphone_driver.c
+++ b/audio/microphone_driver.c
@@ -268,7 +268,6 @@ bool microphone_driver_init_internal(void *settings_data)
    if (!settings->bools.microphone_enable)
    { /* If the user has mic support turned off... */
       mic_st->flags &= ~MICROPHONE_DRIVER_FLAG_ACTIVE;
-      RARCH_DBG("[Microphone]: Refused to initialize microphone driver because it's disabled in the settings.\n");
       return false;
    }
 


### PR DESCRIPTION
## Description

Let's just get rid of this logging after all, since it shows up in database scan log, and isn't very useful info in any case. Then again the initialization logging shows up in database scan log too even when microphone is enabled..
