### PR TITLE
(D3D11+12) Improve 'Max Frame Latency' logging

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -2016,7 +2016,10 @@ static bool d3d11_init_swapchain(d3d11_video_t* d3d11,
 
       DXGISetMaximumFrameLatency(d3d11->swapChain, max_latency);
       DXGIGetMaximumFrameLatency(d3d11->swapChain, &cur_latency);
-      RARCH_LOG("[D3D11]: Requesting %u maximum frame latency, using %u.\n", max_latency, cur_latency);
+      RARCH_LOG("[D3D11]: Requesting %u maximum frame latency, using %u%s.\n",
+            settings->uints.video_max_frame_latency,
+            cur_latency,
+            (d3d11->flags & D3D11_ST_FLAG_WAIT_FOR_VBLANK) ? " with WaitForVBlank" : "");
    }
 
 #ifdef HAVE_DXGI_HDR

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -2371,7 +2371,10 @@ static bool d3d12_init_swapchain(d3d12_video_t* d3d12,
 
       DXGISetMaximumFrameLatency(d3d12->chain.handle, max_latency);
       DXGIGetMaximumFrameLatency(d3d12->chain.handle, &cur_latency);
-      RARCH_LOG("[D3D12]: Requesting %u maximum frame latency, using %u.\n", max_latency, cur_latency);
+      RARCH_LOG("[D3D12]: Requesting %u maximum frame latency, using %u%s.\n",
+            settings->uints.video_max_frame_latency,
+            cur_latency,
+            (d3d12->flags & D3D12_ST_FLAG_WAIT_FOR_VBLANK) ? " with WaitForVBlank" : "");
    }
 
 #ifdef HAVE_WINDOW


### PR DESCRIPTION
## Description

Let's do clearer logging when using the "Max Frame Latency" hack of value 0 which does not really exist.
