### PR TITLE
wayland: Commit viewport resizes

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -131,8 +131,13 @@ void xdg_toplevel_handle_configure_common(gfx_ctx_wayland_data_t *wl,
       wl->buffer_height = wl->fractional_scale ?
          FRACTIONAL_SCALE_MULT(wl->height, wl->fractional_scale_num) : wl->height * wl->buffer_scale;
       wl->resize        = true;
-      if (wl->viewport) /* Update viewport */
+      if (wl->viewport)
+      {
+         /* Stretch old buffer to fill new size, commit/roundtrip to apply */
          wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
+         wl_surface_commit(wl->surface);
+         wl_display_roundtrip(wl->input.dpy);
+      }
    }
 
    if (floating)
@@ -196,8 +201,13 @@ void libdecor_frame_handle_configure_common(struct libdecor_frame *frame,
       wl->buffer_height = wl->fractional_scale ?
          FRACTIONAL_SCALE_MULT(height, wl->fractional_scale_num) : height * wl->buffer_scale;
       wl->resize        = true;
-      if (wl->viewport) /* Update viewport */
+      if (wl->viewport)
+      {
+         /* Stretch old buffer to fill new size, commit/roundtrip to apply */
          wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
+         wl_surface_commit(wl->surface);
+         wl_display_roundtrip(wl->input.dpy);
+      }
    }
 
    state = wl->libdecor_state_new(wl->width, wl->height);
@@ -832,8 +842,13 @@ bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
       wl->buffer_height        = wl->fractional_scale ?
          FRACTIONAL_SCALE_MULT(wl->buffer_height, wl->fractional_scale_num) : wl->buffer_height * wl->buffer_scale;
    }
-   if (wl->viewport) /* Update viewport */
+   if (wl->viewport)
+   {
+      /* Stretch old buffer to fill new size, commit/roundtrip to apply */
       wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
+      wl_surface_commit(wl->surface);
+      wl_display_roundtrip(wl->input.dpy);
+   }
 
 #ifdef HAVE_LIBDECOR_H
    if (wl->libdecor)


### PR DESCRIPTION
## Description

This allows a resize to keep up with the users pointer movements making things feel less sluggish.

| before | after |
|-|-|
| [Screencast from 2024-04-07 17-36-45.webm](https://github.com/libretro/RetroArch/assets/334272/88821915-ca9d-43fe-9c52-b8f2b8290802) | [Screencast from 2024-04-07 17-35-43.webm](https://github.com/libretro/RetroArch/assets/334272/a7830a15-3f14-4608-9548-0c344cefc704) |