### PR TITLE
Flexible thumbnail matching

### DIFF
--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -292,12 +292,12 @@ void gfx_thumbnail_request(
                const char *system                         = NULL;
                const char *img_name                       = NULL;
                static char last_img_name[PATH_MAX_LENGTH] = {0};
-
+               enum playlist_thumbnail_name_flags next_flag;
                if (!playlist)
                   goto end;
 
-               /* Get current image name */
-               if (!gfx_thumbnail_get_img_name(path_data, &img_name))
+               /* Validate entry */
+               if (!gfx_thumbnail_get_img_name(path_data, &img_name, PLAYLIST_THUMBNAIL_FLAG_STD_NAME))
                   goto end;
 
                /* Only trigger a thumbnail download if image
@@ -321,7 +321,15 @@ void gfx_thumbnail_request(
                if (!gfx_thumbnail_get_system(path_data, &system))
                   goto end;
 
-               /* Trigger thumbnail download */
+               /* Apply flexible thumbnail naming: ROM file name - database name - short name */
+               next_flag = playlist_get_next_thumbnail_name_flag(playlist,idx);
+               if (next_flag == PLAYLIST_THUMBNAIL_FLAG_NONE)
+                  goto end;
+
+               /* Trigger thumbnail download *
+                * Note: download will grab all 3 possible thumbnails, no matter
+                * what left/right thumbnails are set at the moment */
+               playlist_update_thumbnail_name_flag(playlist, idx, next_flag);
                task_push_pl_entry_thumbnail_download(
                      system, playlist, (unsigned)idx,
                      false, true);

--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -37,14 +37,23 @@
 
 /* Fills content_img field of path_data using existing
  * content_label field (for internal use only) */
-static void gfx_thumbnail_fill_content_img(char *s, size_t len, const char *src)
+static void gfx_thumbnail_fill_content_img(char *s, size_t len, const char *src, bool shorten)
 {
+   const char* cut = " (";
    char *scrub_char_ptr = NULL;
    /* Copy source label string */
    size_t _len          = strlcpy(s, src, len);
+   int bracketpos       = -1;
+   
+   /* Shortening logic: up to first space + bracket */
+   if (shorten) {
+      bracketpos = string_find_index_substring_string(src, cut);
+      if (bracketpos > 2)
+         _len = bracketpos;
+   }
    /* Scrub characters that are not cross-platform and/or violate the
     * No-Intro filename standard:
-    * http://datomatic.no-intro.org/stuff/The%20Official%20No-Intro%20Convention%20(20071030).zip
+    * https://datomatic.no-intro.org/stuff/The%20Official%20No-Intro%20Convention%20(20071030).pdf
     * Replace these characters in the entry name with underscores */
    while ((scrub_char_ptr = strpbrk(s, "&*/:`\"<>?\\|")))
       *scrub_char_ptr = '_';
@@ -289,7 +298,9 @@ bool gfx_thumbnail_set_content(gfx_thumbnail_path_data_t *path_data, const char 
 
    /* Determine content image name */
    gfx_thumbnail_fill_content_img(path_data->content_img,
-         sizeof(path_data->content_img), path_data->content_label);
+         sizeof(path_data->content_img), path_data->content_label, false);
+   gfx_thumbnail_fill_content_img(path_data->content_img_short,
+         sizeof(path_data->content_img_short), path_data->content_label, true);
 
    /* Have to set content path to *something*...
     * Just use label value (it doesn't matter) */
@@ -444,8 +455,6 @@ bool gfx_thumbnail_set_content_playlist(
             "", sizeof(path_data->content_label));
 
    /* Determine content image name */
-   if (settings->bools.playlist_use_filename ||
-       playlist_thumbnail_match_with_filename(playlist))
    {
       char* content_name_no_ext = NULL;
       char tmp_buf[PATH_MAX_LENGTH];
@@ -457,13 +466,12 @@ bool gfx_thumbnail_set_content_playlist(
       strlcpy(tmp_buf, base_name, sizeof(tmp_buf));
       content_name_no_ext = path_remove_extension(tmp_buf);
       
+      gfx_thumbnail_fill_content_img(path_data->content_img_full,
+         sizeof(path_data->content_img_full), content_name_no_ext,false);
       gfx_thumbnail_fill_content_img(path_data->content_img,
-         sizeof(path_data->content_img), content_name_no_ext);
-   }
-   else
-   {
-      gfx_thumbnail_fill_content_img(path_data->content_img,
-         sizeof(path_data->content_img), path_data->content_label);
+         sizeof(path_data->content_img), path_data->content_label,false);
+      gfx_thumbnail_fill_content_img(path_data->content_img_short,
+         sizeof(path_data->content_img_short), path_data->content_label,true);
    }
 
    /* Store playlist index */
@@ -620,10 +628,28 @@ bool gfx_thumbnail_update_path(
       /* >> Add type */
       fill_pathname_join_special(tmp_buf, thumbnail_path, type, sizeof(tmp_buf));
 
-      /* >> Add content image */
       thumbnail_path[0] = '\0';
-      fill_pathname_join_special(thumbnail_path, tmp_buf,
-            path_data->content_img, PATH_MAX_LENGTH * sizeof(char));
+      /* >> Add content image - first try with full file name */
+      if(path_data->content_img_full[0] != '\0') {
+         fill_pathname_join_special(thumbnail_path, tmp_buf,
+               path_data->content_img_full, PATH_MAX_LENGTH * sizeof(char));
+      }
+      /* >> Add content image - second try with label (database name) */
+      if(!path_is_valid(thumbnail_path) && path_data->content_img[0] != '\0')
+      {
+         thumbnail_path[0] = '\0';
+         fill_pathname_join_special(thumbnail_path, tmp_buf,
+               path_data->content_img, PATH_MAX_LENGTH * sizeof(char));
+      }
+      /* >> Add content image - third try with shortened name (title only) */
+      if(!path_is_valid(thumbnail_path) && path_data->content_img_short[0] != '\0')
+      {
+         thumbnail_path[0] = '\0';
+         fill_pathname_join_special(thumbnail_path, tmp_buf,
+               path_data->content_img_short, PATH_MAX_LENGTH * sizeof(char));
+      }
+      /* This logic is valid for locally stored thumbnails. For optional downloads, 
+       * gfx_thumbnail_get_img_name() is used */
    }
 
    /* Final error check - is cached path empty? */
@@ -715,18 +741,35 @@ bool gfx_thumbnail_get_core_name(
    return true;
 }
 
-/* Fetches current thumbnail image name
+/* Fetches current thumbnail image name according to name flag
  * (name is the same for all thumbnail types).
  * Returns true if image name is valid. */
 bool gfx_thumbnail_get_img_name(
-      gfx_thumbnail_path_data_t *path_data, const char **img_name)
+      gfx_thumbnail_path_data_t *path_data, const char **img_name,
+      enum playlist_thumbnail_name_flags name_flags)
 {
-   if (!path_data || !img_name)
+   if (!path_data || !img_name || name_flags == PLAYLIST_THUMBNAIL_FLAG_NONE)
       return false;
-   if (string_is_empty(path_data->content_img))
-      return false;
+   if (name_flags & PLAYLIST_THUMBNAIL_FLAG_SHORT_NAME) {
+      if (string_is_empty(path_data->content_img_short))
+         return false;
 
-   *img_name = path_data->content_img;
+      *img_name = path_data->content_img_short;
+   }
+   else if (name_flags & PLAYLIST_THUMBNAIL_FLAG_STD_NAME) {
+      if (string_is_empty(path_data->content_img))
+         return false;
+
+      *img_name = path_data->content_img;
+   }
+   else if (name_flags & PLAYLIST_THUMBNAIL_FLAG_FULL_NAME) {
+      if (string_is_empty(path_data->content_img_full))
+         return false;
+
+      *img_name = path_data->content_img_full;
+   }
+   else
+      return false;
 
    return true;
 }

--- a/gfx/gfx_thumbnail_path.h
+++ b/gfx/gfx_thumbnail_path.h
@@ -60,6 +60,8 @@ struct gfx_thumbnail_path_data
    size_t playlist_index;
    char content_path[PATH_MAX_LENGTH];
    char content_img[PATH_MAX_LENGTH];
+   char content_img_short[PATH_MAX_LENGTH];
+   char content_img_full[PATH_MAX_LENGTH];
    char right_path[PATH_MAX_LENGTH];
    char left_path[PATH_MAX_LENGTH];
    char content_label[256];
@@ -147,7 +149,7 @@ bool gfx_thumbnail_get_core_name(gfx_thumbnail_path_data_t *path_data, const cha
 /* Fetches current thumbnail image name
  * (name is the same for all thumbnail types).
  * Returns true if image name is valid. */
-bool gfx_thumbnail_get_img_name(gfx_thumbnail_path_data_t *path_data, const char **img_name);
+bool gfx_thumbnail_get_img_name(gfx_thumbnail_path_data_t *path_data, const char **img_name, enum playlist_thumbnail_name_flags name_flags);
 
 /* Fetches current content directory.
  * Returns true if content directory is valid. */

--- a/playlist.c
+++ b/playlist.c
@@ -1059,6 +1059,48 @@ error:
    return false;
 }
 
+void playlist_update_thumbnail_name_flag(playlist_t *playlist, size_t idx, 
+      enum playlist_thumbnail_name_flags thumbnail_flags)
+{
+   struct playlist_entry *entry = NULL;
+
+   if (!playlist || idx >= RBUF_LEN(playlist->entries))
+      return;
+
+   entry                   = &playlist->entries[idx];
+   entry->thumbnail_flags |= thumbnail_flags;
+}
+
+enum playlist_thumbnail_name_flags playlist_get_curr_thumbnail_name_flag(playlist_t *playlist, size_t idx)
+{
+   struct playlist_entry *entry = NULL;
+
+   if (!playlist || idx >= RBUF_LEN(playlist->entries))
+      return    PLAYLIST_THUMBNAIL_FLAG_NONE;
+
+   entry = &playlist->entries[idx];
+   return entry->thumbnail_flags;
+}
+
+
+enum playlist_thumbnail_name_flags playlist_get_next_thumbnail_name_flag(playlist_t *playlist, size_t idx)
+{
+   struct playlist_entry *entry = NULL;
+
+   if (!playlist || idx >= RBUF_LEN(playlist->entries))
+      return    PLAYLIST_THUMBNAIL_FLAG_NONE;
+   entry = &playlist->entries[idx];
+
+   if (entry->thumbnail_flags & PLAYLIST_THUMBNAIL_FLAG_SHORT_NAME)
+            return PLAYLIST_THUMBNAIL_FLAG_NONE;
+   if (entry->thumbnail_flags & PLAYLIST_THUMBNAIL_FLAG_STD_NAME)
+            return PLAYLIST_THUMBNAIL_FLAG_SHORT_NAME;
+   if (entry->thumbnail_flags & PLAYLIST_THUMBNAIL_FLAG_FULL_NAME)
+            return PLAYLIST_THUMBNAIL_FLAG_STD_NAME;
+   return PLAYLIST_THUMBNAIL_FLAG_FULL_NAME;
+}
+
+
 /**
  * playlist_resolve_path:
  * @mode      : PLAYLIST_LOAD or PLAYLIST_SAVE

--- a/playlist.h
+++ b/playlist.h
@@ -87,6 +87,15 @@ enum playlist_thumbnail_id
    PLAYLIST_THUMBNAIL_LEFT
 };
 
+enum playlist_thumbnail_name_flags
+{
+   PLAYLIST_THUMBNAIL_FLAG_INVALID          = 0,
+   PLAYLIST_THUMBNAIL_FLAG_FULL_NAME        = (1 << 0),
+   PLAYLIST_THUMBNAIL_FLAG_STD_NAME         = (1 << 1),
+   PLAYLIST_THUMBNAIL_FLAG_SHORT_NAME       = (1 << 2),
+   PLAYLIST_THUMBNAIL_FLAG_NONE             = (1 << 3)
+};
+
 typedef struct content_playlist playlist_t;
 
 /* Holds all parameters required to uniquely
@@ -129,6 +138,7 @@ struct playlist_entry
    unsigned last_played_minute;
    unsigned last_played_second;
    enum playlist_runtime_status runtime_status;
+   enum playlist_thumbnail_name_flags thumbnail_flags;
 };
 
 /* Holds all configuration parameters required
@@ -290,6 +300,11 @@ void playlist_update(playlist_t *playlist, size_t idx,
 void playlist_update_runtime(playlist_t *playlist, size_t idx,
       const struct playlist_entry *update_entry,
       bool register_update);
+
+void playlist_update_thumbnail_name_flag(playlist_t *playlist, size_t idx, 
+     enum playlist_thumbnail_name_flags thumbnail_flags);
+enum playlist_thumbnail_name_flags playlist_get_next_thumbnail_name_flag(playlist_t *playlist, size_t idx);
+enum playlist_thumbnail_name_flags playlist_get_curr_thumbnail_name_flag(playlist_t *playlist, size_t idx);
 
 void playlist_get_index_by_path(playlist_t *playlist,
       const char *search_path,


### PR DESCRIPTION
## Description

Add logic to handle 3 possible thumbnail names, in following order:
- most exact name derived from content file (same name, with .png extension)
- usual name derived from playlist (usually coming from database)
- shortened name up to first bracket, chopping off region/publisher etc. info

Example:
`007 - The Living Daylights (1987)(Domark).png`
`007 - The Living Daylights (Domark).png`
`007 - The Living Daylights.png`

For local file system, names are checked always. In theory, this could lead to a small performance impact.
For thumbnail downloads, names are checked in turn each time the item comes up in the playlist, meaning that it may take going back and forth 3 times for a thumbnail to appear. However, as a positive change, failed thumbnail downloads are not repeated for the same playlist, which was not the case earlier.

## Related Issues

I intend this as an enabler for improving the thumbnail situation: enhance match ratio / reduce thumbnail repo size for databases (ZX Spectrum as an example) that contain several alternatives for the same game, typically gathered from Tosec. Using a shorter name, one thumbnail would be enough for e.g. box art, while the option is still there to show different title / snapshot screens. There are already several bit-by-bit duplicates in many repos under different names.

## Related Pull Requests

This PR makes #16022 ineffective. However, I did not remove it as it could serve later as a setting for customizing this order above, if it turns out that one size does not fit all.

Planned future PRs: harmonizing database titles to follow No-Intro naming even if generated from Tosec, improving playlist display with subtitles and/or customizable title scheme, updating thumbnail repos.