### PR TITLE
[PS2] Required after toolchain upgrade: Fixing usage of `cwd`

### DIFF
--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -64,7 +64,7 @@ static void create_path_names(void)
 {
    char user_path[FILENAME_MAX];
    size_t _len = strlcpy(user_path, cwd, sizeof(user_path));
-   strlcpy(user_path + _len, "retroarch", sizeof(user_path) - _len);
+   strlcpy(user_path + _len, "/retroarch", sizeof(user_path) - _len);
    fill_pathname_basedir(g_defaults.dirs[DEFAULT_DIR_PORT], cwd, sizeof(g_defaults.dirs[DEFAULT_DIR_PORT]));
 
    /* Content in the same folder */


### PR DESCRIPTION
## Description

This PR is required after the toolchain upgrade. `ps2` toolchain now returns `getcwd` without a `/` at the end as the standard POSIX implementation is.
