### PR TITLE
Minor improvements for db / playlist handling

### DIFF
--- a/database_info.c
+++ b/database_info.c
@@ -515,8 +515,11 @@ static int database_cursor_iterate(libretrodb_cursor_t *cur,
       }
       else if (string_is_equal(str, "rom_name"))
       {
+/* rom_name is not used anywhere in codebase, but is frequently added to DB */
+#if 0
          if (!string_is_empty(val_string))
             db_info->rom_name = strdup(val_string);
+#endif
       }
       else if (string_is_equal(str, "name"))
       {

--- a/libretro-common/playlists/label_sanitization.c
+++ b/libretro-common/playlists/label_sanitization.c
@@ -26,13 +26,15 @@
 #include <string/stdstring.h>
 #include <string.h>
 
-#define DISC_STRINGS_LENGTH   3
+#define DISC_STRINGS_LENGTH   5
 #define REGION_STRINGS_LENGTH 20
 
 const char *disc_strings[DISC_STRINGS_LENGTH] = {
    "(CD",
    "(Disc",
-   "(Disk"
+   "(Disk",
+   "(Side",
+   "(Tape"
 };
 
 /*


### PR DESCRIPTION
## Description

Do not load rom_name as nothing is using it (but it does occupy memory) 
Add two more media index options for label sanitization

## Related Issues

No specific issues, but new labels should make many 8-bit databases look better if disk index removal is selected.