### PR TITLE
Fix runtime display

### DIFF
--- a/runtime_file.c
+++ b/runtime_file.c
@@ -512,13 +512,12 @@ void runtime_log_get_runtime_str(runtime_log_t *runtime_log,
    s[_len+1]   = '\0';
    if (runtime_log)
    {
-      size_t _len2;
       char t[64];
       t[0]  = '\0';
-      _len2 = snprintf(t, sizeof(t), "%02u:%02u:%02u",
+      snprintf(t, sizeof(t), "%02u:%02u:%02u",
             runtime_log->runtime.hours, runtime_log->runtime.minutes,
             runtime_log->runtime.seconds);
-      strlcpy(s + _len2, t, len - _len2);
+      strlcpy(s + _len + 1, t, len - _len - 1);
    }
    else
    {


### PR DESCRIPTION

## Description

Due to an error in https://github.com/libretro/RetroArch/commit/631301b3f7d58d0969c1ebdaf2bb3907be5d0025, the runtime display string was working well only when the label had a length of 7. Even the English "Runtime:" was a bit truncated as a space was supposed to be added after the :, but it was even more noticeable in other languages.
