### PR TITLE
RETROK_UNKNOWN fixes and cleanups

### DIFF
--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -82,6 +82,10 @@ void apple_direct_input_keyboard_event(bool down,
       unsigned code, uint32_t character, uint32_t mod, unsigned device)
 {
     int apple_key              = rarch_keysym_lut[code];
+
+    if (!apple_key)
+       return;
+
     apple_key_state[apple_key] = down;
     input_keyboard_event(down,
           code,
@@ -435,7 +439,7 @@ static int16_t cocoa_input_state(
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
-                  if ((binds[port][i].key < RETROK_LAST) 
+                  if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
                         && apple_key_state[rarch_keysym_lut[binds[port][i].key]])
                      ret |= (1 << i);
                }
@@ -446,10 +450,13 @@ static int16_t cocoa_input_state(
          if (binds[port][id].valid)
          {
             if (id < RARCH_BIND_LIST_END)
-               if (!keyboard_mapping_blocked || (id == RARCH_GAME_FOCUS_TOGGLE))
-                  if (apple_key_state[rarch_keysym_lut[binds[port][id].key]])
-                     return 1;
-
+            {
+               if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
+                     && apple_key_state[rarch_keysym_lut[binds[port][id].key]]
+                     && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                  )
+                  return 1;
+            }
          }
          break;
       case RETRO_DEVICE_ANALOG:
@@ -469,12 +476,12 @@ static int16_t cocoa_input_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                if (apple_key_state[rarch_keysym_lut[(enum retro_key)id_plus_key]])
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                if (apple_key_state[rarch_keysym_lut[(enum retro_key)id_minus_key]])
                   ret += -0x7fff;
@@ -484,7 +491,7 @@ static int16_t cocoa_input_state(
          break;
 
       case RETRO_DEVICE_KEYBOARD:
-         return (id < RETROK_LAST) && apple_key_state[rarch_keysym_lut[(enum retro_key)id]];
+         return (id && id < RETROK_LAST) && apple_key_state[rarch_keysym_lut[(enum retro_key)id]];
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
          {

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -583,9 +583,7 @@ static int16_t dinput_input_state(
                      {
                         if (binds[port][i].valid)
                         {
-                           if (dinput_mouse_button_pressed(
-                                    di, port, binds[port][i].mbutton)
-                              )
+                           if (dinput_mouse_button_pressed(di, port, binds[port][i].mbutton))
                               ret |= (1 << i);
                         }
                      }
@@ -597,13 +595,13 @@ static int16_t dinput_input_state(
                      {
                         if (binds[port][i].valid)
                         {
-                           if ((binds[port][i].key < RETROK_LAST) &&
-                                 di->state[rarch_keysym_lut
-                                 [(enum retro_key)binds[port][i].key]] & 0x80)
+                           if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                                 && di->state[rarch_keysym_lut[(enum retro_key)binds[port][i].key]] & 0x80)
                               ret |= (1 << i);
                         }
                      }
                   }
+
                   return ret;
                }
 
@@ -611,26 +609,22 @@ static int16_t dinput_input_state(
                {
                   if (binds[port][id].valid)
                   {
-                     if  (binds[port][id].key < RETROK_LAST
-                           && (di->state[rarch_keysym_lut
-                              [(enum retro_key)binds[port][id].key]] & 0x80)
-                           && (   (id == RARCH_GAME_FOCUS_TOGGLE)
-                              || !keyboard_mapping_blocked)
-                         )
+                     if (     binds[port][id].key && binds[port][id].key < RETROK_LAST
+                           && (di->state[rarch_keysym_lut[(enum retro_key)binds[port][id].key]] & 0x80)
+                           && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                        )
                         return 1;
-                     else if (
-                           settings->uints.input_mouse_index[port] == 0
-                           && dinput_mouse_button_pressed(
-                              di, port, binds[port][id].mbutton)
-                           )
-                        return 1;
+                     else if (settings->uints.input_mouse_index[port] == 0)
+                     {
+                        if (dinput_mouse_button_pressed(di, port, binds[port][id].mbutton))
+                           return 1;
+                     }
                   }
                }
             }
             break;
          case RETRO_DEVICE_KEYBOARD:
-            return (id < RETROK_LAST) &&
-               di->state[rarch_keysym_lut[(enum retro_key)id]] & 0x80;
+            return (id && id < RETROK_LAST) && di->state[rarch_keysym_lut[(enum retro_key)id]] & 0x80;
          case RETRO_DEVICE_ANALOG:
             {
                int16_t ret           = 0;
@@ -648,13 +642,13 @@ static int16_t dinput_input_state(
                id_minus_key          = binds[port][id_minus].key;
                id_plus_key           = binds[port][id_plus].key;
 
-               if (id_plus_valid && id_plus_key < RETROK_LAST)
+               if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
                {
                   unsigned sym = rarch_keysym_lut[(enum retro_key)id_plus_key];
                   if (di->state[sym] & 0x80)
                      ret = 0x7fff;
                }
-               if (id_minus_valid && id_minus_key < RETROK_LAST)
+               if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
                {
                   unsigned sym = rarch_keysym_lut[(enum retro_key)id_minus_key];
                   if (di->state[sym] & 0x80)
@@ -832,6 +826,7 @@ static int16_t dinput_input_state(
                         ? bind_joykey  : autobind_joykey;
                      const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE)
                         ? bind_joyaxis : autobind_joyaxis;
+
                      if (binds[port][new_id].valid)
                      {
                         if ((uint16_t)joykey != NO_BTN && joypad->button(
@@ -841,22 +836,18 @@ static int16_t dinput_input_state(
                               ((float)abs(joypad->axis(joyport, joyaxis))
                                / 0x8000) > axis_threshold)
                            return 1;
-                        else if (
-                              binds[port][new_id].key < RETROK_LAST
+                        else if ((binds[port][new_id].key && binds[port][new_id].key < RETROK_LAST)
                               && !keyboard_mapping_blocked
-                              && di->state[rarch_keysym_lut
-                              [(enum retro_key)binds[port][new_id].key]] & 0x80
-                              )
+                              && di->state[rarch_keysym_lut[(enum retro_key)binds[port][new_id].key]] & 0x80)
                            return 1;
                         else
                         {
                            settings = config_get_ptr();
-                           if (
-                                 settings->uints.input_mouse_index[port] == 0
-                                 && dinput_mouse_button_pressed(
-                                    di, port, binds[port][new_id].mbutton)
-                              )
-                              return 1;
+                           if (settings->uints.input_mouse_index[port] == 0)
+                           {
+                              if (dinput_mouse_button_pressed(di, port, binds[port][new_id].mbutton))
+                                 return 1;
+                           }
                         }
                      }
                   }

--- a/input/drivers/linuxraw_input.c
+++ b/input/drivers/linuxraw_input.c
@@ -32,9 +32,6 @@
 #include "../input_keymaps.h"
 #include "../input_driver.h"
 
-/* TODO/FIXME -
- * fix game focus toggle */
-
 typedef struct linuxraw_input
 {
    bool state[0x80];
@@ -93,15 +90,16 @@ static int16_t linuxraw_input_state(
             unsigned i;
             int16_t ret = 0;
 
-            for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
+            if (!keyboard_mapping_blocked)
             {
-               if (binds[port][i].valid)
+               for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
-                  if (
-                        linuxraw->state[rarch_keysym_lut[
-                        (enum retro_key)binds[port][i].key]]
-                        )
-                     ret |= (1 << i);
+                  if (binds[port][i].valid)
+                  {
+                     if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                           && linuxraw->state[rarch_keysym_lut[(enum retro_key)binds[port][i].key]])
+                        ret |= (1 << i);
+                  }
                }
             }
 
@@ -112,9 +110,10 @@ static int16_t linuxraw_input_state(
          {
             if (binds[port][id].valid)
             {
-               if ((linuxraw->state[rarch_keysym_lut
-                        [(enum retro_key)binds[port][id].key]]
-                   ))
+               if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
+                     && linuxraw->state[rarch_keysym_lut[(enum retro_key)binds[port][id].key]]
+                     && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                  )
                   return 1;
             }
          }
@@ -137,13 +136,13 @@ static int16_t linuxraw_input_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                unsigned sym = rarch_keysym_lut[(enum retro_key)id_plus_key];
                if (linuxraw->state[sym] & 0x80)
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                unsigned sym = rarch_keysym_lut[(enum retro_key)id_minus_key];
                if (linuxraw->state[sym] & 0x80)

--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -405,11 +405,12 @@ static int16_t rwebinput_is_pressed(
    const struct retro_keybind *bind = &binds[id];
    int key                          = bind->key;
 
-   if ((key < RETROK_LAST) && rwebinput_key_pressed(rwebinput, key))
-      if ((id == RARCH_GAME_FOCUS_TOGGLE) || !keyboard_mapping_blocked)
-         return 1;
-   if (port == 0 && !!rwebinput_mouse_state(&rwebinput->mouse,
-            bind->mbutton, false))
+   if (     (key && key < RETROK_LAST)
+         && rwebinput_key_pressed(rwebinput, key)
+         && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+      )
+      return 1;
+   if (port == 0 && !!rwebinput_mouse_state(&rwebinput->mouse, bind->mbutton, false))
       return 1;
    return 0;
 }
@@ -479,14 +480,14 @@ static int16_t rwebinput_input_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                if (rwebinput_is_pressed(rwebinput,
                         binds[port], idx, id_plus,
                         keyboard_mapping_blocked))
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                if (rwebinput_is_pressed(rwebinput, 
                         binds[port], idx, id_minus,
@@ -498,11 +499,10 @@ static int16_t rwebinput_input_state(
          }
          break;
       case RETRO_DEVICE_KEYBOARD:
-         return ((id < RETROK_LAST) && rwebinput->keys[id]);
+         return (id && id < RETROK_LAST) && rwebinput->keys[id];
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
-         return rwebinput_mouse_state(&rwebinput->mouse, id,
-               device == RARCH_DEVICE_MOUSE_SCREEN);
+         return rwebinput_mouse_state(&rwebinput->mouse, id, device == RARCH_DEVICE_MOUSE_SCREEN);
       case RETRO_DEVICE_POINTER:
       case RARCH_DEVICE_POINTER_SCREEN:
          if (idx == 0)

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -39,9 +39,6 @@
 #include <dlfcn.h>
 #endif
 
-/* TODO/FIXME -
- * fix game focus toggle */
-
 typedef struct sdl_input
 {
    int mouse_x;
@@ -91,6 +88,9 @@ static bool sdl_key_pressed(int key)
    unsigned sym          = rarch_keysym_lut[(enum retro_key)key];
 #endif
 
+   if (!key)
+      return false;
+
 #ifdef WEBOS
    if (   (key == RETROK_BACKSPACE )
        && sdl_webos_special_keymap[sdl_webos_spkey_back])
@@ -139,11 +139,17 @@ static int16_t sdl_input_state(
          {
             unsigned i;
 
-            for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
+            if (!keyboard_mapping_blocked)
             {
-               if (binds[port][i].valid)
-                  if (sdl_key_pressed(binds[port][i].key))
-                     ret |= (1 << i);
+               for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
+               {
+                  if (binds[port][i].valid)
+                  {
+                     if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                           && sdl_key_pressed(binds[port][i].key))
+                        ret |= (1 << i);
+                  }
+               }
             }
 
             return ret;
@@ -152,8 +158,13 @@ static int16_t sdl_input_state(
          if (id < RARCH_BIND_LIST_END)
          {
             if (binds[port][id].valid)
-               if (sdl_key_pressed(binds[port][id].key))
+            {
+               if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
+                     && sdl_key_pressed(binds[port][id].key)
+                     && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                  )
                   return 1;
+            }
          }
          break;
       case RETRO_DEVICE_ANALOG:
@@ -172,18 +183,18 @@ static int16_t sdl_input_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                if (sdl_key_pressed(id_plus_key))
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                if (sdl_key_pressed(id_minus_key))
                   ret += -0x7fff;
             }
          }
-	 return ret;
+         return ret;
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
          if (config_get_ptr()->uints.input_mouse_index[ port ] == 0)
@@ -284,7 +295,7 @@ static int16_t sdl_input_state(
          }
          break;
       case RETRO_DEVICE_KEYBOARD:
-         return (id < RETROK_LAST) && sdl_key_pressed(id);
+         return (id && id < RETROK_LAST) && sdl_key_pressed(id);
       case RETRO_DEVICE_LIGHTGUN:
          switch (id)
          {

--- a/input/drivers/switch_input.c
+++ b/input/drivers/switch_input.c
@@ -222,12 +222,12 @@ static void switch_input_poll(void *data)
       key_sym     = rarch_key_map_switch[i].sym;
       key_code    = input_keymaps_translate_keysym_to_rk(key_sym);
       key_pressed = hidKeyboardStateGetKey(&kbd_state, key_sym);
-      if (key_pressed && !(sw->keyboard_state[key_sym]))
+      if (key_sym && key_pressed && !(sw->keyboard_state[key_sym]))
       {
          sw->keyboard_state[key_sym] = true;
          input_keyboard_event(true, key_code, 0, mod, RETRO_DEVICE_KEYBOARD);
       }
-      else if (!key_pressed && sw->keyboard_state[key_sym])
+      else if (key_sym && !key_pressed && sw->keyboard_state[key_sym])
       {
          sw->keyboard_state[key_sym] = false;
          input_keyboard_event(false, key_code, 0, mod, RETRO_DEVICE_KEYBOARD);
@@ -317,8 +317,7 @@ static int16_t switch_input_state(
          break;
 #ifdef HAVE_LIBNX
       case RETRO_DEVICE_KEYBOARD:
-         return ((id < RETROK_LAST) && 
-               sw->keyboard_state[rarch_keysym_lut[(enum retro_key)id]]);
+         return (id && id < RETROK_LAST) && sw->keyboard_state[rarch_keysym_lut[(enum retro_key)id]];
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
          {

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -3692,7 +3692,7 @@ static int16_t udev_mouse_state(udev_input_t *udev,
 static bool udev_keyboard_pressed(udev_input_t *udev, unsigned key)
 {
    int bit = rarch_keysym_lut[key];
-   return BIT_GET(udev->state, bit);
+   return (key) ? BIT_GET(udev->state, bit) : false;
 }
 
 static bool udev_mouse_button_pressed(
@@ -3820,14 +3820,15 @@ static int16_t udev_input_state(
                      ret |= (1 << i);
                }
             }
+
             if (!keyboard_mapping_blocked)
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
                   if (binds[port][i].valid)
                   {
-                     if ((binds[port][i].key < RETROK_LAST) &&
-                           udev_keyboard_pressed(udev, binds[port][i].key))
+                     if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                           && udev_keyboard_pressed(udev, binds[port][i].key))
                         ret |= (1 << i);
                   }
                }
@@ -3840,21 +3841,12 @@ static int16_t udev_input_state(
          {
             if (binds[port][id].valid)
             {
-               if (
-                     (binds[port][id].key < RETROK_LAST) &&
-                     udev_keyboard_pressed(udev, binds[port][id].key)
-                     && ((    id != RARCH_GAME_FOCUS_TOGGLE)
-                        && !keyboard_mapping_blocked)
-                     )
+               if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
+                     && udev_keyboard_pressed(udev, binds[port][id].key)
+                     && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                  )
                   return 1;
-               else if (
-                     (binds[port][id].key < RETROK_LAST) &&
-                     udev_keyboard_pressed(udev, binds[port][id].key)
-                     && (    id == RARCH_GAME_FOCUS_TOGGLE)
-                     )
-                  return 1;
-               else if (udev_mouse_button_pressed(udev, port,
-                        binds[port][id].mbutton))
+               else if (udev_mouse_button_pressed(udev, port, binds[port][id].mbutton))
                   return 1;
             }
          }
@@ -3877,13 +3869,13 @@ static int16_t udev_input_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                unsigned sym = rarch_keysym_lut[(enum retro_key)id_plus_key];
                if BIT_GET(udev->state, sym)
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                unsigned sym = rarch_keysym_lut[(enum retro_key)id_minus_key];
                if (BIT_GET(udev->state, sym))
@@ -3894,8 +3886,7 @@ static int16_t udev_input_state(
          }
          break;
       case RETRO_DEVICE_KEYBOARD:
-         return (id < RETROK_LAST) && udev_keyboard_pressed(udev, id);
-
+         return (id && id < RETROK_LAST) && udev_keyboard_pressed(udev, id);
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
 #ifdef UDEV_TOUCH_SUPPORT
@@ -3951,17 +3942,13 @@ static int16_t udev_input_state(
                   const uint64_t bind_joyaxis    = input_config_binds[port][new_id].joyaxis;
                   const uint64_t autobind_joykey = input_autoconf_binds[port][new_id].joykey;
                   const uint64_t autobind_joyaxis= input_autoconf_binds[port][new_id].joyaxis;
-                  uint16_t joyport                  = joypad_info->joy_idx;
+                  uint16_t joyport               = joypad_info->joy_idx;
                   float axis_threshold           = joypad_info->axis_threshold;
                   const uint64_t joykey          = (bind_joykey != NO_BTN)
                      ? bind_joykey  : autobind_joykey;
                   const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE)
                      ? bind_joyaxis : autobind_joyaxis;
-                  if (!keyboard_mapping_blocked)
-                     if ((binds[port][new_id].key < RETROK_LAST)
-                           && udev_keyboard_pressed(udev, binds[port]
-                              [new_id].key))
-                        return 1;
+
                   if (binds[port][new_id].valid)
                   {
                      if ((uint16_t)joykey != NO_BTN && joypad->button(
@@ -3971,8 +3958,12 @@ static int16_t udev_input_state(
                            ((float)abs(joypad->axis(joyport, joyaxis))
                             / 0x8000) > axis_threshold)
                         return 1;
-                     if (udev_mouse_button_pressed(udev, port,
-                              binds[port][new_id].mbutton))
+                     else if ((binds[port][new_id].key && binds[port][new_id].key < RETROK_LAST)
+                           && !keyboard_mapping_blocked
+                           && udev_keyboard_pressed(udev, binds[port][new_id].key)
+                        )
+                        return 1;
+                     else if (udev_mouse_button_pressed(udev, port, binds[port][new_id].mbutton))
                         return 1;
                   }
                }

--- a/input/drivers/uwp_input.c
+++ b/input/drivers/uwp_input.c
@@ -67,28 +67,25 @@ static int16_t uwp_input_state(
             unsigned i;
             int16_t ret = 0;
 
+            for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
+            {
+               if (binds[port][i].valid)
+               {
+                  if (uwp_mouse_state(port, binds[port][i].mbutton, false))
+                     ret |= (1 << i);
+               }
+            }
+
             if (!keyboard_mapping_blocked)
             {
                for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                {
                   if (binds[port][i].valid)
                   {
-                     if (     
-                           ((binds[port][i].key < RETROK_LAST) 
-                            && uwp_keyboard_pressed(binds[port][i].key))
-                        )
+                     if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                           && uwp_keyboard_pressed(binds[port][i].key))
                         ret |= (1 << i);
                   }
-               }
-            }
-
-            for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
-            {
-               if (binds[port][i].valid)
-               {
-                  if (uwp_mouse_state(port,
-                           binds[port][i].mbutton, false))
-                     ret |= (1 << i);
                }
             }
 
@@ -99,14 +96,12 @@ static int16_t uwp_input_state(
          {
             if (binds[port][id].valid)
             {
-               if ((binds[port][id].key < RETROK_LAST) 
+               if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
                      && uwp_keyboard_pressed(binds[port][id].key)
-                     && ((id == RARCH_GAME_FOCUS_TOGGLE)
-                     || !keyboard_mapping_blocked)
-                     )
+                     && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                  )
                   return 1;
-               else if (uwp_mouse_state(port,
-                        binds[port][id].mbutton, false))
+               else if (uwp_mouse_state(port, binds[port][id].mbutton, false))
                   return 1;
             }
          }
@@ -129,12 +124,12 @@ static int16_t uwp_input_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                if (uwp_keyboard_pressed(id_plus_key))
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                if (uwp_keyboard_pressed(id_minus_key))
                   ret += -0x7fff;
@@ -144,12 +139,10 @@ static int16_t uwp_input_state(
          }
          break;
       case RETRO_DEVICE_KEYBOARD:
-         return (id < RETROK_LAST) && uwp_keyboard_pressed(id);
-
+         return (id && id < RETROK_LAST) && uwp_keyboard_pressed(id);
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
          return uwp_mouse_state(port, id, device == RARCH_DEVICE_MOUSE_SCREEN);
-
       case RETRO_DEVICE_POINTER:
       case RARCH_DEVICE_POINTER_SCREEN:
          return uwp_pointer_state(index, id, device == RARCH_DEVICE_POINTER_SCREEN);

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -191,8 +191,8 @@ static int16_t input_wl_state(
                {
                   if (binds[port][i].valid)
                   {
-                     if (BIT_GET(wl->key_state,
-                              rarch_keysym_lut[binds[port][i].key]) )
+                     if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                           && BIT_GET(wl->key_state, rarch_keysym_lut[binds[port][i].key]))
                         ret |= (1 << i);
                   }
                }
@@ -203,18 +203,13 @@ static int16_t input_wl_state(
 
          if (id < RARCH_BIND_LIST_END)
          {
-            if (binds[port][id].valid && binds[port][id].key < RETROK_LAST)
+            if (binds[port][id].valid)
             {
-               if (id != RARCH_GAME_FOCUS_TOGGLE && !keyboard_mapping_blocked)
-               {
-                  if (BIT_GET(wl->key_state, rarch_keysym_lut[binds[port][id].key]))
-                     return 1;
-               }
-               else if (id == RARCH_GAME_FOCUS_TOGGLE)
-               {
-                  if (BIT_GET(wl->key_state, rarch_keysym_lut[binds[port][id].key]))
-                     return 1;
-               }
+               if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
+                     && BIT_GET(wl->key_state, rarch_keysym_lut[binds[port][id].key])
+                     && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
+                  )
+                  return 1;
 
                /* TODO: support default mouse-to-retropad bindings */
                /* else if (wl_mouse_button_pressed(udev, port, binds[port][i].mbutton))
@@ -241,13 +236,13 @@ static int16_t input_wl_state(
             id_minus_key          = binds[port][id_minus].key;
             id_plus_key           = binds[port][id_plus].key;
 
-            if (id_plus_valid && id_plus_key < RETROK_LAST)
+            if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
             {
                unsigned sym = rarch_keysym_lut[(enum retro_key)id_plus_key];
                if (BIT_GET(wl->key_state, sym))
                   ret = 0x7fff;
             }
-            if (id_minus_valid && id_minus_key < RETROK_LAST)
+            if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
                unsigned sym = rarch_keysym_lut[(enum retro_key)id_minus_key];
                if (BIT_GET(wl->key_state, sym))
@@ -258,8 +253,7 @@ static int16_t input_wl_state(
          }
          break;
       case RETRO_DEVICE_KEYBOARD:
-         return id < RETROK_LAST &&
-            BIT_GET(wl->key_state, rarch_keysym_lut[(enum retro_key)id]);
+         return (id && id < RETROK_LAST) && BIT_GET(wl->key_state, rarch_keysym_lut[(enum retro_key)id]);
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
          if (port == 0) /* TODO/FIXME: support mouse on additional ports */

--- a/input/drivers/wiiu_input.c
+++ b/input/drivers/wiiu_input.c
@@ -60,7 +60,7 @@ static void kb_key_callback(KBDKeyEvent *key)
 
    code                    = input_keymaps_translate_keysym_to_rk(
          key->scancode);
-   if (code < RETROK_LAST)
+   if (code && code < RETROK_LAST)
       keyboard_state[code] = pressed;
 
    if (key->modifier & KBD_WIIU_SHIFT)
@@ -106,7 +106,7 @@ static int16_t wiiu_input_state(
       case RETRO_DEVICE_ANALOG:
          break;
       case RETRO_DEVICE_KEYBOARD:
-         if (id < RETROK_LAST && keyboard_state[id] && (keyboard_channel > 0))
+         if (id && id < RETROK_LAST && keyboard_state[id] && (keyboard_channel > 0))
             return 1;
          break;
       case RETRO_DEVICE_POINTER:

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -780,8 +780,7 @@ static int16_t winraw_input_state(
                   {
                      if (binds[port][i].valid)
                      {
-                        if (winraw_mouse_button_pressed(wr,
-                                 mouse, port, binds[port][i].mbutton))
+                        if (winraw_mouse_button_pressed(wr, mouse, port, binds[port][i].mbutton))
                            ret |= (1 << i);
                      }
                   }
@@ -793,8 +792,8 @@ static int16_t winraw_input_state(
                   {
                      if (binds[port][i].valid)
                      {
-                        if ((binds[port][i].key < RETROK_LAST) &&
-                              WINRAW_KEYBOARD_PRESSED(wr, binds[port][i].key))
+                        if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                              && WINRAW_KEYBOARD_PRESSED(wr, binds[port][i].key))
                            ret |= (1 << i);
                      }
                   }
@@ -807,15 +806,12 @@ static int16_t winraw_input_state(
             {
                if (binds[port][id].valid)
                {
-                  if (
-                        (binds[port][id].key < RETROK_LAST)
+                  if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
                         && WINRAW_KEYBOARD_PRESSED(wr, binds[port][id].key)
-                        && ((    id == RARCH_GAME_FOCUS_TOGGLE)
-                           || !keyboard_mapping_blocked)
+                        && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
                      )
                      return 1;
-                  else if (mouse && winraw_mouse_button_pressed(wr,
-                           mouse, port, binds[port][id].mbutton))
+                  else if (mouse && winraw_mouse_button_pressed(wr, mouse, port, binds[port][id].mbutton))
                      return 1;
                }
             }
@@ -836,12 +832,12 @@ static int16_t winraw_input_state(
                id_minus_key          = binds[port][id_minus].key;
                id_plus_key           = binds[port][id_plus].key;
 
-               if (id_plus_valid && id_plus_key < RETROK_LAST)
+               if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
                {
                   if (WINRAW_KEYBOARD_PRESSED(wr, id_plus_key))
                      ret = 0x7fff;
                }
-               if (id_minus_valid && id_minus_key < RETROK_LAST)
+               if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
                {
                   if (WINRAW_KEYBOARD_PRESSED(wr, id_minus_key))
                      ret += -0x7fff;
@@ -849,7 +845,7 @@ static int16_t winraw_input_state(
             }
             return ret;
          case RETRO_DEVICE_KEYBOARD:
-            return (id < RETROK_LAST) && WINRAW_KEYBOARD_PRESSED(wr, id);
+            return (id && id < RETROK_LAST) && WINRAW_KEYBOARD_PRESSED(wr, id);
          case RETRO_DEVICE_MOUSE:
          case RARCH_DEVICE_MOUSE_SCREEN:
             if (mouse)
@@ -996,6 +992,7 @@ static int16_t winraw_input_state(
                         ? bind_joykey  : autobind_joykey;
                      const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE)
                         ? bind_joyaxis : autobind_joyaxis;
+
                      if (binds[port][new_id].valid)
                      {
                         if ((uint16_t)joykey != NO_BTN && joypad->button(
@@ -1005,19 +1002,14 @@ static int16_t winraw_input_state(
                               ((float)abs(joypad->axis(joyport, joyaxis))
                                / 0x8000) > axis_threshold)
                            return 1;
-                        else if (
-                              binds[port][new_id].key < RETROK_LAST
+                        else if ((binds[port][new_id].key && binds[port][new_id].key < RETROK_LAST)
                               && !keyboard_mapping_blocked
-                              && WINRAW_KEYBOARD_PRESSED(wr, binds[port]
-                                 [new_id].key)
-                              )
+                              && WINRAW_KEYBOARD_PRESSED(wr, binds[port][new_id].key)
+                           )
                            return 1;
-                        else
+                        else if (mouse)
                         {
-                           if (
-                                 mouse && winraw_mouse_button_pressed(wr,
-                                    mouse, port, binds[port][new_id].mbutton)
-                              )
+                           if (winraw_mouse_button_pressed(wr, mouse, port, binds[port][new_id].mbutton))
                               return 1;
                         }
                      }

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -169,20 +169,20 @@ static int16_t x_input_state(
                   {
                      if (binds[port][i].valid)
                      {
-                        if (x_mouse_button_pressed(x11, port,
-                                 binds[port][i].mbutton))
+                        if (x_mouse_button_pressed(x11, port, binds[port][i].mbutton))
                            ret |= (1 << i);
                      }
                   }
                }
+
                if (!keyboard_mapping_blocked)
                {
                   for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
                   {
                      if (binds[port][i].valid)
                      {
-                        if ((binds[port][i].key < RETROK_LAST) &&
-                              x_keyboard_pressed(x11, binds[port][i].key))
+                        if (     (binds[port][i].key && binds[port][i].key < RETROK_LAST)
+                              && x_keyboard_pressed(x11, binds[port][i].key))
                            ret |= (1 << i);
                      }
                   }
@@ -195,17 +195,14 @@ static int16_t x_input_state(
             {
                if (binds[port][id].valid)
                {
-                  if (
-                        ((binds[port][id].key < RETROK_LAST) && 
-                         x_keyboard_pressed(x11, binds[port][id].key)) 
-                        && ((    id == RARCH_GAME_FOCUS_TOGGLE) 
-                           || !keyboard_mapping_blocked)
+                  if (     (binds[port][id].key && binds[port][id].key < RETROK_LAST)
+                        && x_keyboard_pressed(x11, binds[port][id].key)
+                        && (id == RARCH_GAME_FOCUS_TOGGLE || !keyboard_mapping_blocked)
                      )
                      return 1;
                   else if (settings->uints.input_mouse_index[port] == 0)
                   {
-                     if (x_mouse_button_pressed(x11, port,
-                              binds[port][id].mbutton))
+                     if (x_mouse_button_pressed(x11, port, binds[port][id].mbutton))
                         return 1;
                   }
                }
@@ -231,13 +228,13 @@ static int16_t x_input_state(
                id_minus_key          = binds[port][id_minus].key;
                id_plus_key           = binds[port][id_plus].key;
 
-               if (id_plus_valid && id_plus_key < RETROK_LAST)
+               if (id_plus_valid && id_plus_key && id_plus_key < RETROK_LAST)
                {
                   unsigned sym = rarch_keysym_lut[(enum retro_key)id_plus_key];
                   if (x11->state[sym >> 3] & (1 << (sym & 7)))
                      ret = 0x7fff;
                }
-               if (id_minus_valid && id_minus_key < RETROK_LAST)
+               if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
                {
                   unsigned sym = rarch_keysym_lut[(enum retro_key)id_minus_key];
                   if (x11->state[sym >> 3] & (1 << (sym & 7)))
@@ -248,7 +245,7 @@ static int16_t x_input_state(
             }
             break;
          case RETRO_DEVICE_KEYBOARD:
-            return (id < RETROK_LAST) && x_keyboard_pressed(x11, id);
+            return (id && id < RETROK_LAST) && x_keyboard_pressed(x11, id);
          case RETRO_DEVICE_MOUSE:
          case RARCH_DEVICE_MOUSE_SCREEN:
             switch (id)
@@ -395,11 +392,7 @@ static int16_t x_input_state(
                         ? bind_joykey  : autobind_joykey;
                      const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE)
                         ? bind_joyaxis : autobind_joyaxis;
-                     if (!keyboard_mapping_blocked)
-                        if ((binds[port][new_id].key < RETROK_LAST) 
-                              && x_keyboard_pressed(x11, binds[port]
-                                 [new_id].key) )
-                           return 1;
+
                      if (binds[port][new_id].valid)
                      {
                         if ((uint16_t)joykey != NO_BTN && joypad->button(
@@ -409,10 +402,14 @@ static int16_t x_input_state(
                               ((float)abs(joypad->axis(joyport, joyaxis)) 
                                / 0x8000) > axis_threshold)
                            return 1;
+                        else if ((binds[port][new_id].key && binds[port][new_id].key < RETROK_LAST) 
+                              && !keyboard_mapping_blocked
+                              && x_keyboard_pressed(x11, binds[port][new_id].key)
+                           )
+                           return 1;
                         else if (settings->uints.input_mouse_index[port] == 0)
                         {
-                           if (x_mouse_button_pressed(x11, port,
-                                    binds[port][new_id].mbutton))
+                           if (x_mouse_button_pressed(x11, port, binds[port][new_id].mbutton))
                               return 1;
                         }
                      }

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -91,18 +91,6 @@
       || ((autoconf_bind)->joyaxis != AXIS_NONE)) \
 )
 
-/* Checks if hotkey or RetroPad has any bindings at all. */
-#define CHECK_INPUT_DRIVER_EMPTY_BIND(port, i) \
-( \
-         (binds[port][i].key     == RETROK_UNKNOWN) \
-      && (binds[port][i].mbutton == NO_BTN) \
-      && (  (  binds[port][i].joykey  == NO_BTN \
-            && binds[port][i].joyaxis == AXIS_NONE) \
-         || (  joypad_info->auto_binds[i].joykey  == NO_BTN \
-            && joypad_info->auto_binds[i].joyaxis == AXIS_NONE) \
-         ) \
-)
-
 /* Human readable order of input binds */
 const unsigned input_config_bind_order[24] = {
    RETRO_DEVICE_ID_JOYPAD_UP,
@@ -791,26 +779,6 @@ static int32_t input_state_wrap(
             device,
             idx,
             id);
-
-   if (device == RETRO_DEVICE_JOYPAD)
-   {
-      /* No binds, no input. This is for ignoring RETROK_UNKNOWN
-       * if the driver allows setting the key down somehow.
-       * Otherwise all hotkeys and inputs with null bind get triggered. */
-      if (id == RETRO_DEVICE_ID_JOYPAD_MASK)
-      {
-         int i;
-         for (i = 0; i < RARCH_FIRST_META_KEY; i++)
-         {
-            if (CHECK_INPUT_DRIVER_EMPTY_BIND(_port, i))
-               ret &= ~(UINT64_C(1) << i);
-         }
-         return ret;
-      }
-      else if (id != RETRO_DEVICE_ID_JOYPAD_MASK
-            && CHECK_INPUT_DRIVER_EMPTY_BIND(_port, id))
-         return 0;
-   }
 
    return ret;
 }
@@ -4868,7 +4836,7 @@ static void input_keys_pressed(
                port, RETRO_DEVICE_JOYPAD, 0,
                RETRO_DEVICE_ID_JOYPAD_MASK);
 
-      for (i = 0; i < RARCH_FIRST_META_KEY; i++)
+      for (i = 0; i < RARCH_FIRST_CUSTOM_BIND; i++)
       {
          if (     (ret & (UINT64_C(1) << i))
                || input_keys_pressed_other_sources(input_st, i, p_new_state))


### PR DESCRIPTION
## Description

Since the previous attempt has issues again, it is time to go nuclear and forget the empty bind checking in post, and instead prevent `RETROK_UNKNOWN` being set and/or being read in the first place in each input driver that reads keyboards.

Also unified similar code bits between drivers and filled some missing stuff. Please double-check that the logic is sound. I could only confirm winraw and dinput, since sdl2 will use dinput.

## Related Pull Requests

#16233
