### PR TITLE
[Wayland] Support for mouse buttons 4&5 and horizontal wheel

### DIFF
--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -213,6 +213,8 @@ static void wl_pointer_handle_leave(void *data,
    wl->input.mouse.left       = false;
    wl->input.mouse.right      = false;
    wl->input.mouse.middle     = false;
+   wl->input.mouse.side       = false;
+   wl->input.mouse.extra      = false;
 
    if (wl->input.mouse.surface == surface)
       wl->input.mouse.surface = NULL;
@@ -270,6 +272,12 @@ static void wl_pointer_handle_button(void *data,
          case BTN_MIDDLE:
             wl->input.mouse.middle = true;
             break;
+         case BTN_SIDE:
+            wl->input.mouse.side = true;
+            break;
+         case BTN_EXTRA:
+            wl->input.mouse.extra = true;
+            break;
       }
    }
    else
@@ -284,6 +292,12 @@ static void wl_pointer_handle_button(void *data,
             break;
          case BTN_MIDDLE:
             wl->input.mouse.middle = false;
+            break;
+         case BTN_SIDE:
+            wl->input.mouse.side = false;
+            break;
+         case BTN_EXTRA:
+            wl->input.mouse.extra = false;
             break;
       }
    }

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -123,7 +123,7 @@ typedef struct input_ctx_wayland_data
       int delta_x, delta_y;
       bool last_valid;
       bool focus;
-      bool left, right, middle;
+      bool left, right, middle, side, extra;
       bool wu, wd, wl, wr;
    } mouse;
 

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -284,7 +284,18 @@ static int16_t input_wl_state(
                   return wl->mouse.right;
                case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                   return wl->mouse.middle;
-                  /* TODO/FIXME: Rest of the mouse inputs. */
+               case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+                  return wl->mouse.side;
+               case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
+                  return wl->mouse.extra;
+               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+                  state        = wl->mouse.wl;
+                  wl->mouse.wl = false;
+                  return state;
+               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+                  state        = wl->mouse.wr;
+                  wl->mouse.wr = false;
+                  return state;
             }
          }
          break;


### PR DESCRIPTION
## Description

Connecting the dots. Horizontal scroll wheel was even prepared, just not passed on. 

Tested with a programmable keyboard emulating the extra mouse functions. Buttons 4 and 5 bind is OK, horizontal scroll wheel tested in XMB menu, but apparently scroll wheels can not be bound, which is probably a separate issue.

## Related Issues

Fixes partially #14087 (x11 still remains)

## Related Pull Requests

#16690, thanks for taking the initiative!
