### PR TITLE
Wii/Wii U: Fix 3 USB controllers (NES/SNES/Retrode)

### DIFF
--- a/input/connect/connect_nesusb.c
+++ b/input/connect/connect_nesusb.c
@@ -79,7 +79,7 @@ static int16_t hidpad_nesusb_get_axis(void *data, unsigned axis)
    if (!device || axis >= 2)
       return 0;
 
-   val = device->data[4 + axis];
+   val = device->data[3 + axis];
    val = (val << 8) - 0x8000;
 
    if (abs(val) > 0x1000)

--- a/input/connect/connect_retrode.c
+++ b/input/connect/connect_retrode.c
@@ -118,9 +118,9 @@ static int16_t hidpad_retrode_get_axis(void *pad_data, unsigned axis)
       return 0;
 
    if (pad->datatype == RETRODE_TYPE_PAD)
-      val = pad->data[2 + axis];
+      val = pad->data[1 + axis];
    else
-      val = device->pad_data[0].data[2 + axis];
+      val = device->pad_data[0].data[1 + axis];
 
    /* map Retrode values to a known gamepad (VID=0x0079, PID=0x0011) */
    if (val == 0x9C)

--- a/input/connect/connect_snesusb.c
+++ b/input/connect/connect_snesusb.c
@@ -80,7 +80,7 @@ static int16_t hidpad_snesusb_get_axis(void *data, unsigned axis)
    if (!device || axis >= 2)
       return 0;
 
-   val = device->data[1 + axis];
+   val = device->data[axis];
    val = (val << 8) - 0x8000;
 
    if (abs(val) > 0x1000)


### PR DESCRIPTION
## Description
Wii/Wii U were not detecting some USB controllers correctly. No reaction or random input.
This fixes commit a4b934b which did not update all array indices.

## Steps to test
1. Launch RA through the HBC
2. Set the joypad driver to hid and restart
3. Connect a supported HID controller (NES/SNES/Retrode)

Other controllers might still be broken, but I don't have any others to test.
I tested NES and Retrode successfully. For SNES I'm pretty sure I fixed it without testing.
Tested on Wii (.dol) and Wii U (.rpx)

## Related Issues
#7015

## Reviewers
@gblues
