### PR TITLE
Fix crash when using threaded video

### DIFF
--- a/gfx/common/d3d9_common.c
+++ b/gfx/common/d3d9_common.c
@@ -1211,7 +1211,7 @@ uintptr_t d3d9_load_texture(void *video_data, void *data,
 
 #ifdef HAVE_THREADS
    if (threaded)
-      return video_thread_texture_load(&info,
+      return video_thread_texture_handle(&info,
             d3d9_video_texture_load_wrap_d3d);
 #endif
 

--- a/gfx/drivers/d3d8.c
+++ b/gfx/drivers/d3d8.c
@@ -2121,7 +2121,7 @@ static uintptr_t d3d8_load_texture(void *video_data, void *data,
    info.type     = filter_type;
 
    if (threaded)
-      return video_thread_texture_load(&info,
+      return video_thread_texture_handle(&info,
             d3d8_video_texture_load_wrap_d3d);
 
    d3d8_video_texture_load_d3d(&info, &id);

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1423,7 +1423,7 @@ bool video_thread_font_init(const void **font_driver, void **font_handle,
    return pkt.data.font_init.return_value;
 }
 
-unsigned video_thread_texture_load(void *data, custom_command_method_t func)
+unsigned video_thread_texture_handle(void *data, custom_command_method_t func)
 {
    thread_packet_t pkt;
    video_driver_state_t *video_st = video_state_get_ptr();

--- a/gfx/video_thread_wrapper.h
+++ b/gfx/video_thread_wrapper.h
@@ -61,7 +61,7 @@ enum thread_cmd
    CMD_POKE_SET_HDR_MAX_NITS,
    CMD_POKE_SET_HDR_PAPER_WHITE_NITS,
    CMD_POKE_SET_HDR_CONTRAST,
-   CMD_POKE_SET_HDR_EXPAND_GAMUT,   
+   CMD_POKE_SET_HDR_EXPAND_GAMUT,
 
    CMD_DUMMY = INT_MAX
 };
@@ -270,7 +270,7 @@ bool video_thread_font_init(
       custom_font_command_method_t func,
       bool is_threaded);
 
-unsigned video_thread_texture_load(void *data,
+unsigned video_thread_texture_handle(void *data,
       custom_command_method_t func);
 
 RETRO_END_DECLS


### PR DESCRIPTION
## Description

Starting with version 23.2 Mesa [check](https://gitlab.freedesktop.org/mesa/mesa/-/commit/45ea17d2449576ffc1bf3c602d679c77dd63f39f) the thread for `glXMakeContextCurrent`. This fix moves the call to the rendering thread.

## Related Issues

#16123 

## Related commit

This [commit](https://github.com/libretro/RetroArch/commit/a8a06d498c40a271999effdfbab397fdad942a8b) was supposed to fix something, but the `glXMakeContextCurrent` was added to the wrong thread. On my system, deleting these calls doesn't change anything, but it's probably better to leave them just in case.

## Reviewers

[If possible @mention all the people that should review your pull request]
