### PR TITLE
[Vulkan] Fix a validation error

### DIFF
--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2161,6 +2161,7 @@ bool Pass::init_pipeline()
    /* Shaders */
    module_info.sType         = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
    module_info.pNext         = NULL;
+   module_info.flags         = 0;
    module_info.codeSize      = vertex_shader.size() * sizeof(uint32_t);
    module_info.pCode         = vertex_shader.data();
    shader_stages[0].stage    = VK_SHADER_STAGE_VERTEX_BIT;


### PR DESCRIPTION
> [ERROR] [Vulkan]: Validation Error: Validation Error: [ VUID-VkShaderModuleCreateInfo-flags-zerobitmask ] Object 0: handle = 0x23ff64c6360, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xe1764af4 | vkCreateShaderModule: parameter pCreateInfo->flags must be 0. The Vulkan spec states: flags must be 0 (https://vulkan.lunarg.com/doc/view/1.3.236.0/windows/1.3-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-flags-zerobitmask)