### PR TITLE
wayland: Load cursor theme/size based on settings

### DIFF
--- a/gfx/common/dbus_common.c
+++ b/gfx/common/dbus_common.c
@@ -25,6 +25,7 @@ static unsigned int dbus_screensaver_cookie = 0;
 #endif
 
 #include "../../verbosity.h"
+#include <string.h>
 
 void dbus_ensure_connection(void)
 {
@@ -162,3 +163,144 @@ bool dbus_suspend_screensaver(bool enable)
 #endif
    return false;
 }
+
+static bool
+get_cursor_settings_from_env(char **theme, int *size)
+{
+	char *env_xtheme;
+	char *env_xsize;
+
+	env_xtheme = getenv("XCURSOR_THEME");
+	if (env_xtheme != NULL)
+		*theme = strdup(env_xtheme);
+
+	env_xsize = getenv("XCURSOR_SIZE");
+	if (env_xsize != NULL)
+		*size = atoi(env_xsize);
+
+	return env_xtheme != NULL && env_xsize != NULL;
+}
+
+#ifdef HAVE_DBUS
+static DBusMessage *
+get_setting_sync(DBusConnection *const connection,
+      const char *key,
+      const char *value)
+{
+   DBusError error;
+   dbus_bool_t success;
+   DBusMessage *message;
+   DBusMessage *reply;
+
+   message = dbus_message_new_method_call(
+      "org.freedesktop.portal.Desktop",
+      "/org/freedesktop/portal/desktop",
+      "org.freedesktop.portal.Settings",
+      "Read");
+
+   success = dbus_message_append_args(message,
+      DBUS_TYPE_STRING, &key,
+      DBUS_TYPE_STRING, &value,
+      DBUS_TYPE_INVALID);
+
+   if (!success)
+      return NULL;
+
+   dbus_error_init(&error);
+
+   reply = dbus_connection_send_with_reply_and_block(
+         connection,
+         message,
+         DBUS_TIMEOUT_USE_DEFAULT,
+         &error);
+
+   dbus_message_unref(message);
+
+   if (dbus_error_is_set(&error)) {
+      dbus_error_free(&error);
+      return NULL;
+   }
+
+   dbus_error_free(&error);
+   return reply;
+}
+
+static bool
+parse_type(DBusMessage *const reply,
+      const int type,
+      void *value)
+{
+   DBusMessageIter iter[3];
+
+   dbus_message_iter_init(reply, &iter[0]);
+   if (dbus_message_iter_get_arg_type(&iter[0]) != DBUS_TYPE_VARIANT)
+      return false;
+
+   dbus_message_iter_recurse(&iter[0], &iter[1]);
+   if (dbus_message_iter_get_arg_type(&iter[1]) != DBUS_TYPE_VARIANT)
+      return false;
+
+   dbus_message_iter_recurse(&iter[1], &iter[2]);
+   if (dbus_message_iter_get_arg_type(&iter[2]) != type)
+      return false;
+
+   dbus_message_iter_get_basic(&iter[2], value);
+
+   return true;
+}
+
+bool
+dbus_get_cursor_settings(char **theme, int *size)
+{
+   static const char name[] = "org.gnome.desktop.interface";
+   static const char key_theme[] = "cursor-theme";
+   static const char key_size[] = "cursor-size";
+
+   DBusError error;
+   DBusConnection *connection;
+   DBusMessage *reply;
+   const char *value_theme = NULL;
+
+   dbus_error_init(&error);
+
+   connection = dbus_bus_get(DBUS_BUS_SESSION, &error);
+
+   if (dbus_error_is_set(&error))
+      goto fallback;
+
+   reply = get_setting_sync(connection, name, key_theme);
+   if (!reply)
+      goto fallback;
+
+   if (!parse_type(reply, DBUS_TYPE_STRING, &value_theme)) {
+      dbus_message_unref(reply);
+      goto fallback;
+   }
+
+   *theme = strdup(value_theme);
+
+   dbus_message_unref(reply);
+
+   reply = get_setting_sync(connection, name, key_size);
+   if (!reply)
+      goto fallback;
+
+   if (!parse_type(reply, DBUS_TYPE_INT32, size)) {
+      dbus_message_unref(reply);
+      goto fallback;
+   }
+
+   dbus_message_unref(reply);
+
+   return true;
+
+fallback:
+   return get_cursor_settings_from_env(theme, size);
+}
+#else
+bool
+dbus_get_cursor_settings(char **theme, int *size)
+{
+   return get_cursor_settings_from_env(theme, size);
+}
+#endif

--- a/gfx/common/dbus_common.h
+++ b/gfx/common/dbus_common.h
@@ -28,4 +28,6 @@ void dbus_screensaver_uninhibit(void);
 
 bool dbus_suspend_screensaver(bool enable);
 
+bool dbus_get_cursor_settings(char **theme, int *size);
+
 #endif

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -805,8 +805,10 @@ bool gfx_ctx_wl_init_common(
    wl->input.keyboard_focus  = true;
    wl->input.mouse.focus     = true;
 
+   wl->cursor.theme_name = NULL;
+   wl->cursor.size = 24;
    wl->cursor.surface        = wl_compositor_create_surface(wl->compositor);
-   wl->cursor.theme          = wl_cursor_theme_load(NULL, 16, wl->shm);
+   wl->cursor.theme          = wl_cursor_theme_load(wl->cursor.theme_name, wl->cursor.size, wl->shm);
    wl->cursor.default_cursor = wl_cursor_theme_get_cursor(wl->cursor.theme, "left_ptr");
 
    wl->num_active_touches    = 0;

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -45,6 +45,8 @@
 #define FRACTIONAL_SCALE_V1_DEN 120
 #define FRACTIONAL_SCALE_MULT(v, scale_num) \
    (((v) * (scale_num) + FRACTIONAL_SCALE_V1_DEN / 2) / FRACTIONAL_SCALE_V1_DEN)
+#define FRACTIONAL_SCALE_MULT_DOUBLE(v, scale_num) \
+   (((double)(v) * (double)(scale_num) + (double)FRACTIONAL_SCALE_V1_DEN / 2.0) / (double)FRACTIONAL_SCALE_V1_DEN)
 
 #define UDEV_KEY_MAX            0x2ff
 #define UDEV_MAX_KEYS           (UDEV_KEY_MAX + 7) / 8
@@ -195,6 +197,8 @@ typedef struct gfx_ctx_wayland_data
       struct wl_cursor_theme *theme;
       struct wl_surface *surface;
       uint32_t serial;
+      char *theme_name;
+      int size;
       bool visible;
    } cursor;
 


### PR DESCRIPTION
## Description

Load cursor at integer scale larger than required, use `wl_surface_set_buffer_scale` to shrink down.

Based on code from SDL, libdecor and gtk.

## Related Issues

Fixes #16679 so long as compiled with `--enable-dbus`

## Reviewers

