### PR TITLE
Force fullscreen in case of context driver without windowed support

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1243,7 +1243,8 @@ void video_switch_refresh_rate_maybe(
    unsigned video_bfi                 = settings->uints.video_black_frame_insertion;
    unsigned shader_subframes          = settings->uints.video_shader_subframes;
    bool vrr_runloop_enable            = settings->bools.vrr_runloop_enable;
-   bool exclusive_fullscreen          = settings->bools.video_fullscreen && !settings->bools.video_windowed_fullscreen;
+   bool exclusive_fullscreen          = (video_st->flags | VIDEO_FLAG_FORCE_FULLSCREEN) || (
+                                        settings->bools.video_fullscreen && !settings->bools.video_windowed_fullscreen);
    bool windowed_fullscreen           = settings->bools.video_fullscreen && settings->bools.video_windowed_fullscreen;
    bool all_fullscreen                = settings->bools.video_fullscreen || settings->bools.video_windowed_fullscreen;
 


### PR DESCRIPTION
## Description

Change GL2, GL3 and Vulkan drivers to behave as fullscreen if context driver does not support windowed mode at all (such as KMS/DRM or KHR), but configuration calls for windowed setup. This can only happen if same RetroArch installation is used both in windowed (X11/Wayland) and in console-only (KMS) modes.

Tested on a Raspberry Pi 4 with Ubuntu, with GL2, GL3, Vulkan, startup and refresh rate switch was checked. (Refresh rate switch does not work with Vulkan in KMS mode, due to lack of display server.) Fullscreen resolution is honored, fullscreen flag is not overwritten.

Same effect can be reached if RetroArch is started with "retroarch -f" option, but evaluation of that option is way too early for the video context driver to be initialized, so it could not be merged with that.

## Related Issues

Closes #16613 

## Related Pull Requests

#15301 #15326 

## Reviewers
@kokoko3k
