### PR TITLE
Do not exclude browser and config directory settings if RGUI is disabled

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1619,9 +1619,10 @@ static struct config_path_setting *populate_settings_path(
    SETTING_PATH("menu_wallpaper",                settings->paths.path_menu_wallpaper, false, NULL, true);
 #ifdef HAVE_RGUI
    SETTING_PATH("rgui_menu_theme_preset",        settings->paths.path_rgui_theme_preset, false, NULL, true);
+#endif
+   /* Browser and config directories are not RGUI dependent, but name is kept to avoid config file change */
    SETTING_PATH("rgui_browser_directory",        settings->paths.directory_menu_content, true, NULL, true);
    SETTING_PATH("rgui_config_directory",         settings->paths.directory_menu_config, true, NULL, true);
-#endif
 #ifdef HAVE_XMB
    SETTING_PATH("xmb_font",                      settings->paths.path_menu_xmb_font, false, NULL, true);
 #endif


### PR DESCRIPTION
## Description
Re-enable rgui_config_dir and rgui_browser_dir even if HAVE_RGUI is false. These variables are used for all menus.

## Related Issues
Closes https://github.com/libretro/RetroArch/issues/15728
