### PR TITLE
Fix screen resolution always tied to the main monitor on win32 platforms

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -2680,16 +2680,20 @@ void win32_get_video_output_next(
 }
 
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0500 /* 2K */
-#define WIN32_GET_VIDEO_OUTPUT(iModeNum, dm) EnumDisplaySettingsEx(NULL, iModeNum, dm, EDS_ROTATEDMODE)
+#define WIN32_GET_VIDEO_OUTPUT(devName, iModeNum, dm) EnumDisplaySettingsEx(devName, iModeNum, dm, EDS_ROTATEDMODE)
 #else
-#define WIN32_GET_VIDEO_OUTPUT(iModeNum, dm) EnumDisplaySettings(NULL, iModeNum, dm)
+#define WIN32_GET_VIDEO_OUTPUT(devName, iModeNum, dm) EnumDisplaySettings(devName, iModeNum, dm)
 #endif
 
 bool win32_get_video_output(DEVMODE *dm, int mode, size_t len)
 {
+   MONITORINFOEX current_mon;
+   HMONITOR hm_to_use        = NULL;
+   unsigned mon_id           = 0;
    memset(dm, 0, len);
    dm->dmSize  = len;
-   if (WIN32_GET_VIDEO_OUTPUT((mode == -1)
+   win32_monitor_info(&current_mon, &hm_to_use, &mon_id);
+   if (WIN32_GET_VIDEO_OUTPUT(&current_mon.szDevice, (mode == -1)
             ? ENUM_CURRENT_SETTINGS
             : (DWORD)mode,
             dm) == 0)

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -228,6 +228,9 @@ static bool win32_display_server_set_window_decorations(void *data, bool on)
 static bool win32_display_server_set_resolution(void *data,
       unsigned width, unsigned height, int int_hz, float hz, int center, int monitor_index, int xoffset, int padjust)
 {
+   MONITORINFOEX current_mon;
+   HMONITOR hm_to_use        = NULL;
+   unsigned mon_id           = 0;
    DEVMODE dm                = {0};
    LONG res                  = 0;
    unsigned i                = 0;
@@ -288,12 +291,13 @@ static bool win32_display_server_set_resolution(void *data,
       dm.dmFields |= DM_DISPLAYORIENTATION;
 #endif
 
-      res = win32_change_display_settings(NULL, &dm, CDS_TEST);
+      win32_monitor_info(&current_mon, &hm_to_use, &mon_id);
+      res = win32_change_display_settings(&current_mon.szDevice, &dm, CDS_TEST);
 
       switch (res)
       {
          case DISP_CHANGE_SUCCESSFUL:
-            res = win32_change_display_settings(NULL, &dm, 0);
+            res = win32_change_display_settings(&current_mon.szDevice, &dm, 0);
             switch (res)
             {
                case DISP_CHANGE_SUCCESSFUL:


### PR DESCRIPTION
## Description

This fix addresses two issues appears when using multi monitor setup:
- [x]  The full screen mode always tied/applied to the main monitor even if you set the monitor index to an other one,
- [x] The screen resolution list always show main monitor screen resolutions.

Note: This fix was tested under windows 11.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
