### PR TITLE
libretro-common: Fix redefinition warnings of _POSIX_C_SOURCE

### DIFF
--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -22,7 +22,9 @@
 
 #ifdef __unix__
 #ifndef __sun__
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 199309
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Small change to fix redefinition of `_POSIX_C_SOURCE` if it's already defined.