### PR TITLE
UWP: Handle key presses while ALT is held down

### DIFF
--- a/uwp/uwp_main.h
+++ b/uwp/uwp_main.h
@@ -46,7 +46,6 @@ namespace RetroArchUWP
       void OnVisibilityChanged(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
       void OnWindowClosed(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::CoreWindowEventArgs^ args);
       void OnWindowActivated(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::WindowActivatedEventArgs^ args);
-      void OnKey(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ args);
       void OnAcceleratorKey(Windows::UI::Core::CoreDispatcher^ sender, Windows::UI::Core::AcceleratorKeyEventArgs^ args);
       void OnPointer(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::PointerEventArgs^ args);
 
@@ -75,7 +74,6 @@ namespace RetroArchUWP
       Platform::String^ m_launchOnExit;
       bool m_launchOnExitShutdown;
       void ParseProtocolArgs(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args, int *argc, std::vector<char*> *argv, std::vector<std::string> *argvTmp);
-      bool GetKey(Windows::UI::Core::CoreWindow^ window, Windows::System::VirtualKey vkey, bool down, bool extended, unsigned& keycode, uint16_t& mod);
       static App^ m_instance;
    };
 }


### PR DESCRIPTION
## Description
This is an additional fix for #15651 which was only the first attempt at improving keyboard events on UWP.

This now fixes pressing keys while ALT is being held down. Before ALT was recognized but additional key events were ignored until ALT was released.
In addition to that, it also releases held keys when deactivating the window. This means pressing ALT+TAB on Windows desktop will actually release the held ALT key properly like the native Windows input drivers do.

## Related Issues

## Related Pull Requests
#15651

## Reviewers
@greenchili2 
