### PR TITLE
Bump AGP

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.0'
+    classpath 'com.android.tools.build:gradle:4.2.0'
   }
 }
 


### PR DESCRIPTION
ref: https://issuetracker.google.com/issues/184872412

This issue of AGP 4.1 was fixed in  4.2 or above.

We've been fixing this for F-Droid for a while: https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.retroarch.yml#L43
