### PR TITLE
Graceful fallback to readonly mode if RDB can't be opened readwrite

### DIFF
--- a/database_info.c
+++ b/database_info.c
@@ -717,7 +717,7 @@ static int database_cursor_open(libretrodb_t *db,
    const char *error     = NULL;
    libretrodb_query_t *q = NULL;
 
-   if ((libretrodb_open(path, db)) != 0)
+   if ((libretrodb_open(path, db, false)) != 0)
       return -1;
 
    if (query)

--- a/libretro-db/libretrodb.c
+++ b/libretro-db/libretrodb.c
@@ -181,22 +181,14 @@ void libretrodb_close(libretrodb_t *db)
    db->fd   = NULL;
 }
 
-int libretrodb_open(const char *path, libretrodb_t *db)
+int libretrodb_open(const char *path, libretrodb_t *db, bool write)
 {
    libretrodb_header_t header;
    libretrodb_metadata_t md;
    RFILE *fd = filestream_open(path,
-         RETRO_VFS_FILE_ACCESS_READ_WRITE | RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING,
+         write ? RETRO_VFS_FILE_ACCESS_READ_WRITE | RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING : RETRO_VFS_FILE_ACCESS_READ,
          RETRO_VFS_FILE_ACCESS_HINT_NONE);
-   db->can_write = true;
-   if (!fd)
-   {
-     /* Try to reopen in readonly mode */
-     fd = filestream_open(path,
-                          RETRO_VFS_FILE_ACCESS_READ,
-                          RETRO_VFS_FILE_ACCESS_HINT_NONE);
-     db->can_write = false;
-   }
+   db->can_write = write;
    if (!fd)
      return -1;
 

--- a/libretro-db/libretrodb.h
+++ b/libretro-db/libretrodb.h
@@ -49,7 +49,7 @@ int libretrodb_create(RFILE *fd, libretrodb_value_provider value_provider, void 
 
 void libretrodb_close(libretrodb_t *db);
 
-int libretrodb_open(const char *path, libretrodb_t *db);
+int libretrodb_open(const char *path, libretrodb_t *db, bool write);
 
 int libretrodb_create_index(libretrodb_t *db, const char *name,
       const char *field_name);

--- a/libretro-db/libretrodb_tool.c
+++ b/libretro-db/libretrodb_tool.c
@@ -60,7 +60,7 @@ int main(int argc, char ** argv)
    if (!db || !cur)
       goto error;
 
-   if ((rv = libretrodb_open(path, db)) != 0)
+   if ((rv = libretrodb_open(path, db, true)) != 0)
    {
       printf("Could not open db file '%s'\n", path);
       goto error;

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -583,7 +583,7 @@ explore_state_t *menu_explore_build_list(const char *directory_playlist,
                ext_path[3] = 'b';
             }
 
-            if (libretrodb_open(tmp, newrdb.handle) != 0)
+            if (libretrodb_open(tmp, newrdb.handle, false) != 0)
             {
                /* Invalid RDB file */
                libretrodb_free(newrdb.handle);


### PR DESCRIPTION
My guess is that this will fix #15566 , but I can't test on UWP.

This PR also replaces some stray tabs with spaces.