### PR TITLE
Log initial core av_info

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -4535,6 +4535,12 @@ static bool runloop_event_load_core(runloop_state_t *runloop_st,
          ((video_st->av_info.timing.fps > 0.0) ?
                video_st->av_info.timing.fps : 60.0);
 
+   RARCH_LOG("[Core]: Geometry: %ux%u, Aspect: %.3f, FPS: %.2f, Sample rate: %.2f Hz.\n",
+         video_st->av_info.geometry.base_width, video_st->av_info.geometry.base_height,
+         video_st->av_info.geometry.aspect_ratio,
+         video_st->av_info.timing.fps,
+         video_st->av_info.timing.sample_rate);
+
    return true;
 }
 


### PR DESCRIPTION
## Description

Currently core av_info is logged only on environment calls `SET_GEOMETRY` & `SET_SYSTEM_AV_INFO`, so let's log also the initial state so that those environment calls are not necessary to know what is going on at startup.
