### PR TITLE
Update wayland-protocols version to 1.31 due to fractional-scale-v1

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -523,7 +523,7 @@ check_header '' XSHM X11/Xlib.h X11/extensions/XShm.h
 check_val '' XKBCOMMON -lxkbcommon '' xkbcommon 0.3.2 '' false
 check_val '' WAYLAND '-lwayland-egl -lwayland-client' '' wayland-egl 10.1.0 '' false
 check_val '' WAYLAND_CURSOR -lwayland-cursor '' wayland-cursor 1.12 '' false
-check_pkgconf WAYLAND_PROTOS wayland-protocols 1.15
+check_pkgconf WAYLAND_PROTOS wayland-protocols 1.31
 check_pkgconf WAYLAND_SCANNER wayland-scanner '1.15 1.12'
 
 if [ "$HAVE_WAYLAND_SCANNER" = yes ] &&


### PR DESCRIPTION
## Description

Compilation failure reported on Discord by iX. With the addition of #15965 , [wayland-protocols v1.31](https://lists.freedesktop.org/archives/wayland-devel/2022-November/042524.html) would be appropriate.

Issue was not seen in other builds due to some factors:
- buildbot docker image has wayland-protocols v1.10, so it would fall back anyway to bundled protocols
- on my personal system, there is wayland-protocols 1.25 but it is not found by pkg-config so again it falls back to bundled protocols

## Related Pull Requests

#15965 

