### PR TITLE
Lakka: provide update URL and target name at buildtime

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1056,22 +1056,20 @@ endif
 
 ifeq ($(HAVE_LAKKA), 1)
    DEFINES += -DHAVE_LAKKA
+   ifneq ($(HAVE_LAKKA_PROJECT),)
+      DEFINES += -DHAVE_LAKKA_PROJECT=\"${HAVE_LAKKA_PROJECT}\"
+   else
+      $(error You asked for Lakka, but you did not specify a target device name in HAVE_LAKKA_PROJECT)
+   endif
+   ifneq ($(HAVE_LAKKA_SERVER),)
+      DEFINES += -DHAVE_LAKKA_SERVER=\"${HAVE_LAKKA_SERVER}\"
+   else
+      $(error You asked for Lakka, but you did not specify update server in HAVE_LAKKA_SERVER)
+   endif
 endif
 
 ifeq ($(HAVE_LAKKA_SWITCH), 1)
    DEFINES += -DHAVE_LAKKA_SWITCH
-endif
-
-ifeq ($(HAVE_LAKKA_NIGHTLY), 1)
-   DEFINES += -DHAVE_LAKKA_NIGHTLY
-endif
-
-ifneq ($(HAVE_LAKKA_CANARY),)
-   DEFINES += -DHAVE_LAKKA_CANARY=\"${HAVE_LAKKA_CANARY}\"
-endif
-
-ifeq ($(HAVE_LAKKA_DEVBUILD), 1)
-   DEFINES += -DHAVE_LAKKA_DEVBUILD
 endif
 
 ifeq ($(HAVE_MENU_COMMON), 1)

--- a/file_path_special.h
+++ b/file_path_special.h
@@ -76,15 +76,6 @@ RETRO_BEGIN_DECLS
 #define FILE_PATH_LOBBY_LIBRETRO_URL "http://lobby.libretro.com/"
 #define FILE_PATH_CORE_THUMBNAILS_URL "http://thumbnails.libretro.com"
 #define FILE_PATH_CORE_THUMBNAILPACKS_URL "http://thumbnailpacks.libretro.com"
-#ifdef HAVE_LAKKA_CANARY
-#define FILE_PATH_LAKKA_URL HAVE_LAKKA_CANARY
-#elif defined (HAVE_LAKKA_NIGHTLY)
-#define FILE_PATH_LAKKA_URL "http://nightly.builds.lakka.tv/.updater"
-#elif defined (HAVE_LAKKA_DEVBUILD)
-#define FILE_PATH_LAKKA_URL "http://nightly.builds.lakka.tv/.devbuild"
-#else
-#define FILE_PATH_LAKKA_URL "http://le.builds.lakka.tv"
-#endif
 #define FILE_PATH_SHADERS_GLSL_ZIP "shaders_glsl.zip"
 #define FILE_PATH_SHADERS_SLANG_ZIP "shaders_slang.zip"
 #define FILE_PATH_SHADERS_CG_ZIP "shaders_cg.zip"
@@ -120,6 +111,19 @@ RETRO_BEGIN_DECLS
 #endif
 #define FILE_PATH_CORE_INFO_CACHE "core_info.cache"
 #define FILE_PATH_CORE_INFO_CACHE_REFRESH "core_info.refresh"
+
+#ifdef HAVE_LAKKA
+ #ifdef HAVE_LAKKA_SERVER
+  #define FILE_PATH_LAKKA_URL HAVE_LAKKA_SERVER
+ #else
+  #error "Building for Lakka, but no update server was defined! Add -DHAVE_LAKKA_SERVER=\\\"http://...\\\""
+ #endif
+ #ifdef HAVE_LAKKA_PROJECT
+  #define LAKKA_PROJECT HAVE_LAKKA_PROJECT
+ #else
+  #error "Building for Lakka, but no target device name was defined! Add -DHAVE_LAKKA_PROJECT=\\\"DeviceName.arch\\\""
+ #endif
+#endif
 
 enum application_special_type
 {

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -246,30 +246,6 @@ static int (funcname)(const char *path, const char *label, unsigned type, size_t
    return generic_action_ok_help(path, label, type, idx, entry_idx, _id, _id2); \
 }
 
-#ifdef HAVE_NETWORKING
-#ifdef HAVE_LAKKA
-static char *lakka_get_project(void)
-{
-#ifndef HAVE_LAKKA_CANARY
-   size_t len;
-   static char lakka_project[128];
-   FILE *command_file = popen("cat /etc/release | cut -d - -f 1", "r");
-
-   fgets(lakka_project, sizeof(lakka_project), command_file);
-   len = strlen(lakka_project);
-
-   if (len > 0 && lakka_project[len-1] == '\n')
-      lakka_project[--len] = '\0';
-
-   pclose(command_file);
-   return lakka_project;
-#else
-   return "/";
-#endif
-}
-#endif
-#endif
-
 static enum msg_hash_enums action_ok_dl_to_enum(unsigned lbl)
 {
    switch (lbl)
@@ -5049,7 +5025,7 @@ static int generic_action_ok_network(const char *path,
          /* TODO unhardcode this path */
          fill_pathname_join_special(url_path,
                FILE_PATH_LAKKA_URL,
-               lakka_get_project(), sizeof(url_path));
+               LAKKA_PROJECT, sizeof(url_path));
          fill_pathname_join_special(url_path, url_path,
                FILE_PATH_INDEX_URL,
                sizeof(url_path));
@@ -5340,7 +5316,7 @@ static int action_ok_download_generic(const char *path,
 #ifdef HAVE_LAKKA
          /* TODO unhardcode this path*/
          fill_pathname_join_special(s, FILE_PATH_LAKKA_URL,
-               lakka_get_project(), sizeof(s));
+               LAKKA_PROJECT, sizeof(s));
 #endif
          break;
       case MENU_ENUM_LABEL_CB_UPDATE_ASSETS:


### PR DESCRIPTION
it is more convenient to provide the URL via make option rather than rely on hardcoded value in the code base. it provides more flexibility in case of different servers for stable, daily, canary, community, ...

and instead of parsing a file in the filesystem to obtain target name of the device on which lakka is running, we can provide the target name at build time as well. the target name is used for the full path URL for the download of updates.

there is no need to have these values editable via retroarch frontend and saved in the config file. it is safer to provide them at build time and have them set this way, so maybe the TODO comments (unhardcode this path) are obsolete.

these make options are now invalid/redundand and have been removed: `HAVE_LAKKA_NIGHTY`, `HAVE_LAKKA_DEVBUILD`, `HAVE_LAKKA_CANNARY`

also checks were added that Lakka build (`HAVE_LAKKA=1`) will not start / fail unless the remaining make options (`HAVE_LAKKA_PROJECT` and `HAVE_LAKKA_SERVER`) are also present.

dropped function `static char *lakka_get_project(void)`, as it is not needed anymore.