### PR TITLE
(cheevos) disallow video_swap_interval and black_frame_insertion in hardcore

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8034,6 +8034,8 @@ static void general_write_handler(rarch_setting_t *setting)
 #ifdef HAVE_CHEEVOS
       case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY:
       case MENU_ENUM_LABEL_VIDEO_FRAME_DELAY_AUTO:
+      case MENU_ENUM_LABEL_VIDEO_SWAP_INTERVAL:
+      case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
          rcheevos_validate_config_settings();
          break;
 #endif


### PR DESCRIPTION
## Description

Manually specifying the video swap interval or inserting black frames while vsync is enabled can cause emulation to run slower than intended. This is not allowed in hardcore, so we've decided to disallow any black frame insertion or manual video swap intervals higher than 1. 1 is only allowed as it's the default and most users won't know how to change it. I would expect auto to be better for all users.

## Related Issues

Cheating reported in RetroAchievements server.

## Related Pull Requests

n/a

## Reviewers

@Sanaki