### PR TITLE
Correction for not showing mouse cursor with overlay

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4391,7 +4391,7 @@ static void input_overlay_enable_(bool enable)
       : settings->floats.input_overlay_opacity;
    bool auto_rotate               = settings->bools.input_overlay_auto_rotate;
    bool hide_mouse_cursor         = !settings->bools.input_overlay_show_mouse_cursor
-         && (input_st->flags & INP_FLAG_GRAB_MOUSE_STATE);
+         && settings->bools.video_fullscreen;
 
    if (!ol)
       return;


### PR DESCRIPTION
## Description

Since one of the goals of that PR was
```
- Don't apply input_overlay_show_mouse_cursor in windowed mode (controlled by mouse grab only)
```
And since windowed fullscreen will not grab, it also won't hide the cursor as desired. So instead of forcing the use of exclusive fullscreen, let's rather allow the cursor to be hidden when any fullscreen mode is active.

Not sure why can't it be allowed to be hidden in windowed too, as in by the option alone..

## Related Pull Requests

#15463

