### PR TITLE
x11: add support for Xss screensaver disabling

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1305,6 +1305,9 @@ ifeq ($(HAVE_X11), 1)
    ifeq ($(HAVE_XCB),1)
       LIBS += -lX11-xcb
    endif
+   ifeq ($(HAVE_XSCRNSAVER),1)
+      LIBS += -lXss
+   endif
    ifneq ($(HAVE_OPENGLES), 1)
       OBJ += gfx/drivers_context/x_ctx.o
    endif

--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -505,6 +505,7 @@ if [ "$HAVE_X11" != 'no' ]; then
    check_val '' XCB -lxcb '' xcb '' '' false
    check_val '' XEXT -lXext '' xext '' '' false
    check_val '' XF86VM -lXxf86vm '' xxf86vm '' '' false
+   check_val '' XSCRNSAVER -lXss '' xscrnsaver '' '' false
 else
    die : 'Notice: X11 not present. Skipping X11 code paths.'
 fi

--- a/qb/config.params.sh
+++ b/qb/config.params.sh
@@ -92,6 +92,7 @@ HAVE_OPENGLES3_1=no        # OpenGLES3.1 support
 HAVE_OPENGLES3_2=no        # OpenGLES3.2 support
 HAVE_X11=auto              # everything X11.
 HAVE_XRANDR=auto           # Xrandr support.
+HAVE_XSCRNSAVER=auto       # Xss support.
 HAVE_OMAP=no               # OMAP video support
 HAVE_XINERAMA=auto         # Xinerama support.
 HAVE_KMS=auto              # KMS context support


### PR DESCRIPTION
in case xdg-screensaver isn't installed.

## Description

if Xss library is detected, it is used to disable screensaver on X11 before falling back to xdg-screensaver.
