### PR TITLE
Savestate thumbnail fixes

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3612,8 +3612,8 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
 
    /* Savestate thumbnails are only relevant
     * when viewing the running quick menu or state slots */
-   if (!(      (ozone->is_quick_menu && menu_is_running_quick_menu())
-            || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
+   if (!(   (ozone->is_quick_menu && menu_is_running_quick_menu())
+         || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
       return;
 
    if (savestate_thumbnail)
@@ -3694,13 +3694,8 @@ static void ozone_update_savestate_thumbnail_image(void *data)
    settings_t *settings  = config_get_ptr();
    unsigned thumbnail_upscale_threshold
                          = settings->uints.gfx_thumbnail_upscale_threshold;
-   if ((!ozone) || (ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET))
-      return;
 
-   /* Savestate thumbnails are only relevant
-    * when viewing the running quick menu or state slots */
-   if (!((ozone->is_quick_menu && menu_is_running_quick_menu())
-         || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT)))
+   if ((!ozone) || (ozone->flags & OZONE_FLAG_SKIP_THUMBNAIL_RESET))
       return;
 
    /* If path is empty, just reset thumbnail */
@@ -11957,6 +11952,10 @@ static void ozone_populate_entries(
    if (animate)
       if (ozone->categories_selection_ptr == ozone->categories_active_idx_old)
          ozone_list_open(ozone, ozone_collapse_sidebar, (!(ozone->flags & OZONE_FLAG_FIRST_FRAME)));
+
+   /* Reset savestate thumbnails always */
+   ozone_update_savestate_thumbnail_path(ozone, (unsigned)menu_st->selection_ptr);
+   ozone_update_savestate_thumbnail_image(ozone);
 
    /* Thumbnails
     * > Note: Leave current thumbnails loaded when

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -6929,6 +6929,9 @@ static void rgui_reset_savestate_thumbnail(void *data)
 {
    rgui_t *rgui    = (rgui_t*)data;
 
+   if (string_is_empty(rgui->savestate_thumbnail_file_path))
+      return;
+
    rgui->mini_left_thumbnail.width    = 0;
    rgui->mini_left_thumbnail.height   = 0;
    rgui->mini_left_thumbnail.is_valid = false;
@@ -6939,12 +6942,6 @@ static void rgui_update_savestate_thumbnail_image(void *data)
 {
    rgui_t *rgui    = (rgui_t*)data;
    if (!rgui)
-      return;
-
-   /* Savestate thumbnails are only relevant
-    * when viewing the running quick menu or state slots */
-   if (!(   (rgui->is_quick_menu && menu_is_running_quick_menu())
-         || (rgui->flags & RGUI_FLAG_IS_STATE_SLOT)))
       return;
 
    /* If path is empty, just reset thumbnail */
@@ -7041,15 +7038,11 @@ static void rgui_scan_selected_entry_thumbnail(rgui_t *rgui, bool force_load)
          has_thumbnail = gfx_thumbnail_update_path(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT) || has_thumbnail;
    }
 
-   /* Save state thumbnails */
-   if (     (rgui->is_quick_menu)
-         || (rgui->flags & RGUI_FLAG_IS_STATE_SLOT))
+   /* Reset savestate thumbnails always */
+   if (selection < list_size)
    {
-      if (selection < list_size)
-      {
-         rgui_update_savestate_thumbnail_path(rgui, (unsigned)selection);
-         rgui_update_savestate_thumbnail_image(rgui);
-      }
+      rgui_update_savestate_thumbnail_path(rgui, (unsigned)selection);
+      rgui_update_savestate_thumbnail_image(rgui);
    }
 
    /* Check whether thumbnails should be loaded */

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1480,11 +1480,6 @@ static void xmb_update_savestate_thumbnail_image(void *data)
    if (!xmb || xmb->skip_thumbnail_reset)
       return;
 
-   /* Savestate thumbnails are only relevant
-    * when viewing the running quick menu or state slots */
-   if (!((xmb->is_quick_menu && menu_is_running_quick_menu()) || xmb->is_state_slot))
-      return;
-
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(xmb->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&xmb->thumbnails.savestate);


### PR DESCRIPTION
## Description

Corrections for all savestate thumbnail supported menu drivers regarding proper and consistent behavior when navigating back to playlist while content is still running.

## Related Issues

Closes #15832
