### PR TITLE
(cheevos) prevent write-past-end-of-buffer when signed value wraps

### DIFF
--- a/deps/rcheevos/src/rcheevos/alloc.c
+++ b/deps/rcheevos/src/rcheevos/alloc.c
@@ -22,11 +22,13 @@ void* rc_alloc_scratch(void* pointer, int32_t* offset, uint32_t size, uint32_t a
   buffer = &scratch->buffer;
   do {
     const uint32_t aligned_buffer_offset = (buffer->offset + alignment - 1) & ~(alignment - 1);
-    const uint32_t remaining = sizeof(buffer->buffer) - aligned_buffer_offset;
+    if (aligned_buffer_offset < sizeof(buffer->buffer)) {
+      const uint32_t remaining = sizeof(buffer->buffer) - aligned_buffer_offset;
 
-    if (remaining >= size) {
-      /* claim the required space from an existing buffer */
-      return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL, -1);
+      if (remaining >= size) {
+        /* claim the required space from an existing buffer */
+        return rc_alloc(buffer->buffer, &buffer->offset, size, alignment, NULL, -1);
+      }
     }
 
     if (!buffer->next)


### PR DESCRIPTION
## Description

Fixes a crash when loading some games with large strings (reported against Legend of Legaia). Introduced in #15859.

Subtraction of two unsigned values resulted in a very large unsigned value, so the greater than comparison succeeded when it shouldn't have.

## Related Issues

[Discord](https://discord.com/channels/184109094070779904/469974542299955210/1170410375590715442)

## Related Pull Requests

n/a

## Reviewers

@Sanaki 
