### PR TITLE
Fix for Potential CWE 457 Issue in video_driver.c

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -4308,7 +4308,7 @@ void video_frame_rest(video_driver_state_t *video_st,
    static int frame_time_near_count  = 0;
    static int frame_time_try_count   = 0;
    double video_stddev               = 0;
-   audio_statistics_t audio_stats;
+   audio_statistics_t audio_stats ={0};
 
    /* Must require video and audio deviation standards */
    video_monitor_fps_statistics(NULL, &video_stddev, NULL);

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -4308,7 +4308,7 @@ void video_frame_rest(video_driver_state_t *video_st,
    static int frame_time_near_count  = 0;
    static int frame_time_try_count   = 0;
    double video_stddev               = 0;
-   audio_statistics_t audio_stats ={0};
+   audio_statistics_t audio_stats = {0};
 
    /* Must require video and audio deviation standards */
    video_monitor_fps_statistics(NULL, &video_stddev, NULL);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This pull request is sent after identifying a potential CWE-457 issue in the video_display.c file(Line:4311-4315).
I have used the static analysis tool, CodeQL, to analyze RetroArch. During this analysis, I found a piece of code in gfx/video_driver.c that could potentially lead to a CWE-457 issue.
```
audio_statistics_t audio_stats;

/* Must require video and audio deviation standards */
video_monitor_fps_statistics(NULL, &video_stddev, NULL);
audio_compute_buffer_statistics(&audio_stats);
```
In the above code, the variable audio_stats is used in audio_compute_buffer_statistics without being initialized.

To address this, I have initialized the variable to prevent the CWE-457 issue. Below is the modified code:
```
audio_statistics_t audio_stats = {0};

/* Must require video and audio deviation standards */
video_monitor_fps_statistics(NULL, &video_stddev, NULL);
audio_compute_buffer_statistics(&audio_stats);
```
Thank you.


## Related Issues

[CWE-457: Use of Uninitialized Variable](https://cwe.mitre.org/data/definitions/457.html)
In some languages such as C and C++, stack variables are not initialized by default. They generally contain junk data with the contents of stack memory before the function was invoked. An attacker can sometimes control or read these contents. In other languages or conditions, a variable that is not explicitly initialized can be given a default value that has security implications, depending on the logic of the program. The presence of an uninitialized variable can sometimes indicate a typographic error in the code.

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
