### PR TITLE
Add sensible limits to input_axis_threshold menu item

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -15306,7 +15306,7 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            menu_settings_list_current_add_range(list, list_info, 0, 1.0, 0.01, true, true);
+            menu_settings_list_current_add_range(list, list_info, 0.05, 0.99, 0.01, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
             CONFIG_FLOAT(


### PR DESCRIPTION
## Description

Let's make it impossible for users to lock themselves out and ruin the setup if autosaving is on, since if this value is small enough menu goes crazy and uncontrollable, and if it is at maximum it won't work at all.
