### PR TITLE
change default audio settings for emscripten builds

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1099,6 +1099,9 @@
 #elif defined(_3DS) || defined(RETROFW)
 #define DEFAULT_OUTPUT_RATE 32730
 #define DEFAULT_INPUT_RATE  32730
+#elif defined(EMSCRIPTEN)
+#define DEFAULT_OUTPUT_RATE 44100
+#define DEFAULT_INPUT_RATE  44100
 #else
 #define DEFAULT_OUTPUT_RATE 48000
 #define DEFAULT_INPUT_RATE  48000
@@ -1607,7 +1610,7 @@
 
 #if defined(__QNX__) || defined(_XBOX1) || defined(_XBOX360) || (defined(__MACH__) && defined(IOS)) || defined(ANDROID) || defined(WIIU) || defined(HAVE_NEON) || defined(GEKKO) || defined(__ARM_NEON__) || defined(__PS3__)
 #define DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL RESAMPLER_QUALITY_LOWER
-#elif defined(PSP) || defined(_3DS) || defined(VITA) || defined(PS2) || defined(DINGUX)
+#elif defined(PSP) || defined(_3DS) || defined(VITA) || defined(PS2) || defined(DINGUX) || defined(EMSCRIPTEN)
 #define DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL RESAMPLER_QUALITY_LOWEST
 #else
 #define DEFAULT_AUDIO_RESAMPLER_QUALITY_LEVEL RESAMPLER_QUALITY_NORMAL


### PR DESCRIPTION
## Description

More info and video example here: https://github.com/EmulatorJS/EmulatorJS/issues/739
While testing the latest emscripten builds I noticed consistent static in the audio output on Chromium based browsers and  Safari. It seems they both expect the sampling rate to be 44100 and performance is helped pretty drastically by bumping down to lowest for resampler quality. Firefox was happy with 48000 but 44100 does not hurt it and lowering resampler helps as well. 

Before: 

https://github.com/libretro/RetroArch/assets/1852688/e67dd14f-e96a-4986-94eb-e1d0a8ed12a1

After: 

https://github.com/libretro/RetroArch/assets/1852688/88a92b43-4944-40a1-8852-2c8d32d5a5ba


Tested Browsers: 

* Chromium Windows
* Chromium Linux
* Chrome Windows
* Chrome Linux
* Brave Windows
* Brave Linux
* Firefox Windows
* Firefox Linux
* Safari iPad
* Edge Xbox Series S
