### PR TITLE
iOS: Restore orientation lock feature

### DIFF
--- a/pkg/apple/HelperBar/CocoaView+HelperBar.swift
+++ b/pkg/apple/HelperBar/CocoaView+HelperBar.swift
@@ -50,7 +50,7 @@ extension CocoaView: HelperBarActionDelegate {
    }
    
    func orientationLockButtonTapped() {
-      #if TARGET_OS_IOS
+      #if os(iOS)
       shouldLockCurrentInterfaceOrientation.toggle()
       if shouldLockCurrentInterfaceOrientation {
          let currentOrientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation ?? UIInterfaceOrientation.portrait


### PR DESCRIPTION
## Description

When fixing the tvOS build in #15637, I messed up on the compiler flag check and used obj-c syntax instead of swift. This restores the orientation lock feature and fixes it. 
