### PR TITLE
Fix #15919

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -4256,13 +4256,10 @@ static bool event_init_content(
 
    content_set_subsystem_info();
 
-   /* If core is contentless, just initialise SRAM
-    * interface, otherwise fill all content-related
-    * paths */
    if (flags & CONTENT_ST_FLAG_CORE_DOES_NOT_NEED_CONTENT)
       runloop_path_init_savefile_internal(runloop_st);
-   else
-      runloop_path_fill_names();
+
+   runloop_path_fill_names();
 
    if (!content_init())
       return false;


### PR DESCRIPTION
## Description

- Contentless support and populated content paths are not mutually exclusive in practice
- It just looked that way because most cores that support contentless mode to date don't use softpatching very much
- melonDS DS fits into both categories, however; it supports contentless mode (by booting into the DS or DSi menu), and it supports softpatching ROMs.

## Related Issues

Fixes #15919
