### PR TITLE
More widget corrections

### DIFF
--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -217,6 +217,7 @@ typedef struct dispgfx_widget
    unsigned generic_message_height;
 
    unsigned msg_queue_height;
+   unsigned msg_queue_padding;
    unsigned msg_queue_spacing;
    unsigned msg_queue_rect_start_x;
    unsigned msg_queue_internal_icon_size;


### PR DESCRIPTION
## Description

Fixed some more inconsistencies with the task widget width and position with different menu drivers, since menu driver manages to influence font sizes due to scaling differences, and task widget was using the wrong font for padding calculations.

Also limited the widget font size to keep it readable with small resolutions.
