### PR TITLE
(Ozone) Sublabel scope test

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -5656,6 +5656,7 @@ border_iterate:
    {
       char rich_label[255];
       char entry_value_ticker[255];
+      char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
       uintptr_t texture;
       menu_entry_t entry;
       gfx_animation_ctx_ticker_t ticker;
@@ -5764,7 +5765,6 @@ border_iterate:
          if (node->wrap && !string_is_empty(sublabel_str))
          {
             int sublabel_max_width = ozone_get_sublabel_max_width(ozone, video_info_width, entry_padding);
-            char wrapped_sublabel_str[MENU_SUBLABEL_MAX_LENGTH];
 
             wrapped_sublabel_str[0] = '\0';
             (ozone->word_wrap)(wrapped_sublabel_str,


### PR DESCRIPTION
## Description

One more attempt to fix the Android problem caused by #15645.

Doesn't this sound feasible, since just below the word wrap function is `sublabel_str = wrapped_sublabel_str;`, so would make sense that the variable does not exist anymore outside of that inner block if it is defined there, but why oh why does it work with Windows..
