### PR TITLE
libretro: Fix documentation for RETRO_GET_MIDI_INTERFACE

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -1763,7 +1763,7 @@ enum retro_mod
 /**
  * Gets an interface that the core can use for raw MIDI I/O.
  *
- * @param[out] data <tt>struct retro_midi_interface **</tt>.
+ * @param[out] data <tt>struct retro_midi_interface *</tt>.
  * Pointer to the MIDI interface.
  * May be \c NULL.
  * @return \c true if the environment call is available,


### PR DESCRIPTION
As pointed out by @bbbradsmith in https://github.com/libretro/libretro-common/issues/209 , `RETRO_ENVIRONMENT_GET_MIDI_INTERFACE` is a pointer to a struct, rather than a struct array. This updates the documentation to reflect that.

Fixes https://github.com/libretro/libretro-common/issues/209