### PR TITLE
(XMB+Ozone) Animation corrections

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -10971,8 +10971,8 @@ unsigned menu_displaylist_build_list(
                {MENU_ENUM_LABEL_MATERIALUI_MENU_TRANSITION_ANIMATION,         PARSE_ONLY_UINT,   true},
                {MENU_ENUM_LABEL_MENU_HORIZONTAL_ANIMATION,                    PARSE_ONLY_BOOL,   true},
                {MENU_ENUM_LABEL_MENU_XMB_ANIMATION_HORIZONTAL_HIGHLIGHT,      PARSE_ONLY_UINT,   false},
+               {MENU_ENUM_LABEL_MENU_XMB_ANIMATION_OPENING_MAIN_MENU,         PARSE_ONLY_UINT,   false},
                {MENU_ENUM_LABEL_MENU_XMB_ANIMATION_MOVE_UP_DOWN,              PARSE_ONLY_UINT,   true},
-               {MENU_ENUM_LABEL_MENU_XMB_ANIMATION_OPENING_MAIN_MENU,         PARSE_ONLY_UINT,   true},
             };
 
             for (i = 0; i < ARRAY_SIZE(build_list); i++)
@@ -10980,6 +10980,7 @@ unsigned menu_displaylist_build_list(
                switch (build_list[i].enum_idx)
                {
                   case MENU_ENUM_LABEL_MENU_XMB_ANIMATION_HORIZONTAL_HIGHLIGHT:
+                  case MENU_ENUM_LABEL_MENU_XMB_ANIMATION_OPENING_MAIN_MENU:
                      if (menu_horizontal_animation)
                         build_list[i].checked = true;
                      break;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -4067,6 +4067,9 @@ static void setting_get_string_representation_uint_menu_xmb_animation_move_up_do
       case 1:
          strlcpy(s, "Easing Out Expo", len);
          break;
+      case 2:
+         strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NONE), len);
+         break;
    }
 }
 
@@ -17381,7 +17384,7 @@ static bool setting_append_list(
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
             (*list)[list_info->index - 1].get_string_representation =
                &setting_get_string_representation_uint_menu_xmb_animation_move_up_down;
-            menu_settings_list_current_add_range(list, list_info, 0, 1, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0, 2, 1, true, true);
             (*list)[list_info->index - 1].ui_type   = ST_UI_TYPE_UINT_RADIO_BUTTONS;
 
             CONFIG_UINT(


### PR DESCRIPTION
## Description

XMB:
- Added a new up/down animation mode: None
- Fixed horizontal animation toggle to apply to all horizontal animations
- Prevented vertical fade from causing blocky horizontal animation fade
- Separated movement easing and alpha easing for slightly more pleasant fade
- Start label alpha animation from lower value for less blurry movement

Ozone:
- Adjusted sublabel width calculation when using menu scale factor
- Prevented double animation when leaving sidebar to non-playlists and vice-versa
- Limited minimum font size so that 320x240 is readable
- Fixed imageviewer preview if only left thumbnail is enabled
- Same easing changes

Both:
- Tab removals and nits