### PR TITLE
Increase save state chunk size for all platforms

### DIFF
--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -56,12 +56,15 @@
 #else
 /* A low common denominator write chunk size.  On a slow 
   (speed class 6) SD card, we can write 6MB/s.  That gives us 
-  roughly 100KB/frame, which is rounded up to 128 KB/s.  
+  roughly 100KB/frame.  
   This means we can write savestates with one syscall for cores 
-  with less than 128KB of state. Class 10 is the standard now 
+  with less than 100KB of state. Class 10 is the standard now 
   even for lousy cards and supports 10MB/s, so you may prefer 
-  to double this. */
-#define SAVE_STATE_CHUNK 128 * 1024
+  to put this to 170KB. This all assumes that task_save's loop
+  is iterated once per frame at 60 FPS; if it's updated less
+  frequently this number could be doubled or quadrupled depending
+  on the tickrate. */
+#define SAVE_STATE_CHUNK 100 * 1024
 #endif
 
 #define RASTATE_VERSION 1

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -53,10 +53,15 @@
 /* Filesystem is in-memory anyway, use huge chunks since each
    read/write is a possible suspend to JS code */
 #define SAVE_STATE_CHUNK 4096 * 4096
-#elif defined(HAVE_LIBNX) || defined(_3DS)
-#define SAVE_STATE_CHUNK 4096 * 10
 #else
-#define SAVE_STATE_CHUNK 4096
+/* A low common denominator write chunk size.  On a slow 
+  (speed class 6) SD card, we can write 6MB/s.  That gives us 
+  roughly 100KB/frame, which is rounded up to 128 KB/s.  
+  This means we can write savestates with one syscall for cores 
+  with less than 128KB of state. Class 10 is the standard now 
+  even for lousy cards and supports 10MB/s, so you may prefer 
+  to double this. */
+#define SAVE_STATE_CHUNK 128 * 1024
 #endif
 
 #define RASTATE_VERSION 1


### PR DESCRIPTION
A rationale is given in the comments, but even a class 6 or class 10 SD card can handle reads and writes on the order of MB/s, which means a 4KB chunk size is just wasting time in syscalls.  This could maybe be fixed with a buffering reader but I don't feel comfortable tweaking libretro-common's VFS to handle that.  Instead, I thought it would be good to both remove an ifdef and increase the chunk size to 128KB.  For cores with small states this will should make state saving virtually instantaneous, and for cores with large states it should be a 32x speedup.
