### PR TITLE
Fix bug that was causing weirdness in Wii builds.

### DIFF
--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -923,11 +923,11 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          if (path_buf[len - 1] == '/')
             path_buf[len - 1] = '\0';
 
-      free(path_buf);
-
       if (stat(path_buf, &stat_buf) < 0)
          return 0;
 
+      free(path_buf);
+      
       if (size)
          *size = (int32_t)stat_buf.st_size;
 


### PR DESCRIPTION
Things like the info files not being read.  User defined directories not sticking ( likely not detected ) and all kinds of other goodness.

Fix has been compiled and tested on the Wii with the Hatari core.

@LibretroAdmin if you could confirm this minor fix.  Thank you.
