### PR TITLE
(WASAPI) Only write when running and fix deadlock

### DIFF
--- a/audio/drivers/wasapi.c
+++ b/audio/drivers/wasapi.c
@@ -27,6 +27,9 @@
 #include "../../verbosity.h"
 #include "../../configuration.h"
 
+/* Max time to wait before continuing */
+#define WASAPI_TIMEOUT 256
+
 typedef struct
 {
    HANDLE write_event;
@@ -200,7 +203,7 @@ static ssize_t wasapi_write_sh_buffer(wasapi_t *w, const void *data, size_t size
    if (!write_avail)
    {
       size_t read_avail = 0;
-      if (!(WaitForSingleObject(w->write_event, INFINITE) == WAIT_OBJECT_0))
+      if (!(WaitForSingleObject(w->write_event, WASAPI_TIMEOUT) == WAIT_OBJECT_0))
          return -1;
 
       if (FAILED(_IAudioClient_GetCurrentPadding(w->client, &padding)))
@@ -228,7 +231,7 @@ static ssize_t wasapi_write_sh(wasapi_t *w, const void *data, size_t size)
    size_t write_avail = 0;
    UINT32 padding     = 0;
 
-   if (!(WaitForSingleObject(w->write_event, INFINITE) == WAIT_OBJECT_0))
+   if (!(WaitForSingleObject(w->write_event, WASAPI_TIMEOUT) == WAIT_OBJECT_0))
       return -1;
 
    if (FAILED(_IAudioClient_GetCurrentPadding(w->client, &padding)))
@@ -319,6 +322,8 @@ static ssize_t wasapi_write(void *wh, const void *data, size_t size)
    ssize_t ir     = 0;
    wasapi_t *w    = (wasapi_t*)wh;
 
+   if (!w->running) return -1;
+
    if (w->nonblock)
    {
       if (w->exclusive)
@@ -330,7 +335,7 @@ static ssize_t wasapi_write(void *wh, const void *data, size_t size)
    {
       for (ir = -1; written < size; written += ir)
       {
-         ir = wasapi_write_ex(w, (char*)data + written, size - written, INFINITE);
+         ir = wasapi_write_ex(w, (char*)data + written, size - written, WASAPI_TIMEOUT);
          if (ir == -1)
             return -1;
       }


### PR DESCRIPTION
## Description
Check if running before attempting to write and add a timeout to waiting for `write_event` from WASAPI. There seems to be a possible race condition between `wasapi_stop` and writing audio in cores with threaded audio. Thus the audio driver is waiting for `write_event` when WASAPI has been stopped effectively deadlocking and freezing the entire frontend.

This fix still needs testing to ensure there are no notable regressions.

## Related Issues

https://steamcommunity.com/app/1118310/discussions/3/4334231144971048528/
https://github.com/libretro/mupen64plus-libretro-nx/issues/537

## Related Pull Requests

None

## Reviewers

@sonninnos 
