### PR TITLE
Fix save new config name when core loaded

### DIFF
--- a/command.c
+++ b/command.c
@@ -1778,12 +1778,14 @@ bool command_event_save_core_config(
       for (i = 0; i < 16; i++)
       {
          size_t _len = strlcpy(tmp, config_path, sizeof(tmp));
+
          if (i)
             _len += snprintf(tmp + _len, sizeof(tmp) - _len, "-%u", i);
          strlcpy(tmp + _len, ".cfg", sizeof(tmp) - _len);
 
          if (!path_is_valid(tmp))
          {
+            strlcpy(config_path, tmp, sizeof(config_path));
             new_path_available = true;
             break;
          }


### PR DESCRIPTION
## Description

New tmp variable was not being used as the final config path, resulting in missing `.cfg` extension.

## Related Pull Requests

Broke in https://github.com/libretro/RetroArch/pull/14062

