### PR TITLE
Make auto-savestates not use the task queue

### DIFF
--- a/command.c
+++ b/command.c
@@ -1278,7 +1278,7 @@ bool command_event_save_auto_state(void)
          ".auto",
          sizeof(savestate_name_auto) - _len);
 
-   if (content_save_state((const char*)savestate_name_auto, true, true))
+   if (content_auto_save_state((const char*)savestate_name_auto))
 	   RARCH_LOG("%s \"%s\" %s.\n",
 			   msg_hash_to_str(MSG_AUTO_SAVE_STATE_TO),
 			   savestate_name_auto, "succeeded");
@@ -1970,7 +1970,7 @@ bool command_event_main_state(unsigned cmd)
                      settings->bools.frame_time_counter_reset_after_save_state;
 
                if (cmd == CMD_EVENT_SAVE_STATE)
-                  content_save_state(state_path, true, false);
+                  content_save_state(state_path, true);
                else
                   content_save_state_to_ram();
 

--- a/content.h
+++ b/content.h
@@ -52,7 +52,10 @@ bool content_ram_state_to_file(const char *path);
 bool content_load_state(const char* path, bool load_to_backup_buffer, bool autoload);
 
 /* Save a state from memory to disk. */
-bool content_save_state(const char *path, bool save_to_disk, bool autosave);
+bool content_save_state(const char *path, bool save_to_disk);
+
+/* Save an automatic savestate to disk. */
+bool content_auto_save_state(const char *path);
 
 /* Check a ram state write to disk. */
 bool content_ram_state_pending(void);


### PR DESCRIPTION
Auto savestate (and its optional thumbnail) is generated on core unload (quit, netplay start, etc). This ends up using the task-queue, which in many cases deadlocks and/or causes a crash due to its asynchronous nature.

Given that this is a state that must be generated before quiting or reloading the core, it makes no sense to use the task queue, it should be a synchronous job like for instance SRAM saving.

This should fix #15248 (tested by @schmurtzm)

This issue affects many UIs that use Retroarch (since they launch and rely on the generated state and screenshot on exit).