### PR TITLE
Fix achievement widget padding

### DIFF
--- a/gfx/widgets/gfx_widget_achievement_popup.c
+++ b/gfx/widgets/gfx_widget_achievement_popup.c
@@ -171,8 +171,7 @@ static void gfx_widget_achievement_popup_frame(void* data, void* userdata)
       /* Calculate padding in screen space */
       if (state->padding_auto)
       {
-         screen_padding_x = p_dispwidget->msg_queue_rect_start_x -
-            p_dispwidget->msg_queue_icon_size_x;
+         screen_padding_x = p_dispwidget->msg_queue_rect_start_x;
          screen_padding_y = screen_padding_x;
       }
       else


### PR DESCRIPTION
## Description

I missed that the achievement widget was also using the old redundant method of padding calculation.
