### PR TITLE
Fallback to screensaver inhibit via D-Bus on Wayland (rebase)

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -28,6 +28,10 @@
 #include "../../frontend/frontend_driver.h"
 #include "../../verbosity.h"
 
+#ifdef HAVE_DBUS
+#include "dbus_common.h"
+#endif
+
 #define SPLASH_SHM_NAME "retroarch-wayland-vk-splash"
 
 #define APP_ID "org.libretro.RetroArch"
@@ -282,6 +286,13 @@ void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
       zxdg_decoration_manager_v1_destroy(wl->deco_manager);
    if (wl->idle_inhibit_manager)
       zwp_idle_inhibit_manager_v1_destroy(wl->idle_inhibit_manager);
+   else
+   {
+#ifdef HAVE_DBUS
+      dbus_screensaver_uninhibit();
+      dbus_close_connection();
+#endif
+   }
    if (wl->pointer_constraints)
       zwp_pointer_constraints_v1_destroy(wl->pointer_constraints);
    if (wl->relative_pointer_manager)
@@ -659,6 +670,9 @@ bool gfx_ctx_wl_init_common(
    if (!wl->idle_inhibit_manager)
    {
       RARCH_LOG("[Wayland]: Compositor doesn't support zwp_idle_inhibit_manager_v1 protocol\n");
+#ifdef HAVE_DBUS
+      dbus_ensure_connection();
+#endif
    }
 
    if (!wl->deco_manager)
@@ -878,7 +892,13 @@ bool gfx_ctx_wl_suppress_screensaver(void *data, bool state)
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
    if (!wl->idle_inhibit_manager)
+#ifdef HAVE_DBUS
+      /* Some Wayland compositors (e.g. Phoc) don't implement Wayland's Idle protocol.
+       * They instead rely on things like Gnome Screensaver. */
+      return dbus_suspend_screensaver(state);
+#else
       return false;
+#endif
    if (state != (!!wl->idle_inhibitor))
    {
       if (state)


### PR DESCRIPTION
## Description

A rebase of #14301 from @puffnfresh,  no additional changes.
_Some Wayland compositors (e.g. Phoc) don't implement Wayland's Idle protocol. They instead rely on things like Gnome Screensaver._

Done some testing on Ubuntu 22.04, behaves as expected. One note: since the default value for HAVE_DBUS is "no" in the scripts invoked by ./configure, this needs to be explicitly enabled during compilation with --enable-dbus before this has any effect.

## Related Pull Requests

#14301 

