### PR TITLE
[X11] Support for mouse buttons 4 and 5

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -669,6 +669,8 @@ bool x11_alive(void *data)
                case 5: /* Scroll down */
                case 6: /* Scroll wheel left */
                case 7: /* Scroll wheel right */
+               case 8: /* Mouse button 4 */
+               case 9: /* Mouse button 5 */
                   x_input_poll_wheel(&event.xbutton, true);
                   break;
             }
@@ -683,6 +685,13 @@ bool x11_alive(void *data)
             break;
 
          case ButtonRelease:
+            switch (event.xbutton.button)
+            {
+               case 8: /* Mouse button 4 - not handled as click */
+               case 9: /* Mouse button 5 - not handled as click */
+                  x_input_poll_wheel(&event.xbutton, true);
+                  break;
+            }
             break;
 
          case KeyRelease:

--- a/input/common/input_x11_common.c
+++ b/input/common/input_x11_common.c
@@ -23,7 +23,9 @@ enum x11_mouse_btn_flags
    X11_MOUSE_WU_BTN   = (1 << 0),
    X11_MOUSE_WD_BTN   = (1 << 1),
    X11_MOUSE_HWU_BTN  = (1 << 2),
-   X11_MOUSE_HWD_BTN  = (1 << 3)
+   X11_MOUSE_HWD_BTN  = (1 << 3),
+   X11_MOUSE_BTN_4    = (1 << 4),
+   X11_MOUSE_BTN_5    = (1 << 5)
 };
 
 /* TODO/FIXME - static globals */
@@ -51,6 +53,13 @@ int16_t x_mouse_state_wheel(unsigned id)
          ret                = (g_x11_mouse_flags & X11_MOUSE_HWD_BTN);
          g_x11_mouse_flags &= ~X11_MOUSE_HWD_BTN;
          break;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+         ret                = (g_x11_mouse_flags & X11_MOUSE_BTN_4);
+         break;
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
+         ret                = (g_x11_mouse_flags & X11_MOUSE_BTN_5);
+         break;
+
    }
 
    return ret;
@@ -73,6 +82,32 @@ void x_input_poll_wheel(XButtonEvent *event, bool latch)
       case 7:
          /* Scroll wheel right == HORIZ_WHEELUP */
          g_x11_mouse_flags |= X11_MOUSE_HWU_BTN;
+         break;
+      case 8:
+         /* Extra buttons are regular press-release events,
+          * while scroll wheels do not stay pressed. */
+         /* Mouse button 4 */
+         switch (event->type)
+         {
+            case ButtonPress:
+               g_x11_mouse_flags |= X11_MOUSE_BTN_4;
+               break;
+            case ButtonRelease:
+               g_x11_mouse_flags &= ~X11_MOUSE_BTN_4;
+               break;
+         }
+         break;
+      case 9:
+         /* Mouse button 5 */
+         switch (event->type)
+         {
+            case ButtonPress:
+               g_x11_mouse_flags |= X11_MOUSE_BTN_5;
+               break;
+            case ButtonRelease:
+               g_x11_mouse_flags &= ~X11_MOUSE_BTN_5;
+               break;
+         }
          break;
    }
 }

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -86,12 +86,8 @@ static bool x_mouse_button_pressed(
          return x11->mouse_r;
       case RETRO_DEVICE_ID_MOUSE_MIDDLE:
          return x11->mouse_m;
-#if 0
       case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
-         return x11->mouse_b4;
       case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
-         return x11->mouse_b5;
-#endif
       case RETRO_DEVICE_ID_MOUSE_WHEELUP:
       case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
       case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
@@ -266,6 +262,8 @@ static int16_t x_input_state(
                case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
                case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
                case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+               case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+               case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
                   return x_mouse_state_wheel(id);
                case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                   return x11->mouse_m;
@@ -489,7 +487,8 @@ static void x_input_poll(void *data)
    x11->mouse_l             = mask & Button1Mask;
    x11->mouse_m             = mask & Button2Mask;
    x11->mouse_r             = mask & Button3Mask;
-
+   /* Buttons 4 and 5 are not returned here, so they are handled elsewhere. */
+   
    /* > Mouse pointer */
    if (!x11->mouse_grabbed)
    {


### PR DESCRIPTION
## Description
Support added for extra mouse buttons. Since these buttons were not returned by XQueryPointer(), some additional logic was needed which fit best to scroll wheel handling.

Tested on current Raspberry Pi OS (Debian Bookworm).

## Related Issues
Closes #14087  (together with the other mentioned, already merged PRs)

## Related Pull Requests
#16690 #16712 
