### PR TITLE
Package *.lck core lock file-extension.

### DIFF
--- a/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj
+++ b/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj
@@ -274,6 +274,10 @@
       <DeploymentContent>true</DeploymentContent>
       <Link>cores\%(Filename)%(Extension)</Link>
     </None>
+    <None Include="cores\$(Platform)\cores\*.lck">
+      <DeploymentContent>true</DeploymentContent>
+      <Link>cores\%(Filename)%(Extension)</Link>
+    </None>
     <None Include="cores\$(Platform)\*.dll">
       <DeploymentContent>true</DeploymentContent>
       <Link>%(Filename)%(Extension)</Link>

--- a/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj.filters
+++ b/pkg/msvc-uwp/RetroArch-msvcUWP/RetroArch-msvcUWP.vcxproj.filters
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="cores\$(Platform)\cores\*.dll" />
+    <None Include="cores\$(Platform)\cores\*.lck" />
     <None Include="cores\$(Platform)\*.dll" />
     <None Include="RetroArch-msvcUWP_TemporaryKey.pfx" />
     <None Include="ANGLE\$(Platform)\*.dll" />


### PR DESCRIPTION
## Description
Re-introduce .lck file-type extension into .vcxproj & vcxproj.filters for RetroArch-msvcUWP.

_Example:_ For demonstrative purpose.
![image](https://github.com/libretro/RetroArch/assets/22002023/ef06d6a9-7edf-4a2a-a120-8ea3f45aceeb)
The LCK file will be packed with the .appx package when published, which is a use case for locking cores included with specialised builds by default. 

_Thoughts_
I am not entirely sure what reason there was to not have the lock file included with UWP configuration as this is particularly useful with Xbox specific builds and required to protect custom cores included in special builds in order for those cores to be skipped by Online Updater. You can still unlock the core manually from the Cores Settings page.

## Related Issues
No Issue

## Related Pull Requests
None
