### PR TITLE
Exclude "System Volume Information" explicitly from directory listing

### DIFF
--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -141,6 +141,11 @@ static int dir_list_read(const char *dir,
 
       if (retro_dirent_is_dir(entry, NULL))
       {
+         /* Exclude this frequent hidden dir on platforms which can not handle hidden attribute */
+#ifndef _WIN32
+         if (!include_hidden && strcmp(name, "System Volume Information") == 0)
+            continue;
+#endif
          if (recursive)
             dir_list_read(file_path, list, ext_list, include_dirs,
                   include_hidden, include_compressed, recursive);


### PR DESCRIPTION
## Description

Okay, bear with me for a moment. It is not as bad of a hack as it looks like, though I can understand if this gets rejected.

I started investigating #15831 and found out that there is no straightforward way to get the hidden attribute of FAT file systems on non-Windows systems. (I would say specifically for PS2 in the current SDK there is no way, since it instructs to use stat() that does not transfer this attribute). 
But even a non-Windows RA install can meet such entry if an USB drive is used under Windows and then loaded to RA, such as transferring ROMs to an embedded system: a directory called "System Volume Information" will appear in the root. IMO it makes sense to treat this special entry as a hidden one. A few lines earlier, entries starting with dot are also excluded without regard to platform, although they do not hold special meaning under Windows.

Note: RA compiled for Windows excludes actual hidden entries elsewhere (in retro_vfs_opendir_impl() ).

## Related Issues

#15831 

## Related Pull Requests

#14724 has brought a change in behavior on PS2, but it was also wrong earlier, just in a different way, so this is no reason to revert that (and it fixes a lot of other things). Current PS2 RA behavior is consistent with a desktop Linux RA install.

