### PR TITLE
Check for focus before reading joypad input.

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -24,6 +24,7 @@
 
 #include "../input_driver.h"
 
+#include "../../gfx/video_driver.h"
 #include "../../tasks/tasks_internal.h"
 #include "../../verbosity.h"
 
@@ -422,7 +423,7 @@ static int16_t sdl_joypad_state(
    uint16_t port_idx                    = joypad_info->joy_idx;
    sdl_joypad_t *pad                    = (sdl_joypad_t*)&sdl_pads[port_idx];
 
-   if (!pad || !pad->joypad)
+   if (!pad || !pad->joypad || !video_driver_has_focus())
       return 0;
    if (port_idx >= MAX_USERS)
       return 0;

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -38,6 +38,8 @@
 #include "../../configuration.h"
 #include "../../config.def.h"
 
+#include "../../gfx/video_driver.h"
+
 #include "../../tasks/tasks_internal.h"
 
 #include "../../verbosity.h"
@@ -742,7 +744,7 @@ static int16_t udev_joypad_state(
    int16_t ret                          = 0;
    uint16_t port_idx                    = joypad_info->joy_idx;
 
-   if (port_idx < MAX_USERS)
+   if (port_idx < MAX_USERS && video_driver_has_focus())
    {
       unsigned i;
       const struct udev_joypad *pad     = (const struct udev_joypad*)


### PR DESCRIPTION
## Description

The udev and sdl joypad drivers were reading input in all cases. Now state is not monitored if window has no focus, connect / disconnect events are still processed.

## Related Issues

Fixes #16261 
