### PR TITLE
Adjust vertical alignment of XMB dialog box

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1017,6 +1017,7 @@ static void xmb_render_messagebox_internal(
    char wrapped_message[MENU_SUBLABEL_MAX_LENGTH];
    int x, y, longest_width           = 0;
    float line_height                 = 0;
+   float text_offset_y               = 0;
    int usable_width                  = 0;
    struct string_list list           = {0};
    bool input_dialog_display_kb      = false;
@@ -1052,7 +1053,8 @@ static void xmb_render_messagebox_internal(
    if (input_dialog_display_kb)
       y_position           = video_height / 4;
    x                       = video_width  / 2;
-   y                       = y_position - (list.size-1) * line_height / 2;
+   y                       = y_position - (int) ((list.size-0.5f) * line_height / 2.0f);
+   text_offset_y           = 0.50f / list.size;
 
    /* find the longest line width */
    for (i = 0; i < list.size; i++)
@@ -1096,7 +1098,7 @@ static void xmb_render_messagebox_internal(
       if (msg)
          gfx_display_draw_text(xmb->font, msg,
                x - longest_width/2.0,
-               y + (i + 0.85) * line_height,
+               y + (i + text_offset_y) * line_height,
                video_width, video_height, 0x444444ff,
                TEXT_ALIGN_LEFT, 1.0f, false, 0.0f, false);
    }


### PR DESCRIPTION
## Description

XMB dialog text (such as invoking Help with Select / rShift) was a bit misaligned.
Before:
![Screenshot from 2023-11-11 10-43-40](https://github.com/libretro/RetroArch/assets/101990835/df7df680-9910-4384-948d-0290a149e287)
![Screenshot from 2023-11-11 10-43-32](https://github.com/libretro/RetroArch/assets/101990835/e67f2f6a-1fd2-4506-bdbf-950dfffb3be6)
![Screenshot from 2023-11-11 10-43-24](https://github.com/libretro/RetroArch/assets/101990835/de370358-9afb-4087-ad0e-b464b4b5053b)

After:
![Screenshot from 2023-11-11 10-42-47](https://github.com/libretro/RetroArch/assets/101990835/5b6f70f6-cc93-4d0c-ae35-43fd746a1fdb)
![Screenshot from 2023-11-11 10-42-38](https://github.com/libretro/RetroArch/assets/101990835/2a47691e-744b-4257-9d82-fe9ee65eabb9)
![Screenshot from 2023-11-11 10-42-25](https://github.com/libretro/RetroArch/assets/101990835/0e41f915-ddce-4819-80c6-2e98c24e1b25)


## Reviewers

A confirmation would be nice that the issue was actually generally visible and not just something particular to my setup (Linux), although code seems generic enough.