### PR TITLE
Fix for "no sound on PS2"

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -6346,6 +6346,9 @@ void menu_driver_toggle(
 
       if (pause_libretro)
       {
+#ifdef PS2
+         command_event(CMD_EVENT_AUDIO_STOP, NULL);
+#endif
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_STOP, NULL);
 #endif
@@ -6376,6 +6379,9 @@ void menu_driver_toggle(
 
       if (pause_libretro)
       {
+#ifdef PS2
+         command_event(CMD_EVENT_AUDIO_START, NULL);
+#endif
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_START, NULL);
 #endif


### PR DESCRIPTION
## Description

Earlier refactor https://github.com/libretro/RetroArch/commit/f121847e00689952df56365f35e3ef1f9a8ece1e has removed CMD_EVENT_AUDIO_START (and stop), however on PS2 it causes no sound, so it is added back behind a compiler switch.
Ideally, PS2 sound driver would also need no special treatment, but my attempts at having the audio driver running by default, or initializing it from ps2_init in ps2_gfx.c, just resulted in freezes.

## Related Issues

Closes #15759 #15655 

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/15523

