### PR TITLE
[android] fix d-pad regression

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -67,8 +67,6 @@ enum {
 };
 #endif
 
-#define AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE AINPUT_SOURCE_TOUCHSCREEN|AINPUT_SOURCE_MOUSE
-
 /* If using an SDK lower than 24 then add missing relative axis codes */
 #ifndef AMOTION_EVENT_AXIS_RELATIVE_X
 #define AMOTION_EVENT_AXIS_RELATIVE_X 27
@@ -1564,7 +1562,7 @@ static void android_input_poll_input_default(android_input_t *android)
                else if ((source & AINPUT_SOURCE_STYLUS) == AINPUT_SOURCE_STYLUS)
                   android_input_poll_event_type_motion_stylus(android, event,
                         port, source);
-               else if ((source & AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE) == AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE)
+               else if ((source & (AINPUT_SOURCE_TOUCHSCREEN | AINPUT_SOURCE_MOUSE)))
                   android_input_poll_event_type_motion(android, event,
                         port, source);
                else


### PR DESCRIPTION
## Description

Discovered today that my PR https://github.com/libretro/RetroArch/pull/15597 introduced a regression that caused D-Pad events to be skipped, due to bad match of bit pattern in the if-sentence.

Fixed in this PR.

## Debug Logs

Before fix, after pressing D-Pad buttons on an external controller:
```
RetroArch: [Autoconf]: Xbox One S Wireless Controller configured in port 1.
RetroArch: Type Event: 00000002
RetroArch: Event is Motion, check source: 01000010
RetroArch: AINPUT_SOURCE_TOUCHPAD: 00000000
RetroArch: AINPUT_SOURCE_STYLUS: 00000000
RetroArch: AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE: 00002002 <---- false match
RetroArch: LEGACY TOUCHSCREEN OR MOUSE: 00000000
RetroArch: KAWABANGA! Handling android_input_poll_event_type_motion  <---- incorrect
```

After fix:

```
RetroArch: [Autoconf]: Xbox One S Wireless Controller configured in port 1.
RetroArch: Type Event: 00000002
RetroArch: Event is Motion, check source: 01000010
RetroArch: AINPUT_SOURCE_TOUCHPAD: 00000000
RetroArch: AINPUT_SOURCE_STYLUS: 00000000
RetroArch: AINPUT_SOURCE_TOUCHSCREEN_OR_MOUSE: 00000000
RetroArch: LEGACY TOUCHSCREEN OR MOUSE: 00000000
RetroArch: KAWABANGA! Handling DPAD  <---- correct
```
