### PR TITLE
increase chunk size for reads/writes under emscripten

### DIFF
--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -62,7 +62,11 @@
 #include "../cheat_manager.h"
 #endif
 
-#if defined(HAVE_LIBNX) || defined(_3DS)
+#ifdef EMSCRIPTEN
+/* Filesystem is in-memory anyway, use huge chunks since each
+   read/write is a possible suspend to JS code */
+#define SAVE_STATE_CHUNK 4096 * 4096
+#elif defined(HAVE_LIBNX) || defined(_3DS)
 #define SAVE_STATE_CHUNK 4096 * 10
 #else
 #define SAVE_STATE_CHUNK 4096


### PR DESCRIPTION
Under emscripten, we only use MEMFS so all reads/writes are in-memory anyway.

Each read/write seems to return control to JavaScript and take a full frame before returning for another read.  For systems with larger save states (e.g. SNES has 800KB+ states), this means it can take 3-4 seconds to save or load a state just because of unnecessary pauses for FS operations.

Accordingly, I've increased the read/write chunk size for states to 16MB.