### PR TITLE
Fix replay rewind/load state bug

### DIFF
--- a/libretro-common/include/streams/interface_stream.h
+++ b/libretro-common/include/streams/interface_stream.h
@@ -88,6 +88,9 @@ int intfstream_getc(intfstream_internal_t *intf);
 int64_t intfstream_seek(intfstream_internal_t *intf,
       int64_t offset, int whence);
 
+int64_t intfstream_truncate(intfstream_internal_t *intf,
+      uint64_t len);
+
 void intfstream_rewind(intfstream_internal_t *intf);
 
 int64_t intfstream_tell(intfstream_internal_t *intf);

--- a/libretro-common/streams/interface_stream.c
+++ b/libretro-common/streams/interface_stream.c
@@ -321,17 +321,9 @@ int64_t intfstream_truncate(intfstream_internal_t *intf, uint64_t len)
       case INTFSTREAM_MEMORY:
          break;
       case INTFSTREAM_CHD:
-#ifdef HAVE_CHD
          break;
-#else
-        break;
-#endif
       case INTFSTREAM_RZIP:
-#if defined(HAVE_ZLIB)
          break;
-#else
-         break;
-#endif
    }
 
    return 0;

--- a/libretro-common/streams/interface_stream.c
+++ b/libretro-common/streams/interface_stream.c
@@ -309,6 +309,34 @@ int64_t intfstream_seek(
    return -1;
 }
 
+int64_t intfstream_truncate(intfstream_internal_t *intf, uint64_t len)
+{
+   if (!intf)
+      return 0;
+
+   switch (intf->type)
+   {
+      case INTFSTREAM_FILE:
+         return filestream_truncate(intf->file.fp, len);
+      case INTFSTREAM_MEMORY:
+         break;
+      case INTFSTREAM_CHD:
+#ifdef HAVE_CHD
+         break;
+#else
+        break;
+#endif
+      case INTFSTREAM_RZIP:
+#if defined(HAVE_ZLIB)
+         break;
+#else
+         break;
+#endif
+   }
+
+   return 0;
+}
+
 int64_t intfstream_read(intfstream_internal_t *intf, void *s, uint64_t len)
 {
    if (!intf)


### PR DESCRIPTION
Currently, doing these actions will cause issues with replays (desync):

1. Start recording a replay in any game and core (e.g. Super Mario Bros on FCEUX)
2. Make a savestate
3. Hold right for 5 seconds
4. Load your savestate
5. Hold left for 1 second
6. Stop recording

On playback, you'll see 1 second of holding left followed by 4 seconds of holding right, because while we seek to the replay state as of the loaded state we don't truncate the file.  This patch adds `intfstream_truncate` and uses it while recording to fix record-and-replay.