### PR TITLE
wayland: Use frontend signal handler to quit

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -143,7 +143,10 @@ void xdg_toplevel_handle_configure_common(gfx_ctx_wayland_data_t *wl,
 }
 
 void xdg_toplevel_handle_close(void *data,
-      struct xdg_toplevel *xdg_toplevel) { command_event(CMD_EVENT_QUIT, NULL); }
+      struct xdg_toplevel *xdg_toplevel)
+{
+   frontend_driver_set_signal_handler_state(1);
+}
 
 #ifdef HAVE_LIBDECOR_H
 void libdecor_frame_handle_configure_common(struct libdecor_frame *frame,
@@ -212,7 +215,10 @@ void libdecor_frame_handle_configure_common(struct libdecor_frame *frame,
 }
 
 void libdecor_frame_handle_close(struct libdecor_frame *frame,
-      void *data) { command_event(CMD_EVENT_QUIT, NULL); }
+      void *data)
+{
+   frontend_driver_set_signal_handler_state(1);
+}
 void libdecor_frame_handle_commit(struct libdecor_frame *frame,
       void *data) { }
 #endif


### PR DESCRIPTION
## Description

Pressing the window close button was causing retroarch to stall when using vulkan.

Moving from `CMD_EVENT_QUIT` to using `frontend_driver_set_signal_handler_state` as it seems to be what other drivers use.
