### PR TITLE
don't track disc changes when achievements are disabled

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -3301,8 +3301,11 @@ static void rcheevos_client_change_media_callback(int result,
 
 void rcheevos_change_disc(const char* new_disc_path, bool initial_disc)
 {
-   rc_client_begin_change_media(rcheevos_locals.client, new_disc_path,
-      NULL, 0, rcheevos_client_change_media_callback, NULL);
+   if (rcheevos_locals.client)
+   {
+      rc_client_begin_change_media(rcheevos_locals.client, new_disc_path,
+         NULL, 0, rcheevos_client_change_media_callback, NULL);
+   }
 }
 
 #else /* !HAVE_RC_CLIENT */


### PR DESCRIPTION
## Description

Fixes #15936 

No longer tries to track the disc changing if achievements are not initialized.

## Related Issues

#15936

## Related Pull Requests

n/a

## Reviewers

@bslenul 
