### PR TITLE
(XMB) Corrections and cleanups

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -66,7 +66,7 @@
 
 #define XMB_RIBBON_ROWS 64
 #define XMB_RIBBON_COLS 64
-#define XMB_RIBBON_VERTICES 2*XMB_RIBBON_COLS*XMB_RIBBON_ROWS-2*XMB_RIBBON_COLS
+#define XMB_RIBBON_VERTICES (XMB_RIBBON_ROWS * (2 * XMB_RIBBON_COLS)) - (2 * XMB_RIBBON_COLS)
 
 #define XMB_TAB_MAX_LENGTH 255
 
@@ -446,40 +446,43 @@ typedef struct xmb_handle
 } xmb_handle_t;
 
 static float xmb_scale_mod[8]   = {
-   1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f
+   1.0f, 1.0f, 1.0f, 1.0f,
+   1.0f, 1.0f, 1.0f, 1.0f
 };
 
-static float xmb_coord_shadow[]       = {
-   0.0f, 0.0f, 0.0f, 0.0f,
-   0.0f, 0.0f, 0.0f, 0.0f,
-   0.0f, 0.0f, 0.0f, 0.0f,
-   0.0f, 0.0f, 0.0f, 0.0f,
-};
-
-static float xmb_coord_black[]       = {
+static float xmb_coord_shadow[] = {
    0.0f, 0.0f, 0.0f, 0.0f,
    0.0f, 0.0f, 0.0f, 0.0f,
    0.0f, 0.0f, 0.0f, 0.0f,
    0.0f, 0.0f, 0.0f, 0.0f,
 };
 
-static float xmb_coord_white[]       = {
+static float xmb_coord_black[]  = {
+   0.0f, 0.0f, 0.0f, 0.0f,
+   0.0f, 0.0f, 0.0f, 0.0f,
+   0.0f, 0.0f, 0.0f, 0.0f,
+   0.0f, 0.0f, 0.0f, 0.0f,
+};
+
+static float xmb_coord_white[]  = {
    1.0f, 1.0f, 1.0f, 1.0f,
    1.0f, 1.0f, 1.0f, 1.0f,
    1.0f, 1.0f, 1.0f, 1.0f,
    1.0f, 1.0f, 1.0f, 1.0f,
 };
 
-static float xmb_item_color[]       = {
+static float xmb_item_color[]   = {
    1.0f, 1.0f, 1.0f, 1.0f,
    1.0f, 1.0f, 1.0f, 1.0f,
    1.0f, 1.0f, 1.0f, 1.0f,
    1.0f, 1.0f, 1.0f, 1.0f,
 };
 
-static INLINE float xmb_item_y(const xmb_handle_t *xmb, int i, size_t current)
+static INLINE float xmb_item_y(const xmb_handle_t *xmb,
+      int i, size_t current)
 {
    float icon_spacing_vertical = xmb->icon_spacing_vertical;
+
    if (i < (int)current)
    {
       if (xmb->depth > 1)
@@ -488,26 +491,25 @@ static INLINE float xmb_item_y(const xmb_handle_t *xmb, int i, size_t current)
    }
    else if (i == (int)current)
       return icon_spacing_vertical    * xmb->active_item_factor;
+
    return icon_spacing_vertical       * (i - (int)current + xmb->under_item_offset);
 }
-
 
 static void xmb_calculate_visible_range(const xmb_handle_t *xmb,
       unsigned height, size_t list_size, unsigned current,
       unsigned *first, unsigned *last)
 {
    unsigned j;
-   float    base_y = xmb->margins_screen_top;
+   float base_y    = xmb->margins_screen_top;
 
    *first          = 0;
    *last           = (unsigned)(list_size ? list_size - 1 : 0);
 
    if (current)
    {
-      for (j = current; j-- > 0; )
+      for (j = current; j-- > 0;)
       {
-         float bottom = xmb_item_y(xmb, j, current)
-            + base_y + xmb->icon_size;
+         float bottom = xmb_item_y(xmb, j, current) + base_y + xmb->icon_size;
 
          if (bottom < 0)
             break;
@@ -516,7 +518,7 @@ static void xmb_calculate_visible_range(const xmb_handle_t *xmb,
       }
    }
 
-   for (j = current+1; j < list_size; j++)
+   for (j = current + 1; j < list_size; j++)
    {
       float top = xmb_item_y(xmb, j, current) + base_y;
 
@@ -527,10 +529,9 @@ static void xmb_calculate_visible_range(const xmb_handle_t *xmb,
    }
 }
 
-
 const char* xmb_theme_ident(void)
 {
-   settings_t    *settings = config_get_ptr();
+   settings_t *settings    = config_get_ptr();
    unsigned menu_xmb_theme = settings->uints.menu_xmb_theme;
 
    switch (menu_xmb_theme)
@@ -609,7 +610,8 @@ static void xmb_free_node(xmb_node_t *node)
  */
 static void xmb_free_list_nodes(file_list_t *list, bool actiondata)
 {
-   unsigned i, size = list ? (unsigned)list->size : 0;
+   unsigned i;
+   unsigned size = list ? (unsigned)list->size : 0;
 
    for (i = 0; i < size; ++i)
    {
@@ -641,8 +643,8 @@ static float *xmb_gradient_ident(unsigned xmb_color_theme)
    static float gradient_golden[16]          = {
       174/255.0, 123/255.0,  44/255.0, 1.0,
       205/255.0, 174/255.0,  84/255.0, 1.0,
-      58/255.0,   43/255.0,  24/255.0, 1.0,
-      58/255.0,   43/255.0,  24/255.0, 1.0,
+       58/255.0,  43/255.0,  24/255.0, 1.0,
+       58/255.0,  43/255.0,  24/255.0, 1.0,
    };
    static float gradient_legacy_red[16]      = {
       171/255.0,  70/255.0,  59/255.0, 1.0,
@@ -651,122 +653,108 @@ static float *xmb_gradient_ident(unsigned xmb_color_theme)
       190/255.0,  80/255.0,  69/255.0, 1.0,
    };
    static float gradient_electric_blue[16]   = {
-      1/255.0,   2/255.0,  67/255.0, 1.0,
-      1/255.0,  73/255.0, 183/255.0, 1.0,
-      1/255.0,  93/255.0, 194/255.0, 1.0,
-      3/255.0, 162/255.0, 254/255.0, 1.0,
+        1/255.0,   2/255.0,  67/255.0, 1.0,
+        1/255.0,  73/255.0, 183/255.0, 1.0,
+        1/255.0,  93/255.0, 194/255.0, 1.0,
+        3/255.0, 162/255.0, 254/255.0, 1.0,
    };
    static float gradient_dark_purple[16]     = {
-      20/255.0,  13/255.0,  20/255.0, 1.0,
-      20/255.0,  13/255.0,  20/255.0, 1.0,
-      92/255.0,  44/255.0,  92/255.0, 1.0,
+       20/255.0,  13/255.0,  20/255.0, 1.0,
+       20/255.0,  13/255.0,  20/255.0, 1.0,
+       92/255.0,  44/255.0,  92/255.0, 1.0,
       148/255.0,  90/255.0, 148/255.0, 1.0,
    };
    static float gradient_midnight_blue[16]   = {
-      44/255.0, 62/255.0, 80/255.0, 1.0,
-      44/255.0, 62/255.0, 80/255.0, 1.0,
-      44/255.0, 62/255.0, 80/255.0, 1.0,
-      44/255.0, 62/255.0, 80/255.0, 1.0,
+       44/255.0,  62/255.0,  80/255.0, 1.0,
+       44/255.0,  62/255.0,  80/255.0, 1.0,
+       44/255.0,  62/255.0,  80/255.0, 1.0,
+       44/255.0,  62/255.0,  80/255.0, 1.0,
    };
-
    static float gradient_apple_green[16]     = {
       102/255.0, 134/255.0,  58/255.0, 1.0,
       122/255.0, 131/255.0,  52/255.0, 1.0,
-      82/255.0, 101/255.0,  35/255.0, 1.0,
-      63/255.0,  95/255.0,  30/255.0, 1.0,
+       82/255.0, 101/255.0,  35/255.0, 1.0,
+       63/255.0,  95/255.0,  30/255.0, 1.0,
    };
-
    static float gradient_undersea[16]        = {
-      23/255.0,  18/255.0,  41/255.0, 1.0,
-      30/255.0,  72/255.0, 114/255.0, 1.0,
-      52/255.0,  88/255.0, 110/255.0, 1.0,
-      69/255.0, 125/255.0, 140/255.0, 1.0,
-
+       23/255.0,  18/255.0,  41/255.0, 1.0,
+       30/255.0,  72/255.0, 114/255.0, 1.0,
+       52/255.0,  88/255.0, 110/255.0, 1.0,
+       69/255.0, 125/255.0, 140/255.0, 1.0,
    };
-
-   static float gradient_volcanic_red[16]    = {
-      1.0, 0.0, 0.1, 1.00,
-      1.0, 0.1, 0.0, 1.00,
-      0.1, 0.0, 0.1, 1.00,
-      0.1, 0.0, 0.1, 1.00,
-   };
-
-   static float gradient_dark[16]            = {
-      0.05, 0.05, 0.05, 1.00,
-      0.05, 0.05, 0.05, 1.00,
-      0.05, 0.05, 0.05, 1.00,
-      0.05, 0.05, 0.05, 1.00,
-   };
-
-   static float gradient_light[16]           = {
-      0.5, 0.5, 0.5, 1.00,
-      0.5, 0.5, 0.5, 1.00,
-      0.5, 0.5, 0.5, 1.00,
-      0.5, 0.5, 0.5, 1.00,
-   };
-
    static float gradient_morning_blue[16]    = {
-      221/255.0, 241/255.0, 254/255.0, 1.00,
-      135/255.0, 206/255.0, 250/255.0, 1.00,
-      0.7, 0.7, 0.7, 1.00,
-      170/255.0, 200/255.0, 252/255.0, 1.00,
+      221/255.0, 241/255.0, 254/255.0, 1.0,
+      135/255.0, 206/255.0, 250/255.0, 1.0,
+            0.7,       0.7,       0.7, 1.0,
+      170/255.0, 200/255.0, 252/255.0, 1.0,
    };
-
    static float gradient_sunbeam[16]         = {
-      20/255.0,  13/255.0,  20/255.0, 1.0,
-      30/255.0,  72/255.0, 114/255.0, 1.0,
-      0.7, 0.7, 0.7, 1.00,
-      0.1, 0.0, 0.1, 1.00,
+       20/255.0,  13/255.0,  20/255.0, 1.0,
+       30/255.0,  72/255.0, 114/255.0, 1.0,
+            0.7,       0.7,       0.7, 1.0,
+            0.1,       0.0,       0.1, 1.0,
    };
-
    static float gradient_lime_green[16]      = {
       209/255.0, 255/255.0,  82/255.0, 1.0,
       146/255.0, 232/255.0,  66/255.0, 1.0,
-      82/255.0, 101/255.0,  35/255.0, 1.0,
-      63/255.0,  95/255.0,  30/255.0, 1.0,
+       82/255.0, 101/255.0,  35/255.0, 1.0,
+       63/255.0,  95/255.0,  30/255.0, 1.0,
    };
-
    static float gradient_pikachu_yellow[16]  = {
-      63/255.0, 63/255.0,  1/255.0, 1.0,
-      174/255.0, 174/255.0,  1/255.0, 1.0,
-      191/255.0, 194/255.0,  1/255.0, 1.0,
-      254/255.0,  221/255.0,  3/255.0, 1.0,
+       63/255.0,  63/255.0,   1/255.0, 1.0,
+      174/255.0, 174/255.0,   1/255.0, 1.0,
+      191/255.0, 194/255.0,   1/255.0, 1.0,
+      254/255.0, 221/255.0,   3/255.0, 1.0,
    };
-
    static float gradient_gamecube_purple[16] = {
-      40/255.0, 20/255.0,  91/255.0, 1.0,
-      160/255.0, 140/255.0,  211/255.0, 1.0,
-      107/255.0, 92/255.0,  177/255.0, 1.0,
-      84/255.0,  71/255.0,  132/255.0, 1.0,
+       40/255.0,  20/255.0,  91/255.0, 1.0,
+      160/255.0, 140/255.0, 211/255.0, 1.0,
+      107/255.0,  92/255.0, 177/255.0, 1.0,
+       84/255.0,  71/255.0, 132/255.0, 1.0,
    };
-
    static float gradient_famicom_red[16]     = {
-      255/255.0, 191/255.0,  171/255.0, 1.0,
-      119/255.0, 49/255.0,  28/255.0, 1.0,
-      148/255.0, 10/255.0,  36/255.0, 1.0,
-      206/255.0,  126/255.0,  110/255.0, 1.0,
+      255/255.0, 191/255.0, 171/255.0, 1.0,
+      119/255.0,  49/255.0,  28/255.0, 1.0,
+      148/255.0,  10/255.0,  36/255.0, 1.0,
+      206/255.0, 126/255.0, 110/255.0, 1.0,
    };
-
    static float gradient_flaming_hot[16]     = {
-      231/255.0, 53/255.0,  53/255.0, 1.0,
+      231/255.0,  53/255.0,  53/255.0, 1.0,
       242/255.0, 138/255.0,  97/255.0, 1.0,
-      236/255.0, 97/255.0,  76/255.0, 1.0,
-      255/255.0,  125/255.0,  3/255.0, 1.0,
+      236/255.0,  97/255.0,  76/255.0, 1.0,
+      255/255.0, 125/255.0,   3/255.0, 1.0,
    };
-
    static float gradient_ice_cold[16]        = {
-      66/255.0, 183/255.0,  229/255.0, 1.0,
-      29/255.0, 164/255.0,  255/255.0, 1.0,
-      176/255.0, 255/255.0,  247/255.0, 1.0,
-      174/255.0,  240/255.0,  255/255.0, 1.0,
+       66/255.0, 183/255.0, 229/255.0, 1.0,
+       29/255.0, 164/255.0, 255/255.0, 1.0,
+      176/255.0, 255/255.0, 247/255.0, 1.0,
+      174/255.0, 240/255.0, 255/255.0, 1.0,
+   };
+   static float gradient_midgar[16]          = {
+      255/255.0,   0/255.0,   0/255.0, 1.0,
+        0/255.0,   0/255.0, 255/255.0, 1.0,
+        0/255.0, 255/255.0,   0/255.0, 1.0,
+       32/255.0,  32/255.0,  32/255.0, 1.0,
+   };
+   static float gradient_volcanic_red[16]    = {
+            1.0,       0.0,       0.1, 1.0,
+            1.0,       0.1,       0.0, 1.0,
+            0.1,       0.0,       0.1, 1.0,
+            0.1,       0.0,       0.1, 1.0,
+   };
+   static float gradient_dark[16]            = {
+           0.05,      0.05,      0.05, 1.0,
+           0.05,      0.05,      0.05, 1.0,
+           0.05,      0.05,      0.05, 1.0,
+           0.05,      0.05,      0.05, 1.0,
+   };
+   static float gradient_light[16]           = {
+            0.5,       0.5,       0.5, 1.0,
+            0.5,       0.5,       0.5, 1.0,
+            0.5,       0.5,       0.5, 1.0,
+            0.5,       0.5,       0.5, 1.0,
    };
 
-   static float gradient_midgar[16]          = {
-      255/255.0, 0/255.0,  0/255.0, 1.0,
-      0/255.0, 0/255.0,  255/255.0, 1.0,
-      0/255.0, 255/255.0,  0/255.0, 1.0,
-      32/255.0,  32/255.0,  32/255.0, 1.0,
-   };
    switch (xmb_color_theme)
    {
       case XMB_THEME_DARK_PURPLE:
@@ -822,7 +810,8 @@ static size_t xmb_list_get_selection(void *data)
    return xmb->categories_selection_ptr;
 }
 
-static size_t xmb_list_get_size(void *data, enum menu_list_type type)
+static size_t xmb_list_get_size(void *data,
+      enum menu_list_type type)
 {
    xmb_handle_t *xmb = (xmb_handle_t*)data;
 
@@ -830,8 +819,8 @@ static size_t xmb_list_get_size(void *data, enum menu_list_type type)
    {
       case MENU_LIST_PLAIN:
          {
-            struct menu_state   *menu_st   = menu_state_get_ptr();
-            menu_list_t *menu_list         = menu_st->entries.list;
+            struct menu_state *menu_st = menu_state_get_ptr();
+            menu_list_t *menu_list     = menu_st->entries.list;
             if (menu_list)
                return MENU_LIST_GET_STACK_SIZE(menu_list, 0);
          }
@@ -840,6 +829,8 @@ static size_t xmb_list_get_size(void *data, enum menu_list_type type)
          return xmb->horizontal_list.size;
       case MENU_LIST_TABS:
          return xmb->system_tab_end;
+      default:
+         break;
    }
 
    return 0;
@@ -848,8 +839,8 @@ static size_t xmb_list_get_size(void *data, enum menu_list_type type)
 static void *xmb_list_get_entry(void *data,
       enum menu_list_type type, unsigned i)
 {
-   size_t list_size = 0;
    xmb_handle_t *xmb = (xmb_handle_t*)data;
+   size_t list_size  = 0;
 
    switch (type)
    {
@@ -881,7 +872,7 @@ static void xmb_draw_icon(
       gfx_display_ctx_driver_t *dispctx,
       unsigned video_width,
       unsigned video_height,
-      bool xmb_shadows_enable,
+      bool shadows_enable,
       int icon_size,
       uintptr_t texture,
       float x,
@@ -898,11 +889,10 @@ static void xmb_draw_icon(
    gfx_display_ctx_draw_t draw;
    struct video_coords coords;
 
-   if (
-         (x < (-icon_size / 2.0f)) ||
-         (x > width)               ||
-         (y < (icon_size  / 2.0f)) ||
-         (y > height + icon_size)
+   if (     (x < (-icon_size / 2.0f))
+         || (x > width)
+         || (y < (icon_size  / 2.0f))
+         || (y > height + icon_size)
       )
       return;
 
@@ -925,7 +915,7 @@ static void xmb_draw_icon(
    draw.prim_type       = GFX_DISPLAY_PRIM_TRIANGLESTRIP;
    draw.pipeline_id     = 0;
 
-   if (xmb_shadows_enable)
+   if (shadows_enable)
    {
       gfx_display_set_alpha(xmb_coord_shadow, color[3] * GFX_SHADOW_ALPHA);
 
@@ -962,13 +952,16 @@ static void xmb_draw_icon(
 }
 
 static void xmb_draw_text(
-      bool xmb_shadows_enable,
+      bool shadows_enable,
       xmb_handle_t *xmb,
       settings_t *settings,
-      const char *str, float x,
-      float y, float scale_factor, float alpha,
+      const char *str,
+      float x, float y,
+      float scale_factor,
+      float alpha,
       enum text_alignment text_align,
-      unsigned width, unsigned height, font_data_t* font)
+      unsigned width, unsigned height,
+      font_data_t* font)
 {
    uint32_t color;
    uint8_t a8;
@@ -993,7 +986,7 @@ static void xmb_draw_text(
 
    gfx_display_draw_text(font, str, x, y,
          width, height, color, text_align, scale_factor,
-         xmb_shadows_enable,
+         shadows_enable,
          xmb->shadow_offset, false);
 }
 
@@ -1010,21 +1003,22 @@ static void xmb_render_messagebox_internal(
       gfx_display_ctx_driver_t *dispctx,
       unsigned video_width,
       unsigned video_height,
-      xmb_handle_t *xmb, const char *message,
+      xmb_handle_t *xmb,
+      const char *message,
       math_matrix_4x4 *mymat)
 {
-   unsigned i, y_position;
-   char wrapped_message[MENU_SUBLABEL_MAX_LENGTH];
-   int x, y, longest_width           = 0;
+   unsigned i, y_position            = 0;
+   int x, y                          = 0;
    float line_height                 = 0;
+   int longest_width                 = 0;
    int usable_width                  = 0;
    struct string_list list           = {0};
    bool input_dialog_display_kb      = false;
+   char wrapped_message[MENU_SUBLABEL_MAX_LENGTH];
 
    wrapped_message[0]                = '\0';
 
-   if ((usable_width =
-            (int)video_width - (xmb->margins_dialog * 8)) < 1)
+   if ((usable_width = (int)video_width - (xmb->margins_dialog * 8)) < 1)
       return;
 
    usable_width = (usable_width < 300) ? 300 : usable_width;
@@ -1048,21 +1042,18 @@ static void xmb_render_messagebox_internal(
 
    input_dialog_display_kb = menu_input_dialog_get_display_kb();
    line_height             = xmb->font->size * 1.30f;
-   y_position              = video_height / 2;
-   if (input_dialog_display_kb)
-      y_position           = video_height / 4;
-   x                       = video_width  / 2;
-   y                       = y_position - (list.size-1) * line_height / 2;
+   y_position              = (input_dialog_display_kb) ? video_height / 4 : video_height / 2;
+   x                       = video_width / 2;
+   y                       = y_position - (list.size - 1) * line_height / 2;
 
-   /* find the longest line width */
+   /* Find the longest line width */
    for (i = 0; i < list.size; i++)
    {
       const char *msg = list.elems[i].data;
 
       if (!string_is_empty(msg))
       {
-         int width    = font_driver_get_message_width(
-               xmb->font, msg, strlen(msg), 1.0f);
+         int width = font_driver_get_message_width(xmb->font, msg, strlen(msg), 1.0f);
          if (width > longest_width)
             longest_width = width;
          if (longest_width > (int)usable_width)
@@ -1078,11 +1069,11 @@ static void xmb_render_messagebox_internal(
          userdata,
          video_width,
          video_height,
-         x - longest_width/2 - xmb->margins_dialog,
+         x - (longest_width / 2) - xmb->margins_dialog,
          y + xmb->margins_slice - xmb->margins_dialog,
          256, 256,
-         longest_width + xmb->margins_dialog * 2,
-         line_height * list.size + xmb->margins_dialog * 2,
+         longest_width + (xmb->margins_dialog * 2),
+         (line_height * list.size) + (xmb->margins_dialog * 2),
          video_width, video_height,
          NULL,
          xmb->margins_slice, xmb->last_scale_factor,
@@ -1095,8 +1086,8 @@ static void xmb_render_messagebox_internal(
 
       if (msg)
          gfx_display_draw_text(xmb->font, msg,
-               x - longest_width/2.0,
-               y + (i + 0.85) * line_height,
+               x - (longest_width / 2.0),
+               y + ((i + 0.85) * line_height),
                video_width, video_height, 0x444444ff,
                TEXT_ALIGN_LEFT, 1.0f, false, 0.0f, false);
    }
@@ -1121,12 +1112,14 @@ static void xmb_render_messagebox_internal(
 
 static char* xmb_path_dynamic_wallpaper(xmb_handle_t *xmb)
 {
-   char path[PATH_MAX_LENGTH];
-   size_t len                         = 0;
-   char       *tmp                    = string_replace_substring(xmb->title_name, "/", STRLEN_CONST("/"), " ", STRLEN_CONST(" "));
    settings_t *settings               = config_get_ptr();
-   const char *dir_dynamic_wallpapers = settings->paths.directory_dynamic_wallpapers;
+   size_t len                         = 0;
    unsigned depth                     = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
+   const char *dir_dynamic_wallpapers = settings->paths.directory_dynamic_wallpapers;
+   const char *tmp                    = string_replace_substring(xmb->title_name, "/", STRLEN_CONST("/"), " ", STRLEN_CONST(" "));
+   char path[PATH_MAX_LENGTH];
+
+   path[0]                            = '\0';
 
    if (!settings->bools.menu_dynamic_wallpaper_enable)
    {
@@ -1137,14 +1130,11 @@ static char* xmb_path_dynamic_wallpaper(xmb_handle_t *xmb)
    }
 
    if (tmp)
-   {
       len = fill_pathname_join_special(
             path,
             dir_dynamic_wallpapers,
             tmp,
             sizeof(path));
-      free(tmp);
-   }
 
    path[  len] = '.';
    path[++len] = 'p';
@@ -1152,11 +1142,12 @@ static char* xmb_path_dynamic_wallpaper(xmb_handle_t *xmb)
    path[++len] = 'g';
    path[++len] = '\0';
 
-   /* Do not update wallpaper in "Load Content" playlists */
-   if ((xmb->categories_selection_ptr == 0 && depth > 4)
-        || (xmb->categories_selection_ptr > xmb->system_tab_end && depth > 1)) {
-	if (string_is_empty(xmb->bg_file_path))
-		return NULL;
+   /* Do not update wallpaper in "Load Content" playlists and inside playlist items */
+   if (    (xmb->categories_selection_ptr == 0 && depth > 4)
+        || (xmb->categories_selection_ptr > xmb->system_tab_end && depth > 1))
+   {
+      if (string_is_empty(xmb->bg_file_path))
+         return strdup(settings->paths.path_menu_wallpaper);
       return strdup(xmb->bg_file_path);
    }
 
@@ -1183,16 +1174,22 @@ static void xmb_update_dynamic_wallpaper(xmb_handle_t *xmb)
             free(xmb->bg_file_path);
          xmb->bg_file_path = strdup(path);
       }
+      else
+      {
+         if (xmb->bg_file_path)
+            free(xmb->bg_file_path);
+         xmb->bg_file_path = strdup("");
+      }
    }
 }
 
 static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
 {
-   settings_t *settings = config_get_ptr();
-   xmb_handle_t *xmb    = (xmb_handle_t*)data;
-   int state_slot       = settings->ints.state_slot;
-   bool savestate_thumbnail_enable
-                        = settings->bools.savestate_thumbnail_enable;
+   xmb_handle_t *xmb        = (xmb_handle_t*)data;
+   settings_t *settings     = config_get_ptr();
+   int state_slot           = settings->ints.state_slot;
+   bool savestate_thumbnail = settings->bools.savestate_thumbnail_enable;
+
    if (!xmb)
       return;
 
@@ -1214,7 +1211,7 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
 
    xmb->fullscreen_thumbnails_available = false;
 
-   if (savestate_thumbnail_enable)
+   if (savestate_thumbnail)
    {
       menu_entry_t entry;
 
@@ -1242,25 +1239,22 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
 
             if (state_slot < 0)
             {
-               path[0] = '\0';
+               path[0]            = '\0';
                _len = fill_pathname_join_delim(path,
                      runloop_st->name.savestate, "auto", '.', sizeof(path));
             }
             else
             {
-               _len = strlcpy(path,
-                     runloop_st->name.savestate, sizeof(path));
+               _len = strlcpy(path, runloop_st->name.savestate, sizeof(path));
                if (state_slot > 0)
-                  _len += snprintf(path + _len, sizeof(path) - _len, "%d",
-                        state_slot);
+                  _len += snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
             }
 
             strlcpy(path + _len, FILE_PATH_PNG_EXTENSION, sizeof(path) - _len);
 
             if (path_is_valid(path))
             {
-               strlcpy(
-                     xmb->savestate_thumbnail_file_path, path,
+               strlcpy(xmb->savestate_thumbnail_file_path, path,
                      sizeof(xmb->savestate_thumbnail_file_path));
 
                xmb->fullscreen_thumbnails_available = true;
@@ -1299,27 +1293,23 @@ static void xmb_update_thumbnail_image(void *data)
    if (string_is_equal(core_name, "imageviewer"))
    {
       /* Right thumbnail */
-      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data,
-            GFX_THUMBNAIL_RIGHT))
+      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
          xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_RIGHT;
       /* Left thumbnail */
-      else if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data,
-            GFX_THUMBNAIL_LEFT))
+      else if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
          xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_LEFT;
    }
    else
    {
       /* Right thumbnail */
-      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data,
-            GFX_THUMBNAIL_RIGHT))
+      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
          xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_RIGHT;
 
       /* Left thumbnail */
-      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data,
-            GFX_THUMBNAIL_LEFT))
+      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
          xmb->thumbnails.pending =
-               (xmb->thumbnails.pending == XMB_PENDING_THUMBNAIL_RIGHT) ?
-                     XMB_PENDING_THUMBNAIL_BOTH : XMB_PENDING_THUMBNAIL_LEFT;
+               (xmb->thumbnails.pending == XMB_PENDING_THUMBNAIL_RIGHT)
+                     ? XMB_PENDING_THUMBNAIL_BOTH : XMB_PENDING_THUMBNAIL_LEFT;
    }
 }
 
@@ -1334,7 +1324,7 @@ static unsigned xmb_get_horizontal_selection_type(xmb_handle_t *xmb)
 {
    if (xmb->categories_selection_ptr > xmb->system_tab_end)
    {
-      size_t i = xmb->categories_selection_ptr - xmb->system_tab_end-1;
+      size_t i = xmb->categories_selection_ptr - xmb->system_tab_end - 1;
       return xmb->horizontal_list.list[i].type;
    }
    return 0;
@@ -1349,9 +1339,10 @@ static void xmb_refresh_thumbnail_image(void *data, unsigned i)
       return;
 
    /* Only refresh thumbnails if thumbnails are enabled */
-   if (   (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
-        || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
-        && (xmb->is_quick_menu || xmb->is_playlist || xmb->is_explore_list))
+   if (     (xmb->is_quick_menu || xmb->is_playlist || xmb->is_explore_list)
+         && (  gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
+            || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+      )
       xmb_update_thumbnail_image(xmb);
 }
 
@@ -1391,11 +1382,11 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
       /* Playlist content */
       if (string_is_empty(s))
       {
-         menu_list_t *menu_list       = menu_st->entries.list;
-         size_t list_size             = (unsigned)MENU_LIST_GET_SELECTION(menu_list, 0)->size;
-         file_list_t *list            = MENU_LIST_GET_SELECTION(menu_list, 0);
-         bool playlist_valid          = false;
-         size_t playlist_index        = selection;
+         menu_list_t *menu_list = menu_st->entries.list;
+         size_t list_size       = (unsigned)MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+         file_list_t *list      = MENU_LIST_GET_SELECTION(menu_list, 0);
+         bool playlist_valid    = false;
+         size_t playlist_index  = selection;
 
          /* Get playlist index corresponding
           * to the selected entry */
@@ -1483,10 +1474,9 @@ static void xmb_set_thumbnail_content(void *data, const char *s)
 
 static void xmb_update_savestate_thumbnail_image(void *data)
 {
-   xmb_handle_t *xmb    = (xmb_handle_t*)data;
-   settings_t *settings = config_get_ptr();
-   unsigned thumbnail_upscale_threshold
-                        = settings->uints.gfx_thumbnail_upscale_threshold;
+   xmb_handle_t *xmb          = (xmb_handle_t*)data;
+   settings_t *settings       = config_get_ptr();
+   unsigned upscale_threshold = settings->uints.gfx_thumbnail_upscale_threshold;
 
    if (!xmb || xmb->skip_thumbnail_reset)
       return;
@@ -1499,12 +1489,12 @@ static void xmb_update_savestate_thumbnail_image(void *data)
       /* Only request thumbnail if:
        * > Thumbnail has never been loaded *OR*
        * > Thumbnail path has changed */
-      if ((xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN) ||
-          !string_is_equal(xmb->savestate_thumbnail_file_path, xmb->prev_savestate_thumbnail_file_path))
+      if (     (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
+            || !string_is_equal(xmb->savestate_thumbnail_file_path, xmb->prev_savestate_thumbnail_file_path))
          gfx_thumbnail_request_file(
                xmb->savestate_thumbnail_file_path,
                &xmb->thumbnails.savestate,
-               thumbnail_upscale_threshold);
+               upscale_threshold);
    }
 
    xmb->thumbnails.savestate.flags |= GFX_THUMB_FLAG_CORE_ASPECT;
@@ -1515,18 +1505,17 @@ static void xmb_selection_pointer_changed(
       xmb_handle_t *xmb, bool allow_animations)
 {
    unsigned i, end, height;
-   uintptr_t tag;
    size_t num                 = 0;
    int threshold              = 0;
    struct menu_state *menu_st = menu_state_get_ptr();
    menu_list_t *menu_list     = menu_st->entries.list;
    file_list_t *selection_buf = MENU_LIST_GET_SELECTION(menu_list, 0);
+   uintptr_t tag              = (uintptr_t)selection_buf;
    size_t selection           = menu_st->selection_ptr;
-   settings_t       *settings = config_get_ptr();
-   unsigned menu_xmb_animation_move_up_down
-                              = settings->uints.menu_xmb_animation_move_up_down;
+   settings_t *settings       = config_get_ptr();
+   unsigned anim_move_up_down = settings->uints.menu_xmb_animation_move_up_down;
 
-   if (menu_xmb_animation_move_up_down > 1)
+   if (anim_move_up_down > 1)
       allow_animations = false;
 
    if (!xmb)
@@ -1534,12 +1523,9 @@ static void xmb_selection_pointer_changed(
 
    end                        = (unsigned)MENU_LIST_GET_SELECTION(menu_list, 0)->size;
    threshold                  = xmb->icon_size * 10;
+   menu_st->entries.begin     = num;
 
    video_driver_get_size(NULL, &height);
-
-   tag                    = (uintptr_t)selection_buf;
-   gfx_animation_kill_by_tag(&tag);
-   menu_st->entries.begin = num;
 
    for (i = 0; i < end; i++)
    {
@@ -1551,12 +1537,12 @@ static void xmb_selection_pointer_changed(
       if (!node)
          continue;
 
-      iy      = xmb_item_y(xmb, i, selection);
-      real_iy = iy + xmb->margins_screen_top;
+      iy               = xmb_item_y(xmb, i, selection);
+      real_iy          = iy + xmb->margins_screen_top;
 
       if (i == selection)
       {
-         unsigned     depth      = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
+         unsigned depth          = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
          unsigned xmb_system_tab = xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr);
 
          /* Update entry index text */
@@ -1585,17 +1571,13 @@ static void xmb_selection_pointer_changed(
          ia                      = xmb->items_active_alpha;
          iz                      = xmb->items_active_zoom;
 
-         if (
-                  gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
-               || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
-            )
+         if (     gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
+               || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
          {
             bool update_thumbnails = false;
 
             /* Playlist updates */
-            if ((  (xmb_system_tab > XMB_SYSTEM_TAB_SETTINGS && depth == 1)
-                || (xmb_system_tab < XMB_SYSTEM_TAB_SETTINGS && depth == 4))
-                &&  xmb->is_playlist)
+            if (xmb->is_playlist)
             {
                xmb_set_thumbnail_content(xmb, NULL);
                update_thumbnails = true;
@@ -1621,8 +1603,8 @@ static void xmb_selection_pointer_changed(
                menu_entry_get(&entry, 0, selection, NULL, true);
                entry_type               = entry.type;
 
-               if (  (entry_type == FILE_TYPE_IMAGEVIEWER) ||
-                     (entry_type == FILE_TYPE_IMAGE))
+               if (     (entry_type == FILE_TYPE_IMAGEVIEWER)
+                     || (entry_type == FILE_TYPE_IMAGE))
                {
                   xmb_set_thumbnail_content(xmb, "imageviewer");
                   update_thumbnails = true;
@@ -1669,15 +1651,15 @@ static void xmb_selection_pointer_changed(
          anim_entry.tag          = tag;
          anim_entry.cb           = NULL;
 
-         switch (menu_xmb_animation_move_up_down)
+         switch (anim_move_up_down)
          {
             case 0:
-               anim_entry.duration     = XMB_DELAY;
-               anim_entry.easing_enum  = EASING_OUT_QUAD;
+               anim_entry.duration    = XMB_DELAY;
+               anim_entry.easing_enum = EASING_OUT_QUAD;
                break;
             case 1:
-               anim_entry.duration     = XMB_DELAY * 4;
-               anim_entry.easing_enum  = EASING_OUT_EXPO;
+               anim_entry.duration    = XMB_DELAY * 4;
+               anim_entry.easing_enum = EASING_OUT_EXPO;
                break;
          }
 
@@ -1704,10 +1686,10 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
       file_list_t *list, int dir, size_t current)
 {
    unsigned i, height;
-   int        threshold           = xmb->icon_size    * 10;
-   size_t           end           = list ? list->size : 0;
-   settings_t           *settings = config_get_ptr();
-   bool menu_horizontal_animation = settings->bools.menu_horizontal_animation;
+   int threshold             = xmb->icon_size    * 10;
+   size_t end                = list ? list->size : 0;
+   settings_t *settings      = config_get_ptr();
+   bool horizontal_animation = settings->bools.menu_horizontal_animation;
 
    video_driver_get_size(NULL, &height);
 
@@ -1727,7 +1709,7 @@ static void xmb_list_open_old(xmb_handle_t *xmb,
 
       real_y = node->y + xmb->margins_screen_top;
 
-      if (     !menu_horizontal_animation
+      if (     !horizontal_animation
             || real_y < -threshold
             || real_y > height + threshold)
       {
@@ -1768,13 +1750,13 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       file_list_t *list, int dir, size_t current)
 {
    unsigned i, height;
-   size_t skip                     = 0;
-   int threshold                   = xmb->icon_size * 10;
-   size_t end                      = list ? list->size : 0;
-   settings_t *settings            = config_get_ptr();
-   struct menu_state *menu_st      = menu_state_get_ptr();
-   bool menu_horizontal_animation  = settings->bools.menu_horizontal_animation;
-   bool savestate_thumbnail_enable = settings->bools.savestate_thumbnail_enable;
+   size_t skip                = 0;
+   int threshold              = xmb->icon_size * 10;
+   size_t end                 = list ? list->size : 0;
+   settings_t *settings       = config_get_ptr();
+   struct menu_state *menu_st = menu_state_get_ptr();
+   bool horizontal_animation  = settings->bools.menu_horizontal_animation;
+   bool savestate_thumbnail   = settings->bools.savestate_thumbnail_enable;
 
    video_driver_get_size(NULL, &height);
 
@@ -1813,7 +1795,7 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       else
          ia          = xmb->items_passive_alpha;
 
-      if (     !menu_horizontal_animation
+      if (     !horizontal_animation
             || real_y < -threshold
             || real_y > height + threshold)
       {
@@ -1866,7 +1848,7 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       }
    }
 
-   if (        savestate_thumbnail_enable
+   if (        savestate_thumbnail
           && ((xmb->is_quick_menu && xmb->depth >= 2)
           ||  (xmb->is_state_slot)))
    {
@@ -1898,8 +1880,7 @@ static xmb_node_t *xmb_node_allocate_userdata(
       node->zoom    = xmb->categories_active_zoom;
    }
 
-   tmp = (xmb_node_t*)file_list_get_userdata_at_offset(
-         &xmb->horizontal_list, i);
+   tmp = (xmb_node_t*)file_list_get_userdata_at_offset(&xmb->horizontal_list, i);
    xmb_free_node(tmp);
 
    xmb->horizontal_list.list[i].userdata = node;
@@ -1910,18 +1891,17 @@ static xmb_node_t *xmb_node_allocate_userdata(
 static xmb_node_t* xmb_get_userdata_from_horizontal_list(
       xmb_handle_t *xmb, unsigned i)
 {
-   return (xmb_node_t*)
-      file_list_get_userdata_at_offset(&xmb->horizontal_list, i);
+   return (xmb_node_t*)file_list_get_userdata_at_offset(&xmb->horizontal_list, i);
 }
 
 static void xmb_push_animations(xmb_node_t *node,
       uintptr_t tag, float ia, float ix)
 {
    gfx_animation_ctx_entry_t anim_entry;
-   settings_t *settings           = config_get_ptr();
-   bool menu_horizontal_animation = settings->bools.menu_horizontal_animation;
+   settings_t *settings      = config_get_ptr();
+   bool horizontal_animation = settings->bools.menu_horizontal_animation;
 
-   if (!menu_horizontal_animation)
+   if (!horizontal_animation)
    {
       node->alpha = node->label_alpha = ia;
       node->x     = ix;
@@ -1955,14 +1935,13 @@ static void xmb_list_switch_old(xmb_handle_t *xmb,
 {
    unsigned i, height;
    size_t end          = list ? list->size : 0;
-   float ix            = -xmb->icon_spacing_horizontal * dir;
-   float ia            = 0;
    unsigned first      = 0;
    unsigned last       = (unsigned)(end > 0 ? end - 1 : 0);
+   float ix            = -xmb->icon_spacing_horizontal * dir;
+   float ia            = 0;
 
    video_driver_get_size(NULL, &height);
-   xmb_calculate_visible_range(xmb, height, end,
-         (unsigned)current, &first, &last);
+   xmb_calculate_visible_range(xmb, height, end, (unsigned)current, &first, &last);
 
    for (i = 0; i < end; i++)
    {
@@ -1985,18 +1964,17 @@ static void xmb_list_switch_new(xmb_handle_t *xmb,
       file_list_t *list, int dir, size_t current)
 {
    unsigned i, height;
-   unsigned last  = 0;
-   unsigned first = 0;
-   size_t end     = 0;
+   unsigned last       = 0;
+   unsigned first      = 0;
+   size_t end          = 0;
 
    if (list)
-      end         = list->size;
+      end              = list->size;
    if (end > 0)
-      last        = (unsigned)(end - 1);
+      last             = (unsigned)(end - 1);
 
    video_driver_get_size(NULL, &height);
-   xmb_calculate_visible_range(xmb, height,
-         end, (unsigned)current, &first, &last);
+   xmb_calculate_visible_range(xmb, height, end, (unsigned)current, &first, &last);
 
    for (i = 0; i < end; i++)
    {
@@ -2027,9 +2005,9 @@ static void xmb_set_title(xmb_handle_t *xmb)
 {
    xmb->title_name_alt[0] = '\0';
 
-   if (xmb->categories_selection_ptr <= xmb->system_tab_end ||
-         (xmb->is_quick_menu && !menu_is_running_quick_menu()) ||
-         xmb->depth > 1)
+   if (     (xmb->categories_selection_ptr <= xmb->system_tab_end)
+         || (xmb->is_quick_menu && !menu_is_running_quick_menu())
+         || (xmb->depth > 1))
       menu_entries_get_title(xmb->title_name, sizeof(xmb->title_name));
    else
    {
@@ -2043,8 +2021,7 @@ static void xmb_set_title(xmb_handle_t *xmb)
          return;
 
       /* Use real title for dynamic backgrounds */
-      fill_pathname_base(
-            xmb->title_name, path, sizeof(xmb->title_name));
+      fill_pathname_base(xmb->title_name, path, sizeof(xmb->title_name));
       path_remove_extension(xmb->title_name);
 
       /* Set alternative title for visible header */
@@ -2108,9 +2085,9 @@ static void xmb_list_switch_horizontal_list(xmb_handle_t *xmb)
    settings_t *settings           = config_get_ptr();
    size_t list_size               = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL)
          + xmb->system_tab_end;
-   bool menu_horizontal_animation = settings->bools.menu_horizontal_animation;
-   unsigned xmb_animation_horizontal_highlight =
-         settings->uints.menu_xmb_animation_horizontal_highlight;
+   bool horizontal_animation      = settings->bools.menu_horizontal_animation;
+   unsigned animation_horizontal_highlight
+                                  = settings->uints.menu_xmb_animation_horizontal_highlight;
 
    for (j = 0; j <= list_size; j++)
    {
@@ -2129,7 +2106,7 @@ static void xmb_list_switch_horizontal_list(xmb_handle_t *xmb)
       }
 
       if (     !xmb->allow_horizontal_animation
-            || !menu_horizontal_animation)
+            || !horizontal_animation)
       {
          node->alpha = ia;
          node->zoom  = iz;
@@ -2143,7 +2120,7 @@ static void xmb_list_switch_horizontal_list(xmb_handle_t *xmb)
       entry.tag          = -1;
       entry.cb           = NULL;
 
-      switch (xmb_animation_horizontal_highlight)
+      switch (animation_horizontal_highlight)
       {
          case 0:
             entry.duration     = XMB_DELAY;
@@ -2187,43 +2164,42 @@ static void xmb_tab_set_selection(void *data)
 static void xmb_list_switch(xmb_handle_t *xmb)
 {
    gfx_animation_ctx_entry_t anim_entry;
+   settings_t *settings             = config_get_ptr();
    struct menu_state *menu_st       = menu_state_get_ptr();
    menu_list_t *menu_list           = menu_st->entries.list;
-   int dir                          = -1;
    file_list_t *selection_buf       = MENU_LIST_GET_SELECTION(menu_list, 0);
    size_t selection                 = 0;
-   settings_t       *settings       = config_get_ptr();
-   bool xmb_main_tab_selected       = false;
-   bool menu_horizontal_animation   = settings->bools.menu_horizontal_animation;
+   int dir                          = -1;
    unsigned remember_selection_type = settings->uints.menu_remember_selection;
    unsigned xmb_system_tab          = xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr);
+   bool xmb_main_tab_selected       = false;
+   bool horizontal_animation        = settings->bools.menu_horizontal_animation;
 
-   if (    xmb->categories_selection_ptr
-         > xmb->categories_selection_ptr_old)
+   if (xmb->categories_selection_ptr > xmb->categories_selection_ptr_old)
       dir = 1;
 
    xmb->categories_active_idx += dir;
 
-   if ((xmb_system_tab == XMB_SYSTEM_TAB_MAIN) || (xmb_system_tab == XMB_SYSTEM_TAB_SETTINGS))
+   if (     (xmb_system_tab == XMB_SYSTEM_TAB_MAIN)
+         || (xmb_system_tab == XMB_SYSTEM_TAB_SETTINGS))
       xmb_main_tab_selected = true;
 
    /* Restore last selection per tab */
-   if    ((remember_selection_type == MENU_REMEMBER_SELECTION_ALWAYS)
-      || ((remember_selection_type == MENU_REMEMBER_SELECTION_PLAYLISTS) && (xmb->is_playlist))
-      || ((remember_selection_type == MENU_REMEMBER_SELECTION_MAIN) && (xmb_main_tab_selected)))
+   if (      (remember_selection_type == MENU_REMEMBER_SELECTION_ALWAYS)
+         || ((remember_selection_type == MENU_REMEMBER_SELECTION_PLAYLISTS) && (xmb->is_playlist))
+         || ((remember_selection_type == MENU_REMEMBER_SELECTION_MAIN) && (xmb_main_tab_selected)))
       xmb_tab_set_selection(xmb);
 
    /* Selection needs to be taken after tab restore */
-   selection               = menu_st->selection_ptr;
+   selection = menu_st->selection_ptr;
 
    xmb_list_switch_horizontal_list(xmb);
 
    /* Horizontal tab icon scroll */
-   if (menu_horizontal_animation)
+   if (horizontal_animation)
    {
       anim_entry.duration     = XMB_DELAY;
-      anim_entry.target_value = xmb->icon_spacing_horizontal
-         * -(float)xmb->categories_selection_ptr;
+      anim_entry.target_value = xmb->icon_spacing_horizontal * -(float)xmb->categories_selection_ptr;
       anim_entry.subject      = &xmb->categories_x_pos;
       anim_entry.easing_enum  = XMB_EASING_XY;
       /* TODO/FIXME - integer conversion resulted in change of sign */
@@ -2235,20 +2211,17 @@ static void xmb_list_switch(xmb_handle_t *xmb)
    }
    else
    {
-      xmb->categories_x_pos = xmb->icon_spacing_horizontal
-         * -(float)xmb->categories_selection_ptr;
+      xmb->categories_x_pos = xmb->icon_spacing_horizontal * -(float)xmb->categories_selection_ptr;
    }
 
-   dir                     = -1;
-   if (    xmb->categories_selection_ptr
-         > xmb->categories_selection_ptr_old)
+   dir = -1;
+   if (xmb->categories_selection_ptr > xmb->categories_selection_ptr_old)
       dir = 1;
 
-   xmb_list_switch_old(xmb, &xmb->selection_buf_old,
-         dir, xmb->selection_ptr_old);
+   xmb_list_switch_old(xmb, &xmb->selection_buf_old, dir, xmb->selection_ptr_old);
 
    /* Check if we are to have horizontal animations. */
-   if (menu_horizontal_animation)
+   if (horizontal_animation)
       xmb_list_switch_new(xmb, selection_buf, dir, selection);
 
    xmb->categories_active_idx_old = (unsigned)xmb->categories_selection_ptr;
@@ -2269,8 +2242,7 @@ static void xmb_list_switch(xmb_handle_t *xmb)
 static void xmb_list_open_horizontal_list(xmb_handle_t *xmb, bool animate)
 {
    unsigned j;
-   size_t list_size = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL)
-      + xmb->system_tab_end;
+   size_t list_size = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL) + xmb->system_tab_end;
 
    for (j = 0; j <= list_size; j++)
    {
@@ -2300,7 +2272,7 @@ static void xmb_list_open_horizontal_list(xmb_handle_t *xmb, bool animate)
             gfx_animation_push(&anim_entry);
       }
       else
-         node->alpha = ia;
+         node->alpha             = ia;
    }
 }
 
@@ -2318,8 +2290,7 @@ static void xmb_context_destroy_horizontal_list(xmb_handle_t *xmb)
          continue;
       if (!(path = xmb->horizontal_list.list[i].path))
          continue;
-      if (string_ends_with_size(path, ".lpl",
-               strlen(path), STRLEN_CONST(".lpl")))
+      if (string_ends_with_size(path, ".lpl", strlen(path), STRLEN_CONST(".lpl")))
       {
          video_driver_texture_unload(&node->icon);
          video_driver_texture_unload(&node->content_icon);
@@ -2330,18 +2301,17 @@ static void xmb_context_destroy_horizontal_list(xmb_handle_t *xmb)
 static void xmb_init_horizontal_list(xmb_handle_t *xmb)
 {
    menu_displaylist_info_t info;
-   settings_t *settings              = config_get_ptr();
-   const char *dir_playlist          = settings->paths.directory_playlist;
-   bool menu_content_show_playlists  = settings->bools.menu_content_show_playlists;
-   bool ozone_truncate_playlist_name = settings->bools.ozone_truncate_playlist_name;
-   bool ozone_sort_after_truncate    = settings->bools.ozone_sort_after_truncate_playlist_name;
+   settings_t *settings             = config_get_ptr();
+   const char *dir_playlist         = settings->paths.directory_playlist;
+   bool menu_content_show_playlists = settings->bools.menu_content_show_playlists;
+   bool truncate_playlist_name      = settings->bools.ozone_truncate_playlist_name;
+   bool sort_after_truncate         = settings->bools.ozone_sort_after_truncate_playlist_name;
 
    menu_displaylist_info_init(&info);
 
    info.list                        = &xmb->horizontal_list;
    info.path                        = strdup(dir_playlist);
-   info.label                       = strdup(
-         msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB));
+   info.label                       = strdup(msg_hash_to_str(MENU_ENUM_LABEL_PLAYLISTS_TAB));
    info.exts                        = strldup("lpl", sizeof("lpl"));
    info.type_default                = FILE_TYPE_PLAIN;
    info.enum_idx                    = MENU_ENUM_LABEL_PLAYLISTS_TAB;
@@ -2350,9 +2320,7 @@ static void xmb_init_horizontal_list(xmb_handle_t *xmb)
    {
       size_t i;
 
-      if (menu_displaylist_ctl(
-               DISPLAYLIST_DATABASE_PLAYLISTS_HORIZONTAL, &info,
-               settings))
+      if (menu_displaylist_ctl(DISPLAYLIST_DATABASE_PLAYLISTS_HORIZONTAL, &info, settings))
       {
          for (i = 0; i < xmb->horizontal_list.size; i++)
             xmb_node_allocate_userdata(xmb, (unsigned)i);
@@ -2373,8 +2341,7 @@ static void xmb_init_horizontal_list(xmb_handle_t *xmb)
          }
 
          /* Remove extension */
-         fill_pathname_base(playlist_file_noext,
-               playlist_file, sizeof(playlist_file_noext));
+         fill_pathname_base(playlist_file_noext, playlist_file, sizeof(playlist_file_noext));
          path_remove_extension(playlist_file_noext);
 
          console_name = playlist_file_noext;
@@ -2383,7 +2350,7 @@ static void xmb_init_horizontal_list(xmb_handle_t *xmb)
           * > Format: "Vendor - Console"
               Remove everything before the hyphen
               and the subsequent space */
-         if (ozone_truncate_playlist_name)
+         if (truncate_playlist_name)
          {
             bool hyphen_found = false;
 
@@ -2413,9 +2380,9 @@ static void xmb_init_horizontal_list(xmb_handle_t *xmb)
 
       /* If playlist names were truncated and option is
        * enabled, re-sort list by console name */
-      if (ozone_truncate_playlist_name &&
-          ozone_sort_after_truncate &&
-          (xmb->horizontal_list.size > 0))
+      if (     truncate_playlist_name
+            && sort_after_truncate
+            && xmb->horizontal_list.size > 0)
          file_list_sort_on_alt(&xmb->horizontal_list);
    }
 
@@ -2425,8 +2392,7 @@ static void xmb_init_horizontal_list(xmb_handle_t *xmb)
 static void xmb_toggle_horizontal_list(xmb_handle_t *xmb)
 {
    unsigned i;
-   size_t list_size = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL)
-      + xmb->system_tab_end;
+   size_t list_size = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL) + xmb->system_tab_end;
 
    for (i = 0; i <= list_size; i++)
    {
@@ -2435,35 +2401,32 @@ static void xmb_toggle_horizontal_list(xmb_handle_t *xmb)
       if (!node)
          continue;
 
-      node->alpha    = 0;
-      node->zoom     = xmb->categories_passive_zoom;
+      node->alpha      = 0;
+      node->zoom       = xmb->categories_passive_zoom;
 
       if (i == xmb->categories_active_idx)
       {
-         node->alpha = xmb->categories_active_alpha;
-         node->zoom  = xmb->categories_active_zoom;
+         node->alpha   = xmb->categories_active_alpha;
+         node->zoom    = xmb->categories_active_zoom;
       }
       else if (xmb->depth <= 1)
-         node->alpha = xmb->categories_passive_alpha;
+         node->alpha   = xmb->categories_passive_alpha;
    }
 }
 
-static void xmb_context_reset_horizontal_list(
-      xmb_handle_t *xmb)
+static void xmb_context_reset_horizontal_list(xmb_handle_t *xmb)
 {
    unsigned i;
    char iconpath[PATH_MAX_LENGTH];
    char icons_path_default[PATH_MAX_LENGTH];
    int depth                       = 1; /* keep this integer */
-   size_t list_size                =
-      xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL);
+   size_t list_size                = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL);
 
-   xmb->categories_x_pos           =
-      xmb->icon_spacing_horizontal *
-      -(float)xmb->categories_selection_ptr;
+   xmb->categories_x_pos           = xmb->icon_spacing_horizontal * -(float)xmb->categories_selection_ptr;
 
    if (xmb->depth > 1)
       depth++;
+
    xmb->x                          = xmb->icon_size * -(depth * 2 - 2);
 
    RHMAP_FREE(xmb->playlist_db_node_map);
@@ -2476,8 +2439,7 @@ static void xmb_context_reset_horizontal_list(
    for (i = 0; i < list_size; i++)
    {
       const char *path = NULL;
-      xmb_node_t *node =
-         xmb_get_userdata_from_horizontal_list(xmb, i);
+      xmb_node_t *node = xmb_get_userdata_from_horizontal_list(xmb, i);
 
       if (!node)
          if (!(node = xmb_node_allocate_userdata(xmb, i)))
@@ -2486,8 +2448,7 @@ static void xmb_context_reset_horizontal_list(
       if (!(path = xmb->horizontal_list.list[i].path))
          continue;
 
-      if (string_ends_with_size(path, ".lpl",
-               strlen(path), STRLEN_CONST(".lpl")))
+      if (string_ends_with_size(path, ".lpl", strlen(path), STRLEN_CONST(".lpl")))
       {
          size_t len;
          struct texture_image ti;
@@ -2499,15 +2460,14 @@ static void xmb_context_reset_horizontal_list(
          /* Add current node to playlist database name map */
          RHMAP_SET_STR(xmb->playlist_db_node_map, path, node);
 
-         len                = fill_pathname_base(
-               sysname, path, sizeof(sysname));
+         len = fill_pathname_base(sysname, path, sizeof(sysname));
          /* Manually strip the extension (and dot) from sysname */
          sysname[len-4]     =
          sysname[len-3]     =
          sysname[len-2]     =
          sysname[len-1]     = '\0';
-         len                = fill_pathname_join_special(
-               texturepath, iconpath, sysname,
+
+         len = fill_pathname_join_special(texturepath, iconpath, sysname,
                sizeof(texturepath));
          texturepath[  len] = '.';
          texturepath[++len] = 'p';
@@ -2519,7 +2479,7 @@ static void xmb_context_reset_horizontal_list(
          if (!path_is_valid(texturepath))
          {
             len = fill_pathname_join_special(texturepath, iconpath, "default",
-            sizeof(texturepath));
+                  sizeof(texturepath));
             texturepath[  len] = '.';
             texturepath[++len] = 'p';
             texturepath[++len] = 'n';
@@ -2537,8 +2497,7 @@ static void xmb_context_reset_horizontal_list(
             if (ti.pixels)
             {
                video_driver_texture_unload(&node->icon);
-               video_driver_texture_load(&ti,
-                     TEXTURE_FILTER_MIPMAP_LINEAR, &node->icon);
+               video_driver_texture_load(&ti, TEXTURE_FILTER_MIPMAP_LINEAR, &node->icon);
             }
 
             image_texture_free(&ti);
@@ -2559,8 +2518,7 @@ static void xmb_context_reset_horizontal_list(
             if (ti.pixels)
             {
                video_driver_texture_unload(&node->content_icon);
-               video_driver_texture_load(&ti,
-                     TEXTURE_FILTER_MIPMAP_LINEAR, &node->content_icon);
+               video_driver_texture_load(&ti, TEXTURE_FILTER_MIPMAP_LINEAR, &node->content_icon);
             }
 
             image_texture_free(&ti);
@@ -2568,8 +2526,7 @@ static void xmb_context_reset_horizontal_list(
 
          /* Console name */
          console_name = xmb->horizontal_list.list[i].alt
-            ? xmb->horizontal_list.list[i].alt
-            : xmb->horizontal_list.list[i].path;
+               ? xmb->horizontal_list.list[i].alt : xmb->horizontal_list.list[i].path;
 
          if (node->console_name)
             free(node->console_name);
@@ -2583,7 +2540,7 @@ static void xmb_context_reset_horizontal_list(
             node->console_name = strdup(path);
       }
       else if (string_ends_with_size(xmb->horizontal_list.list[i].label, ".lvw",
-              strlen(xmb->horizontal_list.list[i].label), STRLEN_CONST(".lvw")))
+            strlen(xmb->horizontal_list.list[i].label), STRLEN_CONST(".lvw")))
       {
          node->console_name = strdup(path + strlen(msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_VIEW)) + 2);
          node->icon = xmb->textures.list[XMB_TEXTURE_CURSOR];
@@ -2644,19 +2601,17 @@ static int xmb_environ(enum menu_environ_cb type, void *data, void *userdata)
 static void xmb_list_open(xmb_handle_t *xmb)
 {
    gfx_animation_ctx_entry_t entry;
+   settings_t *settings       = config_get_ptr();
+   struct menu_state *menu_st = menu_state_get_ptr();
+   menu_list_t *menu_list     = menu_st->entries.list;
+   file_list_t *selection_buf = MENU_LIST_GET_SELECTION(menu_list, 0);
+   size_t selection           = menu_st->selection_ptr;
+   int dir                    = 0;
+   unsigned animation_opening_main_menu
+                              = settings->uints.menu_xmb_animation_opening_main_menu;
+   bool horizontal_animation  = settings->bools.menu_horizontal_animation;
 
-   settings_t *settings           = config_get_ptr();
-   bool menu_horizontal_animation = settings->bools.menu_horizontal_animation;
-   unsigned menu_xmb_animation_opening_main_menu =
-         settings->uints.menu_xmb_animation_opening_main_menu;
-   struct menu_state *menu_st     = menu_state_get_ptr();
-   menu_list_t *menu_list         = menu_st->entries.list;
-   file_list_t *selection_buf     = MENU_LIST_GET_SELECTION(menu_list, 0);
-   size_t selection               = menu_st->selection_ptr;
-   int                    dir     = 0;
-
-   xmb->depth                 = (int)
-      xmb_list_get_size(xmb, MENU_LIST_PLAIN);
+   xmb->depth                 = (int)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
 
    if (xmb->depth > xmb->old_depth)
       dir = 1;
@@ -2665,13 +2620,9 @@ static void xmb_list_open(xmb_handle_t *xmb)
    else
       return; /* If menu hasn't changed, do nothing */
 
-   xmb_list_open_horizontal_list(xmb, menu_horizontal_animation);
-
-   xmb_list_open_old(xmb, &xmb->selection_buf_old,
-         dir, xmb->selection_ptr_old);
-
-   xmb_list_open_new(xmb, selection_buf,
-         dir, selection);
+   xmb_list_open_horizontal_list(xmb, horizontal_animation);
+   xmb_list_open_old(xmb, &xmb->selection_buf_old, dir, xmb->selection_ptr_old);
+   xmb_list_open_new(xmb, selection_buf, dir, selection);
 
    /* Main Menu opening animation */
    entry.target_value = xmb->icon_size * -(xmb->depth * 2 - 2);
@@ -2680,7 +2631,7 @@ static void xmb_list_open(xmb_handle_t *xmb)
    entry.tag          = -1;
    entry.cb           = NULL;
 
-   switch (menu_xmb_animation_opening_main_menu)
+   switch (animation_opening_main_menu)
    {
       case 0:
          entry.easing_enum  = EASING_OUT_QUAD;
@@ -2703,7 +2654,7 @@ static void xmb_list_open(xmb_handle_t *xmb)
    if (     xmb->depth == 1
          || xmb->depth == 2)
    {
-      if (menu_horizontal_animation)
+      if (horizontal_animation)
       {
          gfx_animation_push(&entry);
 
@@ -2725,7 +2676,8 @@ static void xmb_list_open(xmb_handle_t *xmb)
 /* Is called whenever the list/sub-list changes */
 static void xmb_populate_entries(void *data,
       const char *path,
-      const char *label, unsigned k)
+      const char *label,
+      unsigned k)
 {
    unsigned xmb_system_tab, xmb_horizontal_type;
    xmb_handle_t *xmb                  = (xmb_handle_t*)data;
@@ -2746,12 +2698,12 @@ static void xmb_populate_entries(void *data,
    if (xmb->is_quick_menu && depth < xmb->old_depth)
       xmb->skip_thumbnail_reset       = true;
 
-   xmb_system_tab       = xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr);
-   xmb_horizontal_type  = (xmb_system_tab == UINT_MAX ? xmb_get_horizontal_selection_type(xmb) : 0);
+   xmb_system_tab      = xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr);
+   xmb_horizontal_type = (xmb_system_tab == UINT_MAX ? xmb_get_horizontal_selection_type(xmb) : 0);
 
    /* Determine whether this is a playlist */
-   xmb->is_playlist     =
-            (depth == 1
+   xmb->is_playlist =
+         (  depth == 1
          && (  (xmb_system_tab == XMB_SYSTEM_TAB_FAVORITES)
             || (xmb_system_tab == XMB_SYSTEM_TAB_HISTORY)
 #ifdef HAVE_IMAGEVIEWER
@@ -2761,7 +2713,8 @@ static void xmb_populate_entries(void *data,
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
             || (xmb_system_tab == XMB_SYSTEM_TAB_VIDEO)
 #endif
-         ))
+            )
+         )
          || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_PLAYLIST_LIST))
          || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_FAVORITES_LIST))
          || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_IMAGES_LIST))
@@ -2779,8 +2732,8 @@ static void xmb_populate_entries(void *data,
          && !string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL));
 
    xmb->is_playlist_information =
-         string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_INFORMATION)) ||
-         string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL));
+            string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_INFORMATION))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RDB_ENTRY_DETAIL));
 
    /* Determine whether this is a database manager list */
    was_db_manager_list     = xmb->is_db_manager_list && depth >= 4;
@@ -2793,8 +2746,9 @@ static void xmb_populate_entries(void *data,
    }
 
    /* Determine whether this is the contentless cores menu */
-   xmb->is_contentless_cores = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB)) ||
-                               string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST));
+   xmb->is_contentless_cores =
+            string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_CONTENTLESS_CORES_LIST));
 
    /* Determine whether this is a 'file list'
     * (needed for handling thumbnails when viewing images
@@ -2802,19 +2756,23 @@ static void xmb_populate_entries(void *data,
     * > Note: MENU_ENUM_LABEL_FAVORITES is always set
     *   as the 'label' when navigating directories after
     *   selecting 'load content' */
-   xmb->is_file_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES)) ||
-                       string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_MENU_WALLPAPER));
+   xmb->is_file_list =
+            string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_MENU_WALLPAPER));
 
    /* Determine whether this is the quick menu */
-   xmb->is_quick_menu = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS)) ||
-                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_SETTINGS)) ||
-                        string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_SAVESTATE_LIST));
+   xmb->is_quick_menu =
+            string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_SETTINGS))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_SAVESTATE_LIST));
+
    xmb->is_state_slot = string_to_unsigned(path) == MENU_ENUM_LABEL_STATE_SLOT;
 
    /* Explore list */
-   xmb->is_explore_list = string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST)) ||
-                          string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB)) ||
-                          xmb_horizontal_type == MENU_EXPLORE_TAB;
+   xmb->is_explore_list =
+            string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST))
+         || string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB))
+         || xmb_horizontal_type == MENU_EXPLORE_TAB;
 
 #if defined(HAVE_LIBRETRODB)
    if (xmb->is_explore_list)
@@ -2863,14 +2821,13 @@ static void xmb_populate_entries(void *data,
       size_t entry_idx_selection = menu_st->selection_ptr + 1;
       size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
       unsigned entry_idx_offset  = 0;
-      show_entry_idx             =
-            (xmb->is_playlist || xmb->is_explore_list) ? show_entry_idx : false;
+      show_entry_idx             = (xmb->is_playlist || xmb->is_explore_list) ? show_entry_idx : false;
 
       if (xmb->is_explore_list)
       {
          entry_idx_offset = 2;
-         if (string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST)) ||
-               xmb_horizontal_type == MENU_EXPLORE_TAB)
+         if (     string_is_equal(label, msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST))
+               || xmb_horizontal_type == MENU_EXPLORE_TAB)
             entry_idx_offset = 1;
 
          if (entry_idx_selection > entry_idx_offset)
@@ -2900,8 +2857,8 @@ static void xmb_populate_entries(void *data,
     * > This is refined on a case-by-case basis
     *   inside xmb_set_thumbnail_content() */
    xmb->fullscreen_thumbnails_available =
-         (xmb->is_playlist || xmb->is_db_manager_list || xmb->is_file_list) &&
-         !((xmb_system_tab > XMB_SYSTEM_TAB_SETTINGS) && (xmb->depth > 2));
+            (xmb->is_playlist || xmb->is_db_manager_list || xmb->is_file_list)
+         && !(xmb_system_tab > XMB_SYSTEM_TAB_SETTINGS && xmb->depth > 2);
 
    if (     (xmb->is_quick_menu || xmb->is_state_slot)
          && !string_is_empty(xmb->savestate_thumbnail_file_path))
@@ -3375,16 +3332,14 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
          if (core_node)
             return core_node->content_icon;
 
-         switch (xmb_get_system_tab(xmb,
-                  (unsigned)xmb->categories_selection_ptr))
+         switch (xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr))
          {
             case XMB_SYSTEM_TAB_MAIN:
                {
                   const struct playlist_entry *pl_entry = NULL;
                   xmb_node_t *db_node                   = NULL;
 
-                  playlist_get_index(playlist_get_cached(),
-                        0, &pl_entry);
+                  playlist_get_index(playlist_get_cached(), 0, &pl_entry);
 
                   if (      pl_entry
                         && !string_is_empty(pl_entry->db_name)
@@ -3396,6 +3351,8 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
                            return db_node->content_icon;
                         case FILE_TYPE_PLAYLIST_COLLECTION:
                            return db_node->icon;
+                        default:
+                           break;
                      }
                   }
                }
@@ -3461,23 +3418,23 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
       case MENU_SETTING_ACTION_CORE_OPTIONS:
          if (string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_VIDEO];
-         else if (string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS)) ||
-                  string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SOUND_SETTINGS)))
+         else if (string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_AUDIO_SETTINGS))
+               || string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SOUND_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_AUDIO];
          else if (string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_INPUT_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_INPUT_SETTINGS];
          else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ONSCREEN_DISPLAY_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_OSD];
-         else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LATENCY_SETTINGS)) ||
-                  string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_TIMING_SETTINGS)))
+         else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LATENCY_SETTINGS))
+               || string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_TIMING_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_LATENCY];
          else if (string_starts_with(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PERFORMANCE_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_FRAMESKIP];
-         else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MEDIA_SETTINGS)) ||
-                  string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STORAGE_SETTINGS)))
+         else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MEDIA_SETTINGS))
+               || string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STORAGE_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_RDB];
-         else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SYSTEM_SETTINGS)) ||
-                  string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SPECS_SETTINGS)))
+         else if (string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SYSTEM_SETTINGS))
+               || string_is_equal(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SPECS_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_DRIVERS];
          else if (strstr(enum_path, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_HACKS_SETTINGS)))
             return xmb->textures.list[XMB_TEXTURE_POWER];
@@ -3524,10 +3481,8 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
    }
 
 #ifdef HAVE_CHEEVOS
-   if (
-            (type >= MENU_SETTINGS_CHEEVOS_START)
-         && (type < MENU_SETTINGS_NETPLAY_ROOMS_START)
-      )
+   if (     type >= MENU_SETTINGS_CHEEVOS_START
+         && type <  MENU_SETTINGS_NETPLAY_ROOMS_START)
    {
       char buffer[64];
       int index               = type - MENU_SETTINGS_CHEEVOS_START;
@@ -3544,10 +3499,8 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
    }
 #endif
 
-   if (
-            (type >= MENU_SETTINGS_INPUT_BEGIN)
-         && (type <= MENU_SETTINGS_INPUT_DESC_KBD_END)
-      )
+   if (     type >= MENU_SETTINGS_INPUT_BEGIN
+         && type <= MENU_SETTINGS_INPUT_DESC_KBD_END)
    {
       unsigned input_id;
       if (type < MENU_SETTINGS_INPUT_DESC_BEGIN)
@@ -3658,10 +3611,8 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
       else if (type == (input_id + 23))
          return xmb->textures.list[XMB_TEXTURE_INPUT_STCK_R];
    }
-   if (
-            (type >= MENU_SETTINGS_REMAPPING_PORT_BEGIN)
-         && (type <= MENU_SETTINGS_REMAPPING_PORT_END)
-      )
+   if (     type >= MENU_SETTINGS_REMAPPING_PORT_BEGIN
+         && type <= MENU_SETTINGS_REMAPPING_PORT_END)
       return xmb->textures.list[XMB_TEXTURE_INPUT_SETTINGS];
    if (checked)
       return xmb->textures.list[XMB_TEXTURE_CHECKMARK];
@@ -3673,13 +3624,13 @@ static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
 static int xmb_draw_item(
       struct menu_state *menu_st,
       void *userdata,
-      gfx_display_t   *p_disp,
+      gfx_display_t *p_disp,
       gfx_animation_t *p_anim,
       gfx_display_ctx_driver_t *dispctx,
       settings_t *settings,
       unsigned video_width,
       unsigned video_height,
-      bool xmb_shadows_enable,
+      bool shadows_enable,
       math_matrix_4x4 *mymat,
       xmb_handle_t *xmb,
       xmb_node_t *core_node,
@@ -3688,8 +3639,7 @@ static int xmb_draw_item(
       size_t i,
       size_t current,
       unsigned width,
-      unsigned height
-      )
+      unsigned height)
 {
    menu_entry_t entry;
    float icon_x, icon_y, label_offset;
@@ -3709,13 +3659,12 @@ static int xmb_draw_item(
    bool use_smooth_ticker              = settings->bools.menu_ticker_smooth;
    enum gfx_animation_ticker_type menu_ticker_type
                                        = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
-   unsigned xmb_thumbnail_scale_factor = settings->uints.menu_xmb_thumbnail_scale_factor;
-   bool menu_xmb_vertical_thumbnails   = settings->bools.menu_xmb_vertical_thumbnails;
-   bool menu_show_sublabels            = settings->bools.menu_show_sublabels;
-   bool menu_switch_icons              = settings->bools.menu_xmb_switch_icons;
+   unsigned thumbnail_scale_factor     = settings->uints.menu_xmb_thumbnail_scale_factor;
+   bool vertical_thumbnails            = settings->bools.menu_xmb_vertical_thumbnails;
+   bool show_sublabels                 = settings->bools.menu_show_sublabels;
+   bool show_switch_icons              = settings->bools.menu_xmb_switch_icons;
    unsigned show_history_icons         = settings->uints.playlist_show_history_icons;
-   unsigned menu_xmb_vertical_fade_factor
-                                       = settings->uints.menu_xmb_vertical_fade_factor;
+   unsigned vertical_fade_factor       = settings->uints.menu_xmb_vertical_fade_factor;
 
    /* Initial ticker configuration */
    if (use_smooth_ticker)
@@ -3748,8 +3697,7 @@ static int xmb_draw_item(
    if (icon_y > height + xmb->icon_size)
       return -1;
 
-   icon_x = node->x + xmb->margins_screen_left +
-      xmb->icon_spacing_horizontal - half_size;
+   icon_x = node->x + xmb->margins_screen_left + xmb->icon_spacing_horizontal - half_size;
 
    if (icon_x < -half_size || icon_x > width)
       return 0;
@@ -3769,14 +3717,13 @@ static int xmb_draw_item(
    {
       char entry_path[PATH_MAX_LENGTH];
       strlcpy(entry_path, entry.path, sizeof(entry_path));
-      fill_pathname(entry_path, path_basename(entry_path), "",
-            sizeof(entry_path));
+      fill_pathname(entry_path, path_basename(entry_path), "", sizeof(entry_path));
       if (!string_is_empty(entry_path))
          strlcpy(entry.path, entry_path, sizeof(entry.path));
    }
 
    /* Only show switch icons with bool type options */
-   if (menu_switch_icons && entry.setting_type == ST_BOOL)
+   if (show_switch_icons && entry.setting_type == ST_BOOL)
    {
       if (     string_is_equal(entry.value, msg_hash_to_str(MENU_ENUM_LABEL_DISABLED))
             || string_is_equal(entry.value, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_OFF)))
@@ -3833,30 +3780,29 @@ static int xmb_draw_item(
 
    if (!texture_switch)
    {
-      bool menu_xmb_vertical_thumbnails = settings->bools.menu_xmb_vertical_thumbnails;
       bool show_right_thumbnail         =
-            (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
-               && (  (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
-                  || (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_PENDING)));
+               (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
+            && (  (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
+               || (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_PENDING)));
       bool show_left_thumbnail          =
-            (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
-               && (  (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
-                  || (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_PENDING)));
+               (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
+            && (  (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
+               || (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_PENDING)));
 
       if (     (xmb->is_playlist || xmb->is_explore_list)
             && !xmb->is_playlist_information
             && xmb->use_ps3_layout
             && (  show_right_thumbnail
-               || (show_left_thumbnail && menu_xmb_vertical_thumbnails))
+               || (show_left_thumbnail && vertical_thumbnails))
          )
       {
          ticker_limit                   = 40 * xmb_scale_mod[1];
 
          /* Can increase text length if thumbnail is downscaled */
-         if (xmb_thumbnail_scale_factor < 100)
+         if (thumbnail_scale_factor < 100)
          {
             float ticker_scale_factor   =
-                  1.0f - ((float)xmb_thumbnail_scale_factor / 100.0f);
+                  1.0f - ((float)thumbnail_scale_factor / 100.0f);
 
             ticker_limit               +=
                   (unsigned)(ticker_scale_factor * 15.0f * xmb_scale_mod[1]);
@@ -3884,14 +3830,14 @@ static int xmb_draw_item(
 
    /* Don't update ticker limit while waiting for thumbnail status */
    if (     (xmb->is_playlist || xmb->is_explore_list)
-         && (  (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
+         && (  (  gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT)
                && xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
-            || (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
+            || (  gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
                && xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_UNKNOWN))
       )
       ; /* no-op */
    else
-      xmb->ticker_limit = ticker_limit;
+      xmb->ticker_limit         = ticker_limit;
 
    if (!string_is_empty(entry.rich_label))
       ticker_str                = entry.rich_label;
@@ -3911,10 +3857,10 @@ static int xmb_draw_item(
    }
    else
    {
-      ticker.s        = tmp;
-      ticker.len      = xmb->ticker_limit;
-      ticker.str      = ticker_str;
-      ticker.selected = (i == current);
+      ticker.s                  = tmp;
+      ticker.len                = xmb->ticker_limit;
+      ticker.str                = ticker_str;
+      ticker.selected           = (i == current);
 
       if (ticker.str)
          gfx_animation_ticker(&ticker);
@@ -3922,17 +3868,15 @@ static int xmb_draw_item(
 
    label_offset = xmb->margins_label_top;
 
-   if (menu_xmb_vertical_fade_factor)
+   if (vertical_fade_factor)
    {
       float min_alpha  = 0.01f;
-      float max_alpha  = (i == current)
-         ? xmb->items_active_alpha
-         : xmb->items_passive_alpha;
+      float max_alpha  = (i == current) ? xmb->items_active_alpha : xmb->items_passive_alpha;
       float new_alpha  = node->alpha;
       float icon_space = xmb->icon_spacing_vertical;
       float icon_ratio = icon_space / height / icon_space * 4;
       float scr_margin = xmb->margins_screen_top + (icon_space / icon_ratio / 400);
-      float factor     = menu_xmb_vertical_fade_factor / 100.0f / icon_ratio;
+      float factor     = vertical_fade_factor / 100.0f / icon_ratio;
 
       if (!xmb->use_ps3_layout)
          scr_margin -= (icon_space / 8);
@@ -3955,9 +3899,10 @@ static int xmb_draw_item(
          node->alpha = node->label_alpha = new_alpha;
    }
 
-   if (menu_show_sublabels)
+   if (show_sublabels)
    {
-      if (i == current && width > 320 && height > 240
+      if (     i == current
+            && width > 320 && height > 240
             && !string_is_empty(entry.sublabel))
       {
          char entry_sublabel[MENU_SUBLABEL_MAX_LENGTH];
@@ -3975,9 +3920,9 @@ static int xmb_draw_item(
          float sublabel_y                  = xmb->margins_screen_top +
                node->y + (xmb->margins_label_top * 3.5f);
 
-         entry_sublabel[0]             = '\0';
-         entry_sublabel_top_fade[0]    = '\0';
-         entry_sublabel_bottom_fade[0] = '\0';
+         entry_sublabel[0]                 = '\0';
+         entry_sublabel_top_fade[0]        = '\0';
+         entry_sublabel_bottom_fade[0]     = '\0';
 
          if (use_smooth_ticker)
          {
@@ -4035,7 +3980,7 @@ static int xmb_draw_item(
          label_offset = -xmb->margins_label_top;
 
          /* Draw sublabel */
-         xmb_draw_text(xmb_shadows_enable, xmb, settings,
+         xmb_draw_text(shadows_enable, xmb, settings,
                entry_sublabel,
                sublabel_x,
                ticker_y_offset + sublabel_y,
@@ -4045,17 +3990,17 @@ static int xmb_draw_item(
          /* Draw top/bottom line fade effect, if required */
          if (use_smooth_ticker)
          {
-            if (  !string_is_empty(entry_sublabel_top_fade)
-                && ticker_top_fade_alpha > 0.0f)
-               xmb_draw_text(xmb_shadows_enable, xmb, settings,
+            if (     !string_is_empty(entry_sublabel_top_fade)
+                  && ticker_top_fade_alpha > 0.0f)
+               xmb_draw_text(shadows_enable, xmb, settings,
                      entry_sublabel_top_fade,
                      sublabel_x, ticker_top_fade_y_offset + sublabel_y,
                      1, ticker_top_fade_alpha * node->label_alpha, TEXT_ALIGN_LEFT,
                      width, height, xmb->font2);
 
-            if (  !string_is_empty(entry_sublabel_bottom_fade)
-                && ticker_bottom_fade_alpha > 0.0f)
-               xmb_draw_text(xmb_shadows_enable, xmb, settings,
+            if (     !string_is_empty(entry_sublabel_bottom_fade)
+                  && ticker_bottom_fade_alpha > 0.0f)
+               xmb_draw_text(shadows_enable, xmb, settings,
                      entry_sublabel_bottom_fade,
                      sublabel_x, ticker_bottom_fade_y_offset + sublabel_y,
                      1, ticker_bottom_fade_alpha * node->label_alpha, TEXT_ALIGN_LEFT,
@@ -4065,21 +4010,21 @@ static int xmb_draw_item(
    }
 
    /* Draw entry index of current selection */
-   if (i == current &&
-         xmb->entry_idx_enabled &&
-         !string_is_empty(xmb->entry_index_str))
+   if (     i == current
+         && xmb->entry_idx_enabled
+         && !string_is_empty(xmb->entry_index_str))
    {
-      float entry_idx_margin   = 12 * xmb->last_scale_factor;
-      float x_position         = video_width - entry_idx_margin;
-      float y_position         = video_height - entry_idx_margin;
+      float entry_idx_margin = 12 * xmb->last_scale_factor;
+      float x_position       = video_width - entry_idx_margin;
+      float y_position       = video_height - entry_idx_margin;
 
-      xmb_draw_text(xmb_shadows_enable, xmb, settings,
+      xmb_draw_text(shadows_enable, xmb, settings,
             xmb->entry_index_str, x_position, y_position,
-            1, menu_xmb_vertical_thumbnails ? node->label_alpha : 1,
+            1, vertical_thumbnails ? node->label_alpha : 1,
             TEXT_ALIGN_RIGHT, width, height, xmb->font);
    }
 
-   xmb_draw_text(xmb_shadows_enable, xmb, settings, tmp,
+   xmb_draw_text(shadows_enable, xmb, settings, tmp,
          (float)ticker_x_offset
                + node->x
                + xmb->margins_screen_left
@@ -4116,7 +4061,7 @@ static int xmb_draw_item(
    }
 
    if (draw_text_value)
-      xmb_draw_text(xmb_shadows_enable, xmb, settings, tmp,
+      xmb_draw_text(shadows_enable, xmb, settings, tmp,
             (float)ticker_x_offset
                   + node->x
                   + xmb->margins_screen_left
@@ -4132,14 +4077,11 @@ static int xmb_draw_item(
 
    gfx_display_set_alpha(color, MIN(node->alpha, xmb->alpha));
 
-   if (
-           (!xmb->assets_missing)
+   if (     (!xmb->assets_missing)
          && (color[3] != 0)
-         && (
-            (entry.flags & MENU_ENTRY_FLAG_CHECKED)
-         || !((entry_type >= MENU_SETTING_DROPDOWN_ITEM)
-         && (entry_type <= MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM_SPECIAL))
-         )
+         && (  (entry.flags & MENU_ENTRY_FLAG_CHECKED)
+            || !( (entry_type >= MENU_SETTING_DROPDOWN_ITEM)
+               && (entry_type <= MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM_SPECIAL)))
       )
    {
       math_matrix_4x4 mymat_tmp;
@@ -4150,7 +4092,16 @@ static int xmb_draw_item(
       float y                  = icon_y;
       float scale_factor       = node->zoom;
 
-      /* Explore list correction hack for not showing wrong icons as "back" icon */
+      /* Ensure previous menu depth icon is in final position if pointer
+       * change animation is still in progress while entering a menu */
+      if (list == &xmb->selection_buf_old)
+      {
+         node->y     = xmb_item_y(xmb, i, current);
+         node->alpha = xmb->items_active_alpha;
+         node->zoom  = xmb->items_active_zoom;
+      }
+
+      /* Explore list correction hack for not showing wrong icons as "previous" icon */
       if (xmb->is_explore_list && !xmb->is_quick_menu && texture)
       {
          if (node->x < -xmb->icon_spacing_horizontal / 3)
@@ -4267,7 +4218,7 @@ static int xmb_draw_item(
             dispctx,
             video_width,
             video_height,
-            xmb_shadows_enable,
+            shadows_enable,
             xmb->icon_size,
             texture,
             x,
@@ -4295,7 +4246,7 @@ static int xmb_draw_item(
             dispctx,
             video_width,
             video_height,
-            xmb_shadows_enable,
+            shadows_enable,
             xmb->icon_size,
             texture_switch,
             node->x + xmb->margins_screen_left
@@ -4323,31 +4274,29 @@ static void xmb_draw_items(
       settings_t *settings,
       unsigned video_width,
       unsigned video_height,
-      bool xmb_shadows_enable,
+      bool shadows_enable,
       xmb_handle_t *xmb,
       file_list_t *list,
-      size_t current, size_t cat_selection_ptr, float *color,
+      size_t current,
+      size_t cat_selection_ptr,
+      float *color,
       unsigned width, unsigned height,
       math_matrix_4x4 *mymat)
 {
    size_t i;
    unsigned first, last;
-   xmb_node_t *core_node             = NULL;
-   size_t end                        = 0;
+   xmb_node_t *core_node = NULL;
+   size_t end            = 0;
 
    if (!list || !list->size)
       return;
 
-   if (cat_selection_ptr > xmb->system_tab_end)
-      core_node = xmb_get_userdata_from_horizontal_list(
-            xmb, (unsigned)(cat_selection_ptr - (xmb->system_tab_end + 1)));
-
-   end  = list->size;
-   i    = menu_st->entries.begin;
+   end                   = list->size;
+   i                     = menu_st->entries.begin;
 
    if (list == &xmb->selection_buf_old)
    {
-      /* Draw only current item for "back" icon */
+      /* Draw only current item for "previous" icon */
       first = (unsigned)current;
       last  = (unsigned)current;
    }
@@ -4355,28 +4304,32 @@ static void xmb_draw_items(
    {
       first = (unsigned)i;
       last  = (unsigned)(end - 1);
+      xmb_calculate_visible_range(xmb, height, end, (unsigned)current, &first, &last);
    }
 
-   xmb_calculate_visible_range(xmb, height,
-         end, (unsigned)current, &first, &last);
+   if (cat_selection_ptr > xmb->system_tab_end)
+      core_node = xmb_get_userdata_from_horizontal_list(
+            xmb, (unsigned)(cat_selection_ptr - (xmb->system_tab_end + 1)));
 
    for (i = first; i <= last; i++)
    {
       if (xmb_draw_item(
-               menu_st,
-               userdata,
-               p_disp,
-               p_anim,
-               dispctx,
-               settings,
-               video_width,
-               video_height,
-               xmb_shadows_enable,
-               mymat,
-               xmb, core_node,
-               list, color,
-               i, current,
-               width, height) == -1)
+            menu_st,
+            userdata,
+            p_disp,
+            p_anim,
+            dispctx,
+            settings,
+            video_width,
+            video_height,
+            shadows_enable,
+            mymat,
+            xmb,
+            core_node,
+            list,
+            color,
+            i, current,
+            width, height) == -1)
          break;
    }
 }
@@ -4430,8 +4383,7 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
 static void xmb_hide_fullscreen_thumbnails(
       xmb_handle_t *xmb, bool animate)
 {
-   uintptr_t alpha_tag                =
-      (uintptr_t)&xmb->fullscreen_thumbnail_alpha;
+   uintptr_t alpha_tag                = (uintptr_t)&xmb->fullscreen_thumbnail_alpha;
 
    /* Kill any existing fade in/out animations */
    gfx_animation_kill_by_tag(&alpha_tag);
@@ -4470,8 +4422,7 @@ static void xmb_show_fullscreen_thumbnails(
    gfx_animation_ctx_entry_t animation_entry;
    const char *core_name              = NULL;
    bool animate                       = !xmb->want_fullscreen_thumbnails;
-   uintptr_t              alpha_tag   = (uintptr_t)
-      &xmb->fullscreen_thumbnail_alpha;
+   uintptr_t alpha_tag                = (uintptr_t)&xmb->fullscreen_thumbnail_alpha;
 
    /* We can only enable fullscreen thumbnails if
     * current selection has at least one valid thumbnail
@@ -4484,22 +4435,15 @@ static void xmb_show_fullscreen_thumbnails(
       /* imageviewer content requires special treatment,
        * since only one thumbnail can ever be loaded
        * at a time */
-      if (gfx_thumbnail_is_enabled(
-               menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
+      if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT))
       {
-         if (     xmb->thumbnails.right.status
-               != GFX_THUMBNAIL_STATUS_AVAILABLE
-               && xmb->thumbnails.savestate.status
-               != GFX_THUMBNAIL_STATUS_AVAILABLE)
+         if (     xmb->thumbnails.right.status     != GFX_THUMBNAIL_STATUS_AVAILABLE
+               && xmb->thumbnails.savestate.status != GFX_THUMBNAIL_STATUS_AVAILABLE)
             return;
       }
-      else if (
-            gfx_thumbnail_is_enabled(
-               menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+      else if (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
       {
-         if (
-                  xmb->thumbnails.left.status
-               != GFX_THUMBNAIL_STATUS_AVAILABLE)
+         if (xmb->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE)
             return;
       }
       else
@@ -4510,28 +4454,22 @@ static void xmb_show_fullscreen_thumbnails(
       bool left_thumbnail_enabled = gfx_thumbnail_is_enabled(
             menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT);
 
-      if ((       xmb->thumbnails.right.status
-               == GFX_THUMBNAIL_STATUS_AVAILABLE)
-               && (left_thumbnail_enabled
-               &&  ((xmb->thumbnails.left.status
-               != GFX_THUMBNAIL_STATUS_MISSING)
-               && (xmb->thumbnails.left.status
-               != GFX_THUMBNAIL_STATUS_AVAILABLE))))
+      if (     (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
+            && (  left_thumbnail_enabled
+               && (  (xmb->thumbnails.left.status != GFX_THUMBNAIL_STATUS_MISSING)
+                  && (xmb->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE))))
          return;
 
-      if ((       xmb->thumbnails.right.status
-               == GFX_THUMBNAIL_STATUS_MISSING)
-          &&   (!left_thumbnail_enabled
-          ||   (   xmb->thumbnails.left.status
-                != GFX_THUMBNAIL_STATUS_AVAILABLE)))
+      if (     (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_MISSING)
+            && (  !left_thumbnail_enabled
+               || (xmb->thumbnails.left.status != GFX_THUMBNAIL_STATUS_AVAILABLE)))
          return;
    }
 
    /* Cache selected entry label
     * (used as title when fullscreen thumbnails
     * are shown) */
-   if (menu_update_fullscreen_thumbnail_label(
-         xmb->fullscreen_thumbnail_label,
+   if (menu_update_fullscreen_thumbnail_label(xmb->fullscreen_thumbnail_label,
          sizeof(xmb->fullscreen_thumbnail_label),
          xmb->is_quick_menu,
          xmb->title_name) == 0)
@@ -4562,16 +4500,15 @@ static void xmb_show_fullscreen_thumbnails(
 static bool INLINE xmb_fullscreen_thumbnails_available(xmb_handle_t *xmb,
       struct menu_state *menu_st)
 {
-   bool ret =
-         xmb->fullscreen_thumbnails_available
-      && (gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
-      ||  gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
-      && (xmb->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_AVAILABLE
-      ||  xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE);
+   bool ret = xmb->fullscreen_thumbnails_available
+         && (  gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
+            || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+         && (  xmb->thumbnails.left.status  == GFX_THUMBNAIL_STATUS_AVAILABLE
+            || xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE);
 
-   if (       xmb->is_state_slot
-          && (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_MISSING
-          ||  xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN))
+   if (     xmb->is_state_slot
+         && (  xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_MISSING
+            || xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN))
       ret = false;
 
    return ret;
@@ -4648,8 +4585,7 @@ static enum menu_action xmb_parse_menu_entry_action(
             {
                /* Ignore input action if tab switch period
                 * is less than defined limit */
-               if ((current_time - xmb->last_tab_switch_time) <
-                     XMB_TAB_SWITCH_REPEAT_DELAY)
+               if ((current_time - xmb->last_tab_switch_time) < XMB_TAB_SWITCH_REPEAT_DELAY)
                {
                   new_action = MENU_ACTION_NOOP;
                   break;
@@ -4659,14 +4595,14 @@ static enum menu_action xmb_parse_menu_entry_action(
          }
          break;
       case MENU_ACTION_START:
-         if (xmb->is_state_slot ||
-               (xmb->is_quick_menu && menu_is_running_quick_menu()))
+         if (     (xmb->is_state_slot)
+               || (xmb->is_quick_menu && menu_is_running_quick_menu()))
             break;
 
          /* If this is a menu with thumbnails, attempt
           * to show fullscreen thumbnail view */
-         if (    xmb_fullscreen_thumbnails_available(xmb, menu_st)
-             && !xmb->show_fullscreen_thumbnails)
+         if (     xmb_fullscreen_thumbnails_available(xmb, menu_st)
+               && !xmb->show_fullscreen_thumbnails)
          {
             xmb_hide_fullscreen_thumbnails(xmb, false);
             xmb_show_fullscreen_thumbnails(xmb, menu_st, menu_st->selection_ptr);
@@ -4674,7 +4610,8 @@ static enum menu_action xmb_parse_menu_entry_action(
             xmb_set_thumbnail_delay(false);
             new_action = MENU_ACTION_NOOP;
          }
-         else if (xmb->show_fullscreen_thumbnails || xmb->want_fullscreen_thumbnails)
+         else if (xmb->show_fullscreen_thumbnails
+               || xmb->want_fullscreen_thumbnails)
          {
             xmb_set_thumbnail_delay(true);
             xmb_hide_fullscreen_thumbnails(xmb, true);
@@ -4682,18 +4619,18 @@ static enum menu_action xmb_parse_menu_entry_action(
          }
          break;
       case MENU_ACTION_SCAN:
-         if (xmb->fullscreen_thumbnails_available &&
-               !xmb->show_fullscreen_thumbnails &&
-               ((xmb->is_state_slot) ||
-                (xmb->is_quick_menu && !string_is_empty(xmb->savestate_thumbnail_file_path))))
+         if (     xmb->fullscreen_thumbnails_available
+               && !xmb->show_fullscreen_thumbnails
+               && (  (xmb->is_state_slot)
+                  || (xmb->is_quick_menu && !string_is_empty(xmb->savestate_thumbnail_file_path))))
          {
             xmb_hide_fullscreen_thumbnails(xmb, false);
             xmb_show_fullscreen_thumbnails(xmb, menu_st, menu_st->selection_ptr);
             xmb->want_fullscreen_thumbnails = true;
             new_action = MENU_ACTION_NOOP;
          }
-         else if (xmb->show_fullscreen_thumbnails &&
-               (xmb->is_state_slot || (xmb->is_quick_menu && menu_is_running_quick_menu())))
+         else if (xmb->show_fullscreen_thumbnails
+               && (xmb->is_state_slot || (xmb->is_quick_menu && menu_is_running_quick_menu())))
          {
             xmb_hide_fullscreen_thumbnails(xmb, true);
             xmb->want_fullscreen_thumbnails = false;
@@ -4806,7 +4743,6 @@ static enum menu_action xmb_parse_menu_entry_action(
    return new_action;
 }
 
-
 /* Menu entry action callback */
 static int xmb_menu_entry_action(
       void *userdata, menu_entry_t *entry,
@@ -4818,7 +4754,6 @@ static int xmb_menu_entry_action(
    /* Call standard generic_menu_entry_action() function */
    return generic_menu_entry_action(userdata, entry, i, new_action);
 }
-
 
 static void xmb_render(void *data,
       unsigned width, unsigned height, bool is_idle)
@@ -4835,26 +4770,24 @@ static void xmb_render(void *data,
    volatile float scale_factor;
    xmb_handle_t *xmb              = (xmb_handle_t*)data;
    settings_t *settings           = config_get_ptr();
-   struct menu_state   *menu_st   = menu_state_get_ptr();
+   struct menu_state *menu_st     = menu_state_get_ptr();
    menu_input_t *menu_input       = &menu_st->input_state;
    menu_list_t *menu_list         = menu_st->entries.list;
-   size_t      end                = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+   size_t end                     = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
    gfx_display_t *p_disp          = disp_get_ptr();
    gfx_animation_t *p_anim        = anim_get_ptr();
 
    if (!xmb)
       return;
 
-   xmb->use_ps3_layout        = xmb_use_ps3_layout(
-         settings->uints.menu_xmb_layout, width, height);
-   scale_factor               = xmb_get_scale_factor(
-         settings->floats.menu_scale_factor,
+   xmb->use_ps3_layout            = xmb_use_ps3_layout(settings->uints.menu_xmb_layout, width, height);
+   scale_factor                   = xmb_get_scale_factor(settings->floats.menu_scale_factor,
          xmb->use_ps3_layout, width);
 
-   if ((xmb->use_ps3_layout                  != xmb->last_use_ps3_layout) ||
-       (xmb->margins_title                   != xmb->last_margins_title) ||
-       (xmb->margins_title_horizontal_offset != xmb->last_margins_title_horizontal_offset) ||
-       (scale_factor                         != xmb->last_scale_factor))
+   if (     (xmb->use_ps3_layout                  != xmb->last_use_ps3_layout)
+         || (xmb->margins_title                   != xmb->last_margins_title)
+         || (xmb->margins_title_horizontal_offset != xmb->last_margins_title_horizontal_offset)
+         || (scale_factor                         != xmb->last_scale_factor))
    {
       xmb->last_use_ps3_layout                  = xmb->use_ps3_layout;
       xmb->last_margins_title                   = xmb->margins_title;
@@ -5033,9 +4966,7 @@ static void xmb_render(void *data,
 
       /* Explore list needs cached selection index */
       if (xmb->is_explore_list)
-         selection = menu_st->thumbnail_path_data
-            ? menu_st->thumbnail_path_data->playlist_index
-            : 0;
+         selection = menu_st->thumbnail_path_data ? menu_st->thumbnail_path_data->playlist_index : 0;
 
       switch (xmb->thumbnails.pending)
       {
@@ -5048,10 +4979,9 @@ static void xmb_render(void *data,
                   &xmb->thumbnails.left,
                   gfx_thumbnail_upscale_threshold,
                   network_on_demand_thumbnails);
-            if ((       xmb->thumbnails.right.status
-                     != GFX_THUMBNAIL_STATUS_UNKNOWN)
-                 && (   xmb->thumbnails.left.status
-                 != GFX_THUMBNAIL_STATUS_UNKNOWN))
+
+            if (     xmb->thumbnails.right.status != GFX_THUMBNAIL_STATUS_UNKNOWN
+                  && xmb->thumbnails.left.status  != GFX_THUMBNAIL_STATUS_UNKNOWN)
                xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
             break;
          case XMB_PENDING_THUMBNAIL_RIGHT:
@@ -5063,8 +4993,8 @@ static void xmb_render(void *data,
                   &xmb->thumbnails.right,
                   gfx_thumbnail_upscale_threshold,
                   network_on_demand_thumbnails);
-            if (     xmb->thumbnails.right.status
-                  != GFX_THUMBNAIL_STATUS_UNKNOWN)
+
+            if (xmb->thumbnails.right.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
                xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
             break;
          case XMB_PENDING_THUMBNAIL_LEFT:
@@ -5076,8 +5006,8 @@ static void xmb_render(void *data,
                   &xmb->thumbnails.left,
                   gfx_thumbnail_upscale_threshold,
                   network_on_demand_thumbnails);
-            if (     xmb->thumbnails.left.status
-                  != GFX_THUMBNAIL_STATUS_UNKNOWN)
+
+            if (xmb->thumbnails.left.status != GFX_THUMBNAIL_STATUS_UNKNOWN)
                xmb->thumbnails.pending = XMB_PENDING_THUMBNAIL_NONE;
             break;
          default:
@@ -5211,10 +5141,10 @@ static void xmb_draw_dark_layer(
 {
    gfx_display_ctx_draw_t draw;
    float black[16]      = {
-      0, 0, 0, 1,
-      0, 0, 0, 1,
-      0, 0, 0, 1,
-      0, 0, 0, 1,
+         0, 0, 0, 1,
+         0, 0, 0, 1,
+         0, 0, 0, 1,
+         0, 0, 0, 1,
    };
 
    draw.x               = 0;
@@ -5233,8 +5163,7 @@ static void xmb_draw_dark_layer(
 
    if (dispctx->blend_begin)
       dispctx->blend_begin(userdata);
-   gfx_display_draw_bg(p_disp, &draw, userdata,
-         true, MIN(xmb->alpha, 0.75));
+   gfx_display_draw_bg(p_disp, &draw, userdata, true, MIN(xmb->alpha, 0.75));
    if (draw.height > 0 && draw.width > 0)
       if (dispctx && dispctx->draw)
          dispctx->draw(&draw, userdata, width, height);
@@ -5249,7 +5178,7 @@ static void xmb_draw_fullscreen_thumbnails(
       void *userdata,
       unsigned video_width,
       unsigned video_height,
-      bool xmb_shadows_enable,
+      bool shadows_enable,
       unsigned xmb_color_theme,
       settings_t *settings, size_t selection)
 {
@@ -5285,37 +5214,37 @@ static void xmb_draw_fullscreen_thumbnails(
        * hard-code this alpha value for now... */
       float background_alpha            = 0.90f;
       float background_color[16]        = {
-         0.0f, 0.0f, 0.0f, 1.0f,
-         0.0f, 0.0f, 0.0f, 1.0f,
-         0.0f, 0.0f, 0.0f, 1.0f,
-         0.0f, 0.0f, 0.0f, 1.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
+            0.0f, 0.0f, 0.0f, 1.0f,
       };
       uint32_t title_color              = 0xFFFFFF00;
       float header_alpha                = 0.6f;
       float header_color[16]            = {
-         0.0f, 0.0f, 0.0f, 0.0f,
-         0.0f, 0.0f, 0.0f, 0.0f,
-         0.0f, 0.0f, 0.0f, 0.0f,
-         0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 0.0f,
       };
       int frame_width                   = (int)(xmb->icon_size / 8.0f);
       float frame_color[16]             = {
-         1.0f, 1.0f, 1.0f, 1.0f,
-         1.0f, 1.0f, 1.0f, 1.0f,
-         1.0f, 1.0f, 1.0f, 1.0f,
-         1.0f, 1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f, 1.0f,
+            1.0f, 1.0f, 1.0f, 1.0f,
       };
       bool show_header                  = !string_is_empty(xmb->fullscreen_thumbnail_label);
       int header_height                 = show_header ? (int)((float)xmb->font_size * 1.2f) + (frame_width * 2) : 0;
       bool menu_ticker_smooth           = settings->bools.menu_ticker_smooth;
-      enum gfx_animation_ticker_type
-         menu_ticker_type               = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
+      enum gfx_animation_ticker_type menu_ticker_type
+                                        = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
 
       /* Sanity check: Return immediately if this is
        * a menu without thumbnails and we are not currently
        * 'fading out' the fullscreen thumbnail view */
-      if (!xmb->fullscreen_thumbnails_available &&
-          xmb->show_fullscreen_thumbnails)
+      if (     !xmb->fullscreen_thumbnails_available
+            &&  xmb->show_fullscreen_thumbnails)
          goto error;
 
       /* Safety check: ensure that current
@@ -5328,8 +5257,8 @@ static void xmb_draw_fullscreen_thumbnails(
        *   RetroPad A or keyboard 'return' to enter the
        *   quick menu while fullscreen thumbnails are
        *   being displayed */
-      if (   (selection != xmb->fullscreen_thumbnail_selection)
-          && (!xmb->is_quick_menu || xmb->show_fullscreen_thumbnails))
+      if (     (selection != xmb->fullscreen_thumbnail_selection)
+            && (!xmb->is_quick_menu || xmb->show_fullscreen_thumbnails))
          goto error;
 
       /* Get thumbnail pointers */
@@ -5337,15 +5266,15 @@ static void xmb_draw_fullscreen_thumbnails(
       left_thumbnail  = &xmb->thumbnails.left;
 
       /* Get number of 'active' thumbnails */
-      show_right_thumbnail = (
-               right_thumbnail->status == GFX_THUMBNAIL_STATUS_AVAILABLE
+      show_right_thumbnail =
+            (  right_thumbnail->status == GFX_THUMBNAIL_STATUS_AVAILABLE
             || right_thumbnail->status == GFX_THUMBNAIL_STATUS_PENDING);
-      show_left_thumbnail  = (
-               left_thumbnail->status  == GFX_THUMBNAIL_STATUS_AVAILABLE
+      show_left_thumbnail  =
+            (  left_thumbnail->status  == GFX_THUMBNAIL_STATUS_AVAILABLE
             || left_thumbnail->status  == GFX_THUMBNAIL_STATUS_PENDING);
 
-      if ((xmb->is_quick_menu && !string_is_empty(xmb->savestate_thumbnail_file_path)) ||
-            xmb->is_state_slot)
+      if (     (xmb->is_quick_menu && !string_is_empty(xmb->savestate_thumbnail_file_path))
+            || (xmb->is_state_slot))
       {
          left_thumbnail       = &xmb->thumbnails.savestate;
          show_left_thumbnail  = (left_thumbnail->status == GFX_THUMBNAIL_STATUS_AVAILABLE);
@@ -5363,17 +5292,16 @@ static void xmb_draw_fullscreen_thumbnails(
        *   can never happen...
        * > Return instead of error to keep fullscreen
        *   mode after menu/fullscreen toggle */
-      if (num_thumbnails < 1 &&
-            (right_thumbnail->status == GFX_THUMBNAIL_STATUS_MISSING &&
-             left_thumbnail->status  == GFX_THUMBNAIL_STATUS_MISSING))
+      if (     num_thumbnails < 1
+            && (  right_thumbnail->status == GFX_THUMBNAIL_STATUS_MISSING
+               &&  left_thumbnail->status == GFX_THUMBNAIL_STATUS_MISSING))
          return;
 
       /* Get base thumbnail dimensions + draw positions */
 
       /* > Thumbnail bounding box height + y position
        *   are fixed */
-      header_margin = (header_height > thumbnail_margin) ?
-            header_height : thumbnail_margin;
+      header_margin        = (header_height > thumbnail_margin) ? header_height : thumbnail_margin;
       thumbnail_box_height = view_height - header_margin - thumbnail_margin;
       thumbnail_y          = header_margin;
 
@@ -5393,8 +5321,8 @@ static void xmb_draw_fullscreen_thumbnails(
       }
 
       /* Sanity check */
-      if ((thumbnail_box_width < 1) ||
-          (thumbnail_box_height < 1))
+      if (     thumbnail_box_width  < 1
+            || thumbnail_box_height < 1)
          goto error;
 
       /* Get thumbnail draw dimensions
@@ -5493,8 +5421,8 @@ static void xmb_draw_fullscreen_thumbnails(
          memcpy(frame_color + 8,  mean_menu_color, sizeof(mean_menu_color));
          memcpy(frame_color + 12, mean_menu_color, sizeof(mean_menu_color));
       }
-      gfx_display_set_alpha(
-            frame_color, xmb->fullscreen_thumbnail_alpha);
+
+      gfx_display_set_alpha(frame_color, xmb->fullscreen_thumbnail_alpha);
 
       /* Darken background */
       gfx_display_draw_quad(
@@ -5594,7 +5522,7 @@ static void xmb_draw_fullscreen_thumbnails(
 
       /* > Configure shadow effect */
       /* > Disabled for now since the images already have a background border */
-      if (0 && xmb_shadows_enable)
+      if (0 && shadows_enable)
       {
          float shadow_offset            = xmb->icon_size / 24.0f;
 
@@ -5696,62 +5624,61 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    char title_msg[255];
    char title_truncated[255];
    gfx_thumbnail_shadow_t thumbnail_shadow;
-   size_t selection                        = 0;
-   size_t percent_width                    = 0;
-   bool render_background                  = false;
-   file_list_t *selection_buf              = NULL;
-   const float under_thumb_margin          = 0.96f;
-   float left_thumbnail_margin_width       = 0.0f;
-   float right_thumbnail_margin_width      = 0.0f;
-   float thumbnail_margin_height_under     = 0.0f;
-   float thumbnail_margin_height_full      = 0.0f;
-   float left_thumbnail_margin_x           = 0.0f;
-   float right_thumbnail_margin_x          = 0.0f;
-   float pseudo_font_length                = 0.0f;
-   xmb_handle_t *xmb                       = (xmb_handle_t*)data;
-   settings_t *settings                    = config_get_ptr();
-   bool fade_tab_icons                     = false;
-   float fade_tab_icons_x_threshold        = 0.0f;
-   bool menu_core_enable                   = settings->bools.menu_core_enable;
-   float thumbnail_scale_factor            = (float)settings->uints.menu_xmb_thumbnail_scale_factor / 100.0f;
-   bool menu_xmb_show_title_header         = settings->bools.menu_xmb_show_title_header;
-   bool menu_xmb_vertical_thumbnails       = settings->bools.menu_xmb_vertical_thumbnails;
-   unsigned menu_xmb_vertical_fade_factor  = settings->uints.menu_xmb_vertical_fade_factor;
-   void *userdata                          = video_info->userdata;
-   unsigned video_width                    = video_info->width;
-   unsigned video_height                   = video_info->height;
-   bool xmb_shadows_enable                 = video_info->xmb_shadows_enable;
-   float xmb_alpha_factor                  = video_info->xmb_alpha_factor;
-   bool timedate_enable                    = video_info->timedate_enable;
-   bool battery_level_enable               = video_info->battery_level_enable;
-   bool video_fullscreen                   = video_info->fullscreen;
-   bool mouse_grabbed                      = video_info->input_driver_grab_mouse_state;
-   bool menu_mouse_enable                  = video_info->menu_mouse_enable;
-   unsigned xmb_color_theme                = video_info->xmb_color_theme;
-   bool libretro_running                   = video_info->libretro_running;
-   unsigned menu_shader_pipeline           = video_info->menu_shader_pipeline;
-   float menu_wallpaper_opacity            = video_info->menu_wallpaper_opacity;
-   gfx_display_t            *p_disp        = (gfx_display_t*)video_info->disp_userdata;
-   gfx_animation_t          *p_anim        = anim_get_ptr();
-   gfx_display_ctx_driver_t *dispctx       = p_disp->dispctx;
-   video_driver_state_t *video_st          = video_state_get_ptr();
-   struct menu_state   *menu_st            = menu_state_get_ptr();
-   menu_list_t *menu_list                  = menu_st->entries.list;
-   bool input_dialog_display_kb            = menu_input_dialog_get_display_kb();
+   size_t selection                    = 0;
+   size_t percent_width                = 0;
+   bool render_background              = false;
+   file_list_t *selection_buf          = NULL;
+   const float under_thumb_margin      = 0.96f;
+   float left_thumbnail_margin_width   = 0.0f;
+   float right_thumbnail_margin_width  = 0.0f;
+   float thumbnail_margin_height_under = 0.0f;
+   float thumbnail_margin_height_full  = 0.0f;
+   float left_thumbnail_margin_x       = 0.0f;
+   float right_thumbnail_margin_x      = 0.0f;
+   float pseudo_font_length            = 0.0f;
+   xmb_handle_t *xmb                   = (xmb_handle_t*)data;
+   settings_t *settings                = config_get_ptr();
+   bool fade_tab_icons                 = false;
+   float fade_tab_icons_x_threshold    = 0.0f;
+   bool menu_core_enable               = settings->bools.menu_core_enable;
+   float thumbnail_scale_factor        = (float)settings->uints.menu_xmb_thumbnail_scale_factor / 100.0f;
+   bool show_title_header              = settings->bools.menu_xmb_show_title_header;
+   bool vertical_thumbnails            = settings->bools.menu_xmb_vertical_thumbnails;
+   unsigned vertical_fade_factor       = settings->uints.menu_xmb_vertical_fade_factor;
+   void *userdata                      = video_info->userdata;
+   unsigned video_width                = video_info->width;
+   unsigned video_height               = video_info->height;
+   bool shadows_enable                 = video_info->xmb_shadows_enable;
+   float alpha_factor                  = video_info->xmb_alpha_factor;
+   bool timedate_enable                = video_info->timedate_enable;
+   bool battery_level_enable           = video_info->battery_level_enable;
+   bool video_fullscreen               = video_info->fullscreen;
+   bool mouse_grabbed                  = video_info->input_driver_grab_mouse_state;
+   bool menu_mouse_enable              = video_info->menu_mouse_enable;
+   unsigned color_theme                = video_info->xmb_color_theme;
+   bool libretro_running               = video_info->libretro_running;
+   unsigned menu_shader_pipeline       = video_info->menu_shader_pipeline;
+   float menu_wallpaper_opacity        = video_info->menu_wallpaper_opacity;
+   gfx_display_t *p_disp               = (gfx_display_t*)video_info->disp_userdata;
+   gfx_animation_t *p_anim             = anim_get_ptr();
+   gfx_display_ctx_driver_t *dispctx   = p_disp->dispctx;
+   video_driver_state_t *video_st      = video_state_get_ptr();
+   struct menu_state *menu_st          = menu_state_get_ptr();
+   menu_list_t *menu_list              = menu_st->entries.list;
+   bool input_dialog_display_kb        = menu_input_dialog_get_display_kb();
 
    if (!xmb)
       return;
 
-   msg[0]             = '\0';
-   title_msg[0]       = '\0';
-   title_truncated[0] = '\0';
+   msg[0]                              = '\0';
+   title_msg[0]                        = '\0';
+   title_truncated[0]                  = '\0';
 
    /* If menu screensaver is active, draw
     * screensaver and return */
    if (xmb->show_screensaver)
    {
-      menu_screensaver_frame(xmb->screensaver,
-            video_info, p_disp);
+      menu_screensaver_frame(xmb->screensaver, video_info, p_disp);
       return;
    }
 
@@ -5773,7 +5700,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    xmb->margins_title_horizontal_offset    = (float)settings->ints.menu_xmb_title_margin_horizontal_offset * 10.0f;
 
    /* Configure shadow effect */
-   if (xmb_shadows_enable)
+   if (shadows_enable)
    {
       thumbnail_shadow.type          = GFX_THUMBNAIL_SHADOW_OUTLINE;
       thumbnail_shadow.alpha         = 0.50f;
@@ -5790,9 +5717,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    xmb->raster_block.carr.coords.vertices  = 0;
    xmb->raster_block2.carr.coords.vertices = 0;
 
-   gfx_display_set_alpha(xmb_coord_black, MIN(
-            (float)xmb_alpha_factor / 100,
-            xmb->alpha));
+   gfx_display_set_alpha(xmb_coord_black, MIN((float)alpha_factor / 100, xmb->alpha));
    gfx_display_set_alpha(xmb_coord_white, xmb->alpha);
 
    if (dispctx)
@@ -5803,10 +5728,10 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             video_width,
             video_height,
             menu_shader_pipeline,
-            xmb_color_theme,
+            color_theme,
             menu_wallpaper_opacity,
             libretro_running,
-            xmb_alpha_factor / 100,
+            alpha_factor / 100,
             xmb->textures.bg,
             xmb->bg_file_path,
             xmb_coord_black,
@@ -5819,7 +5744,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          !string_is_empty(xmb->title_name_alt) ? xmb->title_name_alt : xmb->title_name,
          sizeof(title_truncated));
 
-   if (!menu_xmb_vertical_fade_factor && selection > 1)
+   if (!vertical_fade_factor && selection > 1)
    {
       /* skip 25 UTF8 multi-byte chars */
       char *end = title_truncated;
@@ -5835,8 +5760,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    }
 
    /* Title text */
-   if (menu_xmb_show_title_header)
-      xmb_draw_text(xmb_shadows_enable, xmb, settings,
+   if (show_title_header)
+      xmb_draw_text(shadows_enable, xmb, settings,
             title_truncated, xmb->margins_title_left,
             xmb->margins_title_top,
             1, 1, TEXT_ALIGN_LEFT,
@@ -5845,7 +5770,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    if (menu_core_enable)
    {
       menu_entries_get_core_title(title_msg, sizeof(title_msg));
-      xmb_draw_text(xmb_shadows_enable, xmb, settings,
+      xmb_draw_text(shadows_enable, xmb, settings,
             title_msg, xmb->margins_title_left,
             video_height - xmb->margins_title_bottom, 1, 1, TEXT_ALIGN_LEFT,
             video_width, video_height, xmb->font);
@@ -5874,9 +5799,9 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    }
 
    /* Allow browsing playlist in fullscreen thumbnail mode */
-   if (    (xmb->is_playlist || xmb->is_explore_list || xmb->is_state_slot)
-         && xmb->show_fullscreen_thumbnails
-         && xmb->fullscreen_thumbnails_available
+   if (     (xmb->is_playlist || xmb->is_explore_list || xmb->is_state_slot)
+         && (xmb->show_fullscreen_thumbnails)
+         && (xmb->fullscreen_thumbnails_available)
          && (menu_st->selection_ptr != xmb->fullscreen_thumbnail_selection))
       xmb_show_fullscreen_thumbnails(xmb, menu_st, menu_st->selection_ptr);
    else if (!xmb->show_fullscreen_thumbnails
@@ -5889,9 +5814,9 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
     * trying to rationalise this any further... */
 
    /* Save state thumbnail, right side in PS3 layout, left in PSP layout */
-   if (       (xmb->is_quick_menu || xmb->is_state_slot)
-          && ((xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
-          ||  (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_PENDING)))
+   if (     (xmb->is_quick_menu || xmb->is_state_slot)
+         && (  (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
+            || (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_PENDING)))
    {
       float thumb_width         = right_thumbnail_margin_width;
       float thumb_height        = thumbnail_margin_height_full;
@@ -5927,11 +5852,11 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    else if (xmb->fullscreen_thumbnails_available)
    {
       bool show_right_thumbnail =
-            (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE) ||
-            (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_PENDING);
+               (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
+            || (xmb->thumbnails.right.status == GFX_THUMBNAIL_STATUS_PENDING);
       bool show_left_thumbnail  =
-            (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE) ||
-            (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_PENDING);
+               (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_AVAILABLE)
+            || (xmb->thumbnails.left.status == GFX_THUMBNAIL_STATUS_PENDING);
 
       /* Check if we are using the proper PS3 layout,
        * or the aborted PSP layout */
@@ -5939,7 +5864,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       {
          /* Check if user has selected vertically
           * stacked thumbnails */
-         if (menu_xmb_vertical_thumbnails)
+         if (vertical_thumbnails)
          {
             /* Right + left thumbnails, right side */
             if (show_right_thumbnail && show_left_thumbnail)
@@ -6123,7 +6048,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   dispctx,
                   video_width,
                   video_height,
-                  xmb_shadows_enable,
+                  shadows_enable,
                   xmb->icon_size,
                   xmb->textures.list[
                   powerstate.charging? XMB_TEXTURE_BATTERY_CHARGING   :
@@ -6151,7 +6076,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             font_driver_get_message_width(
                   xmb->font, msg, strlen(msg), 1.0f);
 
-         xmb_draw_text(xmb_shadows_enable, xmb, settings, msg,
+         xmb_draw_text(shadows_enable, xmb, settings, msg,
                video_width - xmb->margins_title_left - x_pos,
                xmb->margins_title_top, 1, 1, TEXT_ALIGN_RIGHT,
                video_width, video_height, xmb->font);
@@ -6179,7 +6104,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                dispctx,
                video_width,
                video_height,
-               xmb_shadows_enable,
+               shadows_enable,
                xmb->icon_size,
                xmb->textures.list[XMB_TEXTURE_CLOCK],
                video_width - xmb->margins_title_left + margin_offset - x_pos,
@@ -6205,15 +6130,14 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
 
       menu_display_timedate(&datetime);
 
-      xmb_draw_text(xmb_shadows_enable, xmb, settings, timedate,
+      xmb_draw_text(shadows_enable, xmb, settings, timedate,
             video_width - xmb->margins_title_left - xmb->icon_size / 4 - x_pos,
             xmb->margins_title_top, 1, 1, TEXT_ALIGN_RIGHT,
             video_width, video_height, xmb->font);
    }
 
    /* Arrow image */
-   gfx_display_set_alpha(xmb_item_color,
-         MIN(xmb->textures_arrow_alpha, xmb->alpha));
+   gfx_display_set_alpha(xmb_item_color, MIN(xmb->textures_arrow_alpha, xmb->alpha));
 
    if (!xmb->assets_missing)
    {
@@ -6225,7 +6149,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
             dispctx,
             video_width,
             video_height,
-            xmb_shadows_enable,
+            shadows_enable,
             xmb->icon_size,
             xmb->textures.list[XMB_TEXTURE_ARROW],
             xmb->x + xmb->margins_screen_left +
@@ -6249,10 +6173,10 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    if (dispctx && dispctx->blend_begin)
       dispctx->blend_begin(userdata);
 
+   /* Horizontal tab icons */
    if (!xmb->assets_missing)
    {
-      for (i = 0; i <= xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL)
-            + xmb->system_tab_end; i++)
+      for (i = 0; i <= xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL) + xmb->system_tab_end; i++)
       {
          xmb_node_t *node = xmb_get_node(xmb, i);
 
@@ -6265,12 +6189,12 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          {
             math_matrix_4x4 mymat_tmp;
             uintptr_t texture        = node->icon;
-            float x                  = xmb->x + xmb->categories_x_pos +
-               xmb->margins_screen_left +
-               xmb->icon_spacing_horizontal
-               * (i + 1) - xmb->icon_size / 2.0;
+            float x                  = xmb->x + xmb->categories_x_pos
+                  + xmb->margins_screen_left
+                  + xmb->icon_spacing_horizontal * (i + 1)
+                  - xmb->icon_size / 2.0;
             float y                  = xmb->margins_screen_top
-               + xmb->icon_size / 2.0;
+                  + xmb->icon_size / 2.0;
             float scale_factor       = node->zoom;
 
             /* Check whether we need to fade out icons
@@ -6305,9 +6229,9 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                if (scale_factor != 1.0f)
                {
                   static math_matrix_4x4 matrix_scaled = {
-                     { 0.0f,          0.0f,          0.0f,          0.0f ,
-                        0.0f,          0.0f,          0.0f,          0.0f ,
-                        0.0f,          0.0f,          0.0f,          0.0f ,
+                      { 0.0f,          0.0f,          0.0f,          0.0f,
+                        0.0f,          0.0f,          0.0f,          0.0f,
+                        0.0f,          0.0f,          0.0f,          0.0f,
                         0.0f,          0.0f,          0.0f,          1.0f }
                   };
                   MAT_ELEM_4X4(matrix_scaled, 0, 0)    = scale_factor;
@@ -6323,7 +6247,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
                   dispctx,
                   video_width,
                   video_height,
-                  xmb_shadows_enable,
+                  shadows_enable,
                   xmb->icon_size,
                   texture,
                   x,
@@ -6340,7 +6264,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       }
    }
 
-   /* Vertical icons */
+   /* Previous icon */
    xmb_draw_items(
          userdata,
          p_disp,
@@ -6350,13 +6274,11 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          settings,
          video_width,
          video_height,
-         xmb_shadows_enable,
+         shadows_enable,
          xmb,
          &xmb->selection_buf_old,
          xmb->selection_ptr_old,
-         (xmb->depth > 1)
-               ? xmb->categories_selection_ptr
-               : xmb->categories_selection_ptr_old,
+         xmb->categories_selection_ptr,
          &xmb_item_color[0],
          video_width,
          video_height,
@@ -6374,7 +6296,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          settings,
          video_width,
          video_height,
-         xmb_shadows_enable,
+         shadows_enable,
          xmb,
          selection_buf,
          selection,
@@ -6402,8 +6324,8 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          userdata,
          video_width,
          video_height,
-         xmb_shadows_enable,
-         xmb_color_theme,
+         shadows_enable,
+         color_theme,
          settings, selection);
 
    if (input_dialog_display_kb)
@@ -6421,8 +6343,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
 
    if (!string_is_empty(xmb->box_message))
    {
-      strlcpy(msg, xmb->box_message,
-            sizeof(msg));
+      strlcpy(msg, xmb->box_message, sizeof(msg));
       free(xmb->box_message);
       xmb->box_message  = NULL;
       render_background = true;
@@ -6443,8 +6364,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    /* Cursor image */
    if (xmb->show_mouse)
    {
-      bool cursor_visible = (video_fullscreen || mouse_grabbed)
-            && menu_mouse_enable;
+      bool cursor_visible = menu_mouse_enable && (video_fullscreen || mouse_grabbed);
 
       gfx_display_set_alpha(xmb_coord_white, MIN(xmb->alpha, 1.00f));
       if (cursor_visible)
@@ -6490,7 +6410,7 @@ static void xmb_layout_ps3(xmb_handle_t *xmb, int width)
    xmb->items_active_alpha       = 1.0;
    xmb->items_passive_alpha      = 0.85;
 
-   xmb->shadow_offset            = 3.0 * scale_factor;
+   xmb->shadow_offset            = 3.0            * scale_factor;
    if (xmb->shadow_offset < 1.0)
       xmb->shadow_offset         = 1.0;
    if (xmb->shadow_offset > 2.0)
@@ -6545,7 +6465,7 @@ static void xmb_layout_psp(xmb_handle_t *xmb, int width)
    xmb->items_active_alpha       = 1.0;
    xmb->items_passive_alpha      = 0.85;
 
-   xmb->shadow_offset            = 3.0 * scale_factor;
+   xmb->shadow_offset            = 3.0            * scale_factor;
    if (xmb->shadow_offset < 1.0)
       xmb->shadow_offset         = 1.0;
    if (xmb->shadow_offset > 2.0)
@@ -6683,8 +6603,8 @@ static void xmb_layout(xmb_handle_t *xmb)
 static void xmb_ribbon_set_vertex(float *ribbon_verts,
       unsigned idx, unsigned row, unsigned col)
 {
-   ribbon_verts[idx++] = ((float)col) / (XMB_RIBBON_COLS-1) * 2.0f - 1.0f;
-   ribbon_verts[idx++] = ((float)row) / (XMB_RIBBON_ROWS-1) * 2.0f - 1.0f;
+   ribbon_verts[idx++] = ((float)col) / (XMB_RIBBON_COLS - 1) * 2.0f - 1.0f;
+   ribbon_verts[idx++] = ((float)row) / (XMB_RIBBON_ROWS - 1) * 2.0f - 1.0f;
 }
 
 static void xmb_init_ribbon(xmb_handle_t * xmb)
@@ -6694,7 +6614,7 @@ static void xmb_init_ribbon(xmb_handle_t * xmb)
    unsigned i                = 0;
    gfx_display_t *p_disp     = disp_get_ptr();
    video_coord_array_t *ca   = &p_disp->dispca;
-   unsigned   vertices_total = XMB_RIBBON_VERTICES;
+   unsigned vertices_total   = XMB_RIBBON_VERTICES;
    float *dummy              = (float*)calloc(4 * vertices_total, sizeof(float));
    float *ribbon_verts       = (float*)calloc(2 * vertices_total, sizeof(float));
 
@@ -6803,8 +6723,7 @@ static void *xmb_init(void **userdata, bool video_is_threaded)
       xmb->tabs[++xmb->system_tab_end] = XMB_SYSTEM_TAB_ADD;
 
 #if defined(HAVE_DYNAMIC)
-   if (settings->uints.menu_content_show_contentless_cores !=
-         MENU_CONTENTLESS_CORES_DISPLAY_NONE)
+   if (settings->uints.menu_content_show_contentless_cores != MENU_CONTENTLESS_CORES_DISPLAY_NONE)
       xmb->tabs[++xmb->system_tab_end] = XMB_SYSTEM_TAB_CONTENTLESS_CORES;
 #endif
 
@@ -7203,8 +7122,7 @@ static const char *xmb_texture_path(unsigned id)
 static bool xmb_context_reset_textures(
       xmb_handle_t *xmb,
       const char *iconpath,
-      unsigned menu_xmb_theme
-)
+      unsigned menu_xmb_theme)
 {
    unsigned i;
 
@@ -7213,23 +7131,25 @@ static bool xmb_context_reset_textures(
       if (!gfx_display_reset_textures_list(xmb_texture_path(i), iconpath, &xmb->textures.list[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL))
       {
          /* New extra battery icons could be missing */
-         if (i == XMB_TEXTURE_BATTERY_80 || i == XMB_TEXTURE_BATTERY_60 || i == XMB_TEXTURE_BATTERY_40 || i == XMB_TEXTURE_BATTERY_20)
+         if (     i == XMB_TEXTURE_BATTERY_80
+               || i == XMB_TEXTURE_BATTERY_60
+               || i == XMB_TEXTURE_BATTERY_40
+               || i == XMB_TEXTURE_BATTERY_20)
          {
-            if (  /* If there are no extra battery icons revert to the old behaviour */
-                  !gfx_display_reset_textures_list(xmb_texture_path(XMB_TEXTURE_BATTERY_FULL), iconpath, &xmb->textures.list[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL)
-                  && !(menu_xmb_theme == XMB_ICON_THEME_CUSTOM)
-               )
+            /* If there are no extra battery icons revert to the old behaviour */
+            if (     !gfx_display_reset_textures_list(xmb_texture_path(XMB_TEXTURE_BATTERY_FULL), iconpath, &xmb->textures.list[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL)
+                  && !(menu_xmb_theme == XMB_ICON_THEME_CUSTOM))
                return false;
             continue;
          }
          /* If the icon is missing return the subsetting (because some themes are incomplete) */
-         if (!(i == XMB_TEXTURE_DIALOG_SLICE || i == XMB_TEXTURE_KEY_HOVER || i == XMB_TEXTURE_KEY))
+         if ( !(  i == XMB_TEXTURE_DIALOG_SLICE
+               || i == XMB_TEXTURE_KEY_HOVER
+               || i == XMB_TEXTURE_KEY))
          {
             /* OSD Warning only if subsetting icon is missing */
-            if (
-                  !gfx_display_reset_textures_list(xmb_texture_path(XMB_TEXTURE_SUBSETTING), iconpath, &xmb->textures.list[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL)
-                  && !(menu_xmb_theme == XMB_ICON_THEME_CUSTOM)
-               )
+            if (     !gfx_display_reset_textures_list(xmb_texture_path(XMB_TEXTURE_SUBSETTING), iconpath, &xmb->textures.list[i], TEXTURE_FILTER_MIPMAP_LINEAR, NULL, NULL)
+                  && !(menu_xmb_theme == XMB_ICON_THEME_CUSTOM))
             {
                /* Do not draw icons if subsetting is missing */
                return false;
@@ -7303,21 +7223,17 @@ static bool xmb_context_reset_textures(
 #endif
 
    /* Recolor */
-   if (
-         (menu_xmb_theme == XMB_ICON_THEME_MONOCHROME_INVERTED) ||
-         (menu_xmb_theme == XMB_ICON_THEME_AUTOMATIC_INVERTED)
-      )
+   if (     (menu_xmb_theme == XMB_ICON_THEME_MONOCHROME_INVERTED)
+         || (menu_xmb_theme == XMB_ICON_THEME_AUTOMATIC_INVERTED))
       memcpy(xmb_item_color, xmb_coord_black, sizeof(xmb_item_color));
    else
    {
-      if (
-            (menu_xmb_theme == XMB_ICON_THEME_MONOCHROME) ||
-            (menu_xmb_theme == XMB_ICON_THEME_AUTOMATIC)
-         )
+      if (     (menu_xmb_theme == XMB_ICON_THEME_MONOCHROME)
+            || (menu_xmb_theme == XMB_ICON_THEME_AUTOMATIC))
       {
-         for (i=0;i<16;i++)
+         for (i = 0; i < 16; i++)
          {
-            if ((i==3) || (i==7) || (i==11) || (i==15))
+            if ((i == 3) || (i == 7) || (i == 11) || (i == 15))
             {
                xmb_item_color[i] = 1;
                continue;
@@ -7326,8 +7242,7 @@ static bool xmb_context_reset_textures(
          }
       }
       else
-         memcpy(xmb_item_color,
-               xmb_coord_white, sizeof(xmb_item_color));
+         memcpy(xmb_item_color, xmb_coord_white, sizeof(xmb_item_color));
    }
 
    return true;
@@ -7335,10 +7250,10 @@ static bool xmb_context_reset_textures(
 
 static void xmb_context_reset_background(xmb_handle_t *xmb, const char *iconpath)
 {
-   char path[PATH_MAX_LENGTH];
    settings_t *settings               = config_get_ptr();
-   const char *path_menu_wp           = settings->paths.path_menu_wallpaper;
+   const char *path_menu_wallpaper    = settings->paths.path_menu_wallpaper;
    bool menu_dynamic_wallpaper_enable = settings->bools.menu_dynamic_wallpaper_enable;
+   char path[PATH_MAX_LENGTH];
 
    path[0]                            = '\0';
 
@@ -7349,8 +7264,8 @@ static void xmb_context_reset_background(xmb_handle_t *xmb, const char *iconpath
 
    if (!string_is_empty(path) && path_is_valid(path))
       ;/* no-op */
-   else if (!string_is_empty(path_menu_wp))
-      strlcpy(path, path_menu_wp, sizeof(path));
+   else if (!string_is_empty(path_menu_wallpaper))
+      strlcpy(path, path_menu_wallpaper, sizeof(path));
    else if (!string_is_empty(iconpath))
       fill_pathname_join_special(path, iconpath, FILE_PATH_BACKGROUND_IMAGE, sizeof(path));
 
@@ -7395,21 +7310,18 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
       font_driver_free(xmb->font2);
       xmb->font2 = NULL;
    }
+
    fill_pathname_application_special(
          fontpath, sizeof(fontpath), APPLICATION_SPECIAL_DIRECTORY_ASSETS_XMB_FONT);
-   xmb->font            = gfx_display_font_file(p_disp,
-         fontpath, xmb->font_size, is_threaded);
-   xmb->font2           = gfx_display_font_file(p_disp,
-         fontpath, xmb->font2_size, is_threaded);
+   xmb->font            = gfx_display_font_file(p_disp, fontpath, xmb->font_size, is_threaded);
+   xmb->font2           = gfx_display_font_file(p_disp, fontpath, xmb->font2_size, is_threaded);
 
    xmb->wideglyph_width = 100;
 
    if (wideglyph_str)
    {
-      int char_width =
-         font_driver_get_message_width(xmb->font, "a", 1, 1.0f);
-      int wideglyph_width =
-         font_driver_get_message_width(xmb->font, wideglyph_str, strlen(wideglyph_str), 1.0f);
+      int char_width      = font_driver_get_message_width(xmb->font, "a", 1, 1.0f);
+      int wideglyph_width = font_driver_get_message_width(xmb->font, wideglyph_str, strlen(wideglyph_str), 1.0f);
 
       if (wideglyph_width > 0 && char_width > 0)
          xmb->wideglyph_width = wideglyph_width * 100 / char_width;
@@ -7429,9 +7341,9 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
       {
          xmb_free_list_nodes(&xmb->selection_buf_old, false);
          file_list_deinitialize(&xmb->selection_buf_old);
-         xmb->selection_buf_old.list        = NULL;
-         xmb->selection_buf_old.capacity    = 0;
-         xmb->selection_buf_old.size        = 0;
+         xmb->selection_buf_old.list     = NULL;
+         xmb->selection_buf_old.capacity = 0;
+         xmb->selection_buf_old.size     = 0;
       }
    }
    else
@@ -7448,15 +7360,13 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
     * > Thumbnails are enabled
     * > This is a playlist, a database list, a file list
     *   or the quick menu */
-   if (   gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
-       || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
+   if (     gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
+         || gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_LEFT))
    {
       unsigned depth          = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
       unsigned xmb_system_tab = xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr);
 
-      if ((((  (xmb_system_tab > XMB_SYSTEM_TAB_SETTINGS && depth == 1)
-            || (xmb_system_tab < XMB_SYSTEM_TAB_SETTINGS && depth == 4))
-            && xmb->is_playlist))
+      if (     xmb->is_playlist
             || xmb->is_db_manager_list
             || xmb->is_explore_list
             || xmb->is_file_list
@@ -7482,7 +7392,7 @@ static void xmb_context_reset(void *data, bool is_threaded)
 
 static void xmb_navigation_clear(void *data, bool pending_push)
 {
-   xmb_handle_t  *xmb  = (xmb_handle_t*)data;
+   xmb_handle_t *xmb = (xmb_handle_t*)data;
 
    if (!pending_push)
       xmb_selection_pointer_changed(xmb, true);
@@ -7490,19 +7400,19 @@ static void xmb_navigation_clear(void *data, bool pending_push)
 
 static void xmb_navigation_pointer_changed(void *data)
 {
-   xmb_handle_t  *xmb  = (xmb_handle_t*)data;
+   xmb_handle_t *xmb = (xmb_handle_t*)data;
    xmb_selection_pointer_changed(xmb, true);
 }
 
 static void xmb_navigation_set(void *data, bool scroll)
 {
-   xmb_handle_t  *xmb  = (xmb_handle_t*)data;
+   xmb_handle_t *xmb = (xmb_handle_t*)data;
    xmb_selection_pointer_changed(xmb, scroll);
 }
 
 static void xmb_navigation_alphabet(void *data, size_t *unused)
 {
-   xmb_handle_t  *xmb  = (xmb_handle_t*)data;
+   xmb_handle_t *xmb = (xmb_handle_t*)data;
    xmb_selection_pointer_changed(xmb, true);
 }
 
@@ -7570,7 +7480,9 @@ static void xmb_list_free(file_list_t *list, size_t a, size_t b)
    xmb_list_clear(list);
 }
 
-static void xmb_list_deep_copy(const file_list_t *src, file_list_t *dst,
+static void xmb_list_deep_copy(
+      const file_list_t *src,
+      file_list_t *dst,
       size_t first, size_t last)
 {
    size_t i, j   = 0;
@@ -7615,12 +7527,12 @@ static void xmb_list_deep_copy(const file_list_t *src, file_list_t *dst,
 static void xmb_list_cache(void *data, enum menu_list_type type, unsigned action)
 {
    size_t stack_size, list_size;
-   xmb_handle_t      *xmb         = (xmb_handle_t*)data;
-   struct menu_state *menu_st     = menu_state_get_ptr();
-   menu_list_t *menu_list         = menu_st->entries.list;
-   file_list_t *menu_stack        = MENU_LIST_GET(menu_list, 0);
-   file_list_t *selection_buf     = MENU_LIST_GET_SELECTION(menu_list, 0);
-   size_t selection               = menu_st->selection_ptr;
+   xmb_handle_t *xmb          = (xmb_handle_t*)data;
+   struct menu_state *menu_st = menu_state_get_ptr();
+   menu_list_t *menu_list     = menu_st->entries.list;
+   file_list_t *menu_stack    = MENU_LIST_GET(menu_list, 0);
+   file_list_t *selection_buf = MENU_LIST_GET_SELECTION(menu_list, 0);
+   size_t selection           = menu_st->selection_ptr;
 
    if (!xmb)
       return;
@@ -7652,8 +7564,7 @@ static void xmb_list_cache(void *data, enum menu_list_type type, unsigned action
    else
       xmb->selection_ptr_old = selection;
 
-   list_size = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL)
-      + xmb->system_tab_end;
+   list_size = xmb_list_get_size(xmb, MENU_LIST_HORIZONTAL) + xmb->system_tab_end;
 
    switch (type)
    {
@@ -7696,84 +7607,60 @@ static void xmb_list_cache(void *data, enum menu_list_type type, unsigned action
          switch (xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr))
          {
             case XMB_SYSTEM_TAB_MAIN:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_SETTINGS;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU));
+               menu_stack->list[stack_size - 1].type  = MENU_SETTINGS;
                break;
             case XMB_SYSTEM_TAB_SETTINGS:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_SETTINGS_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_SETTINGS_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_SETTINGS_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_SETTINGS_TAB;
                break;
 #ifdef HAVE_IMAGEVIEWER
             case XMB_SYSTEM_TAB_IMAGES:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_IMAGES_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_IMAGES_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_IMAGES_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_IMAGES_TAB;
                break;
 #endif
             case XMB_SYSTEM_TAB_MUSIC:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_MUSIC_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_MUSIC_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_MUSIC_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_MUSIC_TAB;
                break;
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
             case XMB_SYSTEM_TAB_VIDEO:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_VIDEO_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_VIDEO_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_VIDEO_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_VIDEO_TAB;
                break;
 #endif
             case XMB_SYSTEM_TAB_HISTORY:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_HISTORY_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_HISTORY_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_HISTORY_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_HISTORY_TAB;
                break;
             case XMB_SYSTEM_TAB_FAVORITES:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_FAVORITES_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_FAVORITES_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_FAVORITES_TAB;
                break;
 #ifdef HAVE_NETWORKING
             case XMB_SYSTEM_TAB_NETPLAY:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_NETPLAY_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_NETPLAY_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_NETPLAY_TAB;
                break;
 #endif
             case XMB_SYSTEM_TAB_ADD:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_ADD_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_ADD_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_ADD_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_ADD_TAB;
                break;
 #if defined(HAVE_LIBRETRODB)
             case XMB_SYSTEM_TAB_EXPLORE:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_EXPLORE_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_EXPLORE_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_EXPLORE_TAB;
                break;
 #endif
             case XMB_SYSTEM_TAB_CONTENTLESS_CORES:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_CONTENTLESS_CORES_TAB;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_CONTENTLESS_CORES_TAB));
+               menu_stack->list[stack_size - 1].type  = MENU_CONTENTLESS_CORES_TAB;
                break;
             default:
-               menu_stack->list[stack_size - 1].label =
-                  strdup(msg_hash_to_str(MENU_ENUM_LABEL_HORIZONTAL_MENU));
-               menu_stack->list[stack_size - 1].type =
-                  MENU_SETTING_HORIZONTAL_MENU;
+               menu_stack->list[stack_size - 1].label = strdup(msg_hash_to_str(MENU_ENUM_LABEL_HORIZONTAL_MENU));
+               menu_stack->list[stack_size - 1].type  = MENU_SETTING_HORIZONTAL_MENU;
                break;
          }
          break;
@@ -7785,7 +7672,7 @@ static void xmb_list_cache(void *data, enum menu_list_type type, unsigned action
 static void xmb_context_destroy(void *data)
 {
    unsigned i;
-   xmb_handle_t *xmb   = (xmb_handle_t*)data;
+   xmb_handle_t *xmb = (xmb_handle_t*)data;
 
    if (!xmb)
       return;
@@ -7826,9 +7713,9 @@ static void xmb_toggle(void *userdata, bool menu_on)
    }
 
    if (MENU_ENTRIES_NEEDS_REFRESH(menu_st))
-      menu_st->flags                 &=  ~MENU_ST_FLAG_PREVENT_POPULATE;
+      menu_st->flags         &= ~MENU_ST_FLAG_PREVENT_POPULATE;
    else
-      menu_st->flags                 |=   MENU_ST_FLAG_PREVENT_POPULATE;
+      menu_st->flags         |=  MENU_ST_FLAG_PREVENT_POPULATE;
 
    xmb_toggle_horizontal_list(xmb);
 }
@@ -7836,11 +7723,13 @@ static void xmb_toggle(void *userdata, bool menu_on)
 static int xmb_deferred_push_content_actions(menu_displaylist_info_t *info)
 {
    settings_t *settings = config_get_ptr();
-   if (!menu_displaylist_ctl(
-            DISPLAYLIST_HORIZONTAL_CONTENT_ACTIONS, info, settings))
+
+   if (!menu_displaylist_ctl(DISPLAYLIST_HORIZONTAL_CONTENT_ACTIONS, info, settings))
       return -1;
+
    menu_displaylist_process(info);
    menu_displaylist_info_free(info);
+
    return 0;
 }
 
@@ -7900,11 +7789,12 @@ static int xmb_list_push(void *data, void *userdata,
    bool menu_show_online_updater   = settings->bools.menu_show_online_updater;
 #endif
 #if defined(HAVE_MIST)
-   bool menu_show_core_manager_steam = settings->bools.menu_show_core_manager_steam;
+   bool menu_show_core_manager_steam
+                                   = settings->bools.menu_show_core_manager_steam;
 #endif
    bool menu_content_show_settings = settings->bools.menu_content_show_settings;
-   const char *menu_content_show_settings_password =
-      settings->paths.menu_content_show_settings_password;
+   const char *menu_content_show_settings_password
+                                   = settings->paths.menu_content_show_settings_password;
    const char *kiosk_mode_password = settings->paths.kiosk_mode_password;
 
    switch (type)
@@ -7950,7 +7840,7 @@ static int xmb_list_push(void *data, void *userdata,
          break;
       case DISPLAYLIST_MAIN_MENU:
          {
-            uint32_t flags              = runloop_get_flags();
+            uint32_t flags = runloop_get_flags();
 
             menu_entries_clear(info->list);
 
@@ -8169,31 +8059,30 @@ static bool xmb_menu_init_list(void *data)
 {
    menu_displaylist_info_t info;
 
-   settings_t *settings         = config_get_ptr();
-   struct menu_state *menu_st   = menu_state_get_ptr();
-   menu_list_t *menu_list       = menu_st->entries.list;
-   file_list_t *menu_stack      = MENU_LIST_GET(menu_list, 0);
-   file_list_t *selection_buf   = MENU_LIST_GET_SELECTION(menu_list, 0);
+   settings_t *settings       = config_get_ptr();
+   struct menu_state *menu_st = menu_state_get_ptr();
+   menu_list_t *menu_list     = menu_st->entries.list;
+   file_list_t *menu_stack    = MENU_LIST_GET(menu_list, 0);
+   file_list_t *selection_buf = MENU_LIST_GET_SELECTION(menu_list, 0);
 
    menu_displaylist_info_init(&info);
 
-   info.label                   = strdup(
-         msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU));
-   info.exts                    = strldup("lpl", sizeof("lpl"));
-   info.type_default            = FILE_TYPE_PLAIN;
-   info.enum_idx                = MENU_ENUM_LABEL_MAIN_MENU;
+   info.label                 = strdup(msg_hash_to_str(MENU_ENUM_LABEL_MAIN_MENU));
+   info.exts                  = strldup("lpl", sizeof("lpl"));
+   info.type_default          = FILE_TYPE_PLAIN;
+   info.enum_idx              = MENU_ENUM_LABEL_MAIN_MENU;
 
    menu_entries_append(menu_stack, info.path,
          info.label,
          MENU_ENUM_LABEL_MAIN_MENU,
          info.type, info.flags, 0, NULL);
 
-   info.list  = selection_buf;
+   info.list                  = selection_buf;
 
    if (!menu_displaylist_ctl(DISPLAYLIST_MAIN_MENU, &info, settings))
       goto error;
 
-   info.flags    |= MD_FLAG_NEED_PUSH;
+   info.flags                |= MD_FLAG_NEED_PUSH;
 
    if (!menu_displaylist_process(&info))
       goto error;
@@ -8217,11 +8106,11 @@ static int xmb_pointer_up(void *userdata,
    int16_t margin_top;
    int16_t margin_left;
    int16_t margin_right;
-   xmb_handle_t *xmb            = (xmb_handle_t*)userdata;
-   struct menu_state *menu_st   = menu_state_get_ptr();
-   size_t selection             = menu_st->selection_ptr;
-   menu_list_t *menu_list       = menu_st->entries.list;
-   unsigned end                 = (unsigned)MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+   xmb_handle_t *xmb          = (xmb_handle_t*)userdata;
+   struct menu_state *menu_st = menu_state_get_ptr();
+   size_t selection           = menu_st->selection_ptr;
+   menu_list_t *menu_list     = menu_st->entries.list;
+   unsigned end               = (unsigned)MENU_LIST_GET_SELECTION(menu_list, 0)->size;
 
    if (!xmb)
       return -1;
@@ -8253,19 +8142,16 @@ static int xmb_pointer_up(void *userdata,
          if ((int)x < margin_left)
          {
             if ((int)y >= margin_top)
-               return xmb_menu_entry_action(xmb,
-                     entry, selection, MENU_ACTION_CANCEL);
+               return xmb_menu_entry_action(xmb, entry, selection, MENU_ACTION_CANCEL);
             return menu_input_dialog_start_search() ? 0 : -1;
          }
          else if ((int)x > margin_right)
-            return xmb_menu_entry_action(xmb,
-                  entry, selection, MENU_ACTION_SELECT);
+            return xmb_menu_entry_action(xmb, entry, selection, MENU_ACTION_SELECT);
          else if (ptr <= (end - 1))
          {
             /* If pointer item is already 'active', perform 'select' action */
             if (ptr == selection)
-               return xmb_menu_entry_action(xmb,
-                     entry, selection, MENU_ACTION_SELECT);
+               return xmb_menu_entry_action(xmb, entry, selection, MENU_ACTION_SELECT);
 
             /* ...otherwise navigate to the current pointer item */
             menu_st->selection_ptr = ptr;
@@ -8275,8 +8161,7 @@ static int xmb_pointer_up(void *userdata,
       case MENU_INPUT_GESTURE_LONG_PRESS:
          /* 'Reset to default' action */
          if ((ptr <= end - 1) && (ptr == selection))
-            return xmb_menu_entry_action(xmb,
-                  entry, selection, MENU_ACTION_START);
+            return xmb_menu_entry_action(xmb, entry, selection, MENU_ACTION_START);
          break;
       case MENU_INPUT_GESTURE_SWIPE_LEFT:
          /* Navigate left
@@ -8284,8 +8169,7 @@ static int xmb_pointer_up(void *userdata,
           * means switching to the 'next' horizontal list,
           * which is actually a movement to the *right* */
          if ((int)y > margin_top)
-            xmb_menu_entry_action(xmb,
-                  entry, selection,
+            xmb_menu_entry_action(xmb, entry, selection,
                   (xmb->depth == 1) ? MENU_ACTION_RIGHT : MENU_ACTION_LEFT);
          break;
       case MENU_INPUT_GESTURE_SWIPE_RIGHT:
@@ -8294,15 +8178,13 @@ static int xmb_pointer_up(void *userdata,
           * means switching to the 'previous' horizontal list,
           * which is actually a movement to the *left* */
          if ((int)y > margin_top)
-            xmb_menu_entry_action(xmb,
-                  entry, selection,
+            xmb_menu_entry_action(xmb, entry, selection,
                   (xmb->depth == 1) ? MENU_ACTION_LEFT : MENU_ACTION_RIGHT);
          break;
       case MENU_INPUT_GESTURE_SWIPE_UP:
          /* Swipe up in left margin: ascend alphabet */
          if ((int)x < margin_left)
-            xmb_menu_entry_action(xmb,
-                  entry, selection, MENU_ACTION_SCROLL_DOWN);
+            xmb_menu_entry_action(xmb, entry, selection, MENU_ACTION_SCROLL_DOWN);
          else if ((int)x < margin_right)
          {
             /* Swipe up between left and right margins:
@@ -8311,8 +8193,7 @@ static int xmb_pointer_up(void *userdata,
             unsigned last  = end;
 
             if (height)
-               xmb_calculate_visible_range(xmb, height,
-                     end, (unsigned)selection, &first, &last);
+               xmb_calculate_visible_range(xmb, height, end, (unsigned)selection, &first, &last);
 
             if (last < end)
             {
@@ -8321,10 +8202,10 @@ static int xmb_pointer_up(void *userdata,
             }
             else
             {
-               size_t menu_list_size     = menu_st->entries.list ? MENU_LIST_GET_SELECTION(menu_st->entries.list, 0)->size : 0;
-               size_t new_selection      = menu_list_size - 1;
+               size_t menu_list_size  = menu_st->entries.list ? MENU_LIST_GET_SELECTION(menu_st->entries.list, 0)->size : 0;
+               size_t new_selection   = menu_list_size - 1;
 
-               menu_st->selection_ptr    = new_selection;
+               menu_st->selection_ptr = new_selection;
 
                if (menu_st->driver_ctx->navigation_set_last)
                   menu_st->driver_ctx->navigation_set_last(menu_st->userdata);
@@ -8352,8 +8233,7 @@ static int xmb_pointer_up(void *userdata,
              * selection... */
             for (;;)
             {
-               float top = xmb_item_y(xmb, bottom_idx, selection)
-                  + xmb->margins_screen_top;
+               float top = xmb_item_y(xmb, bottom_idx, selection) + xmb->margins_screen_top;
 
                if (top > height)
                {


### PR DESCRIPTION
## Description

- Fixed issues with item positioning when navigating too quickly while still animating
- Fixed issue with dynamic wallpaper not resetting to default if icon theme asset background is missing
- Fixed previous wallpaper flashing before showing new one
- Reintroduced fade-in animation when toggling menu on
- Massive bunch of readability nits, tab removals and cleanups

