### PR TITLE
Set fixed locale for numbers near config read/write

### DIFF
--- a/command.c
+++ b/command.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
+#include <locale.h>
 #ifdef HAVE_NETWORKING
 #include <net/net_compat.h>
 #include <net/net_socket.h>
@@ -1166,6 +1167,10 @@ bool command_event_save_config(
    const char *str  = path_exists ? config_path :
       path_get(RARCH_PATH_CONFIG);
 
+   /* Workaround for libdecor 0.2.0 setting unwanted locale */
+#if defined(HAVE_WAYLAND) && defined(HAVE_DYNAMIC)
+   setlocale(LC_NUMERIC,"C");
+#endif
    if (path_exists && config_save_file(config_path))
    {
       snprintf(s, len, "%s \"%s\".",

--- a/retroarch.c
+++ b/retroarch.c
@@ -5871,6 +5871,10 @@ static bool retroarch_parse_input_and_config(
    if (!(p_rarch->flags & RARCH_FLAGS_BLOCK_CONFIG_READ))
 #endif
    {
+      /* Workaround for libdecor 0.2.0 setting unwanted locale */
+#if defined(HAVE_WAYLAND) && defined(HAVE_DYNAMIC)
+      setlocale(LC_NUMERIC,"C");
+#endif      
       /* If this is a static build, load salamander
        * config file first (sets RARCH_PATH_CORE) */
 #if !defined(HAVE_DYNAMIC)


### PR DESCRIPTION
## Description

Force a fixed locale for numbers. This is a fallback measure when a rogue library modifies the locale, which should be "C" by default. 

## Related Issues
https://github.com/libretro/RetroArch/issues/15756
In this particular issue, the chain was wayland -> libdecor -> gtk plugin -> setlocale(LC_ALL, "")

There may be some other issues related to this, as the error causes bad reading/writing of floats, leading to all sorts of weird controller setups.