### PR TITLE
Allow all systems to check for backslashes (Windows) as last slash in path. Improves portable core logic

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -347,21 +347,20 @@ size_t fill_pathname(char *out_path, const char *in_path,
  * @size               : size of path
  *
  * Find last slash in path. Tries to find
- * a backslash on Windows too which takes precedence
- * over regular slash.
+ * a backslash as used for Windows paths,
+ * otherwise checks for a regular slash.
 
  * @return pointer to last slash/backslash found in @str.
  **/
 char *find_last_slash(const char *str)
 {
    const char *slash     = strrchr(str, '/');
-#ifdef _WIN32
    const char *backslash = strrchr(str, '\\');
 
    if (!slash || (backslash > slash))
       return (char*)backslash;
-#endif
-   return (char*)slash;
+   else
+      return (char*)slash;
 }
 
 /**


### PR DESCRIPTION
## Description

Currently the "Portable Playlists" option under Settings -> Playlists, as implemented back in the day with PRs https://github.com/libretro/RetroArch/pull/11075 and https://github.com/libretro/RetroArch/pull/11172, has one issue that prevents entries from seamlessly detecting the core paths between Windows and Linux installations.

Right now, when using Portable Playlists, cores are automatically detected regardless of whether the full core path written on the playlist is actually present. This is thanks to the `core_info_core_file_id_is_equal` function in `playlist.c`, which extracts the core ID from the full core path and cuts everything before the name of the core and after `_libretro`, also ignoring the filename extension. 
This makes it so that, when you launch a playlist entry with Portable Playlists enabled, RA will look for the core in its full path and, if it's not there, it will try to identify the core ID through the `core_info_core_file_id_is_equal` function. It will then search for that same core ID/name in the local core directory of the system that is being used.

In order to have this work, `core_info_core_file_id_is_equal` also calls another function, which is `find_last_slash` in `libretro-common/file_path.c`.

Now, running RA on Windows makes everything work nicely: on Windows all paths are detected and the cores are properly identified. On the other hand, RA on Linux will not launch any playlist entry that has a Windows core path.

The reason is that on RA compiled for Linux the `find_last_slash` function is only checking for a regular slash ("/"). The backslash check ("\\", which is the default separator for Windows paths) is locked behind an `ifdef WIN32`, which makes Linux RA unable to interpret it for the portable core logic.

This PR aims to fix this by removing the `ifdef` and changing the function to a simpler conditional statement.

_(Sorry for the longwinded text, but it took me nearly 48 hours to understand what was actually happening, haha)_

## Related Issues

Closes https://github.com/libretro/RetroArch/issues/15604.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/11075
https://github.com/libretro/RetroArch/pull/11172

## Reviewers

@LibretroAdmin @sonninnos