### PR TITLE
Fullscreen/windowed fixes when using overrides

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -33,6 +33,7 @@
 #endif
 
 #include "file_path_special.h"
+#include "command.h"
 #include "configuration.h"
 #include "content.h"
 #include "config.def.h"
@@ -4450,6 +4451,10 @@ bool config_load_override_file(const char *config_path)
  */
 bool config_unload_override(void)
 {
+   settings_t *settings = config_st;
+   bool fullscreen_prev = settings->bools.video_fullscreen;
+   uint32_t flags       = runloop_get_flags();
+
    runloop_state_get_ptr()->flags &= ~RUNLOOP_FLAG_OVERRIDES_ACTIVE;
    path_clear(RARCH_PATH_CONFIG_OVERRIDE);
 
@@ -4460,6 +4465,20 @@ bool config_unload_override(void)
    if (!config_load_file(global_get_ptr(),
             path_get(RARCH_PATH_CONFIG), config_st))
       return false;
+
+   if (settings->bools.video_fullscreen != fullscreen_prev)
+   {
+      /* This is for 'win32_common.c', so we don't save
+       * fullscreen size and position if we're switching
+       * back to windowed mode. 
+       * Might be useful for other devices as well? */
+      if (      settings->bools.video_window_save_positions
+            && !settings->bools.video_fullscreen)
+         settings->skip_window_positions = true;
+
+      if (flags & RUNLOOP_FLAG_CORE_RUNNING)
+         command_event(CMD_EVENT_REINIT, NULL);
+   }
 
    RARCH_LOG("[Overrides]: Configuration overrides unloaded, original configuration restored.\n");
 

--- a/configuration.h
+++ b/configuration.h
@@ -568,6 +568,7 @@ typedef struct settings
    } paths;
 
    bool modified;
+   bool skip_window_positions;
 
    struct
    {

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -877,17 +877,27 @@ static void win32_save_position(void)
    placement.rcNormalPosition.right  = 0;
    placement.rcNormalPosition.bottom = 0;
 
-   if (GetWindowPlacement(main_window.hwnd, &placement))
+   /* If 'skip_window_positions' is true it means we've
+    * just unloaded an override that had fullscreen mode
+    * enabled while we have windowed mode set globally,
+    * in this case we skip the following blocks to not
+    * end up with fullscreen size and position. */
+   if (!settings->skip_window_positions)
    {
-      g_win32->pos_x      = placement.rcNormalPosition.left;
-      g_win32->pos_y      = placement.rcNormalPosition.top;
-   }
+      if (GetWindowPlacement(main_window.hwnd, &placement))
+      {
+         g_win32->pos_x      = placement.rcNormalPosition.left;
+         g_win32->pos_y      = placement.rcNormalPosition.top;
+      }
 
-   if (GetWindowRect(main_window.hwnd, &rect))
-   {
-      g_win32->pos_width  = rect.right  - rect.left;
-      g_win32->pos_height = rect.bottom - rect.top;
+      if (GetWindowRect(main_window.hwnd, &rect))
+      {
+         g_win32->pos_width  = rect.right  - rect.left;
+         g_win32->pos_height = rect.bottom - rect.top;
+      }
    }
+   else
+      settings->skip_window_positions = false;
 
    if (window_save_positions)
    {


### PR DESCRIPTION
## Description

Pretty niche issue, but currently when you use an override with a different fullscreen/windowed mode than your global setting it won't restore properly when clicking "Unload Override" while content is running. This PR fixes this by simply reiniting drivers when unloading the override (if fullscreen/windowed mode has changed).

On Windows however this isn't enough when using the "Remember Position and Size" setting, because of these 2 blocks: https://github.com/libretro/RetroArch/blob/1265c92249cac71ece6285a2e0582ecce1ae895f/gfx/common/win32_common.c#L880-L890
when clicking "Unload Override" or "Close Content" these will set the X and Y positions to "0" and the width and height to the screen resolution as if it was still in fullscreen, so you end up with an almost fullscreen window ("almost" because it removes borders and title/menu bar from the width and height) and you have to re-adjust these values manually every time, which becomes very, VERY annoying...

So his PR also adds an `skip_window_positions` bool (inside the `settings` struct, I didn't really know where else to put it), if it's true these 2 blocks will be skipped to prevent incorrect size and position values to be saved. For now it's only used for `win32_common.c` but it seems like the "Remember Position and Size" setting is also available on some Apple devices so it could potentially be useful there too, I don't own any Apple device so I can't check.

## Related Issues

Closes #12000, closes #16208

## Reviewers

Anyone, and if someone has a better way to approach the Windows only issue I'm all ears!

Note: only tested on Windows 10 and a Linux Mint VM.