### PR TITLE
Add RETRO_ENVIRONMENT_SET_MOUSE_GRAB

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2556,6 +2556,14 @@ enum retro_mod
  */
 #define RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY 79
 
+/**
+ * Enable or disable mouse grab.
+ *
+ * Pointer to a single \c bool that indicates whether this frontend should grab the mouse, or release it.
+ * @returns \c true if the environment call is available.
+ */
+#define RETRO_ENVIRONMENT_SET_MOUSE_GRAB 80
+
 /**@}*/
 
 /**

--- a/runloop.c
+++ b/runloop.c
@@ -3572,6 +3572,17 @@ bool runloop_environment_cb(unsigned cmd, void *data)
             }
          }
          break;
+
+      case RETRO_ENVIRONMENT_SET_MOUSE_GRAB:
+         {
+            bool grab_mouse = *(const bool*)data;
+            bool ret = grab_mouse ? input_driver_grab_mouse() : input_driver_ungrab_mouse();
+            RARCH_LOG("[Input]: %s => %s\n",
+                  msg_hash_to_str(MSG_GRAB_MOUSE_STATE),
+                  ret ? "ON" : "OFF");
+            return ret;
+         }
+         break;
       default:
          RARCH_LOG("[Environ]: UNSUPPORTED (#%u).\n", cmd);
          return false;


### PR DESCRIPTION
This will require more discussion, but the goal is to be able to have cores request to set the mouse grab setting. This would be handy for cores like prdoom with a mouse where you want the mouse to be locked. Will mean users won't have to manually hit the Mouse Grab Toggle hotkey themselves.

```
#ifndef RETRO_ENVIRONMENT_SET_MOUSE_GRAB
#define RETRO_ENVIRONMENT_SET_MOUSE_GRAB 80
#endif
bool grab_mouse = true;
environ_cb(RETRO_ENVIRONMENT_SET_MOUSE_GRAB, &grab_mouse);
```

Unsure if it's actually working, yet.
