### PR TITLE
Show also lightgun bind labels instead of only 'N/A'

### DIFF
--- a/config.def.keybinds.h
+++ b/config.def.keybinds.h
@@ -201,9 +201,8 @@ static const struct retro_keybind retro_keybinds_1[] = {
    {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
-      RARCH_LIGHTGUN_RELOAD,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_RELOAD, RETROK_UNKNOWN,
-      NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_RELOAD, RETRO_DEVICE_ID_MOUSE_RIGHT, NO_BTN, 0,
       true
    },
    {
@@ -838,7 +837,7 @@ static const struct retro_keybind retro_keybinds_1[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_RELOAD, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_RELOAD, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_RELOAD, RETRO_DEVICE_ID_MOUSE_RIGHT, NO_BTN, 0,
       true
    },
    {
@@ -1473,7 +1472,7 @@ static const struct retro_keybind retro_keybinds_1[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_RELOAD, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_RELOAD, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_RELOAD, RETRO_DEVICE_ID_MOUSE_RIGHT, NO_BTN, 0,
       true
    },
    {
@@ -2122,7 +2121,7 @@ static const struct retro_keybind retro_keybinds_rest[] = {
       NULL, NULL,
       AXIS_NONE, AXIS_NONE, AXIS_NONE,
       MENU_ENUM_LABEL_VALUE_INPUT_LIGHTGUN_RELOAD, RETROK_UNKNOWN,
-      RARCH_LIGHTGUN_RELOAD, NO_BTN, NO_BTN, 0,
+      RARCH_LIGHTGUN_RELOAD, RETRO_DEVICE_ID_MOUSE_RIGHT, NO_BTN, 0,
       true
    },
    {

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -757,9 +757,9 @@ static int setting_bind_action_start(rarch_setting_t *setting)
       def_binds     = (struct retro_keybind*)retro_keybinds_rest;
 
    bind_type        = setting->bind_type;
-   keybind->key     = def_binds[bind_type - MENU_SETTINGS_BIND_BEGIN].key;
 
-   keybind->mbutton = NO_BTN;
+   keybind->key     = def_binds[bind_type - MENU_SETTINGS_BIND_BEGIN].key;
+   keybind->mbutton = def_binds[bind_type - MENU_SETTINGS_BIND_BEGIN].mbutton;
 
    /* Store new mapping bit */
    input_keyboard_mapping_bits(1, keybind->key);
@@ -9143,7 +9143,10 @@ static bool setting_append_list_input_player_options(
                      sizeof(label) - _len);
             else
             {
-               strlcpy(label + _len, value_na, sizeof(label) - _len);
+               snprintf(label, sizeof(label), "%s (%s)",
+                     input_config_bind_map_get_desc(i),
+                     value_na);
+
                if (settings->bools.input_descriptor_hide_unbound)
                   continue;
             }


### PR DESCRIPTION
## Description

Currently if a core does not have lightgun binds hooked up, all gun binds are shown as "N/A". Let's rather show "Gun Trigger (N/A)" instead etc.

Also accidentally noticed a weird related goof in the default keybinds.
Also added Mouse 2 as default reload button, and fixed mouse bind reset in general to default instead of null.
