### PR TITLE
Minor fixes to udev input drivers.

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -120,12 +120,11 @@
 /* UDEV_TOUCH_PRINTF_DEBUG */
 
 #ifdef UDEV_TOUCH_DEEP_DEBUG
-#define RARCH_DDBG(msg, ...) do{ \
-    RARCH_DBG(msg, __VA_ARGS__); \
+#define RARCH_DDBG(...) do{ \
+    RARCH_DBG(__VA_ARGS__); \
 } while (0)
 #else
-/* TODO - Since C89 doesn't allow variadic macros, we have an empty function instead... */
-void RARCH_DDBG(const char *fmt, ...) { }
+#define RARCH_DDBG(msg, ...)
 #endif
 /* UDEV_TOUCH_DEEP_DEBUG */
 

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -51,6 +51,7 @@
 #include <linux/types.h>
 #include <linux/input.h>
 #include <linux/kd.h>
+#include <linux/version.h>
 #elif defined(__FreeBSD__)
 #include <dev/evdev/input.h>
 #endif
@@ -956,8 +957,13 @@ static void udev_handle_mouse(void *data,
  */
 static void udev_touch_event_ts_copy(const struct input_event *event, udev_touch_ts_t *ts)
 {
-   ts->s  = event->input_event_sec;
-   ts->us = event->input_event_usec;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,16,0)
+  ts->s  = event->input_event_sec;
+  ts->us = event->input_event_usec;
+#else
+  ts->s  = event->time.tv_sec;
+  ts->us = event->time.tv_usec;
+#endif
 }
 
 /**

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -506,6 +506,12 @@ static void udev_joypad_poll(void)
             /* Hotplug removal */
             else if (string_is_equal(action, "remove"))
                udev_joypad_remove_device(devnode);
+            /* Device change */
+            else if  (string_is_equal(action, "change"))
+            {
+               udev_joypad_remove_device(devnode);
+               udev_check_device(dev, devnode);
+            }
          }
 
          udev_device_unref(dev);


### PR DESCRIPTION
This commit does 3 things.

#1 Fixes building gated udev touch support against < 4.16 version of kernel.
#2 Fixes macros for Deep Debug included with the multitouch support, so now it can be compiled.

#3 Adds change event detection to polling in udev_joypad, which basically removes, then adds the controller again, if a change uevent comes in. This is done for controllers like the nintendo joycons that use a userspace app, and permission clamping to prevent single joycon mode to show up in apps, when set up in the combined mode. This allows Joycond(Userspace app) or any other userspace controller app that creates an event for a controller to issue change events as needed, and have retroarch re-detect/setup the controller.