### PR TITLE
Use vendor-neutral OpenGL implementation instead of legacy GLX.

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -401,7 +401,7 @@ if [ "$HAVE_OPENGL" != 'no' ] && [ "$HAVE_OPENGLES" != 'yes' ]; then
       check_lib '' OPENGL -lopengl32
    else
       check_header '' OPENGL "GL/gl.h"
-      check_lib '' OPENGL -lGL
+      check_lib '' OPENGL -lOpenGL
    fi
 
    if [ "$HAVE_OPENGL" = 'yes' ]; then


### PR DESCRIPTION
## Description

Nowadays vendor-neutral GL is used instead of GLX is used in all GNU/Linux distributions.

So, using `-lOpenGL` works for X11, KMS/DRM and Wayland, while legacy `-lGL` only works for X11.  

## Reviewers

@hunterk 