### PR TITLE
don't flag rewind as initialized until after we're able to validate against core info

### DIFF
--- a/state_manager.c
+++ b/state_manager.c
@@ -597,7 +597,6 @@ void state_manager_event_init(
                                  | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_CHECKED
                                  | STATE_MGR_REWIND_ST_FLAG_HOTKEY_WAS_PRESSED
                                     );
-   rewind_st->flags             |= STATE_MGR_REWIND_ST_FLAG_INIT_ATTEMPTED;
 
    /* We cannot initialise the rewind buffer
     * unless the core info struct for the current
@@ -606,6 +605,8 @@ void state_manager_event_init(
     * core is unknown) */
    if (!core_info_get_current_core(&core_info) || !core_info)
       return;
+
+   rewind_st->flags |= STATE_MGR_REWIND_ST_FLAG_INIT_ATTEMPTED;
 
    if (!core_info_current_supports_rewind())
    {


### PR DESCRIPTION
## Description

Fixes an issue where achievement code may try to enable rewind before the core info is initialized, preventing rewind from being enabled later once the core info is available.

My solution is to move the "rewind already initialized" flag logic down a few lines so it's not set unless we're actually able to attempt to initialize rewind. 

It looks like the "already initialized" flag was added to prevent spamming the log (see #13741). As the lack of a core info doesn't generate a log entry, I believe this change to be benign.

## Related Issues

https://github.com/libretro/RetroArch/issues/15933#issuecomment-1844150446

## Related Pull Requests

n/a

## Reviewers

@jdgleaver 
