### PR TITLE
Add ability to "reserve" devices by player in Android using settings

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1481,7 +1481,6 @@ bool config_overlay_enable_default(void)
 static struct config_array_setting *populate_settings_array(
       settings_t *settings, int *size)
 {
-   unsigned i                           = 0;
    unsigned count                       = 0;
    struct config_array_setting  *tmp    = (struct config_array_setting*)calloc(1, (*size + 1) * sizeof(struct config_array_setting));
 
@@ -1512,23 +1511,22 @@ static struct config_array_setting *populate_settings_array(
    SETTING_ARRAY("input_android_physical_keyboard", settings->arrays.input_android_physical_keyboard, false, NULL, true);
 #endif
 
-   for (i = 0; i < MAX_USERS; i++)
-   {
-      size_t _len;
-      char formatted_number[4];
-      char prefix[16];
-      char key[32];
-
-      formatted_number[0] = '\0';
-
-      snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
-      _len       = strlcpy(prefix, "input_player",   sizeof(prefix));
-      strlcpy(prefix + _len, formatted_number, sizeof(prefix) - _len);
-      _len       = strlcpy(key, prefix, sizeof(key));
-      strlcpy(key + _len, "_reserved_device", sizeof(key) - _len);
-
-      SETTING_ARRAY(key, settings->arrays.input_reserved_devices[i], false, NULL, true);
-   }
+   SETTING_ARRAY("input_player1_reserved_device",   settings->arrays.input_reserved_devices[0],  false, NULL, true);
+   SETTING_ARRAY("input_player2_reserved_device",   settings->arrays.input_reserved_devices[1],  false, NULL, true);
+   SETTING_ARRAY("input_player3_reserved_device",   settings->arrays.input_reserved_devices[2],  false, NULL, true);
+   SETTING_ARRAY("input_player4_reserved_device",   settings->arrays.input_reserved_devices[3],  false, NULL, true);
+   SETTING_ARRAY("input_player5_reserved_device",   settings->arrays.input_reserved_devices[4],  false, NULL, true);
+   SETTING_ARRAY("input_player6_reserved_device",   settings->arrays.input_reserved_devices[5],  false, NULL, true);
+   SETTING_ARRAY("input_player7_reserved_device",   settings->arrays.input_reserved_devices[6],  false, NULL, true);
+   SETTING_ARRAY("input_player8_reserved_device",   settings->arrays.input_reserved_devices[7],  false, NULL, true);
+   SETTING_ARRAY("input_player9_reserved_device",   settings->arrays.input_reserved_devices[8],  false, NULL, true);
+   SETTING_ARRAY("input_player10_reserved_device",  settings->arrays.input_reserved_devices[9],  false, NULL, true);
+   SETTING_ARRAY("input_player11_reserved_device",  settings->arrays.input_reserved_devices[10], false, NULL, true);
+   SETTING_ARRAY("input_player12_reserved_device",  settings->arrays.input_reserved_devices[11], false, NULL, true);
+   SETTING_ARRAY("input_player13_reserved_device",  settings->arrays.input_reserved_devices[12], false, NULL, true);
+   SETTING_ARRAY("input_player14_reserved_device",  settings->arrays.input_reserved_devices[13], false, NULL, true);
+   SETTING_ARRAY("input_player15_reserved_device",  settings->arrays.input_reserved_devices[14], false, NULL, true);
+   SETTING_ARRAY("input_player16_reserved_device",  settings->arrays.input_reserved_devices[15], false, NULL, true);
 
 #ifdef HAVE_MENU
    SETTING_ARRAY("menu_driver",                  settings->arrays.menu_driver, false, NULL, true);

--- a/configuration.c
+++ b/configuration.c
@@ -1481,6 +1481,7 @@ bool config_overlay_enable_default(void)
 static struct config_array_setting *populate_settings_array(
       settings_t *settings, int *size)
 {
+   unsigned i                           = 0;
    unsigned count                       = 0;
    struct config_array_setting  *tmp    = (struct config_array_setting*)calloc(1, (*size + 1) * sizeof(struct config_array_setting));
 
@@ -1511,22 +1512,23 @@ static struct config_array_setting *populate_settings_array(
    SETTING_ARRAY("input_android_physical_keyboard", settings->arrays.input_android_physical_keyboard, false, NULL, true);
 #endif
 
-   SETTING_ARRAY("input_player1_reserved_device",  settings->arrays.input_player1_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player2_reserved_device",  settings->arrays.input_player2_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player3_reserved_device",  settings->arrays.input_player3_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player4_reserved_device",  settings->arrays.input_player4_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player5_reserved_device",  settings->arrays.input_player5_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player6_reserved_device",  settings->arrays.input_player6_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player7_reserved_device",  settings->arrays.input_player7_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player8_reserved_device",  settings->arrays.input_player8_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player9_reserved_device",  settings->arrays.input_player9_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_player10_reserved_device", settings->arrays.input_player10_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_player11_reserved_device", settings->arrays.input_player11_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_player12_reserved_device", settings->arrays.input_player12_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_player13_reserved_device", settings->arrays.input_player13_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_player14_reserved_device", settings->arrays.input_player14_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_player15_reserved_device", settings->arrays.input_player15_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_player16_reserved_device", settings->arrays.input_player16_reserved_device, false, NULL, true);
+   for (i = 0; i < MAX_USERS; i++)
+   {
+      size_t _len;
+      char formatted_number[4];
+      char prefix[16];
+      char key[32];
+
+      formatted_number[0] = '\0';
+
+      snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
+      _len       = strlcpy(prefix, "input_player",   sizeof(prefix));
+      strlcpy(prefix + _len, formatted_number, sizeof(prefix) - _len);
+      _len       = strlcpy(key, prefix, sizeof(key));
+      strlcpy(key + _len, "_reserved_device", sizeof(key) - _len);
+
+      SETTING_ARRAY(key, settings->arrays.input_reserved_devices[i], false, NULL, true);
+   }
 
 #ifdef HAVE_MENU
    SETTING_ARRAY("menu_driver",                  settings->arrays.menu_driver, false, NULL, true);

--- a/configuration.c
+++ b/configuration.c
@@ -1481,6 +1481,7 @@ bool config_overlay_enable_default(void)
 static struct config_array_setting *populate_settings_array(
       settings_t *settings, int *size)
 {
+   unsigned i                           = 0;
    unsigned count                       = 0;
    struct config_array_setting  *tmp    = (struct config_array_setting*)calloc(1, (*size + 1) * sizeof(struct config_array_setting));
 
@@ -1511,22 +1512,23 @@ static struct config_array_setting *populate_settings_array(
    SETTING_ARRAY("input_android_physical_keyboard", settings->arrays.input_android_physical_keyboard, false, NULL, true);
 #endif
 
-   SETTING_ARRAY("input_player1_reserved_device",   settings->arrays.input_reserved_devices[0],  false, NULL, true);
-   SETTING_ARRAY("input_player2_reserved_device",   settings->arrays.input_reserved_devices[1],  false, NULL, true);
-   SETTING_ARRAY("input_player3_reserved_device",   settings->arrays.input_reserved_devices[2],  false, NULL, true);
-   SETTING_ARRAY("input_player4_reserved_device",   settings->arrays.input_reserved_devices[3],  false, NULL, true);
-   SETTING_ARRAY("input_player5_reserved_device",   settings->arrays.input_reserved_devices[4],  false, NULL, true);
-   SETTING_ARRAY("input_player6_reserved_device",   settings->arrays.input_reserved_devices[5],  false, NULL, true);
-   SETTING_ARRAY("input_player7_reserved_device",   settings->arrays.input_reserved_devices[6],  false, NULL, true);
-   SETTING_ARRAY("input_player8_reserved_device",   settings->arrays.input_reserved_devices[7],  false, NULL, true);
-   SETTING_ARRAY("input_player9_reserved_device",   settings->arrays.input_reserved_devices[8],  false, NULL, true);
-   SETTING_ARRAY("input_player10_reserved_device",  settings->arrays.input_reserved_devices[9],  false, NULL, true);
-   SETTING_ARRAY("input_player11_reserved_device",  settings->arrays.input_reserved_devices[10], false, NULL, true);
-   SETTING_ARRAY("input_player12_reserved_device",  settings->arrays.input_reserved_devices[11], false, NULL, true);
-   SETTING_ARRAY("input_player13_reserved_device",  settings->arrays.input_reserved_devices[12], false, NULL, true);
-   SETTING_ARRAY("input_player14_reserved_device",  settings->arrays.input_reserved_devices[13], false, NULL, true);
-   SETTING_ARRAY("input_player15_reserved_device",  settings->arrays.input_reserved_devices[14], false, NULL, true);
-   SETTING_ARRAY("input_player16_reserved_device",  settings->arrays.input_reserved_devices[15], false, NULL, true);
+   for (i = 0; i < MAX_USERS; i++)
+   {
+      size_t _len;
+      char formatted_number[4];
+      char prefix[16];
+      char key[32];
+
+      formatted_number[0] = '\0';
+
+      snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
+      _len = strlcpy(prefix, "input_player",   sizeof(prefix));
+      strlcpy(prefix + _len, formatted_number, sizeof(prefix) - _len);
+      _len = strlcpy(key, prefix, sizeof(key));
+      strlcpy(key + _len, "_reserved_device", sizeof(key) - _len);
+
+      SETTING_ARRAY(strdup(key), settings->arrays.input_reserved_devices[i], false, NULL, true);
+   }
 
 #ifdef HAVE_MENU
    SETTING_ARRAY("menu_driver",                  settings->arrays.menu_driver, false, NULL, true);

--- a/configuration.c
+++ b/configuration.c
@@ -1508,7 +1508,23 @@ static struct config_array_setting *populate_settings_array(
    SETTING_ARRAY("input_joypad_driver",          settings->arrays.input_joypad_driver, false, NULL, true);
    SETTING_ARRAY("input_keyboard_layout",        settings->arrays.input_keyboard_layout, false, NULL, true);
 #ifdef ANDROID
-   SETTING_ARRAY("input_android_physical_keyboard", settings->arrays.input_android_physical_keyboard, false, NULL, true);
+   SETTING_ARRAY("input_android_physical_keyboard",        settings->arrays.input_android_physical_keyboard,        false, NULL, true);
+   SETTING_ARRAY("input_android_player1_reserved_device",  settings->arrays.input_android_player1_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player2_reserved_device",  settings->arrays.input_android_player2_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player3_reserved_device",  settings->arrays.input_android_player3_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player4_reserved_device",  settings->arrays.input_android_player4_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player5_reserved_device",  settings->arrays.input_android_player5_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player6_reserved_device",  settings->arrays.input_android_player6_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player7_reserved_device",  settings->arrays.input_android_player7_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player8_reserved_device",  settings->arrays.input_android_player8_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player9_reserved_device",  settings->arrays.input_android_player9_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_android_player10_reserved_device", settings->arrays.input_android_player10_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_player11_reserved_device", settings->arrays.input_android_player11_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_player12_reserved_device", settings->arrays.input_android_player12_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_player13_reserved_device", settings->arrays.input_android_player13_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_player14_reserved_device", settings->arrays.input_android_player14_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_player15_reserved_device", settings->arrays.input_android_player15_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_player16_reserved_device", settings->arrays.input_android_player16_reserved_device, false, NULL, true);
 #endif
 
 #ifdef HAVE_MENU

--- a/configuration.c
+++ b/configuration.c
@@ -1508,24 +1508,25 @@ static struct config_array_setting *populate_settings_array(
    SETTING_ARRAY("input_joypad_driver",          settings->arrays.input_joypad_driver, false, NULL, true);
    SETTING_ARRAY("input_keyboard_layout",        settings->arrays.input_keyboard_layout, false, NULL, true);
 #ifdef ANDROID
-   SETTING_ARRAY("input_android_physical_keyboard",        settings->arrays.input_android_physical_keyboard,        false, NULL, true);
-   SETTING_ARRAY("input_android_player1_reserved_device",  settings->arrays.input_android_player1_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player2_reserved_device",  settings->arrays.input_android_player2_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player3_reserved_device",  settings->arrays.input_android_player3_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player4_reserved_device",  settings->arrays.input_android_player4_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player5_reserved_device",  settings->arrays.input_android_player5_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player6_reserved_device",  settings->arrays.input_android_player6_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player7_reserved_device",  settings->arrays.input_android_player7_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player8_reserved_device",  settings->arrays.input_android_player8_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player9_reserved_device",  settings->arrays.input_android_player9_reserved_device,  false, NULL, true);
-   SETTING_ARRAY("input_android_player10_reserved_device", settings->arrays.input_android_player10_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_android_player11_reserved_device", settings->arrays.input_android_player11_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_android_player12_reserved_device", settings->arrays.input_android_player12_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_android_player13_reserved_device", settings->arrays.input_android_player13_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_android_player14_reserved_device", settings->arrays.input_android_player14_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_android_player15_reserved_device", settings->arrays.input_android_player15_reserved_device, false, NULL, true);
-   SETTING_ARRAY("input_android_player16_reserved_device", settings->arrays.input_android_player16_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_android_physical_keyboard", settings->arrays.input_android_physical_keyboard, false, NULL, true);
 #endif
+
+   SETTING_ARRAY("input_player1_reserved_device",  settings->arrays.input_player1_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player2_reserved_device",  settings->arrays.input_player2_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player3_reserved_device",  settings->arrays.input_player3_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player4_reserved_device",  settings->arrays.input_player4_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player5_reserved_device",  settings->arrays.input_player5_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player6_reserved_device",  settings->arrays.input_player6_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player7_reserved_device",  settings->arrays.input_player7_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player8_reserved_device",  settings->arrays.input_player8_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player9_reserved_device",  settings->arrays.input_player9_reserved_device,  false, NULL, true);
+   SETTING_ARRAY("input_player10_reserved_device", settings->arrays.input_player10_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_player11_reserved_device", settings->arrays.input_player11_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_player12_reserved_device", settings->arrays.input_player12_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_player13_reserved_device", settings->arrays.input_player13_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_player14_reserved_device", settings->arrays.input_player14_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_player15_reserved_device", settings->arrays.input_player15_reserved_device, false, NULL, true);
+   SETTING_ARRAY("input_player16_reserved_device", settings->arrays.input_player16_reserved_device, false, NULL, true);
 
 #ifdef HAVE_MENU
    SETTING_ARRAY("menu_driver",                  settings->arrays.menu_driver, false, NULL, true);

--- a/configuration.h
+++ b/configuration.h
@@ -474,23 +474,24 @@ typedef struct settings
 
 #ifdef ANDROID
       char input_android_physical_keyboard[255];
-      char input_android_player1_reserved_device[255];
-      char input_android_player2_reserved_device[255];
-      char input_android_player3_reserved_device[255];
-      char input_android_player4_reserved_device[255];
-      char input_android_player5_reserved_device[255];
-      char input_android_player6_reserved_device[255];
-      char input_android_player7_reserved_device[255];
-      char input_android_player8_reserved_device[255];
-      char input_android_player9_reserved_device[255];
-      char input_android_player10_reserved_device[255];
-      char input_android_player11_reserved_device[255];
-      char input_android_player12_reserved_device[255];
-      char input_android_player13_reserved_device[255];
-      char input_android_player14_reserved_device[255];
-      char input_android_player15_reserved_device[255];
-      char input_android_player16_reserved_device[255];
 #endif
+
+      char input_player1_reserved_device[255];
+      char input_player2_reserved_device[255];
+      char input_player3_reserved_device[255];
+      char input_player4_reserved_device[255];
+      char input_player5_reserved_device[255];
+      char input_player6_reserved_device[255];
+      char input_player7_reserved_device[255];
+      char input_player8_reserved_device[255];
+      char input_player9_reserved_device[255];
+      char input_player10_reserved_device[255];
+      char input_player11_reserved_device[255];
+      char input_player12_reserved_device[255];
+      char input_player13_reserved_device[255];
+      char input_player14_reserved_device[255];
+      char input_player15_reserved_device[255];
+      char input_player16_reserved_device[255];
 
       char audio_device[255];
       char camera_device[255];

--- a/configuration.h
+++ b/configuration.h
@@ -474,6 +474,22 @@ typedef struct settings
 
 #ifdef ANDROID
       char input_android_physical_keyboard[255];
+      char input_android_player1_reserved_device[255];
+      char input_android_player2_reserved_device[255];
+      char input_android_player3_reserved_device[255];
+      char input_android_player4_reserved_device[255];
+      char input_android_player5_reserved_device[255];
+      char input_android_player6_reserved_device[255];
+      char input_android_player7_reserved_device[255];
+      char input_android_player8_reserved_device[255];
+      char input_android_player9_reserved_device[255];
+      char input_android_player10_reserved_device[255];
+      char input_android_player11_reserved_device[255];
+      char input_android_player12_reserved_device[255];
+      char input_android_player13_reserved_device[255];
+      char input_android_player14_reserved_device[255];
+      char input_android_player15_reserved_device[255];
+      char input_android_player16_reserved_device[255];
 #endif
 
       char audio_device[255];

--- a/configuration.h
+++ b/configuration.h
@@ -476,22 +476,7 @@ typedef struct settings
       char input_android_physical_keyboard[255];
 #endif
 
-      char input_player1_reserved_device[255];
-      char input_player2_reserved_device[255];
-      char input_player3_reserved_device[255];
-      char input_player4_reserved_device[255];
-      char input_player5_reserved_device[255];
-      char input_player6_reserved_device[255];
-      char input_player7_reserved_device[255];
-      char input_player8_reserved_device[255];
-      char input_player9_reserved_device[255];
-      char input_player10_reserved_device[255];
-      char input_player11_reserved_device[255];
-      char input_player12_reserved_device[255];
-      char input_player13_reserved_device[255];
-      char input_player14_reserved_device[255];
-      char input_player15_reserved_device[255];
-      char input_player16_reserved_device[255];
+      char input_reserved_devices[MAX_USERS][255];
 
       char audio_device[255];
       char camera_device[255];

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1045,59 +1045,6 @@ static int android_input_recover_port(android_input_t *android, int id)
    return ret;
 }
 
-static int android_input_get_reserved_device_port(int vendor_id, int product_id, const char *device_name)
-{
-   settings_t *settings = config_get_ptr();
-
-   int  i;
-   bool is_reserved;
-   char settings_key[256];
-   char settings_value[256];
-   int  settings_value_vendor_id;
-   int  settings_value_product_id;
-   char settings_value_device_name[256];
-   char *settings_values[MAX_USERS] = {
-      settings->arrays.input_android_player1_reserved_device,
-      settings->arrays.input_android_player2_reserved_device,
-      settings->arrays.input_android_player3_reserved_device,
-      settings->arrays.input_android_player4_reserved_device,
-      settings->arrays.input_android_player5_reserved_device,
-      settings->arrays.input_android_player6_reserved_device,
-      settings->arrays.input_android_player7_reserved_device,
-      settings->arrays.input_android_player8_reserved_device,
-      settings->arrays.input_android_player9_reserved_device,
-      settings->arrays.input_android_player10_reserved_device,
-      settings->arrays.input_android_player11_reserved_device,
-      settings->arrays.input_android_player12_reserved_device,
-      settings->arrays.input_android_player13_reserved_device,
-      settings->arrays.input_android_player14_reserved_device,
-      settings->arrays.input_android_player15_reserved_device,
-      settings->arrays.input_android_player16_reserved_device,
-   };
-
-   for (i = 0; i < MAX_USERS; i++)
-   {
-      strlcpy(settings_value, settings_values[i], sizeof(settings_value));
-
-      if (!string_is_empty(settings_value))
-      {
-         if (sscanf(settings_value, "%04x:%04x ", &settings_value_vendor_id, &settings_value_product_id) != 2)
-         {
-            strlcpy(settings_value_device_name, settings_value, sizeof(settings_value_device_name));
-            is_reserved = string_is_equal(device_name, settings_value_device_name);
-         }
-         else
-         {
-            is_reserved = (vendor_id == settings_value_vendor_id && product_id == settings_value_product_id);
-         }
-
-         if (is_reserved) return i;
-      }
-   }
-
-   return -1;
-}
-
 static bool is_configured_as_physical_keyboard(int vendor_id, int product_id, const char *device_name)
 {
     bool is_keyboard;
@@ -1451,7 +1398,7 @@ static void handle_hotplug(android_input_t *android,
    else if (strstr(android_app->current_ime, "com.hexad.bluezime"))
       strlcpy(name_buf, android_app->current_ime, sizeof(name_buf));
 
-   reserved_port = android_input_get_reserved_device_port(
+   reserved_port = input_device_get_reserved_port(
       vendorId, productId, device_name);
 
    if (reserved_port > -1) {

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1322,14 +1322,12 @@ static void handle_hotplug(android_input_t *android,
          /* always map remote to port #0 */
          if (strstr(device_name, "Amazon Fire TV Remote"))
          {
-            android->pads_connected = 0;
             *port = 0;
             strlcpy(name_buf, device_name, sizeof(name_buf));
          }
          /* remove the remote when a gamepad enters */
          else if (strstr(android->pad_states[0].name,"Amazon Fire TV Remote"))
          {
-            android->pads_connected = 0;
             *port = 0;
             strlcpy(name_buf, device_name, sizeof(name_buf));
          }
@@ -1346,7 +1344,6 @@ static void handle_hotplug(android_input_t *android,
          || strstr(device_name, "Nexus Remote")
          || strstr(device_name, "SHIELD Remote"))
    {
-      android->pads_connected = 0;
       *port = 0;
       strlcpy(name_buf, device_name, sizeof(name_buf));
    }
@@ -1402,7 +1399,6 @@ static void handle_hotplug(android_input_t *android,
       vendorId, productId, device_name);
 
    if (reserved_port > -1) {
-      android->pads_connected = reserved_port;
       *port = reserved_port;
    }
 
@@ -1417,9 +1413,8 @@ static void handle_hotplug(android_input_t *android,
          vendorId,
          productId);
 
-   android->pad_states[android->pads_connected].id   = 
-      g_android->id[android->pads_connected]         = id;
-   android->pad_states[android->pads_connected].port = *port;
+   android->pad_states[*port].id = g_android->id[*port] = id;
+   android->pad_states[*port].port = *port;
 
    strlcpy(android->pad_states[*port].name, name_buf,
          sizeof(android->pad_states[*port].name));

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1398,9 +1398,8 @@ static void handle_hotplug(android_input_t *android,
    reserved_port = input_device_get_reserved_port(
       vendorId, productId, device_name);
 
-   if (reserved_port > -1) {
+   if (reserved_port > -1)
       *port = reserved_port;
-   }
 
    if (*port < 0)
       *port = android->pads_connected;

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -7289,3 +7289,61 @@ void input_keyboard_event(bool down, unsigned code,
       }
    }
 }
+
+static int input_device_get_reserved_port(int vendor_id,
+      int product_id, const char *device_name)
+{
+   settings_t *settings = config_get_ptr();
+
+   int  port;
+   bool is_reserved;
+   char settings_key[256];
+   char settings_value[256];
+   int  settings_value_vendor_id;
+   int  settings_value_product_id;
+   char settings_value_device_name[256];
+   char *settings_values[MAX_USERS];
+   settings_values[0] = settings->arrays.input_player1_reserved_device;
+   settings_values[1] = settings->arrays.input_player2_reserved_device;
+   settings_values[2] = settings->arrays.input_player3_reserved_device;
+   settings_values[3] = settings->arrays.input_player4_reserved_device;
+   settings_values[4] = settings->arrays.input_player5_reserved_device;
+   settings_values[5] = settings->arrays.input_player6_reserved_device;
+   settings_values[6] = settings->arrays.input_player7_reserved_device;
+   settings_values[7] = settings->arrays.input_player8_reserved_device;
+   settings_values[8] = settings->arrays.input_player9_reserved_device;
+   settings_values[9] = settings->arrays.input_player10_reserved_device;
+   settings_values[10] = settings->arrays.input_player11_reserved_device;
+   settings_values[11] = settings->arrays.input_player12_reserved_device;
+   settings_values[12] = settings->arrays.input_player13_reserved_device;
+   settings_values[13] = settings->arrays.input_player14_reserved_device;
+   settings_values[14] = settings->arrays.input_player15_reserved_device;
+   settings_values[15] = settings->arrays.input_player16_reserved_device;
+
+   for (port = 0; port < MAX_USERS; port++)
+   {
+      strlcpy(settings_value, settings_values[port], sizeof(settings_value));
+
+      if (!string_is_empty(settings_value))
+      {
+         if (sscanf(settings_value, "%04x:%04x ", &settings_value_vendor_id, &settings_value_product_id) != 2)
+         {
+            strlcpy(settings_value_device_name, settings_value, sizeof(settings_value_device_name));
+            is_reserved = string_is_equal(device_name, settings_value_device_name);
+         }
+         else
+         {
+            is_reserved = (vendor_id == settings_value_vendor_id && product_id == settings_value_product_id);
+         }
+
+         if (is_reserved)
+         {
+            RARCH_LOG("[Input]: Device \"%s\" (%d:%d) is reserved for port %d.\n",
+                  device_name, vendor_id, product_id, port);
+            return port;
+         }
+      }
+   }
+
+   return -1;
+}

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -7297,32 +7297,14 @@ static int input_device_get_reserved_port(int vendor_id,
 
    int  port;
    bool is_reserved;
-   char settings_key[256];
    char settings_value[256];
    int  settings_value_vendor_id;
    int  settings_value_product_id;
    char settings_value_device_name[256];
-   char *settings_values[MAX_USERS];
-   settings_values[0] = settings->arrays.input_player1_reserved_device;
-   settings_values[1] = settings->arrays.input_player2_reserved_device;
-   settings_values[2] = settings->arrays.input_player3_reserved_device;
-   settings_values[3] = settings->arrays.input_player4_reserved_device;
-   settings_values[4] = settings->arrays.input_player5_reserved_device;
-   settings_values[5] = settings->arrays.input_player6_reserved_device;
-   settings_values[6] = settings->arrays.input_player7_reserved_device;
-   settings_values[7] = settings->arrays.input_player8_reserved_device;
-   settings_values[8] = settings->arrays.input_player9_reserved_device;
-   settings_values[9] = settings->arrays.input_player10_reserved_device;
-   settings_values[10] = settings->arrays.input_player11_reserved_device;
-   settings_values[11] = settings->arrays.input_player12_reserved_device;
-   settings_values[12] = settings->arrays.input_player13_reserved_device;
-   settings_values[13] = settings->arrays.input_player14_reserved_device;
-   settings_values[14] = settings->arrays.input_player15_reserved_device;
-   settings_values[15] = settings->arrays.input_player16_reserved_device;
 
    for (port = 0; port < MAX_USERS; port++)
    {
-      strlcpy(settings_value, settings_values[port], sizeof(settings_value));
+      strlcpy(settings_value, settings->arrays.input_reserved_devices[port], sizeof(settings_value));
 
       if (!string_is_empty(settings_value))
       {
@@ -7332,9 +7314,7 @@ static int input_device_get_reserved_port(int vendor_id,
             is_reserved = string_is_equal(device_name, settings_value_device_name);
          }
          else
-         {
             is_reserved = (vendor_id == settings_value_vendor_id && product_id == settings_value_product_id);
-         }
 
          if (is_reserved)
          {


### PR DESCRIPTION
## Description

I use RetroArch on an [Arcade1Up Simpsons arcade cabinet](https://arcade1up.com/products/the-simpsons-arcade-cabinet) running Android 10. I wanted to be able to have a controller always map to a specific player when it's plugged in, regardless of the order that it was initialized by RetroArch.

This PR adds settings to the configuration, so that you can "reserve" a device for a given player, based on it's VID/PID, or name. I based this on how the `input_android_physical_keyboard` setting is handled. This is very useful in my specific situation (running a MAME 2003-plus core where the player order needs to match the order of the controllers mounted in the cabinet), but I could image it being useful in other situations, too.

Right now, only the Android input driver is checking to see if a port is reserved, based on the config value. However, other input drivers utilize this change by calling `input_device_get_reserved_port`.

## Related Issues

#12924 

## Reviewers

I'm not sure who to tag for a review, but I'll post the PR in Discord