### PR TITLE
Don't save mouse buttons in autoconfig

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -5004,9 +5004,14 @@ bool config_save_autoconf_profile(const
    {
       const struct retro_keybind *bind = &input_config_binds[user][i];
       if (bind->valid)
-         input_config_save_keybind(
+      {
+         save_keybind_joykey(
                conf, "input", input_config_bind_map_get_base(i),
                bind, false);
+         save_keybind_axis(
+               conf, "input", input_config_bind_map_get_base(i),
+               bind, false);
+      }
    }
 
    ret = config_file_write(conf, autoconf_file, false);


### PR DESCRIPTION
## Description

Currently when you're creating an autoconfig file it also adds some extra mouse buttons (usually "Gun Trigger" and "Gun Reload" as they're bound to mouse 1 and 2 by default) but RetroArch only parses buttons and axis when reading autoconfigs, so these extra lines are completely useless.

So when saving autoconfigs, instead of calling `input_config_save_keybind()` which saves buttons, axis and mouse buttons let's just save buttons and axis to make sure mouse buttons are ignored.

## Related Pull Requests

https://github.com/libretro/retroarch-joypad-autoconfig/pull/1096

## Reviewers

@sonninnos probably? It's a very small PR so shouldn't take long to review, I just want to make sure my logic is fine here and I'm also not sure if there's a better way to handle this.
