### PR TITLE
Save 'overwrite_playlist' to manual scan playlist

### DIFF
--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -513,6 +513,7 @@ enum manual_content_scan_playlist_refresh_status
    bool search_recursively      = false;
    bool search_archives         = false;
    bool filter_dat_content      = false;
+   bool overwrite_playlist      = false;
 #ifdef HAVE_LIBRETRODB
    struct string_list *rdb_list = NULL;
 #endif
@@ -542,6 +543,7 @@ enum manual_content_scan_playlist_refresh_status
    search_recursively = playlist_get_scan_search_recursively(playlist);
    search_archives    = playlist_get_scan_search_archives(playlist);
    filter_dat_content = playlist_get_scan_filter_dat_content(playlist);
+   overwrite_playlist = playlist_get_scan_overwrite_playlist(playlist);
 
    /* Determine system name (playlist basename
     * without extension) */
@@ -712,11 +714,10 @@ enum manual_content_scan_playlist_refresh_status
    scan_settings.search_recursively = search_recursively;
    scan_settings.search_archives    = search_archives;
    scan_settings.filter_dat_content = filter_dat_content;
+   scan_settings.overwrite_playlist = overwrite_playlist;
    /* When refreshing a playlist:
-    * > We never overwrite the existing file
     * > We always validate entries in the
     *   existing file */
-   scan_settings.overwrite_playlist = false;
    scan_settings.validate_entries   = true;
 
 end:

--- a/playlist.c
+++ b/playlist.c
@@ -58,6 +58,7 @@ typedef struct
    bool search_recursively;
    bool search_archives;
    bool filter_dat_content;
+   bool overwrite_playlist;
 } playlist_manual_scan_record_t;
 
 struct content_playlist
@@ -1836,6 +1837,17 @@ void playlist_write_file(playlist_t *playlist)
          }
          rjsonwriter_raw(writer, ",", 1);
          rjsonwriter_raw(writer, "\n", 1);
+
+         rjsonwriter_add_spaces(writer, 2);
+         rjsonwriter_add_string(writer, "scan_overwrite_playlist");
+         rjsonwriter_raw(writer, ":", 1);
+         rjsonwriter_raw(writer, " ", 1);
+         {
+            bool value = playlist->scan_record.overwrite_playlist;
+            rjsonwriter_raw(writer, (value ? "true" : "false"), (value ? 4 : 5));
+         }
+         rjsonwriter_raw(writer, ",", 1);
+         rjsonwriter_raw(writer, "\n", 1);
       }
 
       rjsonwriter_add_spaces(writer, 2);
@@ -2429,6 +2441,8 @@ static bool JSONObjectMemberHandler(void *context, const char *pValue, size_t le
                pCtx->current_meta_bool_val      = &pCtx->playlist->scan_record.search_archives;
             else if (string_is_equal(pValue, "scan_filter_dat_content"))
                pCtx->current_meta_bool_val      = &pCtx->playlist->scan_record.filter_dat_content;
+            else if (string_is_equal(pValue, "scan_overwrite_playlist"))
+               pCtx->current_meta_bool_val      = &pCtx->playlist->scan_record.overwrite_playlist;
             else if (string_is_equal(pValue, "sort_mode"))
                pCtx->current_meta_sort_mode_val = &pCtx->playlist->sort_mode;
             break;
@@ -3267,6 +3281,13 @@ bool playlist_get_scan_filter_dat_content(playlist_t *playlist)
    return playlist->scan_record.filter_dat_content;
 }
 
+bool playlist_get_scan_overwrite_playlist(playlist_t *playlist)
+{
+   if (!playlist)
+      return false;
+   return playlist->scan_record.overwrite_playlist;
+}
+
 bool playlist_scan_refresh_enabled(playlist_t *playlist)
 {
    if (!playlist)
@@ -3472,6 +3493,15 @@ void playlist_set_scan_filter_dat_content(playlist_t *playlist, bool filter_dat_
    if (playlist && playlist->scan_record.filter_dat_content != filter_dat_content)
    {
       playlist->scan_record.filter_dat_content = filter_dat_content;
+      playlist->modified = true;
+   }
+}
+
+void playlist_set_scan_overwrite_playlist(playlist_t *playlist, bool overwrite_playlist)
+{
+   if (playlist && playlist->scan_record.overwrite_playlist != overwrite_playlist)
+   {
+      playlist->scan_record.overwrite_playlist = overwrite_playlist;
       playlist->modified = true;
    }
 }

--- a/playlist.h
+++ b/playlist.h
@@ -361,6 +361,7 @@ const char *playlist_get_scan_dat_file_path(playlist_t *playlist);
 bool playlist_get_scan_search_recursively(playlist_t *playlist);
 bool playlist_get_scan_search_archives(playlist_t *playlist);
 bool playlist_get_scan_filter_dat_content(playlist_t *playlist);
+bool playlist_get_scan_overwrite_playlist(playlist_t *playlist);
 bool playlist_scan_refresh_enabled(playlist_t *playlist);
 
 void playlist_set_default_core_path(playlist_t *playlist, const char *core_path);
@@ -375,6 +376,7 @@ void playlist_set_scan_dat_file_path(playlist_t *playlist, const char *dat_file_
 void playlist_set_scan_search_recursively(playlist_t *playlist, bool search_recursively);
 void playlist_set_scan_search_archives(playlist_t *playlist, bool search_archives);
 void playlist_set_scan_filter_dat_content(playlist_t *playlist, bool filter_dat_content);
+void playlist_set_scan_overwrite_playlist(playlist_t *playlist, bool overwrite_playlist);
 
 /* Returns true if specified entry has a valid
  * core association (i.e. a non-empty string

--- a/tasks/task_manual_content_scan.c
+++ b/tasks/task_manual_content_scan.c
@@ -273,6 +273,8 @@ static void task_manual_content_scan_handler(retro_task_t *task)
                   manual_scan->task_config->search_archives);
             playlist_set_scan_filter_dat_content(manual_scan->playlist,
                   manual_scan->task_config->filter_dat_content);
+            playlist_set_scan_overwrite_playlist(manual_scan->playlist,
+                  manual_scan->task_config->overwrite_playlist);
 
             /* All good - can start iterating
              * > If playlist has content and 'validate


### PR DESCRIPTION
## Description

Overwrite was forcefully disabled by design, but let's allow saving it to ease the refresh process in certain cases.

Please test that it works as expected. It seems to behave fine as far as I can tell.

## Related Issues

Closes #15350

## Reviewers

@i30817 
