### PR TITLE
Add support for joining MITM servers over cmdline

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -299,6 +299,7 @@ extern const bluetooth_driver_t *bluetooth_drivers[];
 struct rarch_state
 {
    char *connect_host; /* Netplay hostname passed from CLI */
+   char *connect_mitm_id; /* Netplay MITM address from CLI */
 
    struct retro_perf_counter *perf_counters_rarch[MAX_COUNTERS];
 
@@ -3780,10 +3781,19 @@ bool command_event(enum event_command cmd, void *data)
                netplay_server  = tmp_netplay_server;
                netplay_session = tmp_netplay_session;
             }
-            if (p_rarch->connect_host)
-            {
-               free(p_rarch->connect_host);
-               p_rarch->connect_host = NULL;
+            
+            if (p_rarch->connect_mitm_id) {
+                netplay_session = strdup(p_rarch->connect_mitm_id);
+            }
+                       
+            if (p_rarch->connect_host) {
+                free(p_rarch->connect_host);
+                p_rarch->connect_host = NULL;
+            }
+
+            if (p_rarch->connect_mitm_id) {
+                free(p_rarch->connect_mitm_id);
+                p_rarch->connect_mitm_id = NULL;
             }
 
             if (string_is_empty(netplay_server))
@@ -5315,6 +5325,8 @@ static void retroarch_print_help(const char *arg0)
          "Connect to netplay server as user 2.\n"
          "      --port=PORT                "
          "Port used to netplay. Default is 55435.\n"
+         "      --mitm-session=ID           "
+         "MITM (relay) session ID to join.\n"
          "      --nick=NICK                "
          "Picks a username (for use with netplay). Not mandatory.\n"
          "      --check-frames=NUMBER      "
@@ -5626,6 +5638,7 @@ static bool retroarch_parse_input_and_config(
 #ifdef HAVE_NETWORKING
       { "host",               0, NULL, 'H' },
       { "connect",            1, NULL, 'C' },
+      { "mitm-session",       1, NULL, 'T' },
       { "check-frames",       1, NULL, RA_OPT_CHECK_FRAMES },
       { "port",               1, NULL, RA_OPT_PORT },
 #ifdef HAVE_NETWORK_CMD
@@ -6053,6 +6066,10 @@ static bool retroarch_parse_input_and_config(
                      RARCH_OVERRIDE_SETTING_NETPLAY_MODE, NULL);
                netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_CLIENT, NULL);
                p_rarch->connect_host = strdup(optarg);
+               break;
+            
+            case 'T':
+               p_rarch->connect_mitm_id = strdup(optarg);
                break;
 
             case RA_OPT_CHECK_FRAMES:

--- a/retroarch.c
+++ b/retroarch.c
@@ -3782,16 +3782,17 @@ bool command_event(enum event_command cmd, void *data)
                netplay_session = tmp_netplay_session;
             }
             
-            if (p_rarch->connect_mitm_id) {
+            if (p_rarch->connect_mitm_id) 
                 netplay_session = strdup(p_rarch->connect_mitm_id);
-            }
                        
-            if (p_rarch->connect_host) {
+            if (p_rarch->connect_host) 
+            {
                 free(p_rarch->connect_host);
                 p_rarch->connect_host = NULL;
             }
 
-            if (p_rarch->connect_mitm_id) {
+            if (p_rarch->connect_mitm_id) 
+            {
                 free(p_rarch->connect_mitm_id);
                 p_rarch->connect_mitm_id = NULL;
             }


### PR DESCRIPTION
## Description

Adds support for third party server browser users to connect to relay servers when using cmdline as the method to launch RA, currently there seems to be no way to pass the mitm ID on the retroarch commandline - many third party server browsers allow connecting to RA relays but the connection always fails as the RATS handshake doesn't take place when the mitm session ID isn't passed to `init_netplay(netplay_server, netplay_port, netplay_session)`.

- Have tested on a linux build (OnionUI Miyoo Mini, forked repo here: https://github.com/OnionUI/RetroArch, though it's an older/modified build)
- Have tested on a fresh clone of main RA built through MSYS/MINGW64

## Example connection using `--mitm-session` opt 

<details>

```
Matt@MattPC MINGW64 ~/RAB
$ ./retroarch.exe -C us-east1.relay.retroarch.com --mitm-session kR0ZxtpemrTD7pDd -v -L ./cores/tgbdual_libretro.dll "./rom/Balloon Kid.gb"
[INFO] RetroArch 1.16.0 (Git 14cb3732eb)
[INFO] === Build =======================================
[INFO] CPU Model Name: 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz
[INFO] Capabilities: MMX MMXEXT SSE SSE2 SSE3 SSSE3 SSE4 SSE42 AES AVX AVX2
[INFO] Version: 1.16.0
[INFO] Git: 14cb3732eb
[INFO] Built: Oct  2 2023
[INFO] =================================================
[INFO] [Input]: Found input driver: "dinput".
[INFO] [Environ]: SET_SUBSYSTEM_INFO.
[INFO] [Core]: Loading dynamic libretro core from: "./cores/tgbdual_libretro.dll"
[INFO] [Environ]: RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE.
[INFO] [Content Override]: File Extension: ' gb' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'dmg' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'gbc' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'cgb' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'sgb' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Overrides]: Redirecting save file to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.srm".
[INFO] [Overrides]: Redirecting save state to "C:\msys64\home\Matt\RAB\states\TGB Dual\Balloon Kid.state".
[INFO] [Environ]: GET_LOG_INTERFACE.
[INFO] [Environ]: PERFORMANCE_LEVEL: 4.
[INFO] [Content]: Loading content file: "./rom/Balloon Kid.gb".
[INFO] [Environ]: SET_VARIABLES.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_screen_placement - Invalid value.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_switch_screens - Invalid value.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_single_screen_mp - Invalid value.
[INFO] [Environ]: SET_GEOMETRY: 320x144, Aspect: 2.222.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_audio_output - Invalid value.
[INFO] [Environ]: SET_INPUT_DESCRIPTORS:
[INFO] [Environ]: SET_PIXEL_FORMAT: RGB565.
[INFO] [Environ]: RETRO_ENVIRONMENT_GET_GAME_INFO_EXT.
[INFO] [Environ]: SET_VARIABLES.
[INFO] [Core]: Saved core options file to "C:\msys64\home\Matt\RAB\config\TGB Dual\TGB Dual.opt".
[INFO] [Environ]: SET_PIXEL_FORMAT: RGB565.
[INFO] [Environ]: SET_GEOMETRY.
[INFO] [Replay]: Found last replay slot: #0
[INFO] [Core]: Version of libretro API: 1, Compiled against API: 1
[INFO] [Core]: Geometry: 320x144, Aspect: 2.222, FPS: 59.73, Sample rate: 44100.00 Hz.
[INFO] [Audio]: Set audio input rate to: 44301.20 Hz.
[INFO] [Video]: Set video size to: 960x432.
[INFO] [Vulkan]: Vulkan dynamic library loaded.
[INFO] [Vulkan]: Found vulkan context: "vk_w".
[INFO] [Vulkan]: Detecting screen resolution: 1920x1080.
[INFO] [Vulkan]: Found GPU at index 0: "NVIDIA GeForce GTX 1660 Ti".
[INFO] [Vulkan]: Using GPU index 0.
[INFO] [Vulkan]: Using fences for WSI acquire.
[INFO] [Vulkan]: Using GPU: "NVIDIA GeForce GTX 1660 Ti".
[INFO] [Vulkan]: Queue family 0 supports 16 sub-queues.
[INFO] [Vulkan]: Got 3 swapchain images.
[INFO] [Vulkan]: Using resolution 960x432.
[INFO] [Vulkan]: Using RGB565 format.
[INFO] [Vulkan]: Loading stock shader.
[INFO] [XInput]: Found XInput v1.4.
[INFO] [Joypad]: Found joypad driver: "dinput".
[INFO] [Video]: Found display server: "win32".
[INFO] [XAudio2]: Requesting 64 ms latency, using 64 ms latency.
[INFO] [Audio]: Started synchronous audio driver.
[INFO] [Microphone]: Initialized microphone driver.
[INFO] [Display]: Found display driver: "vulkan".
[INFO] [Environ]: SET_SUBSYSTEM_INFO.
[INFO] [MIDI]: Output device: "Microsoft GS Wavetable Synth".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_history.lpl".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_music_history.lpl".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_video_history.lpl".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_image_history.lpl".
[INFO] [Playlist]: Loading favorites file: "C:\msys64\home\Matt\RAB\content_favorites.lpl".
[WARN] [Netplay] WARNING: A netplay peer is running a different version of RetroArch. If problems occur, use the same version.
[WARN] [Netplay] WARNING: A netplay peer is running a different version of the core. If problems occur, use the same version.
[INFO] [Content]: CRC32: 0xd4b655ec.
[INFO] [Netplay] Connected to: "0nion - XK9274"
[INFO] [Netplay] You have joined as player 2 (ping: 490 ms)
[INFO] [Config]: Saved new config to "C:\msys64\home\Matt\RAB\retroarch.cfg".
[INFO] [SRAM]: Saving RAM type #0 to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.srm".
[INFO] [SRAM]: Saved successfully to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.srm".
[INFO] [SRAM]: Saving RAM type #1 to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.rtc".
[INFO] [SRAM]: Saved successfully to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.rtc".
[INFO] [Core]: Content ran for a total of: 00 hours, 00 minutes, 11 seconds.
[INFO] [Runtime]: Saving runtime log file: "C:\msys64\home\Matt\RAB\playlists\logs\TGB Dual\Balloon Kid.lrtl".
[INFO] [Core]: Unloading game..
[INFO] [Core]: Unloading core..
[INFO] [Core]: Unloading core symbols..
[INFO] [Core]: Saved core options file to "C:\msys64\home\Matt\RAB\config\TGB Dual\TGB Dual.opt".
[INFO] [Video]: Does not have enough samples for monitor refresh rate estimation. Requires to run for at least 4096 frames.

```

</details>

```./retroarch.exe -C us-east1.relay.retroarch.com --mitm-session kR0ZxtpemrTD7pDd -v -L ./cores/tgbdual_libretro.dll "./rom/Balloon Kid.gb"```

https://github.com/libretro/RetroArch/assets/47260768/8d410eb8-ea04-4cc7-807f-b8bd21a2624f

This PR edits the ```case CMD_EVENT_NETPLAY_INIT:``` block so have also tested to make sure connections (without passing --mitm-session) to a direct IP also continue to work as seen here:

<details>

```
Matt@MattPC MINGW64 ~/RAB
$ ./retroarch.exe -C 81.155.xxx.xxx -v -L ./cores/tgbdual_libretro.dll "./rom/Balloon Kid.gb"
[INFO] RetroArch 1.16.0 (Git 14cb3732eb)
[INFO] === Build =======================================
[INFO] CPU Model Name: 11th Gen Intel(R) Core(TM) i9-11900K @ 3.50GHz
[INFO] Capabilities: MMX MMXEXT SSE SSE2 SSE3 SSSE3 SSE4 SSE42 AES AVX AVX2
[INFO] Version: 1.16.0
[INFO] Git: 14cb3732eb
[INFO] Built: Oct  2 2023
[INFO] =================================================
[INFO] [Input]: Found input driver: "dinput".
[INFO] [Environ]: SET_SUBSYSTEM_INFO.
[INFO] [Core]: Loading dynamic libretro core from: "./cores/tgbdual_libretro.dll"
[INFO] [Environ]: RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE.
[INFO] [Content Override]: File Extension: ' gb' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'dmg' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'gbc' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'cgb' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Content Override]: File Extension: 'sgb' - need_fullpath: FALSE, persistent_data: TRUE
[INFO] [Overrides]: Redirecting save file to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.srm".
[INFO] [Overrides]: Redirecting save state to "C:\msys64\home\Matt\RAB\states\TGB Dual\Balloon Kid.state".
[INFO] [Environ]: GET_LOG_INTERFACE.
[INFO] [Environ]: PERFORMANCE_LEVEL: 4.
[INFO] [Content]: Loading content file: "./rom/Balloon Kid.gb".
[INFO] [Environ]: SET_VARIABLES.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_screen_placement - Invalid value.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_switch_screens - Invalid value.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_single_screen_mp - Invalid value.
[INFO] [Environ]: SET_GEOMETRY: 320x144, Aspect: 2.222.
[ERROR] [Environ]: GET_VARIABLE: tgbdual_audio_output - Invalid value.
[INFO] [Environ]: SET_INPUT_DESCRIPTORS:
[INFO] [Environ]: SET_PIXEL_FORMAT: RGB565.
[INFO] [Environ]: RETRO_ENVIRONMENT_GET_GAME_INFO_EXT.
[INFO] [Environ]: SET_VARIABLES.
[INFO] [Core]: Saved core options file to "C:\msys64\home\Matt\RAB\config\TGB Dual\TGB Dual.opt".
[INFO] [Environ]: SET_PIXEL_FORMAT: RGB565.
[INFO] [Environ]: SET_GEOMETRY.
[INFO] [Replay]: Found last replay slot: #0
[INFO] [Core]: Version of libretro API: 1, Compiled against API: 1
[INFO] [Core]: Geometry: 320x144, Aspect: 2.222, FPS: 59.73, Sample rate: 44100.00 Hz.
[INFO] [Audio]: Set audio input rate to: 44301.20 Hz.
[INFO] [Video]: Set video size to: 960x432.
[INFO] [Vulkan]: Vulkan dynamic library loaded.
[INFO] [Vulkan]: Found vulkan context: "vk_w".
[INFO] [Vulkan]: Detecting screen resolution: 1920x1080.
[INFO] [Vulkan]: Found GPU at index 0: "NVIDIA GeForce GTX 1660 Ti".
[INFO] [Vulkan]: Using GPU index 0.
[INFO] [Vulkan]: Using fences for WSI acquire.
[INFO] [Vulkan]: Using GPU: "NVIDIA GeForce GTX 1660 Ti".
[INFO] [Vulkan]: Queue family 0 supports 16 sub-queues.
[INFO] [Vulkan]: Got 3 swapchain images.
[INFO] [Vulkan]: Using resolution 960x432.
[INFO] [Vulkan]: Using RGB565 format.
[INFO] [Vulkan]: Loading stock shader.
[INFO] [XInput]: Found XInput v1.4.
[INFO] [Joypad]: Found joypad driver: "dinput".
[INFO] [Video]: Found display server: "win32".
[INFO] [XAudio2]: Requesting 64 ms latency, using 64 ms latency.
[INFO] [Audio]: Started synchronous audio driver.
[INFO] [Microphone]: Initialized microphone driver.
[INFO] [Display]: Found display driver: "vulkan".
[INFO] [Environ]: SET_SUBSYSTEM_INFO.
[INFO] [MIDI]: Output device: "Microsoft GS Wavetable Synth".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_history.lpl".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_music_history.lpl".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_video_history.lpl".
[INFO] [Playlist]: Loading history file: "C:\msys64\home\Matt\RAB\content_image_history.lpl".
[INFO] [Playlist]: Loading favorites file: "C:\msys64\home\Matt\RAB\content_favorites.lpl".
[WARN] [Netplay] WARNING: A netplay peer is running a different version of RetroArch. If problems occur, use the same version.
[WARN] [Netplay] WARNING: A netplay peer is running a different version of the core. If problems occur, use the same version.
[INFO] [Content]: CRC32: 0xd4b655ec.
[INFO] [Netplay] Connected to: "0nion - XK9274"
[INFO] [Netplay] You have joined as player 2 (ping: 61 ms)
[INFO] [Config]: Saved new config to "C:\msys64\home\Matt\RAB\retroarch.cfg".
[INFO] [SRAM]: Saving RAM type #0 to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.srm".
[INFO] [SRAM]: Saved successfully to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.srm".
[INFO] [SRAM]: Saving RAM type #1 to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.rtc".
[INFO] [SRAM]: Saved successfully to "C:\msys64\home\Matt\RAB\saves\TGB Dual\.netplay\Balloon Kid.rtc".
[INFO] [Core]: Content ran for a total of: 00 hours, 00 minutes, 01 seconds.
[INFO] [Runtime]: Saving runtime log file: "C:\msys64\home\Matt\RAB\playlists\logs\TGB Dual\Balloon Kid.lrtl".
[INFO] [Core]: Unloading game..
[INFO] [Core]: Unloading core..
[INFO] [Core]: Unloading core symbols..
[INFO] [Core]: Saved core options file to "C:\msys64\home\Matt\RAB\config\TGB Dual\TGB Dual.opt".
[INFO] [Video]: Does not have enough samples for monitor refresh rate estimation. Requires to run for at least 4096 frames.

Matt@MattPC MINGW64 ~/RAB

```
</details>

## Related Issues

https://github.com/libretro/RetroArch/issues/15665
