### PR TITLE
Fix videocore + switchres compile failure

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -33,10 +33,8 @@
 #include "../paths.h"
 #include "gfx_display.h"
 
-#if !defined(HAVE_VIDEOCORE)
 #include "../deps/switchres/switchres_wrapper.h"
 static sr_mode srm;
-#endif
 
 #ifdef HAVE_CONFIG_H
 #include "../config.h"


### PR DESCRIPTION
## Description

After commit f24893b, some definitions were not included when RA is compiled with --enable-videocore option (RPi legacy driver).

Checked compilation and basic operation on RPi 3 (Buster 32-bit).

## Related Issues

Fixes #15949 
Also one of the problems mentioned in https://github.com/libretro/Lakka-LibreELEC/issues/1880 (GPICase and Pi02GPi).
