### PR TITLE
Update Use Filename setting description

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -7410,11 +7410,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_PLAYLIST_USE_FILENAME,
-   "Use Filename"
+   "Use Filenames for Thumbnail Matching"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_PLAYLIST_USE_FILENAME,
-   "Find thumbnails by rom filename instead of label."
+   "When enabled, will find thumbnails by the entry's filename, rather than its label."
    )
    MSG_HASH(
    MENU_ENUM_LABEL_VALUE_MANAGE,


### PR DESCRIPTION
The menu item for matching the thumbnails with filenames was just "Use Filename", which isn't that descriptive. This change tweaks it a bit so that the option is a bit more clear.

So happy to have this feature in place.

## Before

![Screenshot at 2023-09-27 01-23-53](https://github.com/libretro/RetroArch/assets/25086/51fdac72-b738-4182-9cca-a91350fbca28)


## After

![Screenshot at 2023-09-27 01-24-46](https://github.com/libretro/RetroArch/assets/25086/2163592e-41df-4e64-aac4-991efea14146)
