### PR TITLE
fix broken discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ The links below belong to our official channels. Links other than this may have 
 - [YouTube Topic](https://www.youtube.com/channel/UC5q007PYyQPgin0HHbzF0zQ)
 - [Patreon](https://www.patreon.com/libretro)
 - [BOUNTYSOURCE](https://www.bountysource.com/teams/libretro/issues)
-- [Discord](https://discord.gg/27Xxm2h)
+- [Discord](https://discord.com/invite/VZ2b7wghxR)
 - [Teespring](https://teespring.com/stores/retroarch)
 - [Documentation](https://docs.libretro.com/)
 - [Forum](https://forums.libretro.com/)


### PR DESCRIPTION
the old invite had expired, i guess? closes https://github.com/libretro/RetroArch/issues/15568

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

the readme had a broken discord invite, apparently

## Related Issues

[[Any issues this pull request may be addressing]](https://github.com/libretro/RetroArch/issues/15568)

## Related Pull Requests

none

## Reviewers

@LibretroAdmin 
