### PR TITLE
Fix input autodetect notices sometimes not appearing

### DIFF
--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -612,7 +612,7 @@ bool input_autoconfigure_connect(
 
    /* Configure handle */
    if (!(autoconfig_handle = (autoconfig_handle_t*)
-            malloc(sizeof(autoconfig_handle_t))))
+            calloc(1, sizeof(autoconfig_handle_t))))
       goto error;
 
    autoconfig_handle->port                         = port;


### PR DESCRIPTION
`autoconfig_handle->flags` was sometimes not 0 after `malloc()`.