### PR TITLE
Allow more keyboard actions with menu osk

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -6307,18 +6307,38 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
             && current_input
             && current_input->input_state)
       {
-         /* Set RetroPad Select bit when pressing Escape while keyboard
-          * is open in order to clear the input window and close it */
-         if (current_input->input_state(
-                  input_st->current_data,
-                  joypad,
-                  sec_joypad,
-                  &joypad_info,
-                  (const retro_keybind_set *)input_config_binds,
-                  (input_st->flags & INP_FLAG_KB_MAPPING_BLOCKED) ? true : false,
-                  0,
-                  RETRO_DEVICE_KEYBOARD, 0, RETROK_ESCAPE))
-            BIT256_SET_PTR(current_bits, RETRO_DEVICE_ID_JOYPAD_SELECT);
+         /* Allow arrows, LCtrl as OK, character map switches,
+          * and set RetroPad Select bit when pressing Escape
+          * in order to clear the input window and close it. */
+         unsigned i;
+         unsigned ids[][2] =
+         {
+            {RETROK_LCTRL,     RETRO_DEVICE_ID_JOYPAD_A      },
+            {RETROK_UP,        RETRO_DEVICE_ID_JOYPAD_UP     },
+            {RETROK_DOWN,      RETRO_DEVICE_ID_JOYPAD_DOWN   },
+            {RETROK_LEFT,      RETRO_DEVICE_ID_JOYPAD_LEFT   },
+            {RETROK_RIGHT,     RETRO_DEVICE_ID_JOYPAD_RIGHT  },
+            {RETROK_PAGEUP,    RETRO_DEVICE_ID_JOYPAD_L      },
+            {RETROK_PAGEDOWN,  RETRO_DEVICE_ID_JOYPAD_R      },
+            {RETROK_ESCAPE,    RETRO_DEVICE_ID_JOYPAD_SELECT },
+         };
+
+         if (settings->bools.input_menu_swap_ok_cancel_buttons)
+            ids[0][1] = RETRO_DEVICE_ID_JOYPAD_B;
+
+         for (i = 0; i < ARRAY_SIZE(ids); i++)
+         {
+            if (current_input->input_state(
+                     input_st->current_data,
+                     joypad,
+                     sec_joypad,
+                     &joypad_info,
+                     (const retro_keybind_set *)input_config_binds,
+                     (input_st->flags & INP_FLAG_KB_MAPPING_BLOCKED) ? true : false,
+                     0,
+                     RETRO_DEVICE_KEYBOARD, 0, ids[i][0]))
+               BIT256_SET_PTR(current_bits, ids[i][1]);
+         }
       }
    }
    else


### PR DESCRIPTION
## Description

Currently the on-screen keyboard kills pretty much all keyboard input for typing purposes, thus we lose some useful things, like being able to use keyboard arrow keys like D-Pad. Also added PageUp/Down as L/R, and allowed unused Left Control to act as OK button, since Enter can't be used for that. This makes it possible to at least somehow use the search and freetype options with keyboard devices such as I-PAC.
