### PR TITLE
Update pixman-private.h (musl issue)

### DIFF
--- a/gfx/include/pixman/pixman-private.h
+++ b/gfx/include/pixman/pixman-private.h
@@ -1,4 +1,3 @@
-#include <float.h>
 #include <retro_inline.h>
 
 #ifndef PIXMAN_PRIVATE_H
@@ -31,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stddef.h>
+#include <float.h>
 
 #include "pixman-compiler.h"
 


### PR DESCRIPTION
patch to fix build issue with musl
https://lore.kernel.org/buildroot/569BA820.6040300@scalemp.com/
https://lists.buildroot.org/pipermail/buildroot/2019-April/247487.html

issue I faced when build with musl
```
/home/user/x-tools/arm-unknown-linux-musleabihf/arm-unknown-linux-musleabihf/sysroot/usr/include/float.h: Assembler messages:
/home/user/x-tools/arm-unknown-linux-musleabihf/arm-unknown-linux-musleabihf/sysroot/usr/include/float.h:8: Error: bad instruction `int __flt_rounds(void)'
make: *** [Makefile:224: obj-unix/release/gfx/include/pixman/pixman-arm-neon-asm.o] Error 1
```