### PR TITLE
Input test function for Remote RetroPad

### DIFF
--- a/cores/libretro-net-retropad/controllertest.ratst
+++ b/cores/libretro-net-retropad/controllertest.ratst
@@ -1,0 +1,130 @@
+[
+{
+  "expected_button": 8,
+  "message": "Press A"
+},
+{
+  "expected_button": 0,
+  "message": "Press B"
+},
+{
+  "expected_button": 9,
+  "message": "Press X"
+},
+{
+  "expected_button": 1,
+  "message": "Press Y"
+},
+{
+  "expected_button": 2,
+  "message": "Press Select"
+},
+{
+  "expected_button": 3,
+  "message": "Press Start"
+},
+{
+  "expected_button": 4,
+  "message": "Press D-Pad Up"
+},
+{
+  "expected_button": 5,
+  "message": "Press D-Pad Down"
+},
+{
+  "expected_button": 6,
+  "message": "Press D-Pad Left"
+},
+{
+  "expected_button": 7,
+  "message": "Press D-Pad Right"
+},
+{
+  "expected_button": 10,
+  "message": "Press L1"
+},
+{
+  "expected_button": 11,
+  "message": "Press R1"
+},
+{
+  "expected_button": 12,
+  "message": "Press L2"
+},
+{
+  "expected_button": 13,
+  "message": "Press R2"
+},
+{
+  "expected_button": 14,
+  "message": "Press L3"
+},
+{
+  "expected_button": 15,
+  "message": "Press R3"
+},
+{
+  "expected_button": 25,
+  "message": "Move left analog stick up slightly"
+},
+{
+  "expected_button": 24,
+  "message": "Move left analog stick up fully"
+},
+{
+  "expected_button": 26,
+  "message": "Move left analog stick down slightly"
+},
+{
+  "expected_button": 27,
+  "message": "Move left analog stick down fully"
+},
+{
+  "expected_button": 17,
+  "message": "Move left analog stick left slightly"
+},
+{
+  "expected_button": 16,
+  "message": "Move left analog stick left fully"
+},
+{
+  "expected_button": 18,
+  "message": "Move left analog stick right slightly"
+},
+{
+  "expected_button": 19,
+  "message": "Move left analog stick right fully"
+},
+{
+  "expected_button": 29,
+  "message": "Move right analog stick up slightly"
+},
+{
+  "expected_button": 28,
+  "message": "Move right analog stick up fully"
+},
+{
+  "expected_button": 30,
+  "message": "Move right analog stick down slightly"
+},
+{
+  "expected_button": 31,
+  "message": "Move right analog stick down fully"
+},
+{
+  "expected_button": 21,
+  "message": "Move right analog stick left slightly"
+},
+{
+  "expected_button": 20,
+  "message": "Move right analog stick left fully"
+},
+{
+  "expected_button": 22,
+  "message": "Move right analog stick right slightly"
+},
+{
+  "expected_button": 23,
+  "message": "Move right analog stick right fully"
+}
+]


### PR DESCRIPTION
## Description

Add input test capability for Remote Retropad core:
- read an .ratst file (JSON format) with test steps
- display instruction (via libretro SET_MESSAGE)
- highlight input to be activated
- display summary when test is finished

Since the Remote Retropad does not support content loading, the only way to pass the `.ratst` file is to invoke RA from command line:
`retroarch -L netretropad <testfile.ratst>`

This will result in a sequence where user is instructed to activate inputs / axes one after the other:
```
[INFO] [Environ]: SET_MESSAGE: Press A
[libretro INFO] [Remote RetroPad]: Proceeding to test step 0 at frame 301, next: 601
[libretro INFO] [Remote RetroPad]: Test step 0 successful at frame 363
[INFO] [Environ]: SET_MESSAGE: Press B
[libretro INFO] [Remote RetroPad]: Proceeding to test step 1 at frame 364, next: 664
[libretro INFO] [Remote RetroPad]: Test step 1 successful at frame 401
...
[INFO] [Environ]: SET_MESSAGE: Move right analog stick right fully
[libretro INFO] [Remote RetroPad]: Proceeding to test step 31 at frame 1353, next: 1653
[libretro INFO] [Remote RetroPad]: Test step 31 successful at frame 1354
[INFO] [Environ]: SET_MESSAGE: Test sequence finished, result: 32/32 inputs detected
[libretro INFO] [Remote RetroPad]: Test sequence finished at frame 1355, result: 32/32 inputs detected
```
Combined with --max-frames, --appendconfig, a bit of log parsing, and test input driver(s) - to be created separately -, it can serve as a test harness for input related functions. 

Already in the present form, it can be used for manual troubleshooting, by asking the user to start the remote pad, try to send inputs, then press A+B which will print a short summary to log. Some combo inputs are recorded explicitly (d-pad diagonals, opposing directions, and the combos currently selectable for menu/exit).
`[libretro INFO] [Remote RetroPad]: Validated state: 00003dfd combo: 00002a0f`

JSON reader functions lifted and adapted from disk_index_file.c . Sample test file supplied, with all current RetroPad inputs.

## Related Pull Requests
#16342 
