### PR TITLE
Do not try to fetch full name thumbnails if not set explicitly.

### DIFF
--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -292,6 +292,7 @@ void gfx_thumbnail_request(
                const char *system                         = NULL;
                const char *img_name                       = NULL;
                static char last_img_name[PATH_MAX_LENGTH] = {0};
+               settings_t *settings                       = config_get_ptr();
                enum playlist_thumbnail_name_flags curr_flag;
                if (!playlist)
                   goto end;
@@ -326,6 +327,11 @@ void gfx_thumbnail_request(
                curr_flag = playlist_get_curr_thumbnail_name_flag(playlist,idx);
                if (curr_flag & PLAYLIST_THUMBNAIL_FLAG_NONE || curr_flag & PLAYLIST_THUMBNAIL_FLAG_SHORT_NAME)
                   goto end;
+               /* Do not try to fetch full names here, if it is not explicitly wanted */
+               if (!settings->bools.playlist_use_filename && 
+                   !playlist_thumbnail_match_with_filename(playlist) &&
+                   curr_flag == PLAYLIST_THUMBNAIL_FLAG_INVALID)
+                    playlist_update_thumbnail_name_flag(playlist, idx, PLAYLIST_THUMBNAIL_FLAG_FULL_NAME);
 
                /* Trigger thumbnail download *
                 * Note: download will grab all 3 possible thumbnails, no matter


### PR DESCRIPTION
## Description

Change the on-demand thumbnail downloader to do not even try long names, unless the option is enabled in settings or in playlist.

Should fix "no thumbnail retrieved at first try" issue with the well-estabilished DB+thumbnail cases (like N64)
## Related Pull Requests

#16040 