### PR TITLE
Separate ffmpeg/mpv and audiomixer conditionals

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -12737,7 +12737,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_RUN_MUSIC,
-   "Run"
+   "Play in Media Player"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SECONDS,

--- a/menu/cbs/menu_cbs_deferred_push.c
+++ b/menu/cbs/menu_cbs_deferred_push.c
@@ -408,7 +408,7 @@ static int general_push(menu_displaylist_info_t *info,
    char newstring2[PATH_MAX_LENGTH];
    settings_t                  *settings      = config_get_ptr();
    menu_handle_t                  *menu       = menu_state_get_ptr()->driver_data;
-#if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV) || defined (HAVE_AUDIOMIXER)
    bool 
       multimedia_builtin_mediaplayer_enable   = settings->bools.multimedia_builtin_mediaplayer_enable;
 #endif
@@ -559,13 +559,29 @@ static int general_push(menu_displaylist_info_t *info,
                string_list_initialize(&str_list3);
                string_split_noalloc(&str_list3, newstring, "|");
 
-#ifdef HAVE_IBXM
+#if defined(HAVE_AUDIOMIXER)
+               if (multimedia_builtin_mediaplayer_enable)
                {
                   union string_list_elem_attr attr;
                   attr.i = 0;
+#if defined(HAVE_DR_MP3)
+                  string_list_append(&str_list3, "mp3", attr);
+#endif
+#if defined(HAVE_STB_VORBIS)
+                  string_list_append(&str_list3, "ogg", attr);
+#endif
+#if defined(HAVE_DR_FLAC)
+                  string_list_append(&str_list3, "flac", attr);
+#endif
+#if defined(HAVE_RWAV)
+                  string_list_append(&str_list3, "wav", attr);
+#endif
+#ifdef HAVE_IBXM
+
                   string_list_append(&str_list3, "s3m", attr);
                   string_list_append(&str_list3, "mod", attr);
                   string_list_append(&str_list3, "xm", attr);
+#endif
                }
 #endif
                string_list_join_concat(newstring2, sizeof(newstring2),

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -800,16 +800,8 @@ enum msg_file_type msg_hash_to_file_type(uint32_t hash)
          return FILE_TYPE_MOV;
       case MENU_VALUE_FILE_WMV:
          return FILE_TYPE_WMV;
-      case MENU_VALUE_FILE_MP3:
-         return FILE_TYPE_MP3;
       case MENU_VALUE_FILE_M4A:
          return FILE_TYPE_M4A;
-      case MENU_VALUE_FILE_OGG:
-         return FILE_TYPE_OGG;
-      case MENU_VALUE_FILE_FLAC:
-         return FILE_TYPE_FLAC;
-      case MENU_VALUE_FILE_WAV:
-         return FILE_TYPE_WAV;
       case MENU_VALUE_FILE_3G2:
          return FILE_TYPE_3G2;
       case MENU_VALUE_FILE_MPG:
@@ -835,13 +827,31 @@ enum msg_file_type msg_hash_to_file_type(uint32_t hash)
       case MENU_VALUE_FILE_WMA:
          return FILE_TYPE_WMA;
 #endif
-#ifdef HAVE_IBXM
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV) || defined(HAVE_AUDIOMIXER)
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_DR_MP3)
+      case MENU_VALUE_FILE_MP3:
+         return FILE_TYPE_MP3;
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_STB_VORBIS)
+      case MENU_VALUE_FILE_OGG:
+         return FILE_TYPE_OGG;
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_DR_FLAC)
+      case MENU_VALUE_FILE_FLAC:
+         return FILE_TYPE_FLAC;
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_RWAV)
+      case MENU_VALUE_FILE_WAV:
+         return FILE_TYPE_WAV;
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_IBXM)
        case MENU_VALUE_FILE_MOD:
            return FILE_TYPE_MOD;
        case MENU_VALUE_FILE_S3M:
            return FILE_TYPE_S3M;
        case MENU_VALUE_FILE_XM:
            return FILE_TYPE_XM;
+#endif
 #endif
 #ifdef HAVE_IMAGEVIEWER
       case MENU_VALUE_FILE_JPG:

--- a/retroarch.c
+++ b/retroarch.c
@@ -2036,11 +2036,26 @@ enum rarch_content_type path_is_media_type(const char *path)
       case FILE_TYPE_MXF:
          return RARCH_CONTENT_MOVIE;
       case FILE_TYPE_WMA:
-      case FILE_TYPE_OGG:
-      case FILE_TYPE_MP3:
       case FILE_TYPE_M4A:
+#endif
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV) || defined(HAVE_AUDIOMIXER)
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_STB_VORBIS)
+      case FILE_TYPE_OGG:
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_DR_MP3)
+      case FILE_TYPE_MP3:
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_DR_FLAC)
       case FILE_TYPE_FLAC:
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_RWAV)
       case FILE_TYPE_WAV:
+#endif
+#if !defined(HAVE_AUDIOMIXER) || defined(HAVE_IBXM)
+      case FILE_TYPE_MOD:
+      case FILE_TYPE_S3M:
+      case FILE_TYPE_XM:
+#endif
          return RARCH_CONTENT_MUSIC;
 #endif
 #ifdef HAVE_IMAGEVIEWER
@@ -2050,13 +2065,6 @@ enum rarch_content_type path_is_media_type(const char *path)
       case FILE_TYPE_BMP:
          return RARCH_CONTENT_IMAGE;
 #endif
-#ifdef HAVE_IBXM
-      case FILE_TYPE_MOD:
-      case FILE_TYPE_S3M:
-      case FILE_TYPE_XM:
-         return RARCH_CONTENT_MUSIC;
-#endif
-
       case FILE_TYPE_NONE:
       default:
          break;


### PR DESCRIPTION
## Description

There are cases when mixer exists without ffmpeg. In such cases, some music content can still be added to the mixer for playback. Logic added to separate the two cases.

Now it behaves as follows:
- music file extensions supported by either the mixer or the media player will appear in content list if "use builtin mediaplayer" is enabled
- "Add to mixer" / "Add to mixer and play" entries will be present if there is audiomixer and the respective format support is compiled in
- "Play in Media Player" (renamed from "Run") will be present if the media player supports the file. (Note: it needed an extra check because tracker modules like s3m are not supported by ffmpeg, and for wav,  #3388 is still open so it will be horrible,)

There are a few minor improvements that could still be done: if there is any core that supports the particular music file type (such as ep128emu and wav support), "Run" will not be shown, unless "use builtin mediaplayer" is turned off, and "add to mixer and play" does not turn on mixer, although that would be convenient.

## Related Issues

Closes #8451 

