### PR TITLE
Prevent left-right hold in boolean menu items

### DIFF
--- a/menu/menu_entries.h
+++ b/menu/menu_entries.h
@@ -46,6 +46,7 @@ RETRO_BEGIN_DECLS
    entry.entry_idx          = 0; \
    entry.idx                = 0; \
    entry.type               = 0; \
+   entry.setting_type       = 0; \
    entry.spacing            = 0; \
    entry.flags              = 0
 


### PR DESCRIPTION
## Description

Minor QoL boost by making left/right behave like OK only in boolean settings - as in only once per press - and otherwise allow holding down with usual acceleration.

On second thought finetuned it so that pressing right does nothing when switch already is right, etc.
