### PR TITLE
Prevent proceeding to next bind when single binding

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5024,6 +5024,9 @@ static bool menu_input_key_bind_iterate(
 
       if (complete)
       {
+         /* Always stop binding when not binding all */
+         bool stop_binding                   = new_binds.order == 0 && new_binds.begin == new_binds.last;
+
          /* Update bind */
          *(new_binds.output)                 = new_binds.buffer;
 
@@ -5045,7 +5048,7 @@ static bool menu_input_key_bind_iterate(
          new_binds.begin = MENU_SETTINGS_BIND_BEGIN + input_config_bind_order[new_binds.order];
 
          if (     new_binds.order > ARRAY_SIZE(input_config_bind_order) - 1
-               || new_binds.last != MENU_SETTINGS_BIND_LAST)
+               || stop_binding)
          {
             input_st->keyboard_press_cb      = NULL;
             input_st->keyboard_press_data    = NULL;


### PR DESCRIPTION
## Description

Due to changing the "set all" progress order to match the visible item order, it managed to botch the logic so that when binding only right stick up, it continues to bind d-pad down as if "set all" was pressed, because right stick up is the last bind internally..
