### PR TITLE
Tweaks to how the "Analog to Digital Type" setting is saved

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -6062,7 +6062,7 @@ void input_remapping_cache_global_config(void)
                     | INP_FLAG_OLD_LIBRETRO_DEVICE_SET;
 }
 
-void input_remapping_restore_global_config(bool clear_cache)
+void input_remapping_restore_global_config(bool clear_cache, bool restore_analog_dpad_mode)
 {
    unsigned i;
    settings_t *settings           = config_get_ptr();
@@ -6073,7 +6073,8 @@ void input_remapping_restore_global_config(bool clear_cache)
 
    for (i = 0; i < MAX_USERS; i++)
    {
-      if ((input_st->flags & INP_FLAG_OLD_ANALOG_DPAD_MODE_SET)
+      if (   (input_st->flags & INP_FLAG_OLD_ANALOG_DPAD_MODE_SET)
+          &&  restore_analog_dpad_mode
           && (settings->uints.input_analog_dpad_mode[i] !=
                input_st->old_analog_dpad_mode[i]))
          configuration_set_uint(settings,
@@ -6195,7 +6196,7 @@ void input_remapping_set_defaults(bool clear_cache)
     * the last core init
     * > Prevents remap changes from 'bleeding through'
     *   into the main config file */
-   input_remapping_restore_global_config(clear_cache);
+   input_remapping_restore_global_config(clear_cache, true);
 }
 
 void input_driver_collect_system_input(input_driver_state_t *input_st,

--- a/input/input_remapping.h
+++ b/input/input_remapping.h
@@ -58,11 +58,16 @@ void input_remapping_cache_global_config(void);
  * init if INP_FLAG_REMAPPING_CACHE_ACTIVE is set.
  * Must be called on core deinitialization. 
  * 
- * @param clear_cache  If true, function becomes a NOOP until the next time
- *                     `input_remapping_cache_global_config()` is called, and 
- *                     INP_FLAG_REMAPPING_CACHE_ACTIVE is set.
+ * @param clear_cache               If true, function becomes a NOOP until the next time
+ *                                  `input_remapping_cache_global_config()` is called, and
+ *                                  INP_FLAG_REMAPPING_CACHE_ACTIVE is set.
+ * @param restore_analog_dpad_mode  Treat 'Analog to Digital Type' like a regular setting,
+ *                                  meaning this should be false when we're not using any
+ *                                  remap file so its value is saved globally on close/quit,
+ *                                  and it should be true when we're using a remap or if
+ *                                  we're resetting settings, to restore its global value.
  */
-void input_remapping_restore_global_config(bool clear_cache);
+void input_remapping_restore_global_config(bool clear_cache, bool restore_analog_dpad_mode);
 
 /**
  * Must be called whenever `settings->uints.input_remap_ports` is modified.

--- a/retroarch.c
+++ b/retroarch.c
@@ -3666,7 +3666,7 @@ bool command_event(enum event_command cmd, void *data)
                input_remapping_set_defaults(true);
             }
             else
-               input_remapping_restore_global_config(true);
+               input_remapping_restore_global_config(true, false);
 
 #ifdef HAVE_CONFIGFILE
             if (runloop_st->flags & RUNLOOP_FLAG_OVERRIDES_ACTIVE)
@@ -7578,7 +7578,7 @@ bool retroarch_main_init(int argc, char *argv[])
             input_remapping_set_defaults(true);
          }
          else
-            input_remapping_restore_global_config(true);
+            input_remapping_restore_global_config(true, false);
 
 #ifdef HAVE_CONFIGFILE
          /* Reload the original config */
@@ -8155,15 +8155,6 @@ bool retroarch_main_quit(void)
    }
    if (!(runloop_st->flags & RUNLOOP_FLAG_SHUTDOWN_INITIATED))
    {
-      /* Save configs before quitting
-       * as for UWP depending on `OnSuspending` is not important as we can call it directly here
-       * specifically we need to get width,height which requires UI thread and it will not be available on exit
-       */
-#if defined(HAVE_DYNAMIC)
-      if (config_save_on_exit)
-         command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
-#endif
-
       if (settings->bools.savestate_auto_save &&
           runloop_st->current_core_type != CORE_TYPE_DUMMY)
          command_event_save_auto_state();
@@ -8183,7 +8174,7 @@ bool retroarch_main_quit(void)
          input_remapping_set_defaults(true);
       }
       else
-         input_remapping_restore_global_config(true);
+         input_remapping_restore_global_config(true, false);
 
 #ifdef HAVE_CONFIGFILE
       if (runloop_st->flags & RUNLOOP_FLAG_OVERRIDES_ACTIVE)
@@ -8192,6 +8183,16 @@ bool retroarch_main_quit(void)
          config_unload_override();
       }
 #endif
+
+      /* Save configs before quitting
+       * as for UWP depending on `OnSuspending` is not important as we can call it directly here
+       * specifically we need to get width,height which requires UI thread and it will not be available on exit
+       */
+#if defined(HAVE_DYNAMIC)
+      if (config_save_on_exit)
+         command_event(CMD_EVENT_MENU_SAVE_CURRENT_CONFIG, NULL);
+#endif
+
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
       runloop_st->runtime_shader_preset_path[0] = '\0';
 #endif

--- a/runloop.c
+++ b/runloop.c
@@ -4088,7 +4088,7 @@ void runloop_event_deinit_core(void)
       input_remapping_set_defaults(true);
    }
    else
-      input_remapping_restore_global_config(true);
+      input_remapping_restore_global_config(true, false);
 
    RARCH_LOG("[Core]: Unloading core symbols..\n");
    uninit_libretro_symbols(&runloop_st->current_core);


### PR DESCRIPTION
## Description

2 tweaks for the "Analog to Digital Type" setting:

* Save config after the remap stuff was cleared, this prevents the setting from being saved globally when using a remap file and when exiting RetroArch directly without closing content first.
* To avoid confusion for the user, the setting will be treated like a normal setting: if it's changed while content is running, the setting will be saved globally if we're not using a remap file, however if we do have one or if we reset settings it will be reverted to its global value.

## Related Issues

Closes #16138

## Reviewers

@sonninnos , and anyone else with suggestions/comments of course!