### PR TITLE
(Win32) Fix numlock/pause key release events

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1091,14 +1091,12 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
             unsigned keysym       = (lparam >> 16) & 0xff;
             bool extended         = (lparam >> 24) & 0x1;
 
+            /* NumLock vs Pause correction */
+            if (keysym == 0x45 && (wparam == VK_NUMLOCK || wparam == VK_PAUSE))
+               extended = !extended;
+
             /* extended keys will map to dinput if the high bit is set */
             if (extended)
-               keysym |= 0x80;
-
-            /* NumLock vs Pause correction */
-            if (GetKeyState(VK_NUMLOCK) & 0x80 && extended)
-               keysym &= ~0x80;
-            else if (GetKeyState(VK_PAUSE) & 0x80 && !extended)
                keysym |= 0x80;
 
             keycode = input_keymaps_translate_keysym_to_rk(keysym);
@@ -1344,14 +1342,12 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
             unsigned keysym       = (lparam >> 16) & 0xff;
             bool extended         = (lparam >> 24) & 0x1;
 
+            /* NumLock vs Pause correction */
+            if (keysym == 0x45 && (wparam == VK_NUMLOCK || wparam == VK_PAUSE))
+               extended = !extended;
+
             /* extended keys will map to dinput if the high bit is set */
             if (extended)
-               keysym |= 0x80;
-
-            /* NumLock vs Pause correction */
-            if (GetKeyState(VK_NUMLOCK) & 0x80 && extended)
-               keysym &= ~0x80;
-            else if (GetKeyState(VK_PAUSE) & 0x80 && !extended)
                keysym |= 0x80;
 
             keycode = input_keymaps_translate_keysym_to_rk(keysym);


### PR DESCRIPTION
## Description

On Win32, the `numlock` and `pause` keys need special handling. But the existing code did only handle it correctly for pressing and not releasing those keys. It separately called `GetKeyState` for the two keys which only returned true while pressing a key and not while releasing it. This then caused the releasing of the `pause` key to be treated as releasing the `numlock` key and vice versa. This fix handles releasing the two keys correctly.

The issue #15513 caused this previous insufficient fix to be made in #15533. A separate problem existed in DOSBox Pure (which was used as the test case for the report #15513) which made the core not handle releasing of the `pause` key which I just fixed in  schellingb/dosbox-pure@185cebd.

## Related Issues
- #15513

## Related Pull Requests
- #15533

## Reviewers
@sonninnos 🙏 