### PR TITLE
Bring back audio toggling on menu toggle

### DIFF
--- a/audio/drivers/wasapi.c
+++ b/audio/drivers/wasapi.c
@@ -395,22 +395,9 @@ static bool wasapi_alive(void *wh)
    return w->running;
 }
 
-static void wasapi_insert_silence(wasapi_t *w)
-{
-   int i;
-
-   for (i = 0; i < 12; i++)
-      audio_driver_menu_sample();
-}
-
 static void wasapi_set_nonblock_state(void *wh, bool nonblock)
 {
    wasapi_t *w = (wasapi_t*)wh;
-
-   /* Since exclusive mode keeps repeating last sample while
-    * in paused menu, generate some silence first. */
-   if (!nonblock && w->exclusive)
-      wasapi_insert_silence(w);
 
    w->nonblock = nonblock;
 }

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -6263,7 +6263,8 @@ void menu_driver_toggle(
     * struct is NULL
     */
    video_driver_t *current_video      = (video_driver_t*)curr_video_data;
-   bool pause_libretro                = false;
+   bool menu_pause_libretro           = false;
+   bool audio_enable_menu             = false;
    runloop_state_t *runloop_st        = runloop_state_get_ptr();
    struct menu_state *menu_st         = &menu_driver_state;
    bool runloop_shutdown_initiated    = (runloop_st->flags &
@@ -6277,10 +6278,13 @@ void menu_driver_toggle(
    if (settings)
    {
 #ifdef HAVE_NETWORKING
-      pause_libretro                  = settings->bools.menu_pause_libretro &&
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL);
+      menu_pause_libretro             = settings->bools.menu_pause_libretro
+            && netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL);
 #else
-      pause_libretro                  = settings->bools.menu_pause_libretro;
+      menu_pause_libretro             = settings->bools.menu_pause_libretro;
+#endif
+#ifdef HAVE_AUDIOMIXER
+      audio_enable_menu               = settings->bools.audio_enable_menu;
 #endif
 #ifdef HAVE_OVERLAY
       input_overlay_hide_in_menu      = settings->bools.input_overlay_hide_in_menu;
@@ -6346,11 +6350,10 @@ void menu_driver_toggle(
       /* Stop all rumbling before entering the menu. */
       command_event(CMD_EVENT_RUMBLE_STOP, NULL);
 
-      if (pause_libretro)
+      if (menu_pause_libretro)
       {
-#ifdef PS2
-         command_event(CMD_EVENT_AUDIO_STOP, NULL);
-#endif
+         if (!audio_enable_menu)
+            command_event(CMD_EVENT_AUDIO_STOP, NULL);
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_STOP, NULL);
 #endif
@@ -6379,11 +6382,10 @@ void menu_driver_toggle(
       if (!runloop_shutdown_initiated)
          driver_set_nonblock_state();
 
-      if (pause_libretro)
+      if (menu_pause_libretro)
       {
-#ifdef PS2
-         command_event(CMD_EVENT_AUDIO_START, NULL);
-#endif
+         if (!audio_enable_menu)
+            command_event(CMD_EVENT_AUDIO_START, NULL);
 #ifdef HAVE_MICROPHONE
          command_event(CMD_EVENT_MICROPHONE_START, NULL);
 #endif

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8640,9 +8640,15 @@ static void general_write_handler(rarch_setting_t *setting)
       case MENU_ENUM_LABEL_AUDIO_ENABLE_MENU:
 #ifdef HAVE_AUDIOMIXER
          if (settings->bools.audio_enable_menu)
+         {
+            command_event(CMD_EVENT_AUDIO_START, NULL);
             audio_driver_load_system_sounds();
+         }
          else
+         {
             audio_driver_mixer_stop_stream(AUDIO_MIXER_SYSTEM_SLOT_BGM);
+            command_event(CMD_EVENT_AUDIO_STOP, NULL);
+         }
 #endif
          break;
       case MENU_ENUM_LABEL_MENU_SOUND_BGM:


### PR DESCRIPTION
## Description

Since apparently keeping audio alive always when toggling menu causes more problems than it solves (current audio buffer keeps repeating with certain drivers), let's bring it mostly back like it was, which is to start and stop audio depending on whether menu sounds or menu pause requires audio or not.

Of course also removed the band-aid for Wasapi exclusive, which for some reason does not even work anymore, even though I'm pretty sure it did when I added it, since it caused a clear delay the longer the silence generation was, but whatever. Currently the silencing path only triggers when toggling menu off, but it only serves a purpose when toggling menu on.

Also removed the related fix for PS2 since it is not needed anymore either.

I tried to make sure that application does not hang when toggling menu sounds and menu pause in any possible order, but please confirm that I did not goof anything.

No idea what other drivers were affected, but apparently also whatever 3DS is using.

## Related Issues

Closes #15711


