### PR TITLE
Make it easy to create a "portable" osx build

### DIFF
--- a/pkg/apple/OSX/Info_Metal.plist
+++ b/pkg/apple/OSX/Info_Metal.plist
@@ -51,5 +51,7 @@
 	<string>MainMenu_Metal</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>RAPortableInstall</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Default to false, except steam builds where it's forced true; a portable build has the behavior of putting all files next to the application.