### PR TITLE
Log level prefix cleanup

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -896,19 +896,19 @@ static void libretro_log_cb(
    switch (level)
    {
       case RETRO_LOG_DEBUG:
-         RARCH_LOG_V("[libretro DEBUG]", fmt, vp);
+         RARCH_LOG_V("libretro " FILE_PATH_LOG_DBG, fmt, vp);
          break;
 
       case RETRO_LOG_INFO:
-         RARCH_LOG_OUTPUT_V("[libretro INFO]", fmt, vp);
+         RARCH_LOG_OUTPUT_V("libretro " FILE_PATH_LOG_INFO, fmt, vp);
          break;
 
       case RETRO_LOG_WARN:
-         RARCH_WARN_V("[libretro WARN]", fmt, vp);
+         RARCH_WARN_V("libretro " FILE_PATH_LOG_WARN, fmt, vp);
          break;
 
       case RETRO_LOG_ERROR:
-         RARCH_ERR_V("[libretro ERROR]", fmt, vp);
+         RARCH_ERR_V("libretro " FILE_PATH_LOG_ERROR, fmt, vp);
          break;
 
       default:

--- a/verbosity.h
+++ b/verbosity.h
@@ -32,10 +32,10 @@
 
 RETRO_BEGIN_DECLS
 
-#define FILE_PATH_LOG_DBG   "[DEBUG]"
-#define FILE_PATH_LOG_INFO  "[INFO]"
-#define FILE_PATH_LOG_ERROR "[ERROR]"
-#define FILE_PATH_LOG_WARN  "[WARN]"
+#define FILE_PATH_LOG_DBG   "[DBG]"
+#define FILE_PATH_LOG_INFO  "[NFO]"
+#define FILE_PATH_LOG_ERROR "[ERR]"
+#define FILE_PATH_LOG_WARN  "[WRN]"
 
 bool verbosity_is_enabled(void);
 


### PR DESCRIPTION
## Description

Minor readability boost to logging by making all different log level prefixes as 3 letter versions.
