### PR TITLE
Small warning fixes

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -3291,13 +3291,13 @@ static int udev_input_add_device(udev_input_t *udev,
          device->mouse.y_max = absinfo.maximum;
       }
 
-#ifdef UDEV_TOUCH_SUPPORT
       if (touch)
       {
+#ifdef UDEV_TOUCH_SUPPORT
           udev_init_touch_dev(device);
           udev_sync_touch(device);
-      }
 #endif
+      }
 
       if (!mouse)
          goto end;

--- a/ui/drivers/qt/qt_downloads.cpp
+++ b/ui/drivers/qt/qt_downloads.cpp
@@ -1,4 +1,5 @@
 #include <QDir>
+#include <QHash>
 #include <QApplication>
 #include <QProgressDialog>
 


### PR DESCRIPTION
## Description

This should remove the final 2 warnings that are currently in Linux x64 compilation:

```
input/drivers/udev_input.c: In function 'udev_input_add_device':
input/drivers/udev_input.c:3229:12: warning: variable 'touch' set but not used [-Wunused-but-set-variable]
 3229 |       bool touch = 0;
      |            ^~~~~
```

and

```
In file included from /usr/include/x86_64-linux-gnu/qt5/QtGui/qbrush.h:39,
                 from /usr/include/x86_64-linux-gnu/qt5/QtGui/qpalette.h:39,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qwidget.h:41,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qdialog.h:37,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qprogressdialog.h:37,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QProgressDialog:1,
                 from ui/drivers/qt/qt_downloads.cpp:3:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qvector.h: In instantiation of 'QVector<T>::iterator QVector<T>::erase(QVector<T>::iterator, QVector<T>::iterator) [with T = QHash<QString, QString>; QVector<T>::iterator = QHash<QString, QString>*]':
/usr/include/x86_64-linux-gnu/qt5/QtCore/qvector.h:418:3:   required from 'void QVector<T>::remove(int) [with T = QHash<QString, QString>]'
/usr/include/x86_64-linux-gnu/qt5/QtCore/qvector.h:173:36:   required from 'T QVector<T>::takeAt(int) [with T = QHash<QString, QString>]'
ui/drivers/qt/qt_downloads.cpp:768:83:   required from here
/usr/include/x86_64-linux-gnu/qt5/QtCore/qvector.h:711:20: warning: 'void* memmove(void*, const void*, size_t)' writing to an object of type 'class QHash<QString, QString>' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
  711 |             memmove(abegin, aend, (d->size - itemsToErase - itemsUntouched) * sizeof(T));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qshareddata.h:39,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qfileinfo.h:39,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qdir.h:38,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QDir:1,
                 from ui/drivers/qt/qt_downloads.cpp:1:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qhash.h:315:7: note: 'class QHash<QString, QString>' declared here
  315 | class QHash
      |       ^~~~~
```

It is not terribly important, but removing these helps spotting any new issue.