### PR TITLE
(UWP/Menu) Small Tweaks

### DIFF
--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -68,12 +68,6 @@ static void frontend_uwp_get_os(char *s, size_t len, int *major, int *minor)
       case PROCESSOR_ARCHITECTURE_AMD64:
          arch = "x64";
          break;
-      case PROCESSOR_ARCHITECTURE_INTEL:
-         arch = "x86";
-         break;
-      case PROCESSOR_ARCHITECTURE_ARM:
-         arch = "ARM";
-         break;
       case PROCESSOR_ARCHITECTURE_ARM64:
          arch = "ARM64";
          break;
@@ -87,48 +81,26 @@ static void frontend_uwp_get_os(char *s, size_t len, int *major, int *minor)
    if (minor)
       *minor = vi.dwMinorVersion;
 
-   if (vi.dwMajorVersion == 4 && vi.dwMinorVersion == 0)
-      snprintf(build_str, sizeof(build_str), "%lu", (DWORD)(LOWORD(vi.dwBuildNumber))); /* Windows 95 build number is in the low-order word only */
-   else
-      snprintf(build_str, sizeof(build_str), "%lu", vi.dwBuildNumber);
+   snprintf(build_str, sizeof(build_str), "%lu", vi.dwBuildNumber);
 
    switch (vi.dwMajorVersion)
    {
       case 10:
          if (server)
-            _len = strlcpy(s, "Windows Server 2016", len);
-         else
-            _len = strlcpy(s, "Windows 10", len);
-         break;
-      case 6:
-         switch (vi.dwMinorVersion)
          {
-            case 3:
-               if (server)
-                  _len = strlcpy(s, "Windows Server 2012 R2", len);
-               else
-                  _len = strlcpy(s, "Windows 8.1", len);
-               break;
-            case 2:
-               if (server)
-                  _len = strlcpy(s, "Windows Server 2012", len);
-               else
-                  _len = strlcpy(s, "Windows 8", len);
-               break;
-            case 1:
-               if (server)
-                  _len = strlcpy(s, "Windows Server 2008 R2", len);
-               else
-                  _len = strlcpy(s, "Windows 7", len);
-               break;
-            case 0:
-               if (server)
-                  _len = strlcpy(s, "Windows Server 2008", len);
-               else
-                  _len = strlcpy(s, "Windows Vista", len);
-               break;
-            default:
-               break;
+            if ((vi.dwBuildNumber >= 14393) && (vi.dwBuildNumber < 17763))
+               _len = strlcpy(s, "Windows Server 2016", len);
+            else if ((vi.dwBuildNumber >= 17763) && (vi.dwBuildNumber < 20348))
+               _len = strlcpy(s, "Windows Server 2019", len);
+            else if (vi.dwBuildNumber >= 20348)
+               _len = strlcpy(s, "Windows Server 2022", len);
+         }
+         else
+         {
+            if ((vi.dwBuildNumber >= 10240) && (vi.dwBuildNumber < 22000))
+               _len = strlcpy(s, "Windows 10", len);
+            else if (vi.dwBuildNumber >= 22000)
+               _len = strlcpy(s, "Windows 11", len);
          }
          break;
       default:
@@ -202,10 +174,6 @@ enum frontend_architecture frontend_uwp_get_arch(void)
    {
       case PROCESSOR_ARCHITECTURE_AMD64:
          return FRONTEND_ARCH_X86_64;
-      case PROCESSOR_ARCHITECTURE_INTEL:
-         return FRONTEND_ARCH_X86;
-      case PROCESSOR_ARCHITECTURE_ARM:
-         return FRONTEND_ARCH_ARM;
       case PROCESSOR_ARCHITECTURE_ARM64:
          return FRONTEND_ARCH_ARMV8;
       default:

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -4559,8 +4559,10 @@ static const char * msvc_vercode_to_str(const unsigned vercode)
       default:
          if (vercode >= 1910 && vercode < 1920)
             return " msvc2017";
-         else if (vercode >= 1920 && vercode < 2000)
+         else if (vercode >= 1920 && vercode < 1930)
             return " msvc2019";
+         else if (vercode >= 1930)
+            return " msvc2022";
          break;
    }
 

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -1103,8 +1103,10 @@ extern "C" {
 
    const char* uwp_get_cpu_model_name(void)
    {
-      /* TODO/FIXME - Xbox codepath should have a hardcoded CPU model name */
-      if (is_running_on_xbox()) { }
+      if (is_running_on_xbox())
+      {
+        return "Xbox One/Series CPU";
+      }
       else
       {
          Platform::String^ cpu_id    = nullptr;


### PR DESCRIPTION
## Description

- **Menu**: If RetroArch was built using Visual Studio and the latest versions of MVSC, the menu now shows that it was built with msvc2022.
- **UWP (uwp_main.cpp)**: Report back a generic CPU model name if the app is used on Xbox Consoles. Also takes care of a FIXME comment.
- **UWP (platform_uwp.cpp)**: Cleans up the code used to report back what version of Windows is being used. 
First, older versions of Windows where UWP apps are not supported and wouldn't run to begin with were removed alongside their relevant code. 

  Second, any mentions of the x86 and ARM/AMR32 CPU architectures were removed since we no longer support UWP builds for those two architectures. 

  And finally, since a lot of Windows versions share the same major and minor numbers in their version numbers (10.0) with the build number being how they were distinguished, more checks were added to correctly report the version of Windows that is actually being used. This fixes an issue where Windows 11 systems (such as the Xbox Series consoles) were reporting back to RetroArch that it was running Windows 10 instead.

Here's a screenshot with all the relevant changes shown at once:
![Unknown-2023_08_28-21_57_30](https://github.com/libretro/RetroArch/assets/35014183/b9c31bb9-d7a5-4508-a4d7-b593279d5717)
