### PR TITLE
(UWP) Fix d3d12 Driver in Debug Builds

### DIFF
--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -2444,13 +2444,8 @@ static void d3d12_init_base(d3d12_video_t* d3d12)
    int i = 0;
    DXGIAdapter adapter = NULL;
 #ifdef DEBUG
-#ifdef __WINRT__
-   if (SUCCEEDED(D3D12GetDebugInterface(uuidof(ID3D12Debug), (void**)&d3d12->debugController)))
-      d3d12->debugController->lpVtbl->EnableDebugLayer(&d3d12->debugController);
-#else
    if (SUCCEEDED(D3D12GetDebugInterface(uuidof(ID3D12Debug), (void**)&d3d12->debugController)))
       d3d12->debugController->lpVtbl->EnableDebugLayer(d3d12->debugController);
-#endif
 #endif
 
 #ifdef __WINRT__


### PR DESCRIPTION
## Description

The D3D12 Driver was broken when using UWP Debug builds, so this commit fixes that so we can now Debug the app with this video driver just fine.

## Reviewers

Anyone knowledgeable I guess.
