### PR TITLE
reinitialize rewind buffer after loading game with achievements

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -586,6 +586,8 @@ static void rcheevos_progress_hide(rcheevos_locals_t* locals)
       gfx_widget_set_achievement_progress(NULL, NULL);
 }
 
+#endif
+
 static void rcheevos_client_log_message(const char* message, const rc_client_t* client)
 {
    CHEEVOS_LOG(RCHEEVOS_TAG "%s\n", message);
@@ -667,8 +669,6 @@ static void rcheevos_client_event_handler(const rc_client_event_t* event, rc_cli
       break;
    }
 }
-
-#endif
 
 int rcheevos_get_richpresence(char* s, size_t len)
 {

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2433,13 +2433,13 @@ static void rcheevos_client_load_game_callback(int result,
 #ifdef HAVE_THREADS
          if (!task_is_on_main_thread())
          {
-            /* Have to "schedule" this. CMD_EVENT_REWIND_INIT should
+            /* Have to "schedule" this. CMD_EVENT_REWIND_REINIT should
              * only be called on the main thread */
-            rcheevos_locals.queued_command = CMD_EVENT_REWIND_INIT;
+            rcheevos_locals.queued_command = CMD_EVENT_REWIND_REINIT;
          }
          else
 #endif
-            command_event(CMD_EVENT_REWIND_INIT, NULL);
+            command_event(CMD_EVENT_REWIND_REINIT, NULL);
       }
 #endif
    }
@@ -3144,6 +3144,7 @@ bool rcheevos_load(const void *data)
    {
       rcheevos_enforce_hardcore_settings();
    }
+#ifndef HAVE_RC_CLIENT
    else
    {
 #if HAVE_REWIND
@@ -3167,6 +3168,7 @@ bool rcheevos_load(const void *data)
       }
 #endif
    }
+#endif
 
    /* provide hooks for reading files */
    rc_hash_reset_cdreader_hooks();

--- a/command.h
+++ b/command.h
@@ -88,6 +88,8 @@ enum event_command
    CMD_EVENT_REWIND_DEINIT,
    /* Initializes rewind. */
    CMD_EVENT_REWIND_INIT,
+   /* Reinitializes rewind (primarily if the state size changes). */
+   CMD_EVENT_REWIND_REINIT,
    /* Toggles rewind. */
    CMD_EVENT_REWIND_TOGGLE,
    /* Initializes autosave. */

--- a/retroarch.c
+++ b/retroarch.c
@@ -2997,6 +2997,17 @@ bool command_event(enum event_command cmd, void *data)
          }
 #endif
          break;
+      case CMD_EVENT_REWIND_REINIT:
+#ifdef HAVE_REWIND
+         /* to reinitialize the the rewind state manager, we have to recreate it.
+          * the easiest way to do that is a full deinit followed by an init. */
+         if (runloop_st->rewind_st.state != NULL)
+         {
+            command_event(CMD_EVENT_REWIND_DEINIT, NULL);
+            command_event(CMD_EVENT_REWIND_INIT, NULL);
+         }
+#endif
+         break;
       case CMD_EVENT_REWIND_TOGGLE:
 #ifdef HAVE_REWIND
          {


### PR DESCRIPTION
## Description

Fixes #15933.

Because the achievement state needs to be included in the rewind buffer, the rewind manager has to be reset after the achievements are loaded so it has the proper size of a per-frame state.

Prior to #15912 rewind was disabled after identifying the game being loaded, and then re-enabled after the game was loaded. Identifying the loaded game is an asynchronous call to the server, so rewind wouldn't be disabled immediately when the game was loaded. And when it was re-enabled, the per frame state size would include the achievement state.

With the changes in #15912, identifying the game is part of a library call to load a game, so rewind was being disabled earlier; too early. The achievement `rcheevos_load` handler is being called earlier in `content_init` than the rewind state initialization code, so rewind was getting re-enabled immediately and it was still enabled when the achievement code tried to re-enable it later. As a result, the rewind state manager was still expecting frames without achievement state, so when a frame was captured with achievement state, it was too big and the state manager would discard it.

Solution: Instead of disabling rewind when `rcheevos_load` is called, quickly toggle it off and back on once the achievements are loaded so the per-frame size is correct.

## Related Issues

#15933

## Related Pull Requests

n/a

## Reviewers

@Sanaki
