### PR TITLE
wayland: Ignore configure events during splash

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -789,6 +789,9 @@ bool gfx_ctx_wl_init_common(
       }
    }
 
+   // Ignore configure events until splash screen has been replaced
+   wl->ignore_configuration = true;
+
    wl->input.fd = wl_display_get_fd(wl->input.dpy);
 
    wl->input.keyboard_focus  = true;

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -63,6 +63,8 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   if (wl->ignore_configuration)
+      return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
 #ifdef HAVE_EGL
    if (wl->win)
@@ -113,6 +115,7 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
    if (!wl->fractional_scale)
       wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
 
+   wl->ignore_configuration = false;
 #ifdef HAVE_EGL
    wl_egl_window_resize(wl->win, width, height, 0, 0);
 #endif
@@ -126,6 +129,8 @@ libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   if (wl->ignore_configuration)
+      return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 
 #ifdef HAVE_EGL

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -55,6 +55,8 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   if (wl->ignore_configuration)
+      return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
    wl->configured = false;
 }
@@ -92,6 +94,7 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 
    if (vulkan_create_swapchain(&wl->vk, width, height, wl->swap_interval))
    {
+      wl->ignore_configuration = false;
       wl->vk.context.flags |= VK_CTX_FLAG_INVALID_SWAPCHAIN;
       if (wl->vk.flags & VK_DATA_FLAG_CREATED_NEW_SWAPCHAIN)
          vulkan_acquire_next_image(&wl->vk);
@@ -111,6 +114,8 @@ libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl   = (gfx_ctx_wayland_data_t*)data;
+   if (wl->ignore_configuration)
+      return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 
    wl->configured = false;

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -219,6 +219,7 @@ typedef struct gfx_ctx_wayland_data
    bool maximized;
    bool resize;
    bool configured;
+   bool ignore_configuration;
    bool activated;
    bool reported_display_size;
    bool swap_complete;


### PR DESCRIPTION
Configure events while the splash screen were causing the gl/vk surfaces to be created with the wrong size.

This problem can be consistently reproduced by restricting CPU usage:
```bash
systemd-run --user --pty --same-dir -p CPUQuota=1% ./retroarch
```

There's probably a better solution, but for now this solves the problem.

## Related Issues

Fixes: https://github.com/libretro/RetroArch/issues/16198