### PR TITLE
Enqueue replay record/playback until next frame

### DIFF
--- a/command.c
+++ b/command.c
@@ -737,8 +737,8 @@ bool command_play_replay_slot(command_t *cmd, const char *arg)
       {
          input_driver_state_t *input_st = input_state_get_ptr();
          task_queue_wait(NULL,NULL);
-         if(input_st->bsv_movie_state_handle)
-            snprintf(reply, sizeof(reply) - 1, "PLAY_REPLAY_SLOT %lld", (long long)(input_st->bsv_movie_state_handle->identifier));
+         if(input_st->bsv_movie_state_next_handle)
+            snprintf(reply, sizeof(reply) - 1, "PLAY_REPLAY_SLOT %lld", (long long)(input_st->bsv_movie_state_next_handle->identifier));
          else
             snprintf(reply, sizeof(reply) - 1, "PLAY_REPLAY_SLOT 0");
          command_post_state_loaded();

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5039,11 +5039,27 @@ static void input_keys_pressed(
 /* Forward declaration */
 void bsv_movie_free(bsv_movie_t*);
 
+void bsv_movie_enqueue(input_driver_state_t *input_st, bsv_movie_t * state, enum bsv_flags flags)
+{ 
+   if (input_st->bsv_movie_state_next_handle)
+      bsv_movie_free(input_st->bsv_movie_state_next_handle);
+   input_st->bsv_movie_state_next_handle    = state;
+   input_st->bsv_movie_state.flags          = flags;
+}
+
 void bsv_movie_deinit(input_driver_state_t *input_st)
 {
    if (input_st->bsv_movie_state_handle)
       bsv_movie_free(input_st->bsv_movie_state_handle);
    input_st->bsv_movie_state_handle = NULL;
+}
+
+void bsv_movie_deinit_full(input_driver_state_t *input_st)
+{
+   bsv_movie_deinit(input_st);
+   if (input_st->bsv_movie_state_next_handle)
+      bsv_movie_free(input_st->bsv_movie_state_next_handle);
+   input_st->bsv_movie_state_next_handle = NULL;
 }
 
 void bsv_movie_frame_rewind(void)
@@ -5134,7 +5150,16 @@ void bsv_movie_next_frame(input_driver_state_t *input_st)
 {
    settings_t *settings           = config_get_ptr();
    unsigned checkpoint_interval   = settings->uints.replay_checkpoint_interval;
+   // if bsv_movie_state_next_handle is not null, deinit and set bsv_movie_state_handle to bsv_movie_state_next_handle and clear next_handle
    bsv_movie_t         *handle    = input_st->bsv_movie_state_handle;
+   if (input_st->bsv_movie_state_next_handle)
+   {
+      if(handle)
+         bsv_movie_deinit(input_st);
+      handle = input_st->bsv_movie_state_next_handle;
+      input_st->bsv_movie_state_handle = handle;
+      input_st->bsv_movie_state_next_handle = NULL;
+   }
 
    if (!handle)
       return;

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5150,7 +5150,9 @@ void bsv_movie_next_frame(input_driver_state_t *input_st)
 {
    settings_t *settings           = config_get_ptr();
    unsigned checkpoint_interval   = settings->uints.replay_checkpoint_interval;
-   // if bsv_movie_state_next_handle is not null, deinit and set bsv_movie_state_handle to bsv_movie_state_next_handle and clear next_handle
+   /* if bsv_movie_state_next_handle is not null, deinit and set
+      bsv_movie_state_handle to bsv_movie_state_next_handle and clear
+      next_handle */
    bsv_movie_t         *handle    = input_st->bsv_movie_state_handle;
    if (input_st->bsv_movie_state_next_handle)
    {

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -512,6 +512,7 @@ typedef struct
 #endif
 #ifdef HAVE_BSV_MOVIE
    bsv_movie_t     *bsv_movie_state_handle;              /* ptr alignment */
+   bsv_movie_t     *bsv_movie_state_next_handle;         /* ptr alignment */
 #endif
 #ifdef HAVE_OVERLAY
    input_overlay_t *overlay_ptr;
@@ -1003,6 +1004,8 @@ void bsv_movie_frame_rewind(void);
 void bsv_movie_next_frame(input_driver_state_t *input_st);
 void bsv_movie_finish_rewind(input_driver_state_t *input_st);
 void bsv_movie_deinit(input_driver_state_t *input_st);
+void bsv_movie_deinit_full(input_driver_state_t *input_st);
+void bsv_movie_enqueue(input_driver_state_t *input_st, bsv_movie_t *state, enum bsv_flags flags);
 
 bool movie_start_playback(input_driver_state_t *input_st, char *path);
 bool movie_start_record(input_driver_state_t *input_st, char *path);

--- a/tasks/task_movie.c
+++ b/tasks/task_movie.c
@@ -267,8 +267,7 @@ static bool bsv_movie_start_record(input_driver_state_t * input_st, char *path)
       return false;
    }
 
-   input_st->bsv_movie_state_handle         = state;
-   input_st->bsv_movie_state.flags         |= BSV_FLAG_MOVIE_RECORDING;
+   bsv_movie_enqueue(input_st, state, BSV_FLAG_MOVIE_RECORDING);
    movie_rec_str                            = msg_hash_to_str(MSG_STARTING_MOVIE_RECORD_TO);
    _len = strlcpy(msg, movie_rec_str, sizeof(msg));
    snprintf(msg + _len, sizeof(msg) - _len, " \"%s\".", path);
@@ -293,8 +292,7 @@ static bool bsv_movie_start_playback(input_driver_state_t *input_st, char *path)
       return false;
    }
 
-   input_st->bsv_movie_state_handle         = state;
-   input_st->bsv_movie_state.flags         |= BSV_FLAG_MOVIE_PLAYBACK;
+   bsv_movie_enqueue(input_st, state, BSV_FLAG_MOVIE_PLAYBACK);
    starting_movie_str                       =
       msg_hash_to_str(MSG_STARTING_MOVIE_PLAYBACK);
 
@@ -380,7 +378,7 @@ bool movie_stop_playback(input_driver_state_t *input_st)
          NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    RARCH_LOG("%s\n", movie_playback_end_str);
 
-   bsv_movie_deinit(input_st);
+   bsv_movie_deinit_full(input_st);
 
    input_st->bsv_movie_state.flags &= ~(
          BSV_FLAG_MOVIE_END
@@ -397,7 +395,7 @@ bool movie_stop_record(input_driver_state_t *input_st)
          2, 180, true,
          NULL, MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
    RARCH_LOG("%s\n", movie_rec_stopped_str);
-   bsv_movie_deinit(input_st);
+   bsv_movie_deinit_full(input_st);
    input_st->bsv_movie_state.flags &= ~(
          BSV_FLAG_MOVIE_END
          | BSV_FLAG_MOVIE_RECORDING);


### PR DESCRIPTION
This fixes a bug where stdin commands activated via polling would trigger replay record/playback in the middle of a frame, then input checking would pull from them before the next frame came around---it only makes sense to change the active replay in between frames, not during them.