### PR TITLE
Accessibility: make Talkback read RetroArch interface

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2885,6 +2885,11 @@ void config_set_defaults(void *data)
          settings->bools.accessibility_enable, RAIsVoiceOverRunning());
 #endif
 
+#ifdef ANDROID
+   configuration_set_bool(settings,
+         settings->bools.accessibility_enable, is_narrator_running(true));
+#endif
+
 #ifdef HAVE_MENU
    if (first_initialized)
       configuration_set_bool(settings,

--- a/frontend/drivers/platform_unix.h
+++ b/frontend/drivers/platform_unix.h
@@ -180,6 +180,9 @@ struct android_app
    jmethodID getVolumePath;
    jmethodID inputGrabMouse;
 
+   jmethodID isScreenReaderEnabled;
+   jmethodID accessibilitySpeak;
+
    struct
    {
       unsigned width, height;

--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -611,7 +611,6 @@ public class RetroActivityCommon extends NativeActivity
   }
 
   public boolean isScreenReaderEnabled() {
-    getWindow().getDecorView().announceForAccessibility("Hello world!");
     AccessibilityManager accessibilityManager = (AccessibilityManager) getSystemService(ACCESSIBILITY_SERVICE);
     boolean isAccessibilityEnabled = accessibilityManager.isEnabled();
     boolean isExploreByTouchEnabled = accessibilityManager.isTouchExplorationEnabled();

--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
 import android.system.Os;
+import android.view.accessibility.AccessibilityManager;
 import android.view.HapticFeedbackConstants;
 import android.view.InputDevice;
 import android.view.Surface;
@@ -607,5 +608,17 @@ public class RetroActivityCommon extends NativeActivity
         traverseFilesystem(child);
       }
     }
+  }
+
+  public boolean isScreenReaderEnabled() {
+    getWindow().getDecorView().announceForAccessibility("Hello world!");
+    AccessibilityManager accessibilityManager = (AccessibilityManager) getSystemService(ACCESSIBILITY_SERVICE);
+    boolean isAccessibilityEnabled = accessibilityManager.isEnabled();
+    boolean isExploreByTouchEnabled = accessibilityManager.isTouchExplorationEnabled();
+    return isAccessibilityEnabled && isExploreByTouchEnabled;
+  }
+
+  public void accessibilitySpeak(String message) {
+    getWindow().getDecorView().announceForAccessibility(message);
   }
 }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This Pull Request adds Talkback screen reader support on Android via the keyboard. Currently the pull request is in draft because Talkback detection is not triggering correctly, I am trying to fix before marking it as ready but forcing `accessibility_enabled = true` on the configuration file makes Talkback read the interface.

## Related Issues

issue #16610

## Related Pull Requests

None

## Reviewers

[If possible @mention all the people that should review your pull request]
