### PR TITLE
 Fall back to global system dir if content path is empty when 'System Files are in Content Directory' is enabled

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -727,12 +727,22 @@ static int menu_displaylist_parse_core_info(
          strlcpy(tmp_path, path_get(RARCH_PATH_CONTENT), sizeof(tmp_path));
          path_basedir(tmp_path);
 
-         /* Removes trailing slash, doesn't really matter but it's more consistent with how
-          * the path is stored and displayed without 'System Files are in Content Directory' */
-         len = strlen(tmp_path);
-         if (tmp_path[len - 1] == PATH_DEFAULT_SLASH_C())
-            tmp_path[len - 1] = '\0';
-         firmware_info.directory.system = tmp_path;
+         /* If content path is empty, fall back to global system dir path */
+         if (string_is_empty(tmp_path))
+            firmware_info.directory.system = settings->paths.directory_system;
+         else
+         {
+            size_t len       = strlen(tmp_path);
+
+            /* Removes trailing slash (unless root dir), doesn't really matter
+             * but it's more consistent with how the path is stored and
+             * displayed without 'System Files are in Content Directory' */
+            if (     string_count_occurrences_single_character(tmp_path, PATH_DEFAULT_SLASH_C()) > 1
+                  && tmp_path[len - 1] == PATH_DEFAULT_SLASH_C())
+               tmp_path[len - 1] = '\0';
+
+            firmware_info.directory.system = tmp_path;
+         }
       }
       else
          firmware_info.directory.system = settings->paths.directory_system;

--- a/runloop.c
+++ b/runloop.c
@@ -1981,15 +1981,18 @@ bool runloop_environment_cb(unsigned cmd, void *data)
                   strlcpy(tmp_path, fullpath, sizeof(tmp_path));
                   path_basedir(tmp_path);
 
-                  /* Removes trailing slash */
+                  /* Removes trailing slash (unless root dir) */
                   len = strlen(tmp_path);
-                  if (tmp_path[len - 1] == PATH_DEFAULT_SLASH_C())
+                  if (     string_count_occurrences_single_character(tmp_path, PATH_DEFAULT_SLASH_C()) > 1
+                        && tmp_path[len - 1] == PATH_DEFAULT_SLASH_C())
                      tmp_path[len - 1] = '\0';
 
                   dir_set(RARCH_DIR_SYSTEM, tmp_path);
+                  *(const char**)data = dir_get_ptr(RARCH_DIR_SYSTEM);
                }
+               else /* If content path is empty, fall back to global system dir path */
+                  *(const char**)data = dir_system;
 
-               *(const char**)data = dir_get_ptr(RARCH_DIR_SYSTEM);
                RARCH_LOG("[Environ]: SYSTEM_DIRECTORY: \"%s\".\n",
                      *(const char**)data);
             }


### PR DESCRIPTION
## Description

Kind of a followup to #16170

Currently when running a core that requires firmware files without content with "System Files are in Content Directory" enabled, RetroArch will look for the firmware files in either an empty path or the previous system dir used.

So for example with "System Files are in Content Directory" enabled:
* If I start RA and I run LRPS2 contentless, the path "" will be checked.
* If I start RA, run a PS1 game from `C:\Games\PS1`, then run LRPS2 contentless, the path "C:\Games\PS1" will be checked.

(and to be clear: this is not a regression from my previous PR, it was already acting like that before :p )

This PR tries to solve this by falling back to the global system dir instead. So for example if you want to use LRPS2, PUAE or melonDS DS contentless while "System Files are in Content Directory" is enabled, it will now work properly if you have the correct files in your system dir.
If both system dir and content paths are empty not much can be done tho, so it will still keep checking for files from an empty path like before...

Also adjusted my previous PR so that the slash isn't removed from the system path if it's root dir. Although I'm starting to wonder if I should keep that slash removal at all tbh... it's really just there for consistency and cosmetic purpose, idk if it's worth keeping :/

## Reviewers

Anyone really, I'm open to any comment/suggestion.
