### PR TITLE
Minor iOS JIT availability information

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -643,6 +643,10 @@ MSG_HASH(
    "CPU Cores"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_JIT_AVAILABLE,
+   "JIT Available"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_FRONTEND_IDENTIFIER,
    "Frontend Identifier"
    )

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1853,6 +1853,28 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
          count++;
    }
 
+#ifdef IOS
+   {
+      const char *val_yes_str = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_YES);
+      const char *val_no_str  = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO);
+
+      size_t _len     = strlcpy(entry,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_JIT_AVAILABLE),
+            sizeof(entry));
+      entry[  _len]   = ':';
+      entry[++_len]   = ' ';
+      entry[++_len]   = '\0';
+      if (jit_available())
+         strlcpy(entry + _len, val_yes_str, sizeof(entry) - _len);
+      else
+         strlcpy(entry + _len, val_no_str,  sizeof(entry) - _len);
+      if (menu_entries_append(list, entry, "",
+            MENU_ENUM_LABEL_SYSTEM_INFO_ENTRY, MENU_SETTINGS_CORE_INFO_NONE,
+            0, 0, NULL))
+         count++;
+   }
+#endif
+
    /* Input devices */
    {
       const char *menu_driver = menu_driver_ident();

--- a/msg_hash.h
+++ b/msg_hash.h
@@ -858,6 +858,7 @@ enum msg_hash_enums
    /* System information */
    MENU_LABEL(CPU_CORES),
    MENU_LABEL(CPU_ARCHITECTURE),
+   MENU_LABEL(JIT_AVAILABLE),
 
    /* Input  */
 


### PR DESCRIPTION
Without this there's not really a way of knowing if JIT was successfully enabled, other than just trying it. And for cores where JIT is optional you'd never know, they fall back.