### PR TITLE
Minor thumbnail improvements

### DIFF
--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -500,10 +500,19 @@ bool gfx_thumbnail_set_content_playlist(
       {
          char *db_name_no_ext = NULL;
          char tmp_buf[PATH_MAX_LENGTH];
-         /* Remove .lpl extension
-          * > path_remove_extension() requires a char * (not const)
-          *   so have to use a temporary buffer... */
-         strlcpy(tmp_buf, db_name, sizeof(tmp_buf));
+         const char* pos = strchr(db_name, '|');
+         
+         if (pos && (size_t) (pos - db_name)+1 < sizeof(tmp_buf)) {
+            /* If db_name comes from core info, and there are multiple 
+             * databases mentioned separated by |, use only first one */
+            strlcpy(tmp_buf, db_name, (size_t) (pos - db_name)+1);
+         }
+         else {
+            /* Remove .lpl extension
+             * > path_remove_extension() requires a char * (not const)
+             *   so have to use a temporary buffer... */
+            strlcpy(tmp_buf, db_name, sizeof(tmp_buf));
+         }
          db_name_no_ext = path_remove_extension(tmp_buf);
 
          if (!string_is_empty(db_name_no_ext))

--- a/playlist.c
+++ b/playlist.c
@@ -1097,6 +1097,11 @@ enum playlist_thumbnail_name_flags playlist_get_next_thumbnail_name_flag(playlis
             return PLAYLIST_THUMBNAIL_FLAG_SHORT_NAME;
    if (entry->thumbnail_flags & PLAYLIST_THUMBNAIL_FLAG_FULL_NAME)
             return PLAYLIST_THUMBNAIL_FLAG_STD_NAME;
+   /* Special case: only one entry in playlist, only one query is possible
+    * as flag swapping relies on going back and forth among entries
+    * so just use the most likely version here */
+   if (idx == 0 && RBUF_LEN(playlist->entries) == 1)
+            return PLAYLIST_THUMBNAIL_FLAG_STD_NAME;
    return PLAYLIST_THUMBNAIL_FLAG_FULL_NAME;
 }
 


### PR DESCRIPTION
## Description

- set standard name if only one entry is in the playlist
- use first database name for thumbnails if core has multiple

## Related Pull Requests
First one ensures that old setup is used for thumbnail downloads in case of playlists with a single entry, since #16040 would start with the ROM name and fall back when flicking back and forth among playlist entries.
Second one finetunes #16025 in case when core supports multiple databases (such as snes9x).
