### PR TITLE
Netplay netpacket interface fix "Sort Save States into Folders" settings

### DIFF
--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -9376,7 +9376,7 @@ bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)
             /* reset savefile dir as core_netpacket_interface affects it */
             runloop_path_set_redirect(config_get_ptr(),
                dir_get_ptr(RARCH_DIR_SAVEFILE),
-               dir_get_ptr(RARCH_DIR_CURRENT_SAVESTATE));
+               dir_get_ptr(RARCH_DIR_SAVESTATE));
          }
          break;
 


### PR DESCRIPTION
## Description

This fixes the "Sort Save States into Folders" settings for cores that use the new Netplay netpacket interface.

Before this fix with the folder setting enabled a core using the netpacket interface would append the sort folder name twice thus breaking existing save states. Other folder settings regarding saves or screenshots were not affected.

Like previous fixes regarding this feature (i.e. #15797) this issue purely affects cores that enable the new netpacket interface thus not causing trouble with existing cores. Though my core (DOSBox Pure) is now using this interface so I'd like to see this merged as soon as possible.

## Related Issues
- schellingb/dosbox-pure#442

## Related Pull Requests
- #15413
- #15797
- #15986
- #15887

## Reviewers