### PR TITLE
Allow combining saves in content dir with save sorting

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -1976,14 +1976,14 @@ bool runloop_environment_cb(unsigned cmd, void *data)
 
                   if (string_is_empty(dir_system))
                      RARCH_WARN("[Environ]: SYSTEM DIR is empty, assume CONTENT DIR %s\n",
-                           fullpath);
+                                fullpath);
 
                   strlcpy(tmp_path, fullpath, sizeof(tmp_path));
                   path_basedir(tmp_path);
 
                   /* Removes trailing slash (unless root dir) */
                   len = strlen(tmp_path);
-                  if (     string_count_occurrences_single_character(tmp_path, PATH_DEFAULT_SLASH_C()) > 1
+                  if (string_count_occurrences_single_character(tmp_path, PATH_DEFAULT_SLASH_C()) > 1
                         && tmp_path[len - 1] == PATH_DEFAULT_SLASH_C())
                      tmp_path[len - 1] = '\0';
 
@@ -2000,7 +2000,7 @@ bool runloop_environment_cb(unsigned cmd, void *data)
             {
                *(const char**)data = dir_system;
                RARCH_LOG("[Environ]: SYSTEM_DIRECTORY: \"%s\".\n",
-                     dir_system);
+                         dir_system);
             }
          }
          break;
@@ -7925,45 +7925,45 @@ void runloop_path_set_names(void)
 }
 
 void runloop_path_set_redirect(settings_t *settings,
-      const char *old_savefile_dir,
-      const char *old_savestate_dir)
+                               const char *old_savefile_dir,
+                               const char *old_savestate_dir)
 {
    char content_dir_name[PATH_MAX_LENGTH];
    char new_savefile_dir[PATH_MAX_LENGTH];
    char new_savestate_dir[PATH_MAX_LENGTH];
    char intermediate_savefile_dir[PATH_MAX_LENGTH];
    char intermediate_savestate_dir[PATH_MAX_LENGTH];
-   runloop_state_t *runloop_st                 = &runloop_state;
-   struct retro_system_info *sysinfo           = &runloop_st->system.info;
-   bool sort_savefiles_enable                  = settings->bools.sort_savefiles_enable;
-   bool sort_savefiles_by_content_enable       = settings->bools.sort_savefiles_by_content_enable;
-   bool sort_savestates_enable                 = settings->bools.sort_savestates_enable;
-   bool sort_savestates_by_content_enable      = settings->bools.sort_savestates_by_content_enable;
-   bool savefiles_in_content_dir               = settings->bools.savefiles_in_content_dir;
-   bool savestates_in_content_dir              = settings->bools.savestates_in_content_dir;
+   runloop_state_t *runloop_st = &runloop_state;
+   struct retro_system_info *sysinfo = &runloop_st->system.info;
+   bool sort_savefiles_enable = settings->bools.sort_savefiles_enable;
+   bool sort_savefiles_by_content_enable = settings->bools.sort_savefiles_by_content_enable;
+   bool sort_savestates_enable = settings->bools.sort_savestates_enable;
+   bool sort_savestates_by_content_enable = settings->bools.sort_savestates_by_content_enable;
+   bool savefiles_in_content_dir = settings->bools.savefiles_in_content_dir;
+   bool savestates_in_content_dir = settings->bools.savestates_in_content_dir;
 
-   content_dir_name[0]  = '\0';
+   content_dir_name[0] = '\0';
 
    /* Initialize current save directories
     * with the values from the config. */
-   strlcpy(intermediate_savefile_dir,  old_savefile_dir,  sizeof(intermediate_savefile_dir));
+   strlcpy(intermediate_savefile_dir, old_savefile_dir, sizeof(intermediate_savefile_dir));
    strlcpy(intermediate_savestate_dir, old_savestate_dir, sizeof(intermediate_savestate_dir));
 
    /* Get content directory name, if per-content-directory
     * saves/states are enabled */
-   if (    (sort_savefiles_by_content_enable
-         || sort_savestates_by_content_enable)
-         && !string_is_empty(runloop_st->runtime_content_path_basename))
+   if ((sort_savefiles_by_content_enable
+        || sort_savestates_by_content_enable)
+       && !string_is_empty(runloop_st->runtime_content_path_basename))
       fill_pathname_parent_dir_name(content_dir_name,
-            runloop_st->runtime_content_path_basename,
-            sizeof(content_dir_name));
+                                    runloop_st->runtime_content_path_basename,
+                                    sizeof(content_dir_name));
 
    /* Set savefile directory if empty to content directory */
    if (string_is_empty(intermediate_savefile_dir) || savefiles_in_content_dir)
    {
       strlcpy(intermediate_savefile_dir,
-            runloop_st->runtime_content_path_basename,
-            sizeof(intermediate_savefile_dir));
+              runloop_st->runtime_content_path_basename,
+              sizeof(intermediate_savefile_dir));
       path_basedir(intermediate_savefile_dir);
 
       if (string_is_empty(intermediate_savefile_dir))
@@ -7971,97 +7971,97 @@ void runloop_path_set_redirect(settings_t *settings,
    }
 
    /* Set savestate directory if empty based on content directory */
-   if (     string_is_empty(intermediate_savestate_dir)
-         || savestates_in_content_dir)
+   if (string_is_empty(intermediate_savestate_dir)
+       || savestates_in_content_dir)
    {
       strlcpy(intermediate_savestate_dir,
-            runloop_st->runtime_content_path_basename,
-            sizeof(intermediate_savestate_dir));
+              runloop_st->runtime_content_path_basename,
+              sizeof(intermediate_savestate_dir));
       path_basedir(intermediate_savestate_dir);
 
       if (string_is_empty(intermediate_savestate_dir))
          RARCH_LOG("Cannot resolve save state file path.\n");
    }
 
-    strlcpy(new_savefile_dir, intermediate_savefile_dir, sizeof(new_savefile_dir));
-    strlcpy(new_savestate_dir, intermediate_savestate_dir, sizeof(new_savestate_dir));
+   strlcpy(new_savefile_dir, intermediate_savefile_dir, sizeof(new_savefile_dir));
+   strlcpy(new_savestate_dir, intermediate_savestate_dir, sizeof(new_savestate_dir));
 
-    if (sysinfo && !string_is_empty(sysinfo->library_name))
-    {
+   if (sysinfo && !string_is_empty(sysinfo->library_name))
+   {
 #ifdef HAVE_MENU
-        if (!string_is_equal(sysinfo->library_name,
-               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
+      if (!string_is_equal(sysinfo->library_name,
+             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
 #endif
-        {
-            /* Per-core and/or per-content-directory saves */
-            if ((       sort_savefiles_enable
-                        || sort_savefiles_by_content_enable)
-                && !string_is_empty(new_savefile_dir))
-            {
-                /* Append content directory name to save location */
-                if (sort_savefiles_by_content_enable)
-                    fill_pathname_join_special(
-                            new_savefile_dir,
-                            new_savefile_dir,
-                            content_dir_name,
-                            sizeof(new_savefile_dir));
+      {
+         /* Per-core and/or per-content-directory saves */
+         if ((sort_savefiles_enable
+              || sort_savefiles_by_content_enable)
+             && !string_is_empty(new_savefile_dir))
+         {
+            /* Append content directory name to save location */
+            if (sort_savefiles_by_content_enable)
+               fill_pathname_join_special(
+                  new_savefile_dir,
+                  new_savefile_dir,
+                  content_dir_name,
+                  sizeof(new_savefile_dir));
 
-                /* Append library_name to the save location */
-                if (sort_savefiles_enable)
-                    fill_pathname_join(
-                            new_savefile_dir,
-                            new_savefile_dir,
-                            sysinfo->library_name,
-                            sizeof(new_savefile_dir));
+            /* Append library_name to the save location */
+            if (sort_savefiles_enable)
+               fill_pathname_join(
+                  new_savefile_dir,
+                  new_savefile_dir,
+                  sysinfo->library_name,
+                  sizeof(new_savefile_dir));
 
-                /* If path doesn't exist, try to create it,
-                 * if everything fails revert to the original path. */
-                if (!path_is_directory(new_savefile_dir))
-                    if (!path_mkdir(new_savefile_dir))
-                    {
-                        RARCH_LOG("%s %s\n",
-                                  msg_hash_to_str(MSG_REVERTING_SAVEFILE_DIRECTORY_TO),
-                                  intermediate_savefile_dir);
+            /* If path doesn't exist, try to create it,
+             * if everything fails revert to the original path. */
+            if (!path_is_directory(new_savefile_dir))
+               if (!path_mkdir(new_savefile_dir))
+               {
+                  RARCH_LOG("%s %s\n",
+                            msg_hash_to_str(MSG_REVERTING_SAVEFILE_DIRECTORY_TO),
+                            intermediate_savefile_dir);
 
-                        strlcpy(new_savefile_dir, intermediate_savefile_dir, sizeof(new_savefile_dir));
-                    }
-            }
+                  strlcpy(new_savefile_dir, intermediate_savefile_dir, sizeof(new_savefile_dir));
+               }
+         }
 
-            /* Per-core and/or per-content-directory savestates */
-            if ((sort_savestates_enable || sort_savestates_by_content_enable)
-                && !string_is_empty(new_savestate_dir))
-            {
-                /* Append content directory name to savestate location */
-                if (sort_savestates_by_content_enable)
-                    fill_pathname_join_special(
-                            new_savestate_dir,
-                            new_savestate_dir,
-                            content_dir_name,
-                            sizeof(new_savestate_dir));
+         /* Per-core and/or per-content-directory savestates */
+         if ((sort_savestates_enable || sort_savestates_by_content_enable)
+             && !string_is_empty(new_savestate_dir))
+         {
+            /* Append content directory name to savestate location */
+            if (sort_savestates_by_content_enable)
+               fill_pathname_join_special(
+                  new_savestate_dir,
+                  new_savestate_dir,
+                  content_dir_name,
+                  sizeof(new_savestate_dir));
 
-                /* Append library_name to the savestate location */
-                if (sort_savestates_enable)
-                    fill_pathname_join(
-                            new_savestate_dir,
-                            new_savestate_dir,
-                            sysinfo->library_name,
-                            sizeof(new_savestate_dir));
+            /* Append library_name to the savestate location */
+            if (sort_savestates_enable)
+               fill_pathname_join(
+                  new_savestate_dir,
+                  new_savestate_dir,
+                  sysinfo->library_name,
+                  sizeof(new_savestate_dir));
 
-                /* If path doesn't exist, try to create it.
-                 * If everything fails, revert to the original path. */
-                if (!path_is_directory(new_savestate_dir))
-                    if (!path_mkdir(new_savestate_dir))
-                    {
-                        RARCH_LOG("%s %s\n",
-                                  msg_hash_to_str(MSG_REVERTING_SAVESTATE_DIRECTORY_TO),
-                                  intermediate_savestate_dir);
-                        strlcpy(new_savestate_dir,
-                                intermediate_savestate_dir,
-                                sizeof(new_savestate_dir));
-                    }
-            }
-        }
-    }
+            /* If path doesn't exist, try to create it.
+             * If everything fails, revert to the original path. */
+            if (!path_is_directory(new_savestate_dir))
+               if (!path_mkdir(new_savestate_dir))
+               {
+                  RARCH_LOG("%s %s\n",
+                            msg_hash_to_str(MSG_REVERTING_SAVESTATE_DIRECTORY_TO),
+                            intermediate_savestate_dir);
+                  strlcpy(new_savestate_dir,
+                          intermediate_savestate_dir,
+                          sizeof(new_savestate_dir));
+               }
+         }
+      }
+   }
 
 
 #ifdef HAVE_NETWORKING
@@ -8081,13 +8081,13 @@ void runloop_path_set_redirect(settings_t *settings,
 
    if (sysinfo && !string_is_empty(sysinfo->library_name))
    {
-      bool savefile_is_dir  = path_is_directory(new_savefile_dir);
+      bool savefile_is_dir = path_is_directory(new_savefile_dir);
       bool savestate_is_dir = path_is_directory(new_savestate_dir);
       if (savefile_is_dir)
          strlcpy(runloop_st->name.savefile, new_savefile_dir,
-               sizeof(runloop_st->name.savefile));
+                 sizeof(runloop_st->name.savefile));
       else
-         savefile_is_dir    = path_is_directory(runloop_st->name.savefile);
+         savefile_is_dir = path_is_directory(runloop_st->name.savefile);
 
       if (savestate_is_dir)
       {
@@ -8095,40 +8095,39 @@ void runloop_path_set_redirect(settings_t *settings,
                  sizeof(runloop_st->name.savestate));
          strlcpy(runloop_st->name.replay, new_savestate_dir,
                  sizeof(runloop_st->name.replay));
-      }
-      else
-         savestate_is_dir   = path_is_directory(runloop_st->name.savestate);
+      } else
+         savestate_is_dir = path_is_directory(runloop_st->name.savestate);
 
       if (savefile_is_dir)
       {
          fill_pathname_dir(runloop_st->name.savefile,
-               !string_is_empty(runloop_st->runtime_content_path_basename)
-               ? runloop_st->runtime_content_path_basename
-               : sysinfo->library_name,
-               FILE_PATH_SRM_EXTENSION,
-               sizeof(runloop_st->name.savefile));
+                           !string_is_empty(runloop_st->runtime_content_path_basename)
+                           ? runloop_st->runtime_content_path_basename
+                           : sysinfo->library_name,
+                           FILE_PATH_SRM_EXTENSION,
+                           sizeof(runloop_st->name.savefile));
          RARCH_LOG("[Overrides]: %s \"%s\".\n",
-               msg_hash_to_str(MSG_REDIRECTING_SAVEFILE_TO),
-               runloop_st->name.savefile);
+                   msg_hash_to_str(MSG_REDIRECTING_SAVEFILE_TO),
+                   runloop_st->name.savefile);
       }
 
       if (savestate_is_dir)
       {
          fill_pathname_dir(runloop_st->name.savestate,
-               !string_is_empty(runloop_st->runtime_content_path_basename)
-               ? runloop_st->runtime_content_path_basename
-               : sysinfo->library_name,
-               FILE_PATH_STATE_EXTENSION,
-               sizeof(runloop_st->name.savestate));
+                           !string_is_empty(runloop_st->runtime_content_path_basename)
+                           ? runloop_st->runtime_content_path_basename
+                           : sysinfo->library_name,
+                           FILE_PATH_STATE_EXTENSION,
+                           sizeof(runloop_st->name.savestate));
          fill_pathname_dir(runloop_st->name.replay,
-               !string_is_empty(runloop_st->runtime_content_path_basename)
-               ? runloop_st->runtime_content_path_basename
-               : sysinfo->library_name,
-               FILE_PATH_BSV_EXTENSION,
-               sizeof(runloop_st->name.replay));
+                           !string_is_empty(runloop_st->runtime_content_path_basename)
+                           ? runloop_st->runtime_content_path_basename
+                           : sysinfo->library_name,
+                           FILE_PATH_BSV_EXTENSION,
+                           sizeof(runloop_st->name.replay));
          RARCH_LOG("[Overrides]: %s \"%s\".\n",
-               msg_hash_to_str(MSG_REDIRECTING_SAVESTATE_TO),
-               runloop_st->name.savestate);
+                   msg_hash_to_str(MSG_REDIRECTING_SAVESTATE_TO),
+                   runloop_st->name.savestate);
       }
 
 #ifdef HAVE_CHEATS
@@ -8147,7 +8146,7 @@ void runloop_path_set_redirect(settings_t *settings,
 #endif
    }
 
-   dir_set(RARCH_DIR_CURRENT_SAVEFILE,  new_savefile_dir);
+   dir_set(RARCH_DIR_CURRENT_SAVEFILE, new_savefile_dir);
    dir_set(RARCH_DIR_CURRENT_SAVESTATE, new_savestate_dir);
 }
 

--- a/runloop.c
+++ b/runloop.c
@@ -7933,14 +7933,14 @@ void runloop_path_set_redirect(settings_t *settings,
    char new_savestate_dir[PATH_MAX_LENGTH];
    char intermediate_savefile_dir[PATH_MAX_LENGTH];
    char intermediate_savestate_dir[PATH_MAX_LENGTH];
-   runloop_state_t *runloop_st = &runloop_state;
-   struct retro_system_info *sysinfo = &runloop_st->system.info;
-   bool sort_savefiles_enable = settings->bools.sort_savefiles_enable;
-   bool sort_savefiles_by_content_enable = settings->bools.sort_savefiles_by_content_enable;
-   bool sort_savestates_enable = settings->bools.sort_savestates_enable;
+   runloop_state_t *runloop_st            = &runloop_state;
+   struct retro_system_info *sysinfo      = &runloop_st->system.info;
+   bool sort_savefiles_enable             = settings->bools.sort_savefiles_enable;
+   bool sort_savefiles_by_content_enable  = settings->bools.sort_savefiles_by_content_enable;
+   bool sort_savestates_enable            = settings->bools.sort_savestates_enable;
    bool sort_savestates_by_content_enable = settings->bools.sort_savestates_by_content_enable;
-   bool savefiles_in_content_dir = settings->bools.savefiles_in_content_dir;
-   bool savestates_in_content_dir = settings->bools.savestates_in_content_dir;
+   bool savefiles_in_content_dir          = settings->bools.savefiles_in_content_dir;
+   bool savestates_in_content_dir         = settings->bools.savestates_in_content_dir;
 
    content_dir_name[0] = '\0';
 
@@ -7990,7 +7990,7 @@ void runloop_path_set_redirect(settings_t *settings,
    {
 #ifdef HAVE_MENU
       if (!string_is_equal(sysinfo->library_name,
-             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
+                           msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_CORE)))
 #endif
       {
          /* Per-core and/or per-content-directory saves */
@@ -8081,7 +8081,7 @@ void runloop_path_set_redirect(settings_t *settings,
 
    if (sysinfo && !string_is_empty(sysinfo->library_name))
    {
-      bool savefile_is_dir = path_is_directory(new_savefile_dir);
+      bool savefile_is_dir  = path_is_directory(new_savefile_dir);
       bool savestate_is_dir = path_is_directory(new_savestate_dir);
       if (savefile_is_dir)
          strlcpy(runloop_st->name.savefile, new_savefile_dir,


### PR DESCRIPTION
## Description

Background: save files are usually compatible between cores, but save states basically never are. Retroarch currently has three settings for each of (savestate, savefile):

- "Put X in content directory"
- "Sort X into folders by core name"
- "Sort X into folders by the content directory"

Currently, turning on the first option overrides the later two, and save(files|states)  will be placed directly into the content directory.

This isn't a great experience because it means that if you put save states into the content directory, and then change the core you're using for the content, you'll get a save state that's invalid for the current core.

I thought it might be better if the options instead stacked. The logic would be:

- Start with the retroarch default dir
- If "put X in content directory" is set, replace that with the content base dir
- If "sort X into folders by core name" is set, append core-name directory
- If "sort X into folders by content directory" is set, append content directory

So if you have content in `/roms`, and you use core X and core Y, with both the content-dir and sort-by-core-name options enabled you'll end up with saves in `/roms/X` and `/roms/Y`.

To me this is more useful because it allows doing a cross-device sync of the content directory and carrying everything - save files, save states, whatever - while still not risking trying to load an incompatible save state on the wrong core. It feels like this better respects what the user is asking for when they toggle both options.

What do you think? PR attached as an example of one potential way to do this.