### PR TITLE
Fix issue #15490

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -61,9 +61,13 @@ enum {
     AMOTION_EVENT_BUTTON_FORWARD = 1 << 4,
     AMOTION_EVENT_AXIS_VSCROLL = 9,
     AMOTION_EVENT_ACTION_HOVER_MOVE = 7,
-    AINPUT_SOURCE_STYLUS = 0x00004000
+    AINPUT_SOURCE_STYLUS = 0x00004002,
+    AMOTION_EVENT_BUTTON_STYLUS_PRIMARY = 1 << 5,
+    AMOTION_EVENT_BUTTON_STYLUS_SECONDARY = 1 << 6
 };
 #endif
+
+#define AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE AINPUT_SOURCE_TOUCHSCREEN|AINPUT_SOURCE_MOUSE
 
 /* If using an SDK lower than 24 then add missing relative axis codes */
 #ifndef AMOTION_EVENT_AXIS_RELATIVE_X
@@ -818,6 +822,86 @@ static INLINE void android_input_poll_event_type_motion(
       android->mouse_r = (android->pointer_count == 2);
 }
 
+
+static INLINE void android_input_poll_event_type_motion_stylus(
+      android_input_t *android, AInputEvent *event,
+      int port, int source)
+{
+   int getaction     = AMotionEvent_getAction(event);
+   int action        = getaction  & AMOTION_EVENT_ACTION_MASK;
+   size_t motion_ptr = getaction >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+
+   if (ENABLE_TOUCH_SCREEN_MOUSE)
+   {
+      // mouse right button press on stylus primary button
+      int btn              = (int)AMotionEvent_getButtonState(event);
+      android->mouse_r     = (btn & AMOTION_EVENT_BUTTON_STYLUS_PRIMARY);
+   }
+
+   bool hovered_or_moving        = (
+            action == AMOTION_EVENT_ACTION_HOVER_MOVE
+         || action == AMOTION_EVENT_ACTION_MOVE);
+
+   if (hovered_or_moving && motion_ptr < MAX_TOUCH)
+   {
+      if (ENABLE_TOUCH_SCREEN_MOUSE)
+      {
+         if (action == AMOTION_EVENT_ACTION_MOVE) {
+            android->mouse_l = 1;
+         } else {
+            android->mouse_l = 0;
+         }
+
+         android_mouse_calculate_deltas(android,event,motion_ptr);
+      }
+
+      if (action == AMOTION_EVENT_ACTION_MOVE) {
+         // move pointer
+
+         struct video_viewport vp;
+         float x = AMotionEvent_getX(event, motion_ptr);
+         float y = AMotionEvent_getY(event, motion_ptr);
+
+         vp.x                        = 0;
+         vp.y                        = 0;
+         vp.width                    = 0;
+         vp.height                   = 0;
+         vp.full_width               = 0;
+         vp.full_height              = 0;
+
+         video_driver_translate_coord_viewport_wrap(
+               &vp,
+               x, y,
+               &android->pointer[motion_ptr].x,
+               &android->pointer[motion_ptr].y,
+               &android->pointer[motion_ptr].full_x,
+               &android->pointer[motion_ptr].full_y);
+
+         android->pointer_count = MAX(
+               android->pointer_count,
+               motion_ptr + 1);
+      } else if (action == AMOTION_EVENT_ACTION_HOVER_MOVE) {
+         // release the pointer
+
+         memmove(android->pointer + motion_ptr,
+         android->pointer + motion_ptr + 1,
+         (MAX_TOUCH - motion_ptr - 1) * sizeof(struct input_pointer));
+
+         if (android->pointer_count > 0)
+            android->pointer_count--;
+      }
+   } else if ((action == AMOTION_EVENT_ACTION_HOVER_EXIT) && motion_ptr < MAX_TOUCH) {
+      if (ENABLE_TOUCH_SCREEN_MOUSE)
+      {
+         android->mouse_l        = 0;
+
+         android_mouse_calculate_deltas(android,event,motion_ptr);
+      }
+
+      // pointer was already released during AMOTION_EVENT_ACTION_HOVER_MOVE
+   }
+}
+
 static bool android_is_keyboard_id(int id)
 {
    unsigned i;
@@ -1477,9 +1561,10 @@ static void android_input_poll_input_default(android_input_t *android)
             case AINPUT_EVENT_TYPE_MOTION:
                if ((source & AINPUT_SOURCE_TOUCHPAD))
                   engine_handle_touchpad(android_app, event, port);
-               /* Only handle events from a touchscreen or mouse */
-               else if ((source & (AINPUT_SOURCE_TOUCHSCREEN 
-                           | AINPUT_SOURCE_STYLUS | AINPUT_SOURCE_MOUSE)))
+               else if ((source & AINPUT_SOURCE_STYLUS) == AINPUT_SOURCE_STYLUS)
+                  android_input_poll_event_type_motion_stylus(android, event,
+                        port, source);
+               else if ((source & AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE) == AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE)
                   android_input_poll_event_type_motion(android, event,
                         port, source);
                else


### PR DESCRIPTION
## Description

Resolves issues with S-Pen on Samsung devices, also adds support for S-Pen button that is handled as r-mouse click now.

##  Rationale and implementation

`android_input.c` implemented handling of `AINPUT_SOURCE_STYLUS` using the same handler for touch motion:
https://github.com/libretro/RetroArch/blob/62e4779fee8aaa29a0fc216a79b5f4d5d13f6061/input/drivers/android_input.c#L1418-L1422

which results in stylus hover events treated as touches and triggering button presses on overlays, etc, prematurely.

I've refactored this part, to _properly_ detect stylus, to have a separate handler that parses events `AMOTION_EVENT_ACTION_MOVE` -> `AMOTION_EVENT_ACTION_HOVER_MOVE` -> `AMOTION_EVENT_ACTION_HOVER_EXIT` into mouse and pointer actions. Additionally, adds support for S-Pen button (`AMOTION_EVENT_BUTTON_STYLUS_PRIMARY`)
that is handled as r-mouse click now.

**Effect of the implementation:**
![showcase](https://github.com/libretro/RetroArch/assets/477998/daaa6cf7-1056-4bfa-9c9b-60f26ecf36d5
)

## Notes

While S-Pen is correctly handled on **libretro** level, in menus and overlays, each individual core is responsible for handling mouse / pointer inputs. Some modern cores like DeSmuME [have a toggle](https://github.com/libretro/desmume/blob/cf0fcc6ea4a85b7491bdf9adc7bf09748b4be7da/desmume/src/frontend/libretro/libretro.cpp#L1942-L1950) that switches between emulated mouse and actual pointer. Some older cores like DosBox and ScummVM are supporting only mouse. It's impossible to map precise stylus `(x,y)` coordinates into relative mouse motion (`(x_delta, y_delta)` polling). So, for those cores additional per-core logic must be implemented to support S-pen taps properly.

## Related Issues

https://github.com/libretro/RetroArch/issues/15490

