### PR TITLE
(Ozone) Prevent metadata and footer overlap

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -5222,6 +5222,10 @@ static void ozone_content_metadata_line(
       uint32_t color,
       uint8_t lines_count)
 {
+   if (*y + (lines_count * (unsigned)ozone->fonts.footer.line_height)
+         > video_height - ozone->dimensions.footer_height)
+      return;
+
    gfx_display_draw_text(
          ozone->fonts.footer.font,
          text,


### PR DESCRIPTION
## Description

For some odd reason metadata text will overlap footer with very wide resolutions, but only with gl drivers, so let's unify it and stop always drawing such text.

I tried inspecting how vulkan and d3d11 are able to detect the footer section and stop even during line breaks without this, but nothing special caught my eye, since they use the same text/font drawing functions..

![retroarch_2023_09_07_03_57_48_636](https://github.com/libretro/RetroArch/assets/45124675/3386ab00-aa22-483c-a7ca-eb981129c441)
