### PR TITLE
(WIN32) Read menubar shortcuts with menubar hidden

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1061,9 +1061,7 @@ static LRESULT CALLBACK wnd_proc_common(
       case WM_COMMAND:
          {
             settings_t *settings     = config_get_ptr();
-            bool ui_menubar_enable   = settings ? settings->bools.ui_menubar_enable : false;
-            if (ui_menubar_enable)
-               win32_menu_loop(main_window.hwnd, wparam);
+            win32_menu_loop(main_window.hwnd, wparam);
          }
          break;
    }


### PR DESCRIPTION
## Description

Let's keep running the function that handles Alt-Enter fullscreen toggling even when menubar is disabled.

## Related Issues

Closes #13854
Closes #12303
