### PR TITLE
Fix string_options_entries size for drivers settings list

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -10308,7 +10308,7 @@ static bool setting_append_list(
       case SETTINGS_LIST_DRIVERS:
          {
             unsigned i, j = 0;
-            struct string_options_entry string_options_entries[13] = {{0}};
+            struct string_options_entry string_options_entries[14] = {{0}};
 
             START_GROUP(list, list_info, &group_info, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DRIVER_SETTINGS), parent_group);
             MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info, MENU_ENUM_LABEL_DRIVER_SETTINGS);


### PR DESCRIPTION
Increase string_options_entries array size by one, due to the new microphone driver entry added recently.
Fixes segfault on retroarch shutdown,