### PR TITLE
Memory leak: Dynamic allocation from msg_hash_get_help_us_enum was not freed

### DIFF
--- a/msg_hash.c
+++ b/msg_hash.c
@@ -49,7 +49,7 @@ int msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len)
    if (temp)
    {
       strlcpy(s, temp, len);
-      free(temp);
+      free((void*)temp);
    }
    return ret;
 }

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -46,7 +46,11 @@ int msg_hash_get_help_enum(enum msg_hash_enums msg, char *s, size_t len)
          "\n",    STRLEN_CONST("\n"),
          "\n \n", STRLEN_CONST("\n \n"));
 
-   strlcpy(s, temp, len);
+   if (temp)
+   {
+      strlcpy(s, temp, len);
+      free(temp);
+   }
    return ret;
 }
 


### PR DESCRIPTION
## Description

The function `msg_hash_get_help_us_enum` returns heap memory that should be freed. In `msg_hash_get_help_enum` it is not.

The leak as reported in valdrind:
```
==32835== 234,384 bytes in 912 blocks are definitely lost in loss record 99 of 99
==32835==    at 0x488559C: malloc (vg_replace_malloc.c:442)
==32835==    by 0x2BF513: string_replace_substring (stdstring.c:118)
==32835==    by 0x159C03: msg_hash_get_help_enum (msg_hash.c:45)
==32835==    by 0x39AD6B: ozone_help_available.lto_priv.0 (ozone.c:7710)
==32835==    by 0x39DD7B: ozone_draw_footer (ozone.c:10640)
==32835==    by 0x3A3F8F: ozone_frame.lto_priv.0 (ozone.c:11534)
==32835==    by 0x3E0553: menu_driver_frame (menu_driver.c:4488)
==32835==    by 0x465BF3: gl2_frame.lto_priv.0 (gl2.c:3647)
==32835==    by 0x45973F: video_thread_loop (video_thread_wrapper.c:464)
==32835==    by 0x44FDFB: thread_wrap (rthreads.c:150)
==32835==    by 0x888F67F: start_thread (pthread_create.c:447)
==32835==    by 0x88F261B: thread_start (clone.S:79)
```
