### PR TITLE
wayland: Ignore splash sized events during splash

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -44,10 +44,6 @@
 #define DEFAULT_WINDOWED_WIDTH 640
 #define DEFAULT_WINDOWED_HEIGHT 480
 
-/* Icon is 16x15 scaled by 16 */
-#define SPLASH_WINDOW_WIDTH 240
-#define SPLASH_WINDOW_HEIGHT 256
-
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC		0x0001U
 #endif

--- a/gfx/common/wayland_common.h
+++ b/gfx/common/wayland_common.h
@@ -21,6 +21,10 @@
 
 #include "../../input/common/wayland_common.h"
 
+/* Icon is 16x15 scaled by 16 */
+#define SPLASH_WINDOW_WIDTH 240
+#define SPLASH_WINDOW_HEIGHT 256
+
 typedef struct toplevel_listener
 {
 #ifdef HAVE_LIBDECOR_H

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -63,7 +63,9 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
+   if (wl->ignore_configuration &&
+       width == SPLASH_WINDOW_WIDTH &&
+       height == SPLASH_WINDOW_HEIGHT)
       return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
 #ifdef HAVE_EGL
@@ -124,12 +126,17 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 }
 
 #ifdef HAVE_LIBDECOR_H
+#include <libdecor.h>
 static void
 libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
+   int width, height;
+   if (wl->ignore_configuration &&
+       wl->libdecor_configuration_get_content_size(configuration, frame, &width, &height) &&
+       width == SPLASH_WINDOW_WIDTH &&
+       height == SPLASH_WINDOW_HEIGHT)
       return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -55,7 +55,9 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
+   if (wl->ignore_configuration &&
+       width == SPLASH_WINDOW_WIDTH &&
+       height == SPLASH_WINDOW_HEIGHT)
       return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
    wl->configured = false;
@@ -109,12 +111,17 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 }
 
 #ifdef HAVE_LIBDECOR_H
+#include <libdecor.h>
 static void
 libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl   = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
+   int width, height;
+   if (wl->ignore_configuration &&
+       wl->libdecor_configuration_get_content_size(configuration, frame, &width, &height) &&
+       width == SPLASH_WINDOW_WIDTH &&
+       height == SPLASH_WINDOW_HEIGHT)
       return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 


### PR DESCRIPTION
## Description

Hopefully this this solves the tiny window without any unexpected side effects.

## Related Issues

https://github.com/libretro/RetroArch/issues/16410
https://github.com/libretro/RetroArch/issues/16198

## Related Pull Requests

Fixes https://github.com/libretro/RetroArch/pull/16398

## Reviewers
