### PR TITLE
Fix reading past the end of an allocated buffer.

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -243,6 +243,7 @@ void gfx_widgets_msg_queue_push(
          {
             title = msg_widget->msg             = strdup(task->title);
             msg_widget->msg_new                 = strdup(title);
+            title_length                        = strlen(title);
             msg_widget->msg_len                 = title_length;
 
             if (!string_is_empty(task->error))


### PR DESCRIPTION
title_length is originally calculated to be the msg length, but later if the task has a title then that is used instead, but the length is not updated. If msg is longer than title, we read past the end of the buffer.