### PR TITLE
Increase emscripten stack size and decrease path size

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -48,7 +48,6 @@ HAVE_7ZIP = 1
 HAVE_BSV_MOVIE = 1
 HAVE_AL = 1
 
-
 # WARNING -- READ BEFORE ENABLING
 # The rwebaudio driver is known to have several audio bugs, such as
 #  minor crackling, or the entire page freezing/crashing.

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -127,8 +127,8 @@ ifneq ($(V), 1)
 endif
 
 ifeq ($(DEBUG), 1)
-   LDFLAGS += -O0 -g
-   CFLAGS += -O0 -g
+   LDFLAGS += -O3 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
+   CFLAGS += -O3 -g -gsource-map -s SAFE_HEAP=1 -s SAFE_HEAP_LOG=1 -s STACK_OVERFLOW_CHECK=2 -s ASSERTIONS=1
 else
    LDFLAGS += -O3 -s WASM=1
    # WARNING: some optimizations can break some cores (ex: LTO breaks tyrquake)
@@ -138,6 +138,9 @@ else
    endif
    CFLAGS += -O3
 endif
+
+# 128 * 1024, double the usual emscripten stack size
+LDFLAGS += -s STACK_SIZE=131072
 
 CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 $(LIBS) #\
 #          -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"

--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -143,7 +143,7 @@ endif
 LDFLAGS += -s STACK_SIZE=131072
 
 CFLAGS += -Wall -I. -Ilibretro-common/include -std=gnu99 $(LIBS) #\
-#          -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"
+#         -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_cmd_savefiles', '_cmd_save_state', '_cmd_take_screenshot']"
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 

--- a/libretro-common/include/retro_miscellaneous.h
+++ b/libretro-common/include/retro_miscellaneous.h
@@ -90,7 +90,7 @@ static INLINE bool bits_any_different(uint32_t *a, uint32_t *b, uint32_t count)
 }
 
 #ifndef PATH_MAX_LENGTH
-#if defined(_XBOX1) || defined(_3DS) || defined(PSP) || defined(PS2) || defined(GEKKO)|| defined(WIIU) || defined(__PSL1GHT__) || defined(__PS3__)
+#if defined(_XBOX1) || defined(_3DS) || defined(PSP) || defined(PS2) || defined(GEKKO)|| defined(WIIU) || defined(__PSL1GHT__) || defined(__PS3__) || defined(HAVE_EMSCRIPTEN)
 #define PATH_MAX_LENGTH 512
 #else
 #define PATH_MAX_LENGTH 4096


### PR DESCRIPTION
This fixes the emscripten build (see discussion in #15690).  My guess is that inlining or other optimizations ended up growing the stack too much after some recent changes.