### PR TITLE
(Linux/udev) Support mouse buttons 4/5

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -884,25 +884,21 @@ static void udev_handle_mouse(void *data,
             case BTN_LEFT:
                mouse->l = event->value;
                break;
-
             case BTN_RIGHT:
                mouse->r = event->value;
                break;
-
             case BTN_MIDDLE:
                mouse->m = event->value;
                break;
             case BTN_TOUCH:
                mouse->pp = event->value;
                break;
-#if 0
-            case BTN_??:
+            case BTN_SIDE:
                mouse->b4 = event->value;
                break;
-            case BTN_??:
+            case BTN_EXTRA:
                mouse->b5 = event->value;
                break;
-#endif
             default:
                break;
          }


### PR DESCRIPTION
## Description

Fixups existing `ifdef`'d out stub and supports Mouse Side Buttons 4 & 5 in Linux `udev` driver. Now properly works in cores and shows as "Mouse 4"/"Mouse 5" in the UI.

(Using MAME (Current) as working example)
![timecris-240614-192855](https://github.com/libretro/RetroArch/assets/7321839/29b7d609-da7c-4b09-8693-f93689aa3b6a)
![2024_06-14 195153](https://github.com/libretro/RetroArch/assets/7321839/bb04f245-c371-43ac-a5b4-bf4fe21cbdfb)

As a sidenote, while udev had mouse 4/5 support through enums, it seems like `input/drivers/x11_input.c` only supports three mouse buttons total. I figured just fixing udev atm would be more important for lightgun systems like e.g. OpenFIRE which supports and uses the side buttons.

## Related Issues

#14087

## Related Pull Requests

None, afaik

## Reviewers

[who do I mention for Linux/input issues? first time contribution, sorry]