### PR TITLE
(Emscripten) Modularize the JavaScript and clean up the web build

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -2,6 +2,7 @@ HAVE_STATIC_DUMMY ?= 0
 ifeq ($(TARGET),)
 ifeq ($(LIBRETRO),)
 TARGET := retroarch.js
+LIBRETRO = dummy
 else
 TARGET := $(LIBRETRO)_libretro.js
 endif
@@ -78,9 +79,10 @@ OBJDIR := obj-emscripten
 #if you compile with SDL2 flag add this Emscripten flag "-s USE_SDL=2" to LDFLAGS:
 
 LIBS    := -s USE_ZLIB=1
-LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']" \
-           -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
-           -s MODULARIZE=1 -s EXPORT_ES6=1 -s EXPORT_NAME=$LIBRETRO \
+LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 \
+           -s "EXPORTED_RUNTIME_METHODS=['callMain', 'FS', 'PATH', 'ERRNO_CODES']" \
+           -s ALLOW_MEMORY_GROWTH=1 -s "EXPORTED_FUNCTIONS=['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
+           -s MODULARIZE=1 -s EXPORT_ES6=1 -s EXPORT_NAME="$(LIBRETRO)" \
            --js-library emscripten/library_errno_codes.js \
            --js-library emscripten/library_rwebcam.js
 

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -105,7 +105,10 @@ else
 endif
 
 ifeq ($(ASYNC), 1)
-   LDFLAGS += -s ASYNCIFY=$(ASYNC)
+   LDFLAGS += -s ASYNCIFY=$(ASYNC) -s ASYNCIFY_STACK_SIZE=8192 
+   ifeq ($(DEBUG), 1)
+     LDFLAGS += -s ASYNCIFY_DEBUG=1 # -s ASYNCIFY_ADVISE
+   endif
 endif
 
 ifeq ($(HAVE_SDL2), 1)
@@ -130,8 +133,8 @@ ifneq ($(V), 1)
 endif
 
 ifeq ($(DEBUG), 1)
-   LDFLAGS += -O3 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
-   CFLAGS += -O3 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
+   LDFLAGS += -O0 -g -gsource-map -s SAFE_HEAP=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
+   CFLAGS += -O0 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
 else
    LDFLAGS += -O3 -s WASM=1
    # WARNING: some optimizations can break some cores (ex: LTO breaks tyrquake)

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -83,6 +83,7 @@ LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RU
            -s "EXPORTED_RUNTIME_METHODS=['callMain', 'FS', 'PATH', 'ERRNO_CODES']" \
            -s ALLOW_MEMORY_GROWTH=1 -s "EXPORTED_FUNCTIONS=['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
            -s MODULARIZE=1 -s EXPORT_ES6=1 -s EXPORT_NAME="$(LIBRETRO)" \
+           -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 \
            --js-library emscripten/library_errno_codes.js \
            --js-library emscripten/library_rwebcam.js
 

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -150,7 +150,7 @@ LDFLAGS += -s STACK_SIZE=131072
 
 LDFLAGS += --extern-pre-js emscripten/pre.js
 
-CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 $(LIBS) #\
+CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 #\
 #          -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -49,7 +49,6 @@ HAVE_7ZIP = 1
 HAVE_BSV_MOVIE = 1
 HAVE_AL = 1
 
-
 # WARNING -- READ BEFORE ENABLING
 # The rwebaudio driver is known to have several audio bugs, such as
 #  minor crackling, or the entire page freezing/crashing.
@@ -145,6 +144,8 @@ endif
 
 # 128 * 1024, double the usual emscripten stack size
 LDFLAGS += -s STACK_SIZE=131072
+
+LDFLAGS += --extern-pre-js emscripten/pre.js
 
 CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 $(LIBS) #\
 #          -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -80,6 +80,7 @@ OBJDIR := obj-emscripten
 LIBS    := -s USE_ZLIB=1
 LDFLAGS := -L. --no-heap-copy -s $(LIBS) -s TOTAL_MEMORY=$(MEMORY) -s NO_EXIT_RUNTIME=0 -s FULL_ES2=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']" \
            -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_load_state', '_cmd_take_screenshot']" \
+           -s MODULARIZE=1 -s EXPORT_ES6=1 -s EXPORT_NAME=$LIBRETRO \
            --js-library emscripten/library_errno_codes.js \
            --js-library emscripten/library_rwebcam.js
 

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -127,8 +127,8 @@ ifneq ($(V), 1)
 endif
 
 ifeq ($(DEBUG), 1)
-   LDFLAGS += -O0 -g
-   CFLAGS += -O0 -g
+   LDFLAGS += -O3 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
+   CFLAGS += -O3 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
 else
    LDFLAGS += -O3 -s WASM=1
    # WARNING: some optimizations can break some cores (ex: LTO breaks tyrquake)
@@ -138,6 +138,9 @@ else
    endif
    CFLAGS += -O3
 endif
+
+# 128 * 1024, double the usual emscripten stack size
+LDFLAGS += -s STACK_SIZE=131072
 
 CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 $(LIBS) #\
 #          -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"

--- a/dist-scripts/dist-cores.sh
+++ b/dist-scripts/dist-cores.sh
@@ -247,8 +247,8 @@ for f in `ls -v *_${platform}.${EXT}`; do
    if [ $MAKEFILE_GRIFFIN = "yes" ]; then
       make -C ../ -f Makefile.griffin $OPTS platform=${platform} $whole_archive $big_stack -j3 || exit 1
    elif [ $PLATFORM = "emscripten" ]; then
-       echo "BUILD COMMAND: make -C ../ -f Makefile.emscripten PTHREAD=$pthread ASYNC=$async LTO=$lto -j7 TARGET=${name}_libretro.js"
-       make -C ../ -f Makefile.emscripten $OPTS PTHREAD=$pthread ASYNC=$async LTO=$lto -j7 TARGET=${name}_libretro.js || exit 1
+       echo "BUILD COMMAND: make -C ../ -f Makefile.emscripten PTHREAD=$pthread ASYNC=$async LTO=$lto -j7 LIBRETRO=${name} TARGET=${name}_libretro.js"
+       make -C ../ -f Makefile.emscripten $OPTS PTHREAD=$pthread ASYNC=$async LTO=$lto -j7 LIBRETRO=${name} TARGET=${name}_libretro.js || exit 1
    elif [ $PLATFORM = "unix" ]; then
       make -C ../ -f Makefile LINK=g++ $whole_archive $big_stack -j3 || exit 1
    elif [ $PLATFORM = "ctr" ]; then

--- a/emscripten/pre.js
+++ b/emscripten/pre.js
@@ -1,0 +1,2 @@
+// To work around a bug in emscripten's polyfills for setImmediate in strict mode
+var setImmediate;

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -160,8 +160,12 @@ int main(int argc, char *argv[])
 {
    dummyErrnoCodes();
 
-   emscripten_set_canvas_element_size("#canvas", 800, 600);
-   emscripten_set_element_css_size("#canvas", 800.0, 600.0);
+   EM_ASM({
+      specialHTMLTargets["!canvas"] = Module.canvas;
+   });
+
+   emscripten_set_canvas_element_size("!canvas", 800, 600);
+   emscripten_set_element_css_size("!canvas", 800.0, 600.0);
    emscripten_set_main_loop(emscripten_mainloop, 0, 0);
    rarch_main(argc, argv, NULL);
 

--- a/gfx/drivers_context/emscriptenegl_ctx.c
+++ b/gfx/drivers_context/emscriptenegl_ctx.c
@@ -70,7 +70,7 @@ static void gfx_ctx_emscripten_get_canvas_size(int *width, int *height)
 
    if (!is_fullscreen)
    {
-      r = emscripten_get_canvas_element_size("#canvas", width, height);
+      r = emscripten_get_canvas_element_size("!canvas", width, height);
 
       if (r != EMSCRIPTEN_RESULT_SUCCESS)
       {
@@ -105,14 +105,14 @@ static void gfx_ctx_emscripten_check_window(void *data, bool *quit,
    if (  (input_width  != emscripten->fb_width)
       || (input_height != emscripten->fb_height))
    {
-      r = emscripten_set_canvas_element_size("#canvas",
+      r = emscripten_set_canvas_element_size("!canvas",
          input_width, input_height);
 
       if (r != EMSCRIPTEN_RESULT_SUCCESS)
          RARCH_ERR("[EMSCRIPTEN/EGL]: error resizing canvas: %d\n", r);
 
       /* fix Module.requestFullscreen messing with the canvas size */
-      r = emscripten_set_element_css_size("#canvas",
+      r = emscripten_set_element_css_size("!canvas",
          (double)input_width, (double)input_height);
 
       if (r != EMSCRIPTEN_RESULT_SUCCESS)
@@ -194,7 +194,7 @@ static void *gfx_ctx_emscripten_init(void *video_driver)
     * be grabbed? */
    if (     (emscripten->initial_width  == 0)
          || (emscripten->initial_height == 0))
-      emscripten_get_canvas_element_size("#canvas",
+      emscripten_get_canvas_element_size("!canvas",
          &emscripten->initial_width,
          &emscripten->initial_height);
 

--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -291,7 +291,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
    rwebinput_generate_lut();
 
    r = emscripten_set_keydown_callback(
-         EMSCRIPTEN_EVENT_TARGET_DOCUMENT, rwebinput, false,
+         "!canvas", rwebinput, false,
          rwebinput_keyboard_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {
@@ -300,7 +300,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
    }
 
    r = emscripten_set_keyup_callback(
-         EMSCRIPTEN_EVENT_TARGET_DOCUMENT, rwebinput, false,
+         "!canvas", rwebinput, false,
          rwebinput_keyboard_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {
@@ -309,7 +309,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
    }
 
    r = emscripten_set_keypress_callback(
-         EMSCRIPTEN_EVENT_TARGET_DOCUMENT, rwebinput, false,
+         "!canvas", rwebinput, false,
          rwebinput_keyboard_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {
@@ -342,7 +342,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
    }
 
    r = emscripten_set_wheel_callback(
-         EMSCRIPTEN_EVENT_TARGET_DOCUMENT, rwebinput, false,
+         "!canvas", rwebinput, false,
          rwebinput_wheel_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {

--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -317,7 +317,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
          "[EMSCRIPTEN/INPUT] failed to create keypress callback: %d\n", r);
    }
 
-   r = emscripten_set_mousedown_callback("#canvas", rwebinput, false,
+   r = emscripten_set_mousedown_callback("!canvas", rwebinput, false,
          rwebinput_mouse_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {
@@ -325,7 +325,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
          "[EMSCRIPTEN/INPUT] failed to create mousedown callback: %d\n", r);
    }
 
-   r = emscripten_set_mouseup_callback("#canvas", rwebinput, false,
+   r = emscripten_set_mouseup_callback("!canvas", rwebinput, false,
          rwebinput_mouse_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {
@@ -333,7 +333,7 @@ static void *rwebinput_input_init(const char *joypad_driver)
          "[EMSCRIPTEN/INPUT] failed to create mouseup callback: %d\n", r);
    }
 
-   r = emscripten_set_mousemove_callback("#canvas", rwebinput, false,
+   r = emscripten_set_mousemove_callback("!canvas", rwebinput, false,
          rwebinput_mouse_cb);
    if (r != EMSCRIPTEN_RESULT_SUCCESS)
    {
@@ -651,7 +651,7 @@ static void rwebinput_input_poll(void *data)
 static void rwebinput_grab_mouse(void *data, bool state)
 {
    if (state)
-      emscripten_request_pointerlock("#canvas", EM_TRUE);
+      emscripten_request_pointerlock("!canvas", EM_TRUE);
    else
       emscripten_exit_pointerlock();
 }

--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -90,7 +90,7 @@ static INLINE bool bits_any_different(uint32_t *a, uint32_t *b, uint32_t count)
 }
 
 #ifndef PATH_MAX_LENGTH
-#if defined(_XBOX1) || defined(_3DS) || defined(PSP) || defined(PS2) || defined(GEKKO)|| defined(WIIU) || defined(__PSL1GHT__) || defined(__PS3__)
+#if defined(_XBOX1) || defined(_3DS) || defined(PSP) || defined(PS2) || defined(GEKKO)|| defined(WIIU) || defined(__PSL1GHT__) || defined(__PS3__) || defined(HAVE_EMSCRIPTEN)
 #define PATH_MAX_LENGTH 512
 #else
 #define PATH_MAX_LENGTH 4096

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -80,7 +80,7 @@ var Module = {
       {
          console.log(text);
       },
-   canvas: document.getElementById('canvas'),
+    canvas: document.getElementById("canvas"),
    totalDependencies: 0,
    monitorRunDependencies: function(left)
       {
@@ -232,6 +232,8 @@ function startRetroArch()
    document.getElementById("btnMenu").disabled = false;
    document.getElementById("btnFullscreen").disabled = false;
 
+    Module["canvas"] = document.getElementById("canvas");
+    Module["canvas"].addEventListener("click", () => Module["canvas"].focus());
    Module['callMain'](Module['arguments']);
    Module['resumeMainLoop']();
    Module['canvas'].focus();
@@ -286,7 +288,7 @@ function switchStorage(backend) {
 
 // When the browser has loaded everything.
 $(function() {
-   // Enable all available ToolTips.
+    // Enable all available ToolTips.
    $('.tooltip-enable').tooltip({
       placement: 'right'
    });
@@ -351,10 +353,9 @@ function loadCore(core) {
    // Make the core the selected core in the UI.
    var coreTitle = $('#core-selector a[data-core="' + core + '"]').addClass('active').text();
    $('#dropdownMenu1').text(coreTitle);
-
    // Load the Core's related JavaScript.
-   import("./"+core+"_libretro.js").then(script => {
-      script.default(Module).then(mod => {
+    import("./"+core+"_libretro.js").then(script => {
+       script.default(Module).then(mod => {
          Module = mod;
          $('#icnRun').removeClass('fa-spinner').removeClass('fa-spin');
          $('#icnRun').addClass('fa-play');

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -79,7 +79,7 @@ var Module = {
       },
    printErr: function(text)
       {
-         console.log(text);
+         console.error(text);
       },
     canvas: document.getElementById("canvas"),
    totalDependencies: 0,

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -6,6 +6,7 @@
 var BrowserFS = BrowserFS;
 var afs;
 var initializationCount = 0;
+var setImmediate;
 
 var Module = {
    noInitialRun: true,
@@ -15,7 +16,7 @@ var Module = {
    message_queue:[],
    message_out:[],
    message_accum:"",
-          
+
    retroArchSend: function(msg) {
       let bytes = this.encoder.encode(msg+"\n");
       this.message_queue.push([bytes,0]);

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -232,11 +232,9 @@ function startRetroArch()
    document.getElementById("btnMenu").disabled = false;
    document.getElementById("btnFullscreen").disabled = false;
 
-   setTimeout(() => {
-      Module['callMain'](Module['arguments']);
-      Module['resumeMainLoop']();
-      document.getElementById('canvas').focus();
-   }, 0);
+   Module['callMain'](Module['arguments']);
+   Module['resumeMainLoop']();
+   Module['canvas'].focus();
 }
 function selectFiles(files)
 {


### PR DESCRIPTION
This adds the -s MODULARIZE flag and some related flags to emscripten, and updates libretro.js and canvas targeting in C code to account for the fact that there is no longer a global Module object.

I want this patch for two reasons: 

1. To ease the use of RA in web applications that use bundlers, and generally to make the script more of a good citizen and not pollute the global namespace
2. To allow embedding multiple instances of RA on a single page without iframes, for purposes like comparing rom hacks side-by-side.
