### PR TITLE
Fix socket close method in remote retropad

### DIFF
--- a/cores/libretro-net-retropad/net_retropad_core.c
+++ b/cores/libretro-net-retropad/net_retropad_core.c
@@ -586,7 +586,7 @@ static void open_UDP_socket()
    socket_target_t in_target;
 
    if (s && s != SOCKET_ERROR)
-      close(s);
+      socket_close(s);
 
    s = socket_create(
          "retropad",


### PR DESCRIPTION

## Description
Use the platform independent socket close function from same place where all other socket communication is used from.

## Related Pull Requests
#16390 

## Reviewers
https://github.com/libretro/RetroArch/pull/16390#issuecomment-2094185966

