### PR TITLE
Fix auto save state when state file does not already exist

### DIFF
--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -1332,7 +1332,7 @@ bool content_auto_save_state(const char *path)
 
    serial_size = core_serialize_size();
 
-   if (serial_size == 0 || !path_is_valid(path))
+   if (serial_size == 0)
       return false;
 
    serial_data = content_get_serialized_data(&serial_size);


### PR DESCRIPTION
## Description

### Context
The [PR](https://github.com/libretro/RetroArch/pull/16061) that went in last week to fix auto save states for Netplay broke saving the auto state when the file did not already exist. This is because the (new) auto save state function differs slightly with the (regular) save state function. The regular function checks if the path is valid, but only to load the existing save state into memory for undo purposes. Since we call the auto save state function from either core unload or quit, we shouldn't need to care about the undo stack.

The auto function currently only works if the state exists (since path would be "valid"), so if the auto state file does not already exist on disk, then it will fail the `path_is_valid()` check and not create a new file.

### Fix

The fix here is to simply remove the `path_is_valid()` check. Since the regular function only checked if a file already exists for purposes of undo, the auto function can simply always (attempt to) write the state data.

## Related Issues

https://github.com/libretro/RetroArch/issues/16080

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/16061

## Reviewers

[If possible @mention all the people that should review your pull request]
