### PR TITLE
Fixes for linuxraw driver

### DIFF
--- a/input/drivers_joypad/linuxraw_joypad.c
+++ b/input/drivers_joypad/linuxraw_joypad.c
@@ -104,7 +104,7 @@ static bool linuxraw_joypad_init_pad(const char *path,
 
       event.events             = EPOLLIN;
       event.data.ptr           = pad;
-
+      RARCH_LOG("[linuxraw]: device name is \"%s\".\n",pad->ident);
       if (epoll_ctl(linuxraw_epoll, EPOLL_CTL_ADD, pad->fd, &event) >= 0)
          return true;
    }
@@ -170,8 +170,12 @@ retry:
                   if (linuxraw_pads[idx].fd >= 0)
                   {
                      if (linuxraw_hotplug)
+                     {
                         input_autoconfigure_disconnect(idx,
                               linuxraw_pads[idx].ident);
+                        RARCH_LOG("[linuxraw]: disconnected \"%s\".\n",
+                              linuxraw_pads[idx].ident);
+                     }
 
                      close(linuxraw_pads[idx].fd);
                      linuxraw_pads[idx].buttons = 0;
@@ -183,7 +187,7 @@ retry:
                      input_autoconfigure_connect(
                            NULL,
                            NULL,
-                           linuxraw_joypad_name(idx),
+                           "linuxraw",
                            idx,
                            0,
                            0);
@@ -196,16 +200,20 @@ retry:
                   char path[256];
                   size_t _len = strlcpy(path, "/dev/input/", sizeof(path));
                   strlcpy(path + _len, event->name, sizeof(path) - _len);
+                  RARCH_DBG("[linuxraw]: reconnecting \"%s\".\n",path);
 
-                  if (     !string_is_empty(linuxraw_pads[idx].ident)
+                  if (     string_is_empty(linuxraw_pads[idx].ident)
                         && linuxraw_joypad_init_pad(path, &linuxraw_pads[idx]))
+                  {
                      input_autoconfigure_connect(
                            linuxraw_pads[idx].ident,
                            NULL,
-                           linuxraw_joypad.ident,
+                           "linuxraw",
                            idx,
                            0,
                            0);
+                     RARCH_LOG("[linuxraw]: reconnected \"%s\".\n",linuxraw_pads[idx].ident);
+                  }
                }
             }
          }
@@ -220,6 +228,7 @@ static void *linuxraw_joypad_init(void *data)
    size_t i, _len;
    char path[PATH_MAX_LENGTH];
    int fd      = epoll_create(32);
+   bool init_ok;
 
    if (fd < 0)
       return NULL;
@@ -231,15 +240,18 @@ static void *linuxraw_joypad_init(void *data)
    {
       struct linuxraw_joypad *pad = (struct linuxraw_joypad*)&linuxraw_pads[i];
 
-      pad->fd                     = -1;
-      pad->ident                  = input_config_get_device_name_ptr(i);
+      pad->fd    = -1;
+      pad->ident = input_config_get_device_name_ptr(i);
 
       snprintf(path + _len, sizeof(path) - _len, "%u", (uint32_t)i);
 
+      init_ok = linuxraw_joypad_init_pad(path, pad);
+
+      RARCH_DBG("[linuxraw]: scanning path \"%s\", ident \"%s\".\n",path,pad->ident);
       input_autoconfigure_connect(pad->ident, NULL, "linuxraw",
             i, 0, 0);
 
-      if (linuxraw_joypad_init_pad(path, pad))
+      if (init_ok)
          linuxraw_poll_pad(pad);
    }
 


### PR DESCRIPTION
## Description

A few things are adjusted:
- device name is filled correctly (this was preventing config save)
- driver name fixed in autoconfig related calls
- hotplug reconnect was not working
- some logging added

Tested initial detection, disconnect/reconnect, config save.

## Related Issues

Fixes #16320 
