### PR TITLE
[Win32] Fix window size when aspect ratio is < 0

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -932,7 +932,7 @@ static void win32_get_av_info_geometry(unsigned *width, unsigned *height)
    if (!video_st || runloop_st->flags & RUNLOOP_FLAG_FASTMOTION)
       return;
 
-   if (video_st->av_info.geometry.aspect_ratio)
+   if (video_st->av_info.geometry.aspect_ratio > 0)
       *width                      = roundf(
               video_st->av_info.geometry.base_height
             * video_st->av_info.geometry.aspect_ratio);


### PR DESCRIPTION
## Description

Issue seen here: https://www.reddit.com/r/RetroArch/comments/180s61q/bsneshd_core_weird_locked_windowed_resolution/

Window size can be completely broken on Windows when core `aspect_ratio` is set to a negative value, this is the case for example in bsnes-hd depending on a core option: https://github.com/DerKoun/bsnes-hd/blob/f46b6d6368ea93943a30b5d4e79e8ed51c2da5e8/bsnes/target-libretro/libretro.cpp#L903-L904

No idea if this is common, but according to the comment in libretro.h it seems legal: https://github.com/libretro/RetroArch/blob/3b27e5b976cebb0b5feef984632cf90c6616fbf3/libretro-common/include/libretro.h#L3622-L3626

## Related Pull Requests

4699d91ed5a4340b2f1f55ee8028cf87742fda64

## Reviewers

@sonninnos 
