### PR TITLE
JSON schema files for test input driver and netretropad

### DIFF
--- a/tests-other/netretropad_input_check_schema.json
+++ b/tests-other/netretropad_input_check_schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.libretro.com/development/input-api/netretropad_input_check_schema.json",
+  "title": "RetroArch_netretropad_validator",
+  "description": "Definition for driving RetroArch's Remote RetroPad test part.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "expected_button": {
+        "description": "Button to wait for",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4294967295
+      },
+      "message": {
+        "description": "Message to be displayed to the user",
+        "type": "string",
+        "maxLength": 512
+      }
+    },
+    "required": [ "expected_button" ]
+  }
+}
+

--- a/tests-other/test_input_driver_schema.json
+++ b/tests-other/test_input_driver_schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.libretro.com/development/input-api/test_input_driver_schema.json",
+  "title": "RetroArch_input_driver",
+  "description": "Definition for driving RetroArch's test input driver.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "description": "Action to do",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4294967295
+      },
+      "param_str": {
+        "description": "String parameter for the action",
+        "type": "string",
+        "maxLength": 255
+      },
+      "param_num": {
+        "description": "Numeric parameter for the action",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4294967295
+      },
+      "frame": {
+        "description": "Timing for the action using RetroArch's internal frame counter, default 60 fps",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4294967295
+      }
+    },
+    "required": [ "action" ]
+  }
+}
+


### PR DESCRIPTION
## Description

JSON schema files for input test driver and the Remote Retropad check side.

I did not find any straightforward method to indicate numeric constants here in the schema, such as: https://github.com/libretro/RetroArch/blob/fee6ac3185c9be12aa2dffc192544e1a78adeab7/input/drivers_joypad/test_joypad.c#L46 for actions, or: https://github.com/libretro/RetroArch/blob/fee6ac3185c9be12aa2dffc192544e1a78adeab7/libretro-common/include/libretro.h#L317 for expected_button, without having to change the processing side, which I would not like to do, so writing test inputs will still be a bit inconvenient.

Schemas can be applied without error:
```
jsonschema test_input_driver_schema.json  -i test_input_joypad.ratst
jsonschema netretropad_input_check_schema.json -i netretropad_all_inputs.ratst

```

## Related Pull Requests
https://github.com/libretro/RetroArch/pull/16370#issuecomment-2008109373

## Reviewers
@JesseTG 
