### PR TITLE
(cheevos) automatically disable hardcore when game identification fails due to network error

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1939,8 +1939,7 @@ static void rcheevos_initialize_runtime_callback(void* userdata)
 
 static void rcheevos_fetch_game_data(void)
 {
-   if (     rcheevos_locals.load_info.state
-         == RCHEEVOS_LOAD_STATE_NETWORK_ERROR)
+   if (rcheevos_load_aborted())
    {
       rcheevos_locals.game.hash = NULL;
       rcheevos_pause_hardcore();

--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -531,7 +531,7 @@ static void rcheevos_async_end_request(rcheevos_async_io_request* request)
 {
    rc_api_destroy_request(&request->request);
 
-   if (request->callback && !rcheevos_load_aborted())
+   if (request->callback)
       request->callback(request->callback_data);
 
    /* rich presence request will be reused on next ping - reset the attempt


### PR DESCRIPTION
## Description

There was logic to ignore callbacks when the load process is aborted, but the callback has to be called to disable hardcore. Callbacks should always be expected to be called. I've updated the logic to always call the callback, and modified the game initialization callbacks to also look for aborts caused by closing the content during the load process.

## Related Issues

Fixes #15574 

## Related Pull Requests

n/a

## Reviewers

@Sanaki