### PR TITLE
Add environment command to get playlists path

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1853,6 +1853,17 @@ enum retro_mod
                                             * input devices does not need to take any action on its own.
                                             */
 
+#define RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY 79
+                                           /* const char ** --
+                                            * Returns the "playlist" directory of the frontend.
+                                            * This directory can be used to store core generated playlists,
+                                            * in case this internal functionality is available (e.g. internal core
+                                            * game detection engine).
+                                            *
+                                            * The returned value can be NULL.
+                                            * If so, no such directory is defined,
+                                            * and it's up to the implementation to find a suitable directory.
+                                            */
 /* VFS functionality */
 
 /* File paths:

--- a/runloop.c
+++ b/runloop.c
@@ -2618,6 +2618,17 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          break;
       }
 
+      case RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY:
+      {
+         const char **dir            = (const char**)data;
+         const char *dir_playlist    = settings->paths.directory_playlist;
+
+         *dir = *dir_playlist ? dir_playlist : NULL;
+         RARCH_LOG("[Environ]: PLAYLIST_DIRECTORY: \"%s\".\n",
+               dir_playlist);
+         break;
+      }
+
       case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
       /**
        * Update the system Audio/Video information.


### PR DESCRIPTION
This feature would be convenient for ScummVM core, which includes a playlist generator based on the internal games detection engine.