### PR TITLE
wayland: Let wl_display_disconnect close fd

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -256,9 +256,6 @@ void gfx_ctx_wl_get_video_size_common(void *data,
 
 void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
 {
-   if (wl->input.dpy != NULL && wl->input.fd >= 0)
-      close(wl->input.fd);
-
 #ifdef HAVE_XKBCOMMON
    free_xkb();
 #endif


### PR DESCRIPTION
## Description

Closing this fd disconnects retroarch from the compositor.
This means the rest of the `wl_*_destroy` calls in this function would have no effect.
The `wl_display` should be the last object to be cleaned up.

Closing the fd early shouldn't cause any issues but overlooking it got in the way of some refactoring I'm attempting.
