### PR TITLE
Enable RetroArch to be set as a Launcher on Android

### DIFF
--- a/pkg/android/phoenix-legacy/AndroidManifest.xml
+++ b/pkg/android/phoenix-legacy/AndroidManifest.xml
@@ -27,6 +27,8 @@
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
                 <category android:name="tv.ouya.intent.category.GAME" />

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -29,6 +29,8 @@
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
                 <category android:name="tv.ouya.intent.category.GAME" />


### PR DESCRIPTION
## Description

Add the relevant Intents to the androidmanifest.xml files to allow RA to be set as a launcher, and called by pressing the Circle/Centre/Home button
https://developer.android.com/reference/android/content/Intent#CATEGORY_HOME
https://developer.android.com/reference/android/content/Intent#CATEGORY_DEFAULT

## Related Issues

https://github.com/libretro/RetroArch/issues/15866
