### PR TITLE
PS2 usability fixes

### DIFF
--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -60,6 +60,10 @@
 #include <sys/time.h>
 #endif
 
+#if defined(PS2)
+#include <ps2sdkapi.h>
+#endif
+
 #ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>

--- a/retroarch.c
+++ b/retroarch.c
@@ -4803,7 +4803,11 @@ void main_exit(void *args)
 #if defined(HAVE_LOGGER) && !defined(ANDROID)
    logger_shutdown();
 #endif
-
+#ifdef PS2
+   /* PS2 frontend driver deinit also detaches filesystem,
+    * so make sure logs are written in advance. */
+   retro_main_log_file_deinit();
+#endif
    frontend_driver_deinit(args);
    frontend_driver_exitspawn(
          path_get_ptr(RARCH_PATH_CORE),


### PR DESCRIPTION
## Description

A few improvements made while checking PS2 bugs.

- Make sure logs are written before frontend deinit - fixes 0-byte logs mentioned in comments of #15763 (this PR does not help with GBA freeze, just the logs)
- Add memory stats - not a very nice solution, but it works.
- Add process_args to frontend to fix some cases when salamander cfg was not filled - fixes a few cases when the core path was not detected, such as starting directly a core .elf in a fresh install and doing Restart. Maybe fixes the remaining problem in #15800 .
- Add a missing include in case someone wants to compile for PS2 with HAVE_THREADS
