### PR TITLE
Android: Remove external storage permission

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -23,6 +23,9 @@
         android:banner="@drawable/banner"
         android:extractNativeLibs="true"
         tools:ignore="UnusedAttribute">
+        <activity
+          android:name=".browser.mainmenu.MigrateRetroarchFolderActivity"
+          android:exported="false"/>
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -9,8 +9,6 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.gamepad" android:required="false"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
@@ -24,7 +22,6 @@
         android:isGame="true"
         android:banner="@drawable/banner"
         android:extractNativeLibs="true"
-        android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>

--- a/pkg/android/phoenix/res/values/strings.xml
+++ b/pkg/android/phoenix/res/values/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="migrate_retroarch_folder_dialog_title">
+    Migrate RetroArch Folder
+  </string>
+  <string name="migrate_retroarch_folder_dialog_message">
+    Because RetroArch was updated, the location of the RetroArch folder has changed. \n
+		Would you like to import data from an existing RetroArch folder?
+  </string>
+  <string name="migrate_retroarch_folder_dialog_positive">
+    Yes, select existing RetroArch folder
+  </string>
+  <string name="migrate_retroarch_folder_dialog_negative">
+    No, don\'t ask again
+  </string>
+  <string name="migrate_retroarch_folder_dialog_neutral">
+    No, ask next time
+  </string>
+  <string name="migrate_retroarch_folder_inprogress">
+    Copying RetroArch Files…
+  </string>
+  <string name="migrate_retroarch_folder_confirm">
+    Your RetroArch folder has been migrated. \n
+    You can find it in the files app under RetroArch > User Data.
+  </string>
+  <string name="migrate_retroarch_folder_confirm_witherror">
+    Your RetroArch folder has been migrated. \n
+    You can find it in the files app under RetroArch > User Data. \n
+    There were errors copying some files.
+  </string>
+</resources>

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -26,92 +26,7 @@ import android.util.Log;
  */
 public final class MainMenuActivity extends PreferenceActivity
 {
-	final private int REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS = 124;
 	public static String PACKAGE_NAME;
-	boolean checkPermissions = false;
-
-	public void showMessageOKCancel(String message, DialogInterface.OnClickListener onClickListener)
-	{
-		new AlertDialog.Builder(this).setMessage(message)
-			.setPositiveButton("OK", onClickListener).setCancelable(false)
-			.setNegativeButton("Cancel", null).create().show();
-	}
-
-	private boolean addPermission(List<String> permissionsList, String permission)
-	{
-		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
-		{
-			if (checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED)
-			{
-				permissionsList.add(permission);
-
-				// Check for Rationale Option
-				if (!shouldShowRequestPermissionRationale(permission))
-					return false;
-			}
-		}
-
-		return true;
-	}
-
-	public void checkRuntimePermissions()
-	{
-		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
-		{
-			// Android 6.0+ needs runtime permission checks
-			List<String> permissionsNeeded = new ArrayList<String>();
-			final List<String> permissionsList = new ArrayList<String>();
-
-			if (!addPermission(permissionsList, Manifest.permission.READ_EXTERNAL_STORAGE))
-				permissionsNeeded.add("Read External Storage");
-			if (!addPermission(permissionsList, Manifest.permission.WRITE_EXTERNAL_STORAGE))
-				permissionsNeeded.add("Write External Storage");
-
-			if (permissionsList.size() > 0)
-			{
-				checkPermissions = true;
-
-				if (permissionsNeeded.size() > 0)
-				{
-					// Need Rationale
-					Log.i("MainMenuActivity", "Need to request external storage permissions.");
-
-					String message = "You need to grant access to " + permissionsNeeded.get(0);
-
-					for (int i = 1; i < permissionsNeeded.size(); i++)
-						message = message + ", " + permissionsNeeded.get(i);
-
-					showMessageOKCancel(message,
-						new DialogInterface.OnClickListener()
-						{
-							@Override
-							public void onClick(DialogInterface dialog, int which)
-							{
-								if (which == AlertDialog.BUTTON_POSITIVE)
-								{
-									requestPermissions(permissionsList.toArray(new String[permissionsList.size()]),
-											REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
-
-									Log.i("MainMenuActivity", "User accepted request for external storage permissions.");
-								}
-							}
-						});
-				}
-				else
-				{
-					requestPermissions(permissionsList.toArray(new String[permissionsList.size()]),
-						REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
-
-					Log.i("MainMenuActivity", "Requested external storage permissions.");
-				}
-			}
-		}
-
-		if (!checkPermissions)
-		{
-			finalStartup();
-		}
-	}
 
 	public void finalStartup()
 	{
@@ -132,33 +47,6 @@ public final class MainMenuActivity extends PreferenceActivity
 		finish();
 	}
 
-	@Override
-	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults)
-	{
-		switch (requestCode)
-		{
-			case REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS:
-				for (int i = 0; i < permissions.length; i++)
-				{
-					if(grantResults[i] == PackageManager.PERMISSION_GRANTED)
-					{
-						Log.i("MainMenuActivity", "Permission: " + permissions[i] + " was granted.");
-					}
-					else
-					{
-						Log.i("MainMenuActivity", "Permission: " + permissions[i] + " was not granted.");
-					}
-				}
-
-				break;
-			default:
-				super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-				break;
-		}
-
-		finalStartup();
-	}
-
 	public static void startRetroActivity(Intent retro, String contentPath, String corePath,
 			String configFilePath, String imePath, String dataDirPath, String dataSourcePath)
 	{
@@ -170,8 +58,8 @@ public final class MainMenuActivity extends PreferenceActivity
 		retro.putExtra("IME", imePath);
 		retro.putExtra("DATADIR", dataDirPath);
 		retro.putExtra("APK", dataSourcePath);
-		retro.putExtra("SDCARD", Environment.getExternalStorageDirectory().getAbsolutePath());
 		String external = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + PACKAGE_NAME + "/files";
+		retro.putExtra("SDCARD", external);
 		retro.putExtra("EXTERNAL", external);
 	}
 
@@ -187,6 +75,6 @@ public final class MainMenuActivity extends PreferenceActivity
 
 		UserPreferences.updateConfigFile(this);
 
-		checkRuntimePermissions();
+		finalStartup();
 	}
 }

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -12,14 +12,6 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 
-import java.util.List;
-import java.util.ArrayList;
-import android.content.pm.PackageManager;
-import android.Manifest;
-import android.content.DialogInterface;
-import android.app.AlertDialog;
-import android.util.Log;
-
 /**
  * {@link PreferenceActivity} subclass that provides all of the
  * functionality of the main menu screen.
@@ -27,6 +19,7 @@ import android.util.Log;
 public final class MainMenuActivity extends PreferenceActivity
 {
 	public static String PACKAGE_NAME;
+	final int REQUEST_CODE_START = 120;
 
 	public void finalStartup()
 	{
@@ -64,6 +57,14 @@ public final class MainMenuActivity extends PreferenceActivity
 	}
 
 	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data)
+	{
+		if(requestCode == REQUEST_CODE_START) {
+			finalStartup();
+		}
+	}
+
+	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
 		super.onCreate(savedInstanceState);
@@ -75,6 +76,7 @@ public final class MainMenuActivity extends PreferenceActivity
 
 		UserPreferences.updateConfigFile(this);
 
-		finalStartup();
+		Intent i = new Intent(this, MigrateRetroarchFolderActivity.class);
+		startActivityForResult(i, REQUEST_CODE_START);
 	}
 }

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MigrateRetroarchFolderActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MigrateRetroarchFolderActivity.java
@@ -1,0 +1,266 @@
+package com.retroarch.browser.mainmenu;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
+import android.content.ContentResolver;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Environment;
+import android.os.ParcelFileDescriptor;
+import android.preference.PreferenceManager;
+import android.provider.DocumentsContract;
+import android.util.Log;
+import android.util.Pair;
+
+import com.retroarch.R;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+
+@TargetApi(26)
+public class MigrateRetroarchFolderActivity extends Activity
+{
+    final int REQUEST_CODE_GET_OLD_RETROARCH_FOLDER = 125;
+
+    @Override
+    public void onStart()
+    {
+        super.onStart();
+
+        // Needs v26 for some of the file handling functions below.
+        // Remove the TargetApi annotation to see which.
+        // If we don't have it, then just skip migration.
+        if (android.os.Build.VERSION.SDK_INT < 26) {
+            finish();
+        }
+        if(true || needToMigrate()){
+            askToMigrate();
+        }else{
+            finish();
+        }
+    }
+
+    boolean needToMigrate()
+    {
+        // As the RetroArch folder has been moved from shared storage to app-specific storage,
+        // people upgrading from older versions using the old location will need to migrate their data.
+        // We identify these users by checking that the app has been updated from an older version,
+        // and that the older version did not use the new location.
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean isNewInstall;
+        try{
+            PackageInfo info = getPackageManager().getPackageInfo(getPackageName(), 0);
+            isNewInstall = info.firstInstallTime == info.lastUpdateTime;
+        }catch(PackageManager.NameNotFoundException ex) {
+            isNewInstall = true;
+        }
+
+        // Avoid asking if new install
+        if(isNewInstall && !prefs.contains("external_retroarch_folder_needs_migrate")){
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putBoolean("external_retroarch_folder_needs_migrate", false);
+            editor.apply();
+        }
+
+        return prefs.getBoolean("external_retroarch_folder_needs_migrate", true);
+    }
+
+    void askToMigrate()
+    {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(R.string.migrate_retroarch_folder_dialog_title);
+        builder.setMessage(R.string.migrate_retroarch_folder_dialog_message);
+        builder.setNegativeButton(R.string.migrate_retroarch_folder_dialog_negative, new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface dialogInterface, int i) {
+                SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(MigrateRetroarchFolderActivity.this).edit();
+                editor.putBoolean("external_retroarch_folder_needs_migrate", false);
+                editor.apply();
+                MigrateRetroarchFolderActivity.this.finish();
+            }
+        });
+        builder.setNeutralButton(R.string.migrate_retroarch_folder_dialog_neutral, new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface dialogInterface, int i) {
+                SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(MigrateRetroarchFolderActivity.this).edit();
+                editor.putBoolean("external_retroarch_folder_needs_migrate", true);
+                editor.apply();
+                MigrateRetroarchFolderActivity.this.finish();
+            }
+        });
+        builder.setPositiveButton(R.string.migrate_retroarch_folder_dialog_positive, new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface dialogInterface, int i) {
+                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+                intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, Uri.fromFile(new File(
+                        Environment.getExternalStorageDirectory().getAbsolutePath() + "/RetroArch"
+                )));
+                startActivityForResult(intent, REQUEST_CODE_GET_OLD_RETROARCH_FOLDER);
+            }
+        });
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+    public void onActivityResult(int requestCode, int resultCode, Intent resultData)
+    {
+        super.onActivityResult(requestCode, resultCode, resultData);
+        if(requestCode == REQUEST_CODE_GET_OLD_RETROARCH_FOLDER){
+            if(resultCode == Activity.RESULT_OK && resultData != null){
+                copyFiles(resultData.getData());
+            }else{
+                //User cancelled or otherwise failed. Go back to the picker screen.
+                askToMigrate();
+            }
+        }
+    }
+
+    void copyFiles(Uri sourceDir)
+    {
+        final ProgressDialog pd = new ProgressDialog(this);
+        pd.setMax(100);
+        pd.setTitle(R.string.migrate_retroarch_folder_inprogress);
+        pd.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+        pd.setCancelable(false);
+
+        CopyThread thread = new CopyThread()
+        {
+            @Override
+            protected void onPreExecute(){
+                super.onPreExecute();
+                pd.show();
+            }
+            @Override
+            protected void onProgressUpdate(Pair<Integer, String>... params)
+            {
+                super.onProgressUpdate(params);
+                pd.setProgress(params[0].first);
+                pd.setMessage(params[0].second);
+            }
+            @Override
+            protected void onPostExecute(Boolean ok)
+            {
+                super.onPostExecute(ok);
+                pd.dismiss();
+                postMigrate(ok);
+            }
+        };
+
+        thread.execute(sourceDir);
+    }
+
+    void postMigrate(boolean ok)
+    {
+        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+        editor.putBoolean("external_retroarch_folder_needs_migrate", false);
+        editor.commit();
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(ok ?
+                R.string.migrate_retroarch_folder_confirm :
+                R.string.migrate_retroarch_folder_confirm_witherror
+        );
+        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+            @Override public void onClick(DialogInterface dialogInterface, int i) {
+                MigrateRetroarchFolderActivity.this.finish();
+            }
+        });
+        builder.create().show();
+    }
+
+    class CopyThread extends AsyncTask<Uri, Pair<Integer, String>, Boolean>
+    {
+        String PACKAGE_NAME;
+        ContentResolver resolver;
+        Uri sourceRoot;
+        boolean error;
+        ArrayList<int[]> progress;
+        public CopyThread()
+        {
+            PACKAGE_NAME = MigrateRetroarchFolderActivity.this.getPackageName();
+            resolver = MigrateRetroarchFolderActivity.this.getContentResolver();
+        }
+        @Override
+        protected Boolean doInBackground(Uri... params)
+        {
+            sourceRoot = params[0];
+            error = false;
+            progress = new ArrayList<>();
+
+            String destination = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + PACKAGE_NAME + "/files/RetroArch";
+            copyFolder(sourceRoot, new File(destination));
+            return !error;
+        }
+        void copyFolder(Uri sourceUri, File dest)
+        {
+            //create destination folder
+            if(!(dest.isDirectory() || dest.mkdirs())) {
+                Log.e("MigrateRetroarchFolder", "Couldn't make new destination folder " + dest.getPath());
+                error = true;
+                return;
+            }
+
+            Uri sourceChildrenResolver;
+            try{ //for subfolders
+                sourceChildrenResolver = DocumentsContract.buildChildDocumentsUriUsingTree(sourceUri, DocumentsContract.getDocumentId(sourceUri));
+            }catch(IllegalArgumentException ex){ //for root selected by document picker
+                sourceChildrenResolver = DocumentsContract.buildChildDocumentsUriUsingTree(sourceUri, DocumentsContract.getTreeDocumentId(sourceUri));
+            }
+            progress.add(new int[]{0, 1});
+            try(
+                    Cursor c = resolver.query(sourceChildrenResolver, new String[]{DocumentsContract.Document.COLUMN_DOCUMENT_ID, DocumentsContract.Document.COLUMN_DISPLAY_NAME, DocumentsContract.Document.COLUMN_MIME_TYPE}, null, null, null)
+            ) {
+                if(c == null) {
+                    Log.e("MigrateRetroarchFolder", "Could not list files in source folder " + sourceUri.toString());
+                    error = true;
+                    return;
+                }
+                progress.get(progress.size() - 1)[1] = c.getCount();
+                while(c.moveToNext()){ //loop through children returned
+                    String childFilename = c.getString(1);
+                    Uri childUri = DocumentsContract.buildDocumentUriUsingTree(sourceUri, c.getString(0));
+                    String childDocumentId = DocumentsContract.getDocumentId(childUri);
+                    File destFile = new File(dest, childFilename);
+
+                    if(c.getString(2).equals(DocumentsContract.Document.MIME_TYPE_DIR)){ //is a folder, recurse
+                        copyFolder(childUri, destFile);
+                    }else{ //is a file, copy it
+                        try(
+                                ParcelFileDescriptor pfd = resolver.openFileDescriptor(childUri, "r");
+                                ParcelFileDescriptor.AutoCloseInputStream sourceStream = new ParcelFileDescriptor.AutoCloseInputStream(pfd);
+                        ) {
+                            Files.copy(sourceStream, destFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                        }catch(Exception ex){
+                            Log.e("MigrateRetroarchFolder", "Error copying file " + childDocumentId, ex);
+                            error = true;
+                        }
+                    }
+                    progress.get(progress.size() - 1)[0]++;
+                    publishProgress(new Pair<Integer, String>(getProgressPercentage(), destFile.getPath()));
+                }
+            }catch(Exception ex){
+                Log.e("MigrateRetroarchFolder", "Error while copying", ex);
+                error = true;
+            }
+            progress.remove(progress.size() - 1);
+        }
+        int getProgressPercentage()
+        {
+            float sum = 0;
+            int lastDenominator = 1;
+            for(int[] frac : progress){
+                sum += ((float) frac[0]) / frac[1] / lastDenominator;
+                lastDenominator *= frac[1];
+            }
+            return (int) (sum * 100);
+        }
+    }
+}

--- a/pkg/android/phoenix/src/com/retroarch/browser/provider/RetroDocumentsProvider.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/provider/RetroDocumentsProvider.java
@@ -11,6 +11,7 @@ import android.graphics.Point;
 import android.os.Build;
 import android.os.CancellationSignal;
 import android.os.ParcelFileDescriptor;
+import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Document;
 import android.provider.DocumentsContract.Root;
 import android.provider.DocumentsProvider;
@@ -35,10 +36,12 @@ import java.util.LinkedList;
  * offering two different ways of accessing your stored data. This would be confusing for users."
  * - http://developer.android.com/guide/topics/providers/document-provider.html#43
  */
-@TargetApi(Build.VERSION_CODES.KITKAT)
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class RetroDocumentsProvider extends DocumentsProvider {
 
     private static final String ALL_MIME_TYPES = "*/*";
+
+    private String DOCUMENTS_AUTHORITY;
 
     // The default columns to return information about a root if no specific
     // columns are requested in a query.
@@ -90,12 +93,43 @@ public class RetroDocumentsProvider extends DocumentsProvider {
     }
 
     @Override
+    public String moveDocument(String sourceDocumentId, String sourceParentDocumentId, String targetParentDocumentId) throws FileNotFoundException {
+        File sourceFile = getFileForDocId(sourceDocumentId);
+        File targetParentFile = getFileForDocId(targetParentDocumentId);
+        File destination = new File(targetParentFile, sourceFile.getName());
+
+        boolean success = sourceFile.renameTo(destination);
+        if(!success){
+            throw new FileNotFoundException("Failed to move file " + sourceDocumentId + " to " + targetParentDocumentId);
+        }
+
+        getContext().getContentResolver().notifyChange(DocumentsContract.buildTreeDocumentUri(DOCUMENTS_AUTHORITY, sourceParentDocumentId), null);
+        getContext().getContentResolver().notifyChange(DocumentsContract.buildTreeDocumentUri(DOCUMENTS_AUTHORITY, targetParentDocumentId), null);
+        return getDocIdForFile(destination);
+    }
+
+    @Override
+    public String renameDocument(String documentId, String displayName) throws FileNotFoundException{
+        File document = getFileForDocId(documentId);
+        File destination = new File(document.getParentFile(), displayName);
+
+        boolean success = document.renameTo(destination);
+        if(!success){
+            throw new FileNotFoundException("Failed to rename file " + documentId + " to " + displayName);
+        }
+
+        getContext().getContentResolver().notifyChange(DocumentsContract.buildTreeDocumentUri(DOCUMENTS_AUTHORITY, getDocIdForFile(document.getParentFile())), null);
+        return getDocIdForFile(destination);
+    }
+
+    @Override
     public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) throws FileNotFoundException {
         final MatrixCursor result = new MatrixCursor(projection != null ? projection : DEFAULT_DOCUMENT_PROJECTION);
         final File parent = getFileForDocId(parentDocumentId);
         for (File file : parent.listFiles()) {
             includeFile(result, null, file);
         }
+        result.setNotificationUri(getContext().getContentResolver(), DocumentsContract.buildTreeDocumentUri(DOCUMENTS_AUTHORITY, parentDocumentId));
         return result;
     }
 
@@ -115,6 +149,7 @@ public class RetroDocumentsProvider extends DocumentsProvider {
 
     @Override
     public boolean onCreate() {
+        DOCUMENTS_AUTHORITY = getContext().getPackageName() + ".documents";
         return true;
     }
 
@@ -138,14 +173,25 @@ public class RetroDocumentsProvider extends DocumentsProvider {
         } catch (IOException e) {
             throw new FileNotFoundException("Failed to create document with id " + newFile.getPath());
         }
+        getContext().getContentResolver().notifyChange(DocumentsContract.buildTreeDocumentUri(DOCUMENTS_AUTHORITY, parentDocumentId), null);
         return newFile.getPath();
     }
 
     @Override
     public void deleteDocument(String documentId) throws FileNotFoundException {
         File file = getFileForDocId(documentId);
-        if (!file.delete()) {
-            throw new FileNotFoundException("Failed to delete document with id " + documentId);
+        rm_r(file);
+        getContext().getContentResolver().notifyChange(DocumentsContract.buildTreeDocumentUri(DOCUMENTS_AUTHORITY, getDocIdForFile(file.getParentFile())), null);
+    }
+
+    void rm_r (File file) throws FileNotFoundException{
+        if(file.isDirectory()){
+            for(File child : file.listFiles()) {
+                rm_r(child);
+            }
+        }
+        if(!file.delete()){
+            throw new FileNotFoundException("Could not delete file " + file.getPath());
         }
     }
 
@@ -248,11 +294,11 @@ public class RetroDocumentsProvider extends DocumentsProvider {
 
         int flags = 0;
         if (file.isDirectory()) {
-            if (file.canWrite()) flags |= Document.FLAG_DIR_SUPPORTS_CREATE;
-        } else if (file.canWrite()) {
-            flags |= Document.FLAG_SUPPORTS_WRITE;
+            if (file.canWrite()) flags |= Document.FLAG_DIR_SUPPORTS_CREATE | Document.FLAG_SUPPORTS_RENAME;
+        } else {
+            if (file.canWrite()) flags |= Document.FLAG_SUPPORTS_WRITE | Document.FLAG_SUPPORTS_RENAME;
         }
-        if (file.getParentFile().canWrite()) flags |= Document.FLAG_SUPPORTS_DELETE;
+        if (file.getParentFile().canWrite()) flags |= Document.FLAG_SUPPORTS_DELETE | Document.FLAG_SUPPORTS_MOVE;
 
         final String displayName = file.getName();
         final String mimeType = getMimeType(file);

--- a/pkg/android/phoenix/src/com/retroarch/browser/provider/RetroDocumentsProvider.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/provider/RetroDocumentsProvider.java
@@ -10,6 +10,7 @@ import android.database.MatrixCursor;
 import android.graphics.Point;
 import android.os.Build;
 import android.os.CancellationSignal;
+import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Document;
@@ -69,19 +70,31 @@ public class RetroDocumentsProvider extends DocumentsProvider {
 
     @Override
     public Cursor queryRoots(String[] projection) throws FileNotFoundException {
-        final File BASE_DIR = new File(getContext().getFilesDir().getParent());
         final MatrixCursor result = new MatrixCursor(projection != null ? projection : DEFAULT_ROOT_PROJECTION);
         @SuppressWarnings("ConstantConditions") final String applicationName = getContext().getString(R.string.app_name);
 
-        final MatrixCursor.RowBuilder row = result.newRow();
-        row.add(Root.COLUMN_ROOT_ID, getDocIdForFile(BASE_DIR));
-        row.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(BASE_DIR));
-        row.add(Root.COLUMN_SUMMARY, null);
-        row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
-        row.add(Root.COLUMN_TITLE, applicationName);
-        row.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
-        row.add(Root.COLUMN_AVAILABLE_BYTES, BASE_DIR.getFreeSpace());
-        row.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+        final File CORE_DIR = new File(getContext().getFilesDir().getParent());
+        final MatrixCursor.RowBuilder core = result.newRow();
+        core.add(Root.COLUMN_ROOT_ID, getDocIdForFile(CORE_DIR));
+        core.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(CORE_DIR));
+        core.add(Root.COLUMN_SUMMARY, "Core Data");
+        core.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
+        core.add(Root.COLUMN_TITLE, applicationName);
+        core.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
+        core.add(Root.COLUMN_AVAILABLE_BYTES, CORE_DIR.getFreeSpace());
+        core.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+
+        final File USER_DIR = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + getContext().getPackageName() + "/files/RetroArch");
+        final MatrixCursor.RowBuilder user = result.newRow();
+        user.add(Root.COLUMN_ROOT_ID, getDocIdForFile(USER_DIR));
+        user.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(USER_DIR));
+        user.add(Root.COLUMN_SUMMARY, "User Data");
+        user.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
+        user.add(Root.COLUMN_TITLE, applicationName);
+        user.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
+        user.add(Root.COLUMN_AVAILABLE_BYTES, USER_DIR.getFreeSpace());
+        user.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+
         return result;
     }
 


### PR DESCRIPTION
## Description
The android client requests blanket access to internal storage, even though it only needs to access the self-contained `/sdcard/RetroArch` folder. 
By getting rid of this permission, we can improve sandboxing and show respect to the user's privacy. Also, this issue is what's holding up play store updates.

We do this by moving the RetroArch folder to app-specific storage, `/sdcard/Android/data/com.retroarch.aarch64/files/RetroArch`. A DocumentsProvider is added to allow the user to easily access it. And a migration flow is added to prompt existing users to copy their RetroArch folder to the new location.

Consequences are that users will have to copy their content into app-specific storage before they play them, and that some automated backup workflows will be disrupted.

It wasn't practical to accomplish this by leaving the folder in place and accessing it through DocumentsContract, since the files couldn't be accessed through the POSIX apis that the rest of the codebase relies on, and because it has a performance penalty.

## Related Issues

This issue is discussed here: https://github.com/libretro/RetroArch/issues/12181

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
