### PR TITLE
Fix compile errors with GCC 14

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -74,6 +74,10 @@
 #include "ui/drivers/cocoa/apple_platform.h"
 #endif
 
+#ifdef HAVE_LAKKA
+#include <time.h>
+#endif
+
 enum video_driver_enum
 {
    VIDEO_GL                 = 0,

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1302,7 +1302,7 @@ static void frontend_unix_set_screen_brightness(int value)
 
    /* Device tree should have 'label = "backlight";' if control is desirable */
    filestream_read_file("/sys/class/backlight/backlight/max_brightness",
-                        &buffer, NULL);
+                        (void **)&buffer, NULL);
    if (buffer)
    {
       sscanf(buffer, "%u", &max_brightness);

--- a/network/drivers_wifi/connmanctl.c
+++ b/network/drivers_wifi/connmanctl.c
@@ -20,6 +20,7 @@
 #include <string/stdstring.h>
 #include <retro_miscellaneous.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "../wifi_driver.h"
 


### PR DESCRIPTION
added two includes to avoid `implicit function declaration` errors and one cast to `void **` to avoid `incompatible pointer type` error

```
configuration.c: In function 'config_set_timezone':
configuration.c:1433:4: error: implicit declaration of function 'tzset' [-Wimplicit-function-declaration]
 1433 |    tzset();
      |    ^~~~~
```

```
network/drivers_wifi/connmanctl.c: In function 'connmanctl_connect_ssid':
network/drivers_wifi/connmanctl.c:408:13: error: implicit declaration of function 'unlink' [-Wimplicit-function-declaration]
  408 |             unlink(settings_path);
      |             ^~~~~~
```

```
frontend/drivers/platform_unix.c:1305:25: error: passing argument 2 of 'filestream_read_file' from incompatible pointer type [-Wincompatible-pointer-types]
 1305 |                         &buffer, NULL);
      |                         ^~~~~~~
      |                         |
      |                         char **
In file included from frontend/drivers/platform_unix.c:73:
./libretro-common/include/streams/file_stream.h:212:55: note: expected 'void **' but argument is of type 'char **'
  212 | int64_t filestream_read_file(const char *path, void **buf, int64_t *len);
      |                                                ~~~~~~~^~~
```