### PR TITLE
Use ZipFS for web player asset bundle

### DIFF
--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -109,7 +109,7 @@
                            <a class="dropdown-item" href="." data-core="vice_xscpu64">VICE xscpu4</a>
                            <a class="dropdown-item" href="." data-core="vice_xvic">VICE xVIC</a>
                            <a class="dropdown-item" href="." data-core="vitaquake2">Vita Quake2</a>
-                           <a class="dropdown-item" href="." data-core="vitaquake2-roque">Vita Quake2 (rogue)</a>
+                           <a class="dropdown-item" href="." data-core="vitaquake2-rogue">Vita Quake2 (rogue)</a>
                            <a class="dropdown-item" href="." data-core="vitaquake2-xatrix">Vita Quake2 (xatrix)</a>
                            <a class="dropdown-item" href="." data-core="vitaquake2-zaero">Vita Quake2 (zaero)</a>
                            <a class="dropdown-item" href="." data-core="virtualjaguar">Virtual Jaguar</a>

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -209,7 +209,7 @@ function setupFileSystem(backend)
    console.log("WEBPLAYER: initializing filesystem: " + backend);
    mfs.mount('/home/web_user/retroarch/userdata', afs);
 
-   mfs.mount('/home/web_user/retroarch/', xfs1);
+   mfs.mount('/home/web_user/retroarch/assets/frontend/', xfs1);
    mfs.mount('/home/web_user/retroarch/userdata/content/downloads', xfs2);
    BrowserFS.initialize(mfs);
    var BFS = new BrowserFS.EmscriptenFS(Module.FS, Module.PATH, Module.ERRNO_CODES);

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -155,7 +155,6 @@ function idbfsSyncComplete()
    $('#icnLocal').addClass('fa-check');
    console.log("WEBPLAYER: idbfs setup successful");
 
-   setupFileSystem("browser");
    appInitialized();
 }
 

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -185,7 +185,7 @@ var zipTOC;
 
 function zipfsInit() {
   // 256 MB max bundle size
-  let buffer = new ArrayBuffer(0, {maxByteLength: 256*1024*1024});
+  let buffer = new ArrayBuffer(256*1024*1024);
   let bufferView = new Uint8Array(buffer);
   let idx = 0;
   // bundle should be in four parts (this can be changed later)
@@ -199,11 +199,10 @@ function zipfsInit() {
         if (idx+buf.byteLength > buffer.maxByteLength) {
           console.log("WEBPLAYER: error: bundle.zip is too large");
         }
-        buffer.resize(idx + buf.byteLength);
         bufferView.set(new Uint8Array(buf), idx, buf.byteLength);
         idx += buf.byteLength;
       }
-      BrowserFS.FileSystem.ZipFS.computeIndex(BrowserFS.BFSRequire('buffer').Buffer(buffer), function(toc) {
+      BrowserFS.FileSystem.ZipFS.computeIndex(BrowserFS.BFSRequire('buffer').Buffer(new Uint8Array(buffer, 0, idx)), function(toc) {
         zipTOC = toc;
         appInitialized();
       });

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -209,7 +209,7 @@ function setupFileSystem(backend)
    console.log("WEBPLAYER: initializing filesystem: " + backend);
    mfs.mount('/home/web_user/retroarch/userdata', afs);
 
-   mfs.mount('/home/web_user/retroarch/assets/frontend/', xfs1);
+   mfs.mount('/home/web_user/retroarch/', xfs1);
    mfs.mount('/home/web_user/retroarch/userdata/content/downloads', xfs2);
    BrowserFS.initialize(mfs);
    var BFS = new BrowserFS.EmscriptenFS(Module.FS, Module.PATH, Module.ERRNO_CODES);


### PR DESCRIPTION
This resolves #15860 and makes the first-time use of web.libretro.com a hundred times faster.  Instead of making 400 requests one at a time (because of limitations in browserfs's synchronous XHR implementation) for a total of 5MB, it makes one request for the 100MB asset bundle.  That request takes about a second instead of over three minutes for individual assets (from 300 seconds to 3 seconds).

Now, there is one major problem:  The zip file is too large for browsers to want to cache.  I introduced a quick fix of splitting the zip into partfiles using `split -b 30M bundle.zip bundle.zip.` and concatenated the downloaded buffers on the client.  Notably this means they can download in parallel which is kind of cool.

So, this adds two steps to the build process:

```
zip -r9 bundle.zip bundle
split -b 30M bundle.zip bundle.zip.
```

If those steps are added (they can be added without breaking the current web player) then we can deploy this change to drastically speed up the first-time experience of web.libretro.com.  We can also remove the indexing step for the frontend assets.

The overall package size could also be reduced if overlays, shaders, themes, BGM.wav, or database files weren't required for retroarch web builds, but I wanted to see how far we could get without removing any files.  The answer is: most of the way there.

I think this also speeds up subsequent boots of retroarch web from about 7 seconds to about 1 second.