### PR TITLE
More widget additions and adjustments

### DIFF
--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -63,6 +63,8 @@ enum gfx_widgets_icon
 
    MENU_WIDGETS_ICON_HOURGLASS,
    MENU_WIDGETS_ICON_CHECK,
+   MENU_WIDGETS_ICON_ADD,
+   MENU_WIDGETS_ICON_EXIT,
 
    MENU_WIDGETS_ICON_INFO,
 
@@ -111,7 +113,10 @@ enum disp_widget_flags_enum
    DISPWIDG_FLAG_EXPIRED                   = (1 << 5),
    /* Unfold animation */
    DISPWIDG_FLAG_UNFOLDED                  = (1 << 6),
-   DISPWIDG_FLAG_UNFOLDING                 = (1 << 7)
+   DISPWIDG_FLAG_UNFOLDING                 = (1 << 7),
+   /* Color style */
+   DISPWIDG_FLAG_POSITIVE                  = (1 << 8),
+   DISPWIDG_FLAG_NEGATIVE                  = (1 << 9)
 };
 
 /* There can only be one message animation at a time to 

--- a/gfx/widgets/gfx_widget_libretro_message.c
+++ b/gfx/widgets/gfx_widget_libretro_message.c
@@ -225,7 +225,7 @@ static void gfx_widget_libretro_message_layout(
    state->frame_width  = divider_width;
 
    /* X-alignment with other widget types */
-   state->bg_x         = (float)state->text_padding * 1.44f;
+   state->bg_x         = (float)state->text_padding * 1.33f;
    state->bg_y_start   = (float)last_video_height + (float)state->frame_width;
    state->bg_y_end     = (float)last_video_height - (float)state->bg_height;
    state->text_x       = state->bg_x + (float)state->text_padding;

--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -44,6 +44,13 @@ enum task_type
    TASK_TYPE_BLOCKING
 };
 
+enum task_style
+{
+   TASK_STYLE_NONE,
+   TASK_STYLE_POSITIVE,
+   TASK_STYLE_NEGATIVE
+};
+
 typedef struct retro_task retro_task_t;
 typedef void (*retro_task_callback_t)(retro_task_t *task,
       void *task_data,
@@ -114,6 +121,7 @@ struct retro_task
    uint32_t ident;
 
    enum task_type type;
+   enum task_style style;
 
    /* if set to true, frontend will
    use an alternative look for the

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -980,6 +980,7 @@ retro_task_t *task_init(void)
    task->progress_cb       = NULL;
    task->title             = NULL;
    task->type              = TASK_TYPE_NONE;
+   task->style             = TASK_STYLE_NONE;
    task->ident             = task_count++;
    task->frontend_userdata = NULL;
    task->alternative_look  = false;

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -518,8 +518,12 @@ static void input_autoconfigure_connect_handler(retro_task_t *task)
     * > Note that 'connection successful' messages
     *   may be suppressed, but error messages are
     *   always shown */
+   task->style = TASK_STYLE_NEGATIVE;
    if (autoconfig_handle->device_info.autoconfigured)
    {
+      /* Successful addition style */
+      task->style = TASK_STYLE_POSITIVE;
+
       if (match_found)
       {
          /* A valid autoconfig was applied */
@@ -777,6 +781,9 @@ static void input_autoconfigure_disconnect_handler(retro_task_t *task)
 
    if (!(autoconfig_handle = (autoconfig_handle_t*)task->state))
       goto task_finished;
+
+   /* Removal style */
+   task->style = TASK_STYLE_NEGATIVE;
 
    /* Get display name for task status message */
    device_display_name = autoconfig_handle->device_info.display_name;


### PR DESCRIPTION
## Description

A bit more honing of the notification styles, and the addition of positive+negative styles for device plug+unplug. Also commented out more unused legacy `msg_queue_icon` related textures.

![retroarch_2024_02_26_05_09_07_359](https://github.com/libretro/RetroArch/assets/45124675/b7b20bc9-c327-43be-bbb0-24afac144b1c)
