### PR TITLE
playlist: add thumbnail match with filename config

### DIFF
--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -444,7 +444,8 @@ bool gfx_thumbnail_set_content_playlist(
             "", sizeof(path_data->content_label));
 
    /* Determine content image name */
-   if (settings->bools.playlist_use_filename)
+   if (settings->bools.playlist_use_filename ||
+       playlist_thumbnail_match_with_filename(playlist))
    {
       char* content_name_no_ext = NULL;
       char tmp_buf[PATH_MAX_LENGTH];

--- a/playlist.h
+++ b/playlist.h
@@ -64,6 +64,13 @@ enum playlist_thumbnail_mode
    PLAYLIST_THUMBNAIL_MODE_BOXARTS
 };
 
+enum playlist_thumbnail_match_mode
+{
+   PLAYLIST_THUMBNAIL_MATCH_MODE_DEFAULT = 0,
+   PLAYLIST_THUMBNAIL_MATCH_MODE_WITH_LABEL = PLAYLIST_THUMBNAIL_MATCH_MODE_DEFAULT,
+   PLAYLIST_THUMBNAIL_MATCH_MODE_WITH_FILENAME
+};
+
 enum playlist_sort_mode
 {
    PLAYLIST_SORT_MODE_DEFAULT = 0,
@@ -354,6 +361,7 @@ const char *playlist_get_default_core_name(playlist_t *playlist);
 enum playlist_label_display_mode playlist_get_label_display_mode(playlist_t *playlist);
 enum playlist_thumbnail_mode playlist_get_thumbnail_mode(
       playlist_t *playlist, enum playlist_thumbnail_id thumbnail_id);
+bool playlist_thumbnail_match_with_filename(playlist_t *playlist);
 enum playlist_sort_mode playlist_get_sort_mode(playlist_t *playlist);
 const char *playlist_get_scan_content_dir(playlist_t *playlist);
 const char *playlist_get_scan_file_exts(playlist_t *playlist);


### PR DESCRIPTION
## Description

In the commit [1], a global configuration "thumbnail match with filename" was added which allows thumbnail match with filename.

This commit adds playlist level "thumbnail match with filename" for more flexible configuration.

[1] 32ed9b604154 ("플레이리스트 롬파일 이름으로 썸네일 이미지를 찾도록 옵션 추가 (#15731)")

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
