### PR TITLE
macOS/iOS/tvOS: enable text-to-speech using AVSpeechSynthesizer.

### DIFF
--- a/griffin/griffin_objc.m
+++ b/griffin/griffin_objc.m
@@ -27,10 +27,6 @@
 #define HAVE_COMPRESSION 1
 #endif
 
-#if defined(__APPLE__) && defined(__MACH__)
-#include "../frontend/drivers/platform_darwin.m"
-#endif
-
 #if defined(HAVE_COCOATOUCH) || defined(HAVE_COCOA) || defined(HAVE_COCOA_METAL)
 
 #include "../ui/drivers/cocoa/cocoa_common.m"
@@ -53,6 +49,10 @@
 
 #ifdef HAVE_MFI
 #include "../input/drivers_joypad/mfi_joypad.m"
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include "../frontend/drivers/platform_darwin.m"
 #endif
 
 #ifdef HAVE_COREAUDIO3

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -22,6 +22,7 @@
 
 #include <AvailabilityMacros.h>
 
+#include "../input_driver.h"
 #include "../../tasks/tasks_internal.h"
 
 #import <GameController/GameController.h>

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -40,6 +40,8 @@
 #include "../../../configuration.h"
 #include "../../../content.h"
 #include "../../../core_info.h"
+#include "../../../defaults.h"
+#include "../../../file_path_special.h"
 #include "../../../menu/menu_cbs.h"
 #include "../../../paths.h"
 #include "../../../retroarch.h"
@@ -48,6 +50,10 @@
 
 #include "../../input/drivers/cocoa_input.h"
 #include "../../input/drivers_keyboard/keyboard_event_apple.h"
+
+#ifdef HAVE_MENU
+#include "../../menu/menu_driver.h"
+#endif
 
 #if defined(HAVE_COCOA_METAL) || defined(HAVE_COCOATOUCH)
 id<ApplePlatform> apple_platform;


### PR DESCRIPTION
Fixes #16532.