### PR TITLE
Fix setting iOS app icon

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9036,7 +9036,11 @@ unsigned menu_displaylist_build_list(
                switch (build_list[i].enum_idx)
                {
                   case MENU_ENUM_LABEL_APPICON_SETTINGS:
-                     build_list[i].checked = (uico_st->drv && uico_st->drv->set_app_icon);
+                     if (uico_st->drv && uico_st->drv->get_app_icons)
+                     {
+                         struct string_list *icons = uico_st->drv->get_app_icons();
+                         build_list[i].checked = icons && icons->size > 1;
+                     }
                      break;
                   case MENU_ENUM_LABEL_ONSCREEN_DISPLAY_SETTINGS:
                      build_list[i].checked = settings->bools.settings_show_onscreen_display;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -19530,33 +19530,22 @@ static bool setting_append_list(
          START_SUB_GROUP(list, list_info, "State", &group_info, &subgroup_info, parent_group);
 
          {
-            uico_driver_state_t *uico_st    = uico_state_get_ptr();
-            struct string_list *icons;
-            if (uico_st->drv && uico_st->drv->get_app_icons && (icons = uico_st->drv->get_app_icons()) && icons->size)
-            {
-               char *options;
-               int len = 0, i = 0;
-               for (; i < (int)icons->size; i++)
-                  len += strlen(icons->elems[i].data) + 1;
-               options = (char*)calloc(len, sizeof(char));
-               string_list_join_concat(options, len, icons, "|");
-               CONFIG_STRING_OPTIONS(
-                  list, list_info,
-                  settings->paths.app_icon,
-                  sizeof(settings->paths.app_icon),
-                  MENU_ENUM_LABEL_APPICON_SETTINGS,
-                  MENU_ENUM_LABEL_VALUE_APPICON_SETTINGS,
-                  icons->elems[0].data,
-                  options,
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler);
-               SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_IS_DRIVER);
-               (*list)[list_info->index - 1].action_ok      = setting_action_ok_uint;
-               (*list)[list_info->index - 1].change_handler = appicon_change_handler;
-            }
+            CONFIG_STRING_OPTIONS(
+               list, list_info,
+               settings->paths.app_icon,
+               sizeof(settings->paths.app_icon),
+               MENU_ENUM_LABEL_APPICON_SETTINGS,
+               MENU_ENUM_LABEL_VALUE_APPICON_SETTINGS,
+               "",
+               (char*)calloc(1, sizeof(char)),
+               &group_info,
+               &subgroup_info,
+               parent_group,
+               general_write_handler,
+               general_read_handler);
+            SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_IS_DRIVER);
+            (*list)[list_info->index - 1].action_ok      = setting_action_ok_uint;
+            (*list)[list_info->index - 1].change_handler = appicon_change_handler;
          }
 
          CONFIG_BOOL(

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -536,6 +536,27 @@ enum
 
    rarch_main(argc, argv, NULL);
 
+   uico_driver_state_t *uico_st     = uico_state_get_ptr();
+   rarch_setting_t *appicon_setting = menu_setting_find_enum(MENU_ENUM_LABEL_APPICON_SETTINGS);
+   struct string_list *icons;
+   if (appicon_setting && uico_st->drv && uico_st->drv->get_app_icons && (icons = uico_st->drv->get_app_icons()) && icons->size > 1)
+   {
+      appicon_setting->default_value.string = icons->elems[0].data;
+      int len = 0, i = 0;
+      const char *iconName = [[application alternateIconName] cStringUsingEncoding:kCFStringEncodingUTF8]; // need to ask uico_st for this
+      for (; i < (int)icons->size; i++)
+      {
+         len += strlen(icons->elems[i].data) + 1;
+         if (string_is_equal(iconName, icons->elems[i].data))
+            appicon_setting->value.target.string = icons->elems[i].data;
+      }
+      char *options = (char*)calloc(len, sizeof(char));
+      string_list_join_concat(options, len, icons, "|");
+      if (appicon_setting->values)
+         free((void*)appicon_setting->values);
+      appicon_setting->values = options;
+   }
+
    rarch_start_draw_observer();
 
 #if TARGET_OS_IOS


### PR DESCRIPTION
The menu entries get built before ui_companion is initialized, so after the ui_companion is initialized we need to come back and repopulate the menu with the app icon choices.

There was also a bug that the current value of the app icon was sometimes wrong on iOS. This fixes that but in a way that is not generic. I need to think through how to make it properly abstracted in ui_companion. Until then, this is iOS-specific.