### PR TITLE
vfs_implementation: Fix warning of unused `include_hidden` parameter

### DIFF
--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -1125,6 +1125,8 @@ libretro_vfs_implementation_dir *retro_vfs_opendir_impl(
       rdir->entry.dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
    else
       rdir->entry.dwFileAttributes &= ~FILE_ATTRIBUTE_HIDDEN;
+#else
+   (void)include_hidden;
 #endif
 
    if (rdir->directory && !dirent_check_error(rdir))


### PR DESCRIPTION
This fixes a warning of the `include_hidden` parameter not being used outside of `_WIN32`.

```
vfs/vfs_implementation.c:1063:30: error: unused parameter ‘include_hidden’ [-Werror=unused-parameter]
 1063 |       const char *name, bool include_hidden)
      |                              ^
cc1: all warnings being treated as error
```