### PR TITLE
Silence compilation warning

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -19536,7 +19536,7 @@ static bool setting_append_list(
             {
                char *options;
                int len = 0, i = 0;
-               for (; i < icons->size; i++)
+               for (; i < (int)icons->size; i++)
                   len += strlen(icons->elems[i].data) + 1;
                options = (char*)calloc(len, sizeof(char));
                string_list_join_concat(options, len, icons, "|");


### PR DESCRIPTION
## Description

Just shutting this up:
```
menu/menu_setting.c:19539:25: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long long unsigned int'} [-Wsign-compare]
19539 |                for (; i < icons->size; i++)
      |                         ^
```
