### PR TITLE
Remove some unneeded logging

### DIFF
--- a/command.c
+++ b/command.c
@@ -1560,7 +1560,7 @@ void command_event_set_replay_auto_index(settings_t *settings)
    struct string_list *dir_list      = NULL;
    unsigned max_idx                  = 0;
    runloop_state_t *runloop_st       = runloop_state_get_ptr();
-   bool replay_auto_index         = settings->bools.replay_auto_index;
+   bool replay_auto_index            = settings->bools.replay_auto_index;
    bool show_hidden_files            = settings->bools.show_hidden_files;
 
    if (!replay_auto_index)
@@ -1609,9 +1609,10 @@ void command_event_set_replay_auto_index(settings_t *settings)
 
    configuration_set_int(settings, settings->ints.replay_slot, max_idx);
 
-   RARCH_LOG("[Replay]: %s: #%d\n",
-         msg_hash_to_str(MSG_FOUND_LAST_REPLAY_SLOT),
-         max_idx);
+   if (max_idx)
+      RARCH_LOG("[Replay]: %s: #%d\n",
+            msg_hash_to_str(MSG_FOUND_LAST_REPLAY_SLOT),
+            max_idx);
 }
 
 void command_event_set_replay_garbage_collect(

--- a/disk_control_interface.c
+++ b/disk_control_interface.c
@@ -831,10 +831,6 @@ bool disk_control_verify_initial_index(
       disk_index_file_set(&disk_control->index_record, 0, NULL);
       disk_index_file_save(&disk_control->index_record);
    }
-   else if (!enabled)
-   {
-      RARCH_LOG("[Disc]: Initial disc index setting disabled.");
-   }
 
    /* If current disk is correct and recorded image
     * path is empty (i.e. first run), need to register


### PR DESCRIPTION
## Description

- Noticed that the "initial disc index disabled" logging was missing a newline, but figured the info is not really relevant anyway
- Last found replay slot is also useless information if it found the same 0 it started with