### PR TITLE
(cheevos) prevent frame step when hitting rewind button while paused in hardcore

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -6097,6 +6097,10 @@ static enum runloop_state_enum runloop_check_state(
 #endif
 
 #ifdef HAVE_CHEEVOS
+   /* Make sure not to evaluate this before calling menu_driver_iterate
+    * as that may change its value */
+   cheevos_hardcore_active = rcheevos_hardcore_active();
+
    if (!cheevos_hardcore_active)
 #endif
    {
@@ -6235,10 +6239,6 @@ static enum runloop_state_enum runloop_check_state(
          pause_pressed             |= BIT256_GET(current_bits, RETRO_DEVICE_ID_JOYPAD_START);
 
 #ifdef HAVE_CHEEVOS
-      /* Make sure not to evaluate this before calling menu_driver_iterate
-       * as that may change its value */
-      cheevos_hardcore_active = rcheevos_hardcore_active();
-
       if (cheevos_hardcore_active)
       {
          static int unpaused_frames = 0;
@@ -6301,7 +6301,11 @@ static enum runloop_state_enum runloop_check_state(
          if (!frameadvance_trigger)
 #endif
             focused = false;
+#ifdef HAVE_CHEEVOS
+         else if (!cheevos_hardcore_active)
+#else
          else
+#endif
             runloop_paused = false;
 
          /* Drop to RUNLOOP_STATE_POLLED_AND_SLEEP if frameadvance is triggered */


### PR DESCRIPTION
## Description

I noticed the behavior reported in #12251 for rewinding while paused, and wanted to make sure it was also disabled for achievements hardcore.

While it doesn't allow single frame rewinding, it does perform a sort of jittery framestep (it steps forwards a number of frames while the button is depressed, then stops when the button is released).

This changes the behavior to remain paused when hitting the rewind button when achievements hardcore is on.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki
