### PR TITLE
[Menu] Tweak the Dracula color theme for rgui and ozone

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -1255,11 +1255,11 @@ static ozone_theme_t ozone_theme_dracula = {
    ozone_background_libretro_running_dracula,            /* background_libretro_running */
 
    /* Float colors for quads and icons */
-   COLOR_HEX_TO_FLOAT(0x282A36, 1.0f),                   /* header_footer_separator */
+   COLOR_HEX_TO_FLOAT(0x282A36, 0.0f),                   /* header_footer_separator */
    COLOR_HEX_TO_FLOAT(0xF8F8F2, 1.0f),                   /* text */
-   COLOR_HEX_TO_FLOAT(0xFF79C6, 1.0f),                   /* selection */
-   COLOR_HEX_TO_FLOAT(0xFF79C6, 1.0f),                   /* selection_border */
-   COLOR_HEX_TO_FLOAT(0x282A36, 1.0f),                   /* entries_border */
+   COLOR_HEX_TO_FLOAT(0x44475A, 1.0f),                   /* selection */
+   COLOR_HEX_TO_FLOAT(0x44475A, 0.0f),                   /* selection_border */
+   COLOR_HEX_TO_FLOAT(0x282A36, 0.0f),                   /* entries_border */
    COLOR_HEX_TO_FLOAT(0xF8F8F2, 1.0f),                   /* entries_icon */
    COLOR_HEX_TO_FLOAT(0xFF79C6, 1.0f),                   /* text_selected */
    COLOR_HEX_TO_FLOAT(0x6272A4, 1.0f),                   /* message_background */

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -745,26 +745,26 @@ static const rgui_theme_t rgui_theme_opaque_brogrammer = {
 };
 
 static const rgui_theme_t rgui_theme_dracula = {
-   0xFFBD93F9, /* hover_color */
+   0xFFFF79C6, /* hover_color */
    0xFFF8F8F2, /* normal_color */
-   0xFFFF79C6, /* title_color */
-   0xC02F3240, /* bg_dark_color */
-   0xC02F3240, /* bg_light_color */
-   0xC06272A4, /* border_dark_color */
-   0xC06272A4, /* border_light_color */
-   0xC00F0F0F, /* shadow_color */
-   0xC06272A4  /* particle_color */
+   0xFFBD93F9, /* title_color */
+   0xFF282A36, /* bg_dark_color */
+   0xFF282A36, /* bg_light_color */
+   0xA044475A, /* border_dark_color */
+   0xA044475A, /* border_light_color */
+   0xA022212C, /* shadow_color */
+   0xA0525F88  /* particle_color */
 };
 
 static const rgui_theme_t rgui_theme_opaque_dracula = {
-   0xFFBD93F9, /* hover_color */
+   0xFFFF79C6, /* hover_color */
    0xFFF8F8F2, /* normal_color */
-   0xFFFF79C6, /* title_color */
-   0xFF1B2936, /* bg_dark_color */
-   0xFF1B2936, /* bg_light_color */
-   0xFF525F88, /* border_dark_color */
-   0xFF525F88, /* border_light_color */
-   0xFF000000, /* shadow_color */
+   0xFFBD93F9, /* title_color */
+   0xFF282A36, /* bg_dark_color */
+   0xFF282A36, /* bg_light_color */
+   0xFF44475A, /* border_dark_color */
+   0xFF44475A, /* border_light_color */
+   0xFF22212C, /* shadow_color */
    0xFF525F88  /* particle_color */
 };
 

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -748,12 +748,12 @@ static const rgui_theme_t rgui_theme_dracula = {
    0xFFFF79C6, /* hover_color */
    0xFFF8F8F2, /* normal_color */
    0xFFBD93F9, /* title_color */
-   0xFF282A36, /* bg_dark_color */
-   0xFF282A36, /* bg_light_color */
-   0xA044475A, /* border_dark_color */
-   0xA044475A, /* border_light_color */
-   0xA022212C, /* shadow_color */
-   0xA0525F88  /* particle_color */
+   0xE6282A36, /* bg_dark_color */
+   0xE6282A36, /* bg_light_color */
+   0xE644475A, /* border_dark_color */
+   0xE644475A, /* border_light_color */
+   0xFF22212C, /* shadow_color */
+   0xE6525F88  /* particle_color */
 };
 
 static const rgui_theme_t rgui_theme_opaque_dracula = {


### PR DESCRIPTION
Ozone's Dracula color theme had a selection color that was similar to the selection background, meaning the settings didn't confine to [minimum contrast accessibility](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html). This change fixes it so that the select colors are much more usable.

## Before

![Screenshot at 2024-02-10 21-14-49](https://github.com/libretro/RetroArch/assets/25086/7563f24b-23d7-44e3-bdf3-67ac926dbdfc)


## After

![Screenshot at 2024-02-10 21-11-51](https://github.com/libretro/RetroArch/assets/25086/31fe28b9-8491-4ad1-bdb7-4d1af6633fa4)
