### PR TITLE
Don't stop audio on menu toggle

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -6107,7 +6107,6 @@ void menu_driver_toggle(
     */
    video_driver_t *current_video      = (video_driver_t*)curr_video_data;
    bool pause_libretro                = false;
-   bool audio_enable_menu             = false;
    runloop_state_t *runloop_st        = runloop_state_get_ptr();
    struct menu_state *menu_st         = &menu_driver_state;
    bool runloop_shutdown_initiated    = runloop_st->flags &
@@ -6125,9 +6124,6 @@ void menu_driver_toggle(
          netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL);
 #else
       pause_libretro                  = settings->bools.menu_pause_libretro;
-#endif
-#ifdef HAVE_AUDIOMIXER
-      audio_enable_menu               = settings->bools.audio_enable_menu;
 #endif
 #ifdef HAVE_OVERLAY
       input_overlay_hide_in_menu      = settings->bools.input_overlay_hide_in_menu;
@@ -6197,13 +6193,10 @@ void menu_driver_toggle(
       command_event(CMD_EVENT_RUMBLE_STOP, NULL);
 
       if (pause_libretro)
-      { /* If the menu pauses the game... */
+      {
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_STOP, NULL);
 #endif
-
-         if (!audio_enable_menu) /* If the menu shouldn't have audio... */
-            command_event(CMD_EVENT_AUDIO_STOP, NULL);
       }
 
       /* Override keyboard callback to redirect to menu instead.
@@ -6230,15 +6223,9 @@ void menu_driver_toggle(
          driver_set_nonblock_state();
 
       if (pause_libretro)
-      { /* If the menu pauses the game... */
-
-         if (!audio_enable_menu) /* ...and the menu doesn't have audio... */
-            command_event(CMD_EVENT_AUDIO_START, NULL);
-            /* ...then re-enable the audio driver (which we shut off earlier) */
-
+      {
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_START, NULL);
-         /* Start the microphone, if it was paused beforehand */
 #endif
       }
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -2971,7 +2971,6 @@ bool command_event(enum event_command cmd, void *data)
 #endif
          break;
       case CMD_EVENT_AUDIO_STOP:
-         midi_driver_set_all_sounds_off();
 #if defined(HAVE_AUDIOMIXER) && defined(HAVE_MENU)
          if (     settings->bools.audio_enable_menu
                && menu_state_get_ptr()->flags & MENU_ST_FLAG_ALIVE)
@@ -3702,7 +3701,6 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_MENU_PAUSE_LIBRETRO:
 #ifdef HAVE_MENU
-         if (menu_st->flags & MENU_ST_FLAG_ALIVE)
          {
 #ifdef HAVE_NETWORKING
             bool menu_pause_libretro  = settings->bools.menu_pause_libretro
@@ -3711,30 +3709,17 @@ bool command_event(enum event_command cmd, void *data)
             bool menu_pause_libretro  = settings->bools.menu_pause_libretro;
 #endif
             if (menu_pause_libretro)
-            { /* If entering the menu pauses the game... */
-               command_event(CMD_EVENT_AUDIO_STOP, NULL);
+            {
 #ifdef HAVE_MICROPHONE
                command_event(CMD_EVENT_MICROPHONE_STOP, NULL);
 #endif
             }
             else
             {
-               command_event(CMD_EVENT_AUDIO_START, NULL);
 #ifdef HAVE_MICROPHONE
                command_event(CMD_EVENT_MICROPHONE_START, NULL);
 #endif
             }
-         }
-         else
-         {
-#ifdef HAVE_NETWORKING
-            bool menu_pause_libretro  = settings->bools.menu_pause_libretro
-               && netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL);
-#else
-            bool menu_pause_libretro  = settings->bools.menu_pause_libretro;
-#endif
-            if (menu_pause_libretro)
-               command_event(CMD_EVENT_AUDIO_START, NULL);
          }
 #endif
          break;

--- a/runloop.c
+++ b/runloop.c
@@ -4703,11 +4703,11 @@ void runloop_pause_checks(void)
 #ifdef HAVE_PRESENCE
    presence_userdata_t userdata;
 #endif
+   video_driver_state_t *video_st = video_state_get_ptr();
    runloop_state_t *runloop_st    = &runloop_state;
    bool is_paused                 = runloop_st->flags & RUNLOOP_FLAG_PAUSED;
    bool is_idle                   = runloop_st->flags & RUNLOOP_FLAG_IDLE;
 #if defined(HAVE_GFX_WIDGETS)
-   video_driver_state_t *video_st = video_state_get_ptr();
    dispgfx_widget_t *p_dispwidget = dispwidget_get_ptr();
    bool widgets_active            = p_dispwidget->active;
    if (widgets_active)
@@ -4730,6 +4730,8 @@ void runloop_pause_checks(void)
 
       if (!is_idle)
          video_driver_cached_frame();
+
+      midi_driver_set_all_sounds_off();
 
 #ifdef HAVE_PRESENCE
       userdata.status = PRESENCE_GAME_PAUSED;
@@ -4758,6 +4760,9 @@ void runloop_pause_checks(void)
 
    /* Signal/reset paused rewind to take the initial step */
    runloop_st->run_frames_and_pause = -1;
+
+   /* Ignore frame delay target temporarily */
+   video_st->frame_delay_pause      = true;
 }
 
 struct string_list *path_get_subsystem_list(void)


### PR DESCRIPTION
## Description

Restored the removal of menu related rather useless audio starting and stopping regardless if menu sounds are enabled or not from the reverted PR #15391.