### PR TITLE
(WIN32) Fix Pause vs NumLock in dinput/sdl2

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1081,9 +1081,16 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
             uint16_t mod          = 0;
             unsigned keycode      = 0;
             unsigned keysym       = (lparam >> 16) & 0xff;
+            bool extended         = (lparam >> 24) & 0x1;
 
             /* extended keys will map to dinput if the high bit is set */
-            if ((lparam >> 24 & 0x1))
+            if (extended)
+               keysym |= 0x80;
+
+            /* NumLock vs Pause correction */
+            if (GetKeyState(VK_NUMLOCK) & 0x80 && extended)
+               keysym &= ~0x80;
+            else if (GetKeyState(VK_PAUSE) & 0x80 && !extended)
                keysym |= 0x80;
 
             keycode = input_keymaps_translate_keysym_to_rk(keysym);
@@ -1327,9 +1334,16 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
             uint16_t mod          = 0;
             unsigned keycode      = 0;
             unsigned keysym       = (lparam >> 16) & 0xff;
+            bool extended         = (lparam >> 24) & 0x1;
 
             /* extended keys will map to dinput if the high bit is set */
-            if ((lparam >> 24 & 0x1))
+            if (extended)
+               keysym |= 0x80;
+
+            /* NumLock vs Pause correction */
+            if (GetKeyState(VK_NUMLOCK) & 0x80 && extended)
+               keysym &= ~0x80;
+            else if (GetKeyState(VK_PAUSE) & 0x80 && !extended)
                keysym |= 0x80;
 
             keycode = input_keymaps_translate_keysym_to_rk(keysym);


### PR DESCRIPTION
## Description

Add correction for unreliable keysyms with Pause and NumLock when using dinput or sdl2.

Closes #15513
