### PR TITLE
(cheevos) fix rewind not working when hardcore is disabled and RetroAchievements cannot identify game

### DIFF
--- a/deps/rcheevos/src/rc_client.c
+++ b/deps/rcheevos/src/rc_client.c
@@ -5384,7 +5384,7 @@ size_t rc_client_progress_size(rc_client_t* client)
     return client->state.external_client->progress_size();
 #endif
 
-  if (!client->game)
+  if (!rc_client_is_game_loaded(client))
     return 0;
 
   rc_mutex_lock(&client->state.mutex);

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -448,8 +448,20 @@ bool content_serialize_state_rewind(void* buffer, size_t buffer_size)
 {
    rastate_size_info_t size;
    size_t len = content_get_rastate_size(&size, true);
-   if (len == 0 || len > buffer_size)
+   if (len == 0)
       return false;
+   if (len > buffer_size)
+   {
+#ifdef DEBUG
+      static size_t last_reported_len = 0;
+      if (len != last_reported_len)
+      {
+         last_reported_len = len;
+         RARCH_WARN("Rewind state size exceeds frame size (%zu > %zu).\n", len, buffer_size);
+      }
+#endif
+      return false;
+   }
    return content_write_serialized_state(buffer, &size, true);
 }
 


### PR DESCRIPTION
## Description

Fixes rewind not functioning properly when RetroAchievements fails to identify the loaded game and hardcore is disabled.

When RetroAchievements are active, the rewind buffer size has to be increased to accommodate the RetroAchievements state. This is typically handled by internally disabling and re-enabling rewind, which doesn't happen if a game isn't successfully loaded. However, rewind save states still try to allocate a bit of extra space for the RetroAchievements data, so the serializer silently fails and any attempt to rewind just resets the game.

Solution: when asked how much space RetroAchievements needs for serialization, return 0 when the "Unknown Game" is loaded.

I've also modified the serializer to write a log message when the buffer isn't large enough (but only for debug builds).

## Related Issues

#15933

## Related Pull Requests

n/a

## Reviewers

@Sanaki
