### PR TITLE
Fix SDL2 GFX Suspend Screensaver Warning

### DIFF
--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -539,7 +539,16 @@ static bool sdl2_gfx_focus(void *data)
    return (SDL_GetWindowFlags(vid->window) & flags) == flags;
 }
 
-static bool sdl2_gfx_suspend_screensaver(void *data, bool enable) { return false; }
+static bool sdl2_gfx_suspend_screensaver(void *data, bool enable)
+{
+#ifdef HAVE_X11
+   /* Use X11's suspend screensaver if X11 available. */
+   return x11_suspend_screensaver(data, enable);
+#else
+   return false;
+#endif
+}
+
 /* TODO/FIXME - implement */
 static bool sdl2_gfx_has_windowed(void *data) { return true; }
 
@@ -714,11 +723,7 @@ video_driver_t video_sdl2 = {
    sdl2_gfx_set_nonblock_state,
    sdl2_gfx_alive,
    sdl2_gfx_focus,
-#ifdef HAVE_X11
-   x11_suspend_screensaver,
-#else
    sdl2_gfx_suspend_screensaver,
-#endif
    sdl2_gfx_has_windowed,
    sdl2_gfx_set_shader,
    sdl2_gfx_free,


### PR DESCRIPTION
When building RetroArch and X11 is available, it will skip using `sdl2_gfx_suspend_screensaver()`, resulting in a warning. This change cleans up the declaration code, and makes the macro condition within the function itself, so that we no longer get the warning when building.

``` c
gfx/drivers/sdl2_gfx.c:542:13: warning: ‘sdl2_gfx_suspend_screensaver’ defined but not used [-Wunused-function]
  542 | static bool sdl2_gfx_suspend_screensaver(void *data, bool enable) { return false; }
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```