### PR TITLE
Enable cheevos for Wii builds

### DIFF
--- a/Makefile.wii
+++ b/Makefile.wii
@@ -162,8 +162,9 @@ HAVE_XMB                 := 0
 HAVE_OZONE               := 0
 HAVE_RGUI                := 1
 HAVE_MATERIALUI          := 0
+HAVE_CHEEVOS             := 1
 
-CFLAGS      += -DHAVE_SOCKET_LEGACY
+CFLAGS      += -DHAVE_SOCKET_LEGACY -DHAVE_CHEEVOS
 
 APP_BOOTER_DIR = wii/app_booter
 PLATOBJS := $(APP_BOOTER_DIR)/app_booter.binobj
@@ -174,6 +175,7 @@ endif
 
 INCLUDE += -I./libretro-common/include \
            -Ideps \
+	   -Ideps/rcheevos/include \
            -Ideps/stb
 CFLAGS += -Wall -std=gnu99 $(MACHDEP) $(PLATCFLAGS) $(INCLUDE)
 

--- a/deps/rcheevos/src/rc_compat.c
+++ b/deps/rcheevos/src/rc_compat.c
@@ -85,7 +85,8 @@ struct tm* rc_gmtime_s(struct tm* buf, const time_t* timer)
 #endif
 
 #ifndef RC_NO_THREADS
-#ifdef _WIN32
+
+#if defined(_WIN32)
 
 /* https://gist.github.com/roxlu/1c1af99f92bafff9d8d9 */
 
@@ -111,6 +112,28 @@ void rc_mutex_lock(rc_mutex_t* mutex)
 void rc_mutex_unlock(rc_mutex_t* mutex)
 {
   ReleaseMutex(mutex->handle);
+}
+
+#elif defined(GEKKO)
+
+void rc_mutex_init(rc_mutex_t *mutex)
+{
+  LWP_MutexInit(mutex, NULL);
+}
+
+void rc_mutex_destroy(rc_mutex_t* mutex)
+{
+  LWP_MutexDestroy(mutex);
+}
+
+void rc_mutex_lock(rc_mutex_t* mutex)
+{
+  LWP_MutexLock(mutex);
+}
+
+void rc_mutex_unlock(rc_mutex_t* mutex)
+{
+  LWP_MutexUnlock(mutex);
 }
 
 #else

--- a/libretro-common/include/net/net_compat.h
+++ b/libretro-common/include/net/net_compat.h
@@ -352,6 +352,8 @@ static INLINE bool isagain(int val)
    return (val == SCE_NET_ERROR_EAGAIN) || (val == SCE_NET_ERROR_EWOULDBLOCK);
 #elif defined(WIIU)
    return (val == -1) && (socketlasterr() == SO_SUCCESS || socketlasterr() == SO_EWOULDBLOCK);
+#elif defined(GEKKO)
+   return (-val == EAGAIN);
 #else
    return (val < 0) && (errno == EAGAIN || errno == EWOULDBLOCK);
 #endif
@@ -367,6 +369,8 @@ static INLINE bool isinprogress(int val)
    return (val == SCE_NET_ERROR_EINPROGRESS);
 #elif defined(WIIU)
    return (val == -1) && (socketlasterr() == SO_EINPROGRESS);
+#elif defined(GEKKO)
+   return (-val == EINPROGRESS);
 #else
    return (val < 0) && (errno == EINPROGRESS);
 #endif


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This PR enables cheevos for Wii builds by:

1. Extending the Makefile.wii to add the cheevos flags
2. Extend the `rc_compat.c` mutex functions to use libogc.
3. Fix an issue in `net_compat.h` where the network codes where interpreted incorrectly.

Some extra notes:

- I build it using Fedora with the latest libogc and `make -f Makefile.wii -j4 EXTERNAL_LIBOGC=1 GX_PTHREAD_LEGACY=0`. I failed to understand how the build bot environment works (any help is welcome). 
- ~~Getting the achievement list is quite slow on the Wii and its instant on Dolphin.~~ Enabling threaded tasks solves the issue.

## Related Issues

- #14982 

## Reviewers
