### PR TITLE
Remove SET_ROTATION log message

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -1903,7 +1903,6 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          unsigned rotation       = *(const unsigned*)data;
          bool video_allow_rotate = settings->bools.video_allow_rotate;
 
-         RARCH_LOG("[Environ]: SET_ROTATION: %u\n", rotation);
          if (sys_info)
             sys_info->core_requested_rotation = rotation;
 


### PR DESCRIPTION
Whenever `SET_ROTATION` is called, it outputs an INFO message in the logs. Can get quite busy. I'm assuming this was here during someone's debugging?

In some cores, it resulted in...
```
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
[INFO] [Environ]: SET_ROTATION: 0
```