### PR TITLE
iOS: Support a helper bar button to lock the current orientation

### DIFF
--- a/pkg/apple/HelperBar/CocoaView+HelperBar.swift
+++ b/pkg/apple/HelperBar/CocoaView+HelperBar.swift
@@ -10,8 +10,10 @@ protocol HelperBarActionDelegate: AnyObject {
    func keyboardButtonTapped()
    func mouseButtonTapped()
    func helpButtonTapped()
+   func orientationLockButtonTapped()
    var isKeyboardEnabled: Bool { get }
    var isMouseEnabled: Bool { get }
+   var isOrientationLocked: Bool { get }
 }
 
 extension CocoaView {
@@ -47,11 +49,26 @@ extension CocoaView: HelperBarActionDelegate {
    func helpButtonTapped() {
    }
    
+   func orientationLockButtonTapped() {
+      shouldLockCurrentInterfaceOrientation.toggle()
+      if shouldLockCurrentInterfaceOrientation {
+         let currentOrientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation ?? UIInterfaceOrientation.portrait
+         self.lockInterfaceOrientation = currentOrientation
+      }
+      if #available(iOS 16, *) {
+         setNeedsUpdateOfSupportedInterfaceOrientations()
+      }
+   }
+   
    var isKeyboardEnabled: Bool {
       !keyboardController.view.isHidden
    }
    
    var isMouseEnabled: Bool {
       mouseHandler.enabled
+   }
+   
+   var isOrientationLocked: Bool {
+      shouldLockCurrentInterfaceOrientation
    }
 }

--- a/pkg/apple/HelperBar/HelperBarItem.swift
+++ b/pkg/apple/HelperBar/HelperBarItem.swift
@@ -9,10 +9,15 @@
 protocol HelperBarItem {
    var image: UIImage? { get }
    var selectedImage: UIImage? { get }
+   var tintColorOnSelection: UIColor? { get }
    var isSelected: Bool { get }
    var shortDescription: String { get }
    var longDescription: String? { get }
    func action()
+}
+
+extension HelperBarItem {
+   var tintColorOnSelection: UIColor? { nil }
 }
 
 struct KeyboardBarItem: HelperBarItem {
@@ -51,5 +56,23 @@ struct MouseBarItem: HelperBarItem {
 
    func action() {
       actionDelegate?.mouseButtonTapped()
+   }
+}
+
+struct LockOrientationBarItem: HelperBarItem {
+   let image = UIImage(systemName: "lock.rotation")
+   let selectedImage = UIImage(systemName: "lock.rotation")
+   var tintColorOnSelection: UIColor? { .red }
+   var isSelected: Bool { actionDelegate?.isOrientationLocked ?? false }
+   let shortDescription = NSLocalizedString("Lock the current screen orientation", comment: "Description for orientation lock item on helper bar")
+   var longDescription: String? { nil }
+   weak var actionDelegate: HelperBarActionDelegate?
+   
+   init(actionDelegate: HelperBarActionDelegate?) {
+      self.actionDelegate = actionDelegate
+   }
+
+   func action() {
+      actionDelegate?.orientationLockButtonTapped()
    }
 }

--- a/pkg/apple/HelperBar/HelperBarViewController.swift
+++ b/pkg/apple/HelperBar/HelperBarViewController.swift
@@ -88,8 +88,14 @@ class HelperBarViewController: UIViewController {
          }
          if helperBarItem.isSelected {
             barButtonItem.image = helperBarItem.selectedImage
+            if let tintColor = helperBarItem.tintColorOnSelection {
+               barButtonItem.tintColor = tintColor
+            } else {
+               barButtonItem.tintColor = nil
+            }
          } else {
             barButtonItem.image = helperBarItem.image
+            barButtonItem.tintColor = nil
          }
       }
    }

--- a/pkg/apple/HelperBar/HelperBarViewModel.swift
+++ b/pkg/apple/HelperBar/HelperBarViewModel.swift
@@ -23,7 +23,8 @@ class HelperBarViewModel {
    
    lazy var barItems: [HelperBarItem] = [
       KeyboardBarItem(actionDelegate: actionDelegate),
-      MouseBarItem(actionDelegate: actionDelegate)
+      MouseBarItem(actionDelegate: actionDelegate),
+      LockOrientationBarItem(actionDelegate: actionDelegate)
    ]
    
    var barItemMapping = [UIBarButtonItem: HelperBarItem]()

--- a/ui/drivers/cocoa/cocoa_common.h
+++ b/ui/drivers/cocoa/cocoa_common.h
@@ -68,6 +68,9 @@
 @property(nonatomic,strong) UIView *helperBarView;
 #endif
 
+@property(readwrite) BOOL shouldLockCurrentInterfaceOrientation;
+@property(readwrite) UIInterfaceOrientation lockInterfaceOrientation;
+
 + (CocoaView*)get;
 @end
 

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -105,8 +105,11 @@ void *glkitview_init(void);
     */
    self.controllerUserInteractionEnabled = YES;
 #endif
-
+  
+#if TARGET_OS_IOS
   self.shouldLockCurrentInterfaceOrientation = NO;
+#endif
+
    return self;
 }
 

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -53,7 +53,6 @@ void *glkitview_init(void);
 ,EmulatorTouchMouseHandlerDelegate
 #endif
 >
-
 @end
 #endif
 
@@ -107,6 +106,7 @@ void *glkitview_init(void);
    self.controllerUserInteractionEnabled = YES;
 #endif
 
+  self.shouldLockCurrentInterfaceOrientation = NO;
    return self;
 }
 
@@ -417,7 +417,23 @@ void *glkitview_init(void);
 /* NOTE: This version runs on iOS6+. */
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-   return (UIInterfaceOrientationMask)apple_frontend_settings.orientation_flags;
+  if (@available(iOS 16, *)) {
+    if (self.shouldLockCurrentInterfaceOrientation) {
+      return 1 << self.lockInterfaceOrientation;
+    } else {
+      return (UIInterfaceOrientationMask)apple_frontend_settings.orientation_flags;
+    }
+  } else {
+    return (UIInterfaceOrientationMask)apple_frontend_settings.orientation_flags;
+  }
+}
+
+/* NOTE: This does not run on iOS 16+ */
+-(BOOL)shouldAutorotate {
+  if (self.shouldLockCurrentInterfaceOrientation) {
+    return NO;
+  }
+  return YES;
 }
 
 /* NOTE: This version runs on iOS2-iOS5, but not iOS6+. */


### PR DESCRIPTION
## Description

Add a screen orientation lock button for iOS to the "helper bar" to lock the current orientation. This is to support cores that use the gyroscope (mGBA, etc) so that the screen does not auto-rotate while interacting using the gyro controls.

![Aug-21-2023 10-17-42](https://github.com/libretro/RetroArch/assets/564774/7305fe68-5156-46c3-bba0-3b36371ddf64)

The code supports both iOS 16 and pre-iOS 16 due to the different way rotation is handled based on the OS version.