### PR TITLE
Fix R3 button combo handling in general.

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -785,11 +785,13 @@ static int32_t input_state_wrap(
       /* Drivers can overflow when sending too many keys at once.. */
       if (id == RETRO_DEVICE_ID_JOYPAD_MASK && ret)
       {
-         /* Deal with menu toggle combo buttons that won't stay inside +32767. */
-         if (ret == -0x8000) /* R3 */
-            ret = 0x8000;
-         else if (ret == -0x4000) /* LR+R3 */
-            ret = 0x8000 + 0x4000;
+         /* Deal with R3 + possible combo buttons that won't stay inside +32767. */
+         if (ret < 0 && ret >= -0x8000) /* R3 */
+         {
+            /* Undo the int16_t conversion effects to int32_t   *
+             * Example: -32752 / 0xffff8010  to  32784 / 0x8010 */
+            ret += 0x10000;
+         }
          else if (ret < 0)
             ret = 0;
          return ret;


### PR DESCRIPTION
## Description

R3 is indicated as bit 15 which poses some problem, as the input driver's input_state returns a signed int16_t (why...? but that seems to be the way it was built).

Tested with slowdown hotkey mapped to R3, other keys continue to work while R3 is pressed.

## Related Issues

Fixes #16215 

## Related Pull Requests

#16168 #16163 

## Reviewers

@sonninnos 
