### PR TITLE
(WIN32) Fix native ui savestate slots + hide Toggle Desktop Menu without Qt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ $(OBJDIR)/%.o: %.S config.h config.mk $(HEADERS)
 $(OBJDIR)/%.o: %.rc $(HEADERS)
 	@mkdir -p $(dir $@)
 	@$(if $(Q), $(shell echo echo WINDRES $<),)
-	$(Q)$(WINDRES) -o $@ $<
+	$(Q)$(WINDRES) $(DEFINES) -o $@ $<
 
 install: $(TARGET)
 	mkdir -p $(DESTDIR)$(BIN_DIR) 2>/dev/null || /bin/true

--- a/Makefile.win
+++ b/Makefile.win
@@ -169,7 +169,7 @@ $(OBJDIR)/%.o: %.cpp | $(dir $@)
 $(OBJDIR)/%.o: %.rc $(HEADERS)
 	@-mkdir -p $(dir $@) || mkdir $(subst /,\,$(dir $@)) || echo .
 	@$(if $(Q), $(shell echo echo WINDRES $<),)
-	$(Q)$(WINDRES) -o $@ $<
+	$(Q)$(WINDRES) $(DEFINES) -o $@ $<
 
 clean:
 	rm -rf $(OBJDIR)

--- a/media/rarch.rc
+++ b/media/rarch.rc
@@ -32,26 +32,26 @@ IDR_MENU MENU
         {
             POPUP "State Index"
             {
-                MENUITEM "-1 (Auto)", ID_M_STATE_INDEX_AUTO
-                MENUITEM "0", ID_M_STATE_INDEX_AUTO
-                MENUITEM "1", ID_M_STATE_INDEX_AUTO
-                MENUITEM "2", ID_M_STATE_INDEX_AUTO
-                MENUITEM "3", ID_M_STATE_INDEX_AUTO
-                MENUITEM "4", ID_M_STATE_INDEX_AUTO
-                MENUITEM "5", ID_M_STATE_INDEX_AUTO
-                MENUITEM "6", ID_M_STATE_INDEX_AUTO
-                MENUITEM "7", ID_M_STATE_INDEX_AUTO
-                MENUITEM "8", ID_M_STATE_INDEX_AUTO
-                MENUITEM "9", ID_M_STATE_INDEX_AUTO
+                MENUITEM "Auto", ID_M_STATE_INDEX_AUTO
+                MENUITEM "0", ID_M_STATE_INDEX_0
+                MENUITEM "1", ID_M_STATE_INDEX_1
+                MENUITEM "2", ID_M_STATE_INDEX_2
+                MENUITEM "3", ID_M_STATE_INDEX_3
+                MENUITEM "4", ID_M_STATE_INDEX_4
+                MENUITEM "5", ID_M_STATE_INDEX_5
+                MENUITEM "6", ID_M_STATE_INDEX_6
+                MENUITEM "7", ID_M_STATE_INDEX_7
+                MENUITEM "8", ID_M_STATE_INDEX_8
+                MENUITEM "9", ID_M_STATE_INDEX_9
             }
             MENUITEM "Load State", ID_M_LOAD_STATE
             MENUITEM "Save State", ID_M_SAVE_STATE
         }
         MENUITEM "Reset", ID_M_RESET
-        MENUITEM "Menu Toggle", ID_M_MENU_TOGGLE
         MENUITEM "Pause Toggle", ID_M_PAUSE_TOGGLE
-        MENUITEM "Mouse Grab Toggle", ID_M_MOUSE_GRAB
+        MENUITEM "Menu Toggle", ID_M_MENU_TOGGLE
         MENUITEM "Take Screenshot", ID_M_TAKE_SCREENSHOT
+        MENUITEM "Mouse Grab Toggle", ID_M_MOUSE_GRAB
     }
     POPUP "Window"
     {
@@ -68,7 +68,9 @@ IDR_MENU MENU
             MENUITEM "9x", ID_M_WINDOW_SCALE_9X
             MENUITEM "10x", ID_M_WINDOW_SCALE_10X
         }
+#ifdef HAVE_QT
         MENUITEM "Toggle Desktop Menu", ID_M_TOGGLE_DESKTOP
+#endif
         MENUITEM "Toggle Exclusive Full Screen", ID_M_FULL_SCREEN
         // Shader dialog is disabled for now, until video_threaded issues are fixed.
         //MENUITEM "Shader Parameters", ID_M_SHADER_PARAMETERS

--- a/media/rarch_ja.rc
+++ b/media/rarch_ja.rc
@@ -29,26 +29,26 @@ IDR_MENU MENU
         {
             POPUP "状態のインデックス"
             {
-                MENUITEM "-1 (自動)", ID_M_STATE_INDEX_AUTO
-                MENUITEM "0", ID_M_STATE_INDEX_AUTO
-                MENUITEM "1", ID_M_STATE_INDEX_AUTO
-                MENUITEM "2", ID_M_STATE_INDEX_AUTO
-                MENUITEM "3", ID_M_STATE_INDEX_AUTO
-                MENUITEM "4", ID_M_STATE_INDEX_AUTO
-                MENUITEM "5", ID_M_STATE_INDEX_AUTO
-                MENUITEM "6", ID_M_STATE_INDEX_AUTO
-                MENUITEM "7", ID_M_STATE_INDEX_AUTO
-                MENUITEM "8", ID_M_STATE_INDEX_AUTO
-                MENUITEM "9", ID_M_STATE_INDEX_AUTO
+                MENUITEM "自動", ID_M_STATE_INDEX_AUTO
+                MENUITEM "0", ID_M_STATE_INDEX_0
+                MENUITEM "1", ID_M_STATE_INDEX_1
+                MENUITEM "2", ID_M_STATE_INDEX_2
+                MENUITEM "3", ID_M_STATE_INDEX_3
+                MENUITEM "4", ID_M_STATE_INDEX_4
+                MENUITEM "5", ID_M_STATE_INDEX_5
+                MENUITEM "6", ID_M_STATE_INDEX_6
+                MENUITEM "7", ID_M_STATE_INDEX_7
+                MENUITEM "8", ID_M_STATE_INDEX_8
+                MENUITEM "9", ID_M_STATE_INDEX_9
             }
             MENUITEM "保存状態をロード", ID_M_LOAD_STATE
             MENUITEM "状態保存", ID_M_SAVE_STATE
         }
         MENUITEM "リセット", ID_M_RESET
-        MENUITEM "メニューに切り替え", ID_M_MENU_TOGGLE
         MENUITEM "一時停止", ID_M_PAUSE_TOGGLE
-        MENUITEM "マウスグラブ切り替え", ID_M_MOUSE_GRAB
+        MENUITEM "メニューに切り替え", ID_M_MENU_TOGGLE
         MENUITEM "スクリーンショットを撮る", ID_M_TAKE_SCREENSHOT
+        MENUITEM "マウスグラブ切り替え", ID_M_MOUSE_GRAB
     }
     POPUP "ウィンドウ"
     {
@@ -65,7 +65,9 @@ IDR_MENU MENU
             MENUITEM "9x", ID_M_WINDOW_SCALE_9X
             MENUITEM "10x", ID_M_WINDOW_SCALE_10X
         }
+#ifdef HAVE_QT
         MENUITEM "デスクトップメニューを表示", ID_M_TOGGLE_DESKTOP
+#endif
         MENUITEM "排他的なフルスクリーン切り替え", ID_M_FULL_SCREEN
         // Shader dialog is disabled for now, until video_threaded issues are fixed.
         //MENUITEM "シェーダーのパラメータ", ID_M_SHADER_PARAMETERS

--- a/ui/drivers/ui_win32_resource.h
+++ b/ui/drivers/ui_win32_resource.h
@@ -1,6 +1,7 @@
 
 #define IDR_MENU                                101
 #define IDD_PICKCORE                            103
+#define IDR_ACCELERATOR1                        104
 #define ID_M_LOAD_CONTENT                       40001
 #define ID_CORELISTBOX                          40002
 #define ID_M_RESET                              40002
@@ -26,7 +27,16 @@
 #define ID_M_FULL_SCREEN                        40022
 #define ID_M_MOUSE_GRAB                         40023
 #define ID_M_STATE_INDEX_AUTO                   40024
-#define ID_M_TAKE_SCREENSHOT                    40025
-#define ID_M_MUTE_TOGGLE                        40026
-#define ID_M_TOGGLE_DESKTOP                     40027
-#define IDR_ACCELERATOR1                	104
+#define ID_M_STATE_INDEX_0                      40025
+#define ID_M_STATE_INDEX_1                      40026
+#define ID_M_STATE_INDEX_2                      40027
+#define ID_M_STATE_INDEX_3                      40028
+#define ID_M_STATE_INDEX_4                      40029
+#define ID_M_STATE_INDEX_5                      40030
+#define ID_M_STATE_INDEX_6                      40031
+#define ID_M_STATE_INDEX_7                      40032
+#define ID_M_STATE_INDEX_8                      40033
+#define ID_M_STATE_INDEX_9                      40034
+#define ID_M_TAKE_SCREENSHOT                    40035
+#define ID_M_MUTE_TOGGLE                        40036
+#define ID_M_TOGGLE_DESKTOP                     40037


### PR DESCRIPTION
## Description

While I was going to hide the "Toggle Desktop Menu" item when Qt is not included I noticed that the save state index slots are completely broken, and every option selected the first auto..

