### PR TITLE
(WIN32) Prefer D3D11 and WASAPI

### DIFF
--- a/Makefile.msvc
+++ b/Makefile.msvc
@@ -25,11 +25,11 @@ HAVE_D3D12               := 1
 HAVE_CG                  := 1
 HAVE_OPENGL              := 1
 HAVE_OPENGL1             := 1
-HAVE_GFX_WIDGETS			 := 1
+HAVE_GFX_WIDGETS         := 1
 HAVE_VULKAN              := 1
 HAVE_XAUDIO              := 1
 HAVE_XINPUT              := 1
-HAVE_WASAPI              := 0
+HAVE_WASAPI              := 1
 HAVE_THREAD_STORAGE      := 1
 HAVE_WINMM               := 1
 

--- a/configuration.c
+++ b/configuration.c
@@ -415,6 +415,9 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_METAL;
 #elif defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 /* Lets default to D3D11 in UWP, even when its compiled with ANGLE, since ANGLE is just calling D3D anyway.*/
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_D3D11;
+#elif defined(HAVE_D3D11) && defined(_WIN32_WINNT) && _WIN32_WINNT >= _WIN32_WINNT_WIN7
+/* Prefer D3D11 with Windows 7 and above. */
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_D3D11;
 #elif defined(HAVE_OPENGL1) && defined(_MSC_VER) && (_MSC_VER <= 1600)
 /* On Windows XP and earlier, use gl1 by default
  * (regular opengl has compatibility issues with
@@ -522,12 +525,12 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_JACK;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_COREAUDIO3;
 #elif defined(HAVE_COREAUDIO)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_COREAUDIO;
+#elif defined(HAVE_WASAPI)
+static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_WASAPI;
 #elif defined(HAVE_XAUDIO)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_XAUDIO;
 #elif defined(HAVE_DSOUND)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_DSOUND;
-#elif defined(HAVE_WASAPI)
-static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_WASAPI;
 #elif defined(HAVE_AL)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_AL;
 #elif defined(HAVE_SL)


### PR DESCRIPTION
## Description

Since D3D11 and WASAPI have been very usable and robust for a long time, let's prefer them as the default drivers where available. I don't see any practical reason to keep defaulting to the old OPENGL2 when D3D11 or even when OPENGL3 exists.

Or perhaps both of these D3D11 defines for Xbox and Win32 before OPENGL could be combined as one single `HAVE_D3D11`, or rather just remove both and move the actual one below to the top?

This should also allow getting rid of the dx9 redist required for the older xaudio.

Also enabled WASAPI in `Makefile.msvc` since it seems very wrong to not have it there, or am I wrong?
