### PR TITLE
Small fixes for signedness warnings in translation service

### DIFF
--- a/accessibility.h
+++ b/accessibility.h
@@ -55,7 +55,7 @@ typedef struct
 
    /* Frame captured during the last call to the translation service */
    uint8_t *last_image;
-   int last_image_size;
+   unsigned last_image_size;
 
    /* 1 if the automatic mode has been enabled, 0 otherwise */
    int ai_service_auto;

--- a/tasks/task_translation.c
+++ b/tasks/task_translation.c
@@ -598,7 +598,7 @@ static access_response_t* parse_response_json(http_transfer_data_t *data)
       
       if (type == RJSON_STRING && (rjson_get_context_count(json) & 1) == 1)
       {
-         int i;
+         unsigned i;
          string = rjson_get_string(json, &length);
          for (i = 0; i < ARRAY_SIZE(ACCESS_RESPONSE_KEYS) && key == -1; i++)
          {
@@ -1094,7 +1094,7 @@ static void translation_response_input(access_response_t *response)
 #ifdef HAVE_ACCESSIBILITY
          else
          {
-            int i      = 0;
+            unsigned i      = 0;
             bool found = false;
             
             for (; i < ARRAY_SIZE(ACCESS_INPUT_LABELS) && !found; i++)


### PR DESCRIPTION
## Description

Current code throws some warnings during compilation:
```
tasks/task_translation.c: In function ‘parse_response_json’:
tasks/task_translation.c:603:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  603 |          for (i = 0; i < ARRAY_SIZE(ACCESS_RESPONSE_KEYS) && key == -1; i++)
      |                        ^
tasks/task_translation.c: In function ‘translation_response_input’:
tasks/task_translation.c:1100:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
 1100 |             for (; i < ARRAY_SIZE(ACCESS_INPUT_LABELS) && !found; i++)
      |                      ^
tasks/task_translation.c: In function ‘translation_dupe_fail’:
tasks/task_translation.c:1318:46: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
 1318 |    bool size_equal            = (frame->size == access_st->last_image_size);
      |                                              ^~
```
Kind of trivial, except for the change in accessibility.h . Negative value for a size could indicate some error situation, but I found no usage for this in the code.

## Reviewers

@xunkar @Cpod12 
