### PR TITLE
Accessibility: Refactor Android is_narrator_running to align with the Retroarch Accessibility API

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2887,7 +2887,7 @@ void config_set_defaults(void *data)
 
 #ifdef ANDROID
    configuration_set_bool(settings,
-         settings->bools.accessibility_enable, RAIsTalkbackRunning());
+         settings->bools.accessibility_enable, is_screen_reader_enabled());
 #endif
 
 #ifdef HAVE_MENU

--- a/configuration.c
+++ b/configuration.c
@@ -2887,7 +2887,7 @@ void config_set_defaults(void *data)
 
 #ifdef ANDROID
    configuration_set_bool(settings,
-         settings->bools.accessibility_enable, is_narrator_running(true));
+         settings->bools.accessibility_enable, RAIsTalkbackRunning());
 #endif
 
 #ifdef HAVE_MENU

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2966,7 +2966,7 @@ end:
 #endif
 
 #ifdef ANDROID
-bool RAIsTalkbackRunning(void)
+bool is_screen_reader_enabled(void)
 {
    JNIEnv *env = jni_thread_getenv();
    jboolean                  jbool   = JNI_FALSE;

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2966,7 +2966,7 @@ end:
 #endif
 
 #ifdef ANDROID
-static bool is_narrator_running_android(void)
+bool RAIsTalkbackRunning(void)
 {
    JNIEnv *env = jni_thread_getenv();
    jboolean                  jbool   = JNI_FALSE;
@@ -2976,6 +2976,13 @@ static bool is_narrator_running_android(void)
             g_android->activity->clazz, g_android->isScreenReaderEnabled);
 
    return jbool == JNI_TRUE;
+}
+
+static bool is_narrator_running_android(void)
+{
+   /* Screen reader is speaking on Android is controlled by the operating
+    * system, so return false to align with the rest of the API. */
+   return false;
 }
 
 static bool accessibility_speak_android(int speed,

--- a/frontend/drivers/platform_unix.h
+++ b/frontend/drivers/platform_unix.h
@@ -367,7 +367,7 @@ void android_app_write_cmd(struct android_app *android_app, int8_t cmd);
 
 extern struct android_app *g_android;
 
-bool RAIsTalkbackRunning(void);
+bool is_screen_reader_enabled(void);
 
 #endif
 

--- a/frontend/drivers/platform_unix.h
+++ b/frontend/drivers/platform_unix.h
@@ -366,6 +366,9 @@ extern JNIEnv *jni_thread_getenv(void);
 void android_app_write_cmd(struct android_app *android_app, int8_t cmd);
 
 extern struct android_app *g_android;
+
+bool RAIsTalkbackRunning(void);
+
 #endif
 
 #endif


### PR DESCRIPTION

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

As noted in #16638 the Android accessibility is_narrator_running_android code, even though it is  working, is not respecting RetroArch accessibility API contract of returning a boolean if Talkback is speaking or not. Since we do not have control on when Talkback speaks or when it will speak our messages, this code changes the is_narrator_running_android function to always return false. This way all messages will be sent to Talkback and the operating system or Talkback itself will control if it should speak the messages.

## Related Issues


Comment on Pull request #16638 

## Related Pull Requests

None.

## Reviewers

@BarryJRowe 
