### PR TITLE
Incorporate FreeBSD port patches

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -440,8 +440,13 @@ bool gfx_ctx_wl_get_metrics_common(void *data,
 static int create_shm_file(off_t size)
 {
    int fd, ret;
+#ifndef __FreeBSD__
    if ((fd = syscall(SYS_memfd_create, SPLASH_SHM_NAME,
                MFD_CLOEXEC | MFD_ALLOW_SEALING)) >= 0)
+#else
+   if ((fd = memfd_create(SPLASH_SHM_NAME,
+               MFD_CLOEXEC | MFD_ALLOW_SEALING)) >= 0)
+#endif
    {
       fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK);
 

--- a/input/input_keymaps.c
+++ b/input/input_keymaps.c
@@ -54,7 +54,7 @@
 #include "SDL.h"
 #endif
 
-#if defined(__linux__) || defined(HAVE_WAYLAND)
+#if defined(__linux__) || defined(HAVE_WAYLAND) || defined(__FreeBSD__) && !defined(__PS4__)
 #if defined(__linux__)
 #include <linux/input.h>
 #include <linux/kd.h>
@@ -1130,7 +1130,7 @@ const struct rarch_key_map rarch_key_map_x11[] = {
 };
 #endif
 
-#if defined(__linux__) || defined(HAVE_WAYLAND)
+#if defined(__linux__) || defined(HAVE_WAYLAND) || defined(__FreeBSD__) && !defined(__PS4__)
 /* Note: Only one input can be mapped to each
  * RETROK_* key. If several physical inputs
  * correspond to the same key, these inputs

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -45,7 +45,7 @@
 
 #if defined(_XBOX360)
 #include <PPCIntrinsics.h>
-#elif !defined(__MACH__) && (defined(__POWERPC__) || defined(__powerpc__) || defined(__ppc__) || defined(__PPC64__) || defined(__powerpc64__))
+#elif !defined(__MACH__) && !defined(__FreeBSD__) && (defined(__POWERPC__) || defined(__powerpc__) || defined(__ppc__) || defined(__PPC64__) || defined(__powerpc64__))
 #ifndef _PPU_INTRINSICS_H
 #include <ppu_intrinsics.h>
 #endif
@@ -181,7 +181,7 @@ retro_perf_tick_t cpu_features_get_perf_counter(void)
    time_ticks = (1000000 * tv_sec + tv_usec);
 #elif defined(GEKKO)
    time_ticks = gettime();
-#elif !defined(__MACH__) && (defined(_XBOX360) || defined(__powerpc__) || defined(__ppc__) || defined(__POWERPC__) || defined(__PSL1GHT__) || defined(__PPC64__) || defined(__powerpc64__))
+#elif !defined(__MACH__) && !defined(__FreeBSD__) && (defined(_XBOX360) || defined(__powerpc__) || defined(__ppc__) || defined(__POWERPC__) || defined(__PSL1GHT__) || defined(__PPC64__) || defined(__powerpc64__))
    time_ticks = __mftb();
 #elif (defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK > 0) || defined(__QNX__) || defined(ANDROID)
    struct timespec tv;


### PR DESCRIPTION
## Description

This commit integrates a series of [patches](https://cgit.freebsd.org/ports/tree/games/retroarch/files) from the FreeBSD port, enhancing build compatibility and resolving specific FreeBSD-related issues. They tackle a variety of issues, including compiler warnings and system-specific dependencies.

## Related Issues

- No specific issues in the upstream repository are directly addressed by this pull request. However, it aims to preemptively solve potential build and compatibility problems for FreeBSD users.

## Related Pull Requests

- None. This is a standalone pull request, requiring no dependent changes from related repositories.
