### PR TITLE
Silence a format truncation warning

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -11922,7 +11922,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               else
                                  snprintf(mode_str      + strlen_mode_str,
                                        sizeof(mode_str) - strlen_mode_str,
-                                       "Mode %d", toc->track[i].mode);
+                                       "Mode %d", toc->track[i].mode%10);
 
                               if (menu_entries_append(info->list,
                                        mode_str,


### PR DESCRIPTION
## Description

This line generates a warning during compilation:

```
menu/menu_displaylist.c:11925:46: warning: '%d' directive output may be truncated writing between 1 and 3 bytes into a region of size 2 [-Wformat-truncation=]
11925 |                                        "Mode %d", toc->track[i].mode);
      |                                              ^~
menu/menu_displaylist.c:11925:40: note: directive argument in the range [0, 255]
11925 |                                        "Mode %d", toc->track[i].mode);
      |                                        ^~~~~~~~~
In file included from /usr/include/stdio.h:936,
                 from ./libretro-common/include/file/file_path.h:26,
                 from menu/menu_displaylist.c:27:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:10: note: '__builtin___snprintf_chk' output between 7 and 9 bytes into a destination of size 7
   64 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   65 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Since the value of the track mode should be either 1 or 2, a modulo 10 should not limit the displayed value, and it removes the warning.
