### PR TITLE
Search box usability improvements

### DIFF
--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -930,6 +930,9 @@ void input_keyboard_line_append(
       struct input_keyboard_line *keyboard_line,
       const char *word, size_t len);
 
+void input_keyboard_line_clear(input_driver_state_t *input_st);
+void input_keyboard_line_free(input_driver_state_t *input_st);
+
 /**
  * input_keyboard_start_line:
  * @userdata                 : Userdata.


### PR DESCRIPTION
## Description

Tiny usability boosts for search box usage:
- RetroPad Cancel will close the window if it is empty (Backspace will not)
- RetroPad Select & Escape will clear and close the window
- RetroPad Y will clear the window but not close
- RetroPad X will search just like Start
