### PR TITLE
Add a debug message for the SET_ROTATION callback

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -1903,6 +1903,7 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          unsigned rotation       = *(const unsigned*)data;
          bool video_allow_rotate = settings->bools.video_allow_rotate;
 
+         RARCH_DBG("[Environ]: SET_ROTATION: %u\n", rotation);
          if (sys_info)
             sys_info->core_requested_rotation = rotation;
 


### PR DESCRIPTION
Follows up from https://github.com/libretro/RetroArch/pull/16453#issuecomment-2067636842
