### PR TITLE
Don't needlessly (re-)create default directories on apple platforms

### DIFF
--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -473,10 +473,6 @@ static void frontend_darwin_get_env(int *argc, char *argv[],
    strlcpy(g_defaults.dirs[DEFAULT_DIR_CACHE],
          temp_dir,
          sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
-
-#ifndef IS_SALAMANDER
-   dir_check_defaults("custom.ini");
-#endif
 }
 
 static int frontend_darwin_get_rating(void)


### PR DESCRIPTION
The custom.ini file does not work on apple platforms because apps get executed with a working directory of /. Also the configured directories will get created as needed if not present.

This same PR probably applies to other platforms as well but without more certainty/testing I didn't want to assume.