### PR TITLE
Don't Sleep to Sync in Non-VRR Normal Running State

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -7225,7 +7225,13 @@ end:
    }
 
    /* if there's a fast forward limit, inject sleeps to keep from going too fast. */
-   if (runloop_st->frame_limit_minimum_time)
+   if (   (runloop_st->frame_limit_minimum_time)
+          && (   (vrr_runloop_enable)
+              || (runloop_st->flags & RUNLOOP_FLAG_FASTMOTION)
+#ifdef HAVE_MENU
+              || (menu_state_get_ptr()->flags & MENU_ST_FLAG_ALIVE && !(settings->bools.video_vsync))
+#endif
+              || (runloop_st->flags & RUNLOOP_FLAG_PAUSED)))
    {
       const retro_time_t end_frame_time  = cpu_features_get_time_usec();
       const retro_time_t to_sleep_ms     = (


### PR DESCRIPTION
The check for sleeping to sync to a specific speed that is meant for fast forward/vrr could be true for a non-vrr normal core running state. Thus causing a possible sleep in a situation it was not intended for, especially at higher hz with lower settings of fast forward ratio (other than 0-upcapped), and thus interfering with frame pacing.