### PR TITLE
Windows mouse ungrab must release the mouse instead of confine it to the current desktop

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1962,9 +1962,7 @@ void win32_clip_window(bool state)
       ClipCursor(&clip_rect);
    }
    else
-   {
-       ClipCursor(NULL);
-   }
+      ClipCursor(NULL);
 }
 #endif
 

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1958,11 +1958,13 @@ void win32_clip_window(bool state)
          free(info);
       }
       info = NULL;
+
+      ClipCursor(&clip_rect);
    }
    else
-      GetWindowRect(GetDesktopWindow(), &clip_rect);
-
-   ClipCursor(&clip_rect);
+   {
+       ClipCursor(NULL);
+   }
 }
 #endif
 


### PR DESCRIPTION
## Description

Windows mouse ungrab was incorrectly confining the mouse to the current screen, rather than truly releasing it. This creates an issue for anyone with multiple monitors.

## Related Issues

* #16487 