### PR TITLE
Wayland: Get system wayland-protocols path via pkg-config

### DIFF
--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -31,17 +31,14 @@ while [ $# -gt 0 ]; do
 done
 
 WAYSCAN="$(exists wayland-scanner || :)"
+PKGCONFIG="$(exists pkg-config || :)"
 
 [ "${WAYSCAN}" ] || die 1 "Error: No wayscan in ($PATH)"
 
 WAYLAND_PROTOS=''
 
-if [ "$PROTOS" != 'no' ]; then
-   for protos in "$SHARE_DIR" /usr/local/share/wayland-protocols /usr/share/wayland-protocols; do
-      [ -d "$protos" ] || continue
-      WAYLAND_PROTOS="$protos"
-      break
-   done
+if [ "$PROTOS" != 'no' -a "$PKGCONFIG" ]; then
+   WAYLAND_PROTOS="$($PKGCONFIG wayland-protocols --variable=pkgdatadir)"
 fi
 
 if [ -z "${WAYLAND_PROTOS}" ]; then


### PR DESCRIPTION
## Description

pkg-config is currently used to decide whether to try to use the systems protocol files based on the installed version.
This MR lets pkg-config define where to look.

## Related Issues

## Related Pull Requests

## Reviewers
