### PR TITLE
(cheevos) [switch] fix crash on first load of game with achievements

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -2463,15 +2463,15 @@ static void rcheevos_client_load_game_callback(int result,
    }
 
 #ifdef HAVE_THREADS
-   if (!task_is_on_main_thread())
+   if (!video_driver_is_threaded() && !task_is_on_main_thread())
    {
       /* have to "schedule" this. game image should not be loaded on background thread */
       rcheevos_locals.queued_command = CMD_CHEEVOS_NON_COMMAND;
       rcheevos_locals.game_placard_requested = true;
    }
    else
-      rcheevos_show_game_placard();
 #endif
+      rcheevos_show_game_placard();
 
    rcheevos_finalize_game_load(client);
 

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1432,6 +1432,11 @@ unsigned video_thread_texture_load(void *data, custom_command_method_t func)
    if (!thr)
       return 0;
 
+   /* if we're already on the video thread, just call the function, otherwise
+    * we may deadlock with ourself waiting for the packet to be processed. */
+   if (sthread_get_thread_id(thr->thread) == sthread_get_current_thread_id())
+      return func(data);
+
    pkt.type                       = CMD_CUSTOM_COMMAND;
    pkt.data.custom_command.method = func;
    pkt.data.custom_command.data   = data;


### PR DESCRIPTION
## Description

Fixes an issue where loading a game with achievements on the Switch version of RetroArch would crash if the game hadn't previously been loaded.

It turns out the problem isn't specific to the Switch, it's related to having Threaded Video on. If an achievement badge is not available when the popup is first queued, the rendering code will will attempt to load it again a few frames later. Since the rendering code runs on the video thread, the logic to better report an attempt to load images on a background thread (see #13247) throws an assertion exception and causes the application to terminate.

The Threaded Video code already marshals the image loading to the video thread, so I've updated the logic for detecting the loading of images on background threads to not run when Threaded Video is enabled. Additionally, I've updated the marshalling logic to not try to marshal if an image load does occur on the video thread.

## Related Issues

https://discord.com/channels/184109094070779904/469974542299955210/1176267096041201704
https://discord.com/channels/310192285306454017/1182431038211899523/1182431038211899523

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
