### PR TITLE
Set save redirect paths before set_environment

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -1996,8 +1996,9 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          break;
 
       case RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY:
-         RARCH_LOG("[Environ]: GET_SAVE_DIRECTORY.\n");
          *(const char**)data = runloop_st->savefile_dir;
+         RARCH_LOG("[Environ]: SAVE_DIRECTORY: \"%s\".\n",
+               runloop_st->savefile_dir);
          break;
 
       case RETRO_ENVIRONMENT_GET_USERNAME:
@@ -4631,7 +4632,7 @@ bool runloop_event_init_core(
             type, &runloop_st->current_core, NULL, NULL))
       return false;
 #ifdef HAVE_RUNAHEAD
-   /* remember last core type created, so creating a
+   /* Remember last core type created, so creating a
     * secondary core will know what core type to use. */
    runloop_st->last_core_type              = type;
 #endif
@@ -4690,7 +4691,7 @@ bool runloop_event_init_core(
          settings, &runloop_st->fastmotion_override.current);
 
 #ifdef HAVE_CHEEVOS
-   /* assume the core supports achievements unless it tells us otherwise */
+   /* Assume the core supports achievements unless it tells us otherwise */
    rcheevos_set_support_cheevos(true);
 #endif
 
@@ -4701,9 +4702,13 @@ bool runloop_event_init_core(
    runloop_st->shader_delay_timer.timer_end   = false; /* not expired */
 #endif
 
-   /* reset video format to libretro's default */
+   /* Reset video format to libretro's default */
    video_st->pix_fmt = RETRO_PIXEL_FORMAT_0RGB1555;
 
+   /* Set save redirection paths */
+   runloop_path_set_redirect(settings, old_savefile_dir, old_savestate_dir);
+
+   /* Set core environment */
    runloop_st->current_core.retro_set_environment(runloop_environment_cb);
 
    /* Load any input remap files
@@ -4719,9 +4724,6 @@ bool runloop_event_init_core(
    if (auto_remaps_enable)
       config_load_remap(dir_input_remapping, &runloop_st->system);
 #endif
-
-   /* Per-core saves: reset redirection paths */
-   runloop_path_set_redirect(settings, old_savefile_dir, old_savestate_dir);
 
    video_st->frame_cache_data              = NULL;
 


### PR DESCRIPTION
## Description

- Fix setting `savefile_directory` in override file by moving redirect set before environment set
- Add final path to `RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY` logging, and renamed to `SAVE_DIRECTORY` like `SYSTEM_DIRECTORY`
- Comment cleanups

Without this change the path changing does work with `--appendconfig`, but not with overrides, even though overrides are parsed right after appends in the same manner.

So is there a better way, or can this cause other problems? Sure feels like the current order is clearly wrong in any case, and this seems fine as far as I can tell. What harm could there be for the core to get the final paths as early as possible..?
