### PR TITLE
Fix rpath on webOS,  make SDL2 lib copy optional

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -7,6 +7,8 @@ WEBOS_FREETYPE_CONFIG ?= $(SDKTARGETSYSROOT)/usr/bin/freetype-config
 WEBOS_INC_DIR         ?= $(SDKTARGETSYSROOT)/usr/include
 WEBOS_LIB_DIR         ?= $(SDKTARGETSYSROOT)/usr/lib
 
+ADD_SDL2_LIB ?= 0
+
 #########################
 #########################
 
@@ -128,7 +130,7 @@ LIBS := -ldl -lz -lrt -pthread
 CFLAGS :=
 CXXFLAGS := -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
 ASFLAGS :=
-LDFLAGS := -Wl,--rpath $ORIGIN/lib,--gc-sections
+LDFLAGS := -Wl,-rpath=\$$ORIGIN/lib,--gc-sections
 INCLUDE_DIRS = -I$(WEBOS_INC_DIR)
 LIBRARY_DIRS = -L$(WEBOS_LIB_DIR)
 DEFINES := -DRARCH_INTERNAL -D_FILE_OFFSET_BITS=64 -UHAVE_STATIC_DUMMY
@@ -232,7 +234,9 @@ ipk: $(TARGET)
 	echo "$$APPINFO" > webos/dist/appinfo.json
 	cp -t webos/dist -vf $(TARGET) webos/icon160.png
 	cp -t webos/dist/lib -vf $(WEBOS_LIB_DIR)/libstdc++.so.6
+ifeq ($(ADD_SDL2_LIB), 1)
 	cp -t webos/dist/lib -vf $(WEBOS_LIB_DIR)/libSDL2-2.0.so.0
+endif
 	$(STRIP) webos/dist/$(TARGET)
 	cd webos && ares-package dist
 


### PR DESCRIPTION
## Description

* rpath added in previous PR did not work as $ORIGIN was interpreted as an environment variable
* sdl2 library in buildroot may cause issues depending on users version so make it optional

## Reviewers

@zoltanvb 