### PR TITLE
Fix #16023 - ssl fails on mac x86 with newer clang

### DIFF
--- a/deps/mbedtls/mbedtls/bn_mul.h
+++ b/deps/mbedtls/mbedtls/bn_mul.h
@@ -177,9 +177,9 @@
         "addq   $8,      %%rdi      \n\t"
 
 #define MULADDC_STOP                        \
-        : "+c" (c), "+D" (d), "+S" (s)      \
-        : "b" (b)                           \
-        : "rax", "rdx", "r8"                \
+        : "+c" (c), "+D" (d), "+S" (s), "+m" (*(uint64_t (*)[16]) d) \
+        : "b" (b), "m" (*(const uint64_t (*)[16]) s)                 \
+        : "rax", "rdx", "r8"                                         \
     );
 
 #endif /* AMD64 */


### PR DESCRIPTION
Fix comes from https://github.com/Mbed-TLS/mbedtls/pull/4947