### PR TITLE
Don't process menu events while input is being flushed

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5239,8 +5239,9 @@ unsigned menu_event(
 
    ok_old                                          = ok_current;
 
-   /* Menu must be alive */
-   if (!(menu_st->flags & MENU_ST_FLAG_ALIVE))
+   /* Menu must be alive, and input must be released after menu toggle. */
+   if (     !(menu_st->flags & MENU_ST_FLAG_ALIVE)
+         || menu_st->input_driver_flushing_input > 0)
       return ret;
 
    /* Get pointer (mouse + touchscreen) input


### PR DESCRIPTION
## Description

Prevent menu event processing immediately after menu is toggled, because otherwise holding Start for menu toggle for example will also toggle fullscreen thumbnails right after launching content from playlist. Running Quick Menu does not even have thumbnails, so the menu event was using stale info from previous menu location. For some reason this only affected RGUI..

Yet another butterfly effect caused by the relocation of menu toggle hotkey checking in runloop.
