### PR TITLE
Audio synchronization menu cleanup

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -14963,7 +14963,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                               if (setting->get_string_representation)
                               {
-                                 for (i = min; i <= max; i += step)
+                                 for (i = min; i <= max + half_step; i += step)
                                  {
                                     char val_s[256];
                                     *setting->value.target.fraction = i;
@@ -14989,7 +14989,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               }
                               else
                               {
-                                 for (i = min; i <= max; i += step)
+                                 for (i = min; i <= max + half_step; i += step)
                                  {
                                     char val_s[16];
                                     snprintf(val_s, sizeof(val_s), "%.2f", i);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7878,8 +7878,7 @@ static void write_handler_audio_rate_control_delta(rarch_setting_t *setting)
 
    if (*setting->value.target.fraction < 0.0005)
    {
-      configuration_set_bool(settings,
-            settings->bools.audio_rate_control, false);
+      configuration_set_bool(settings, settings->bools.audio_rate_control, false);
       audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, 0.0f);
    }
    else
@@ -13807,14 +13806,16 @@ static bool setting_append_list(
                parent_group,
                write_handler_audio_rate_control_delta,
                read_handler_audio_rate_control_delta);
+         (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
          menu_settings_list_current_add_range(
                list,
                list_info,
-               0,
-               0,
+               0.0,
+               0.020,
                0.001,
                true,
-               false);
+               true);
+         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
          SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
          CONFIG_FLOAT(
@@ -13823,7 +13824,7 @@ static bool setting_append_list(
                MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW,
                MENU_ENUM_LABEL_VALUE_AUDIO_MAX_TIMING_SKEW,
                DEFAULT_MAX_TIMING_SKEW,
-               "%.2f",
+               "%.3f",
                &group_info,
                &subgroup_info,
                parent_group,
@@ -13838,6 +13839,7 @@ static bool setting_append_list(
                0.01,
                true,
                true);
+         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
          SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
 #ifdef RARCH_MOBILE


### PR DESCRIPTION
## Description

- Added audio reinit to skew and rate control options for immediate effect
- Reformatted both visible values to have same amount of decimals
- Added ceiling to rate control value and added dropdown
- Fixed float dropdown maximum rounding when step is small enough