### PR TITLE
gfx/drm: fix mode vrefresh calculation

### DIFF
--- a/gfx/common/drm_common.c
+++ b/gfx/common/drm_common.c
@@ -123,8 +123,19 @@ bool drm_get_connector(int fd, unsigned monitor_index)
 
 float drm_calc_refresh_rate(drmModeModeInfo *mode)
 {
-   float refresh_rate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
-   return refresh_rate;
+   unsigned int num, den;
+
+   num = mode->clock;
+   den = mode->htotal * mode->vtotal;
+
+   if (mode->flags & DRM_MODE_FLAG_INTERLACE)
+      num *= 2;
+   if (mode->flags & DRM_MODE_FLAG_DBLSCAN)
+      den *= 2;
+   if (mode->vscan > 1)
+      den *= mode->vscan;
+
+   return num * 1000.0f / den;
 }
 
 bool drm_get_encoder(int fd)


### PR DESCRIPTION
When using an interlaced/doublescan mode, the vertical refresh rate is mis-calculated. Replaced the current calc method with the one from libdrm's 'modetest' utility [1].

Noticed the issue on a component connection from a Raspberry Pi.
Without the patch, the interlaced modelines would be reported at half rate:
```
...
[INFO] [DRM]: Mode 0: (720x480i) 720 x 480, 29.970030 Hz
[INFO] [DRM]: Mode 1: (720x576i) 720 x 576, 25.000000 Hz
[INFO] [DRM]: Mode 2: (720x288) 720 x 288, 50.080128 Hz
[INFO] [DRM]: Mode 3: (720x240) 720 x 240, 60.054451 Hz
...
```
after patching, it shows correctly the interlaced modes:
```
[INFO] [DRM]: Mode 0: (720x480i) 720 x 480, 59.940060 Hz
[INFO] [DRM]: Mode 1: (720x576i) 720 x 576, 50.000000 Hz
[INFO] [DRM]: Mode 2: (720x288) 720 x 288, 50.080128 Hz
[INFO] [DRM]: Mode 3: (720x240) 720 x 240, 60.054451 Hz
```
[1] https://gitlab.freedesktop.org/mesa/drm/-/blob/main/tests/modetest/modetest.c?ref_type=heads#L140
