### PR TITLE
Numlock scrolllock mod fix

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -987,6 +987,8 @@ static LRESULT CALLBACK wnd_proc_common(
                mod |= RETROKMOD_CAPSLOCK;
             if (GetKeyState(VK_SCROLL)  & 0x81)
                mod |= RETROKMOD_SCROLLOCK;
+            if (GetKeyState(VK_NUMLOCK) & 0x81)
+               mod |= RETROKMOD_NUMLOCK;
             if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x80)
                mod |= RETROKMOD_META;
 
@@ -1111,6 +1113,8 @@ static LRESULT CALLBACK wnd_proc_common_internal(HWND hwnd,
                mod |= RETROKMOD_CAPSLOCK;
             if (GetKeyState(VK_SCROLL)  & 0x81)
                mod |= RETROKMOD_SCROLLOCK;
+            if (GetKeyState(VK_NUMLOCK) & 0x81)
+               mod |= RETROKMOD_NUMLOCK;
             if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x80)
                mod |= RETROKMOD_META;
 
@@ -1369,6 +1373,8 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
                mod |= RETROKMOD_CAPSLOCK;
             if (GetKeyState(VK_SCROLL)  & 0x81)
                mod |= RETROKMOD_SCROLLOCK;
+            if (GetKeyState(VK_NUMLOCK) & 0x81)
+               mod |= RETROKMOD_NUMLOCK;
             if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x80)
                mod |= RETROKMOD_META;
 

--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -595,6 +595,8 @@ static void x11_handle_key_event(unsigned keycode, XEvent *event,
       mod |= RETROKMOD_ALT;
    if (state & Mod2Mask)
       mod |= RETROKMOD_NUMLOCK;
+   if (state & Mod3Mask)
+      mod |= RETROKMOD_SCROLLOCK;
    if (state & Mod4Mask)
       mod |= RETROKMOD_META;
 

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -875,6 +875,14 @@ static INLINE void android_input_poll_event_type_keyboard(
       mod |= RETROKMOD_CTRL;
    if (meta & AMETA_SHIFT_ON)
       mod |= RETROKMOD_SHIFT;
+   if (meta & AMETA_CAPS_LOCK_ON)
+      mod |= RETROKMOD_CAPSLOCK;
+   if (meta & AMETA_NUM_LOCK_ON)
+      mod |= RETROKMOD_NUMLOCK;
+   if (meta & AMETA_SCROLL_LOCK_ON)
+      mod |= RETROKMOD_SCROLLOCK;
+   if (meta & AMETA_META_ON)
+      mod |= RETROKMOD_META;
 
    input_keyboard_event(keydown, keyboardcode,
          keyboardcode, mod, RETRO_DEVICE_KEYBOARD);

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -199,6 +199,26 @@ static void *dinput_init(const char *joypad_driver)
    return di;
 }
 
+static uint16_t dinput_get_active_keyboard_mods()
+{
+   uint16_t mod = 0;
+   if (GetKeyState(VK_SHIFT)   & 0x80)
+      mod |= RETROKMOD_SHIFT;
+   if (GetKeyState(VK_CONTROL) & 0x80)
+      mod |= RETROKMOD_CTRL;
+   if (GetKeyState(VK_MENU)    & 0x80)
+      mod |= RETROKMOD_ALT;
+   if (GetKeyState(VK_CAPITAL) & 0x81)
+      mod |= RETROKMOD_CAPSLOCK;
+   if (GetKeyState(VK_SCROLL)  & 0x81)
+      mod |= RETROKMOD_SCROLLOCK;
+   if (GetKeyState(VK_NUMLOCK) & 0x81)
+      mod |= RETROKMOD_NUMLOCK;
+   if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x80)
+      mod |= RETROKMOD_META;
+   return mod;
+}
+
 static void dinput_keyboard_mods(struct dinput_input *di, int mod)
 {
    switch (mod)
@@ -212,7 +232,8 @@ static void dinput_keyboard_mods(struct dinput_input *di, int mod)
                 || (!vk_shift_l &&   (di->flags & DINP_FLAG_SHIFT_L)))
             {
                input_keyboard_event(vk_shift_l, RETROK_LSHIFT,
-                     0, RETROKMOD_SHIFT, RETRO_DEVICE_KEYBOARD);
+                     0, dinput_get_active_keyboard_mods() | RETROKMOD_SHIFT,
+                     RETRO_DEVICE_KEYBOARD);
                if (di->flags & DINP_FLAG_SHIFT_L)
                   di->flags &= ~DINP_FLAG_SHIFT_L;
                else
@@ -223,7 +244,8 @@ static void dinput_keyboard_mods(struct dinput_input *di, int mod)
                 || (!vk_shift_r &&   (di->flags & DINP_FLAG_SHIFT_R)))
             {
                input_keyboard_event(vk_shift_r, RETROK_RSHIFT,
-                     0, RETROKMOD_SHIFT, RETRO_DEVICE_KEYBOARD);
+                     0, dinput_get_active_keyboard_mods() | RETROKMOD_SHIFT,
+                     RETRO_DEVICE_KEYBOARD);
                if (di->flags & DINP_FLAG_SHIFT_R)
                   di->flags &= ~DINP_FLAG_SHIFT_R;
                else
@@ -246,7 +268,8 @@ static void dinput_keyboard_mods(struct dinput_input *di, int mod)
             else if (!vk_alt_l && (di->flags & DINP_FLAG_ALT_L))
             {
                input_keyboard_event(vk_alt_l, RETROK_LALT,
-                     0, RETROKMOD_ALT, RETRO_DEVICE_KEYBOARD);
+                     0, dinput_get_active_keyboard_mods() | RETROKMOD_ALT,
+                     RETRO_DEVICE_KEYBOARD);
                if (di->flags & DINP_FLAG_ALT_L)
                   di->flags &= ~DINP_FLAG_ALT_L;
                else

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -442,6 +442,11 @@ static void sdl_input_poll(void *data)
          if (event.key.keysym.mod & KMOD_CAPS)
             mod |= RETROKMOD_CAPSLOCK;
 
+         /* KMOD_SCROLL was added in SDL 2.0.18, use the raw number
+            to stay backwards compatible with older versions */
+         if (event.key.keysym.mod & 0x8000 /*KMOD_SCROLL*/)
+            mod |= RETROKMOD_SCROLLOCK;
+
          input_keyboard_event(event.type == SDL_KEYDOWN, code, code, mod,
                RETRO_DEVICE_KEYBOARD);
       }

--- a/input/drivers/switch_input.c
+++ b/input/drivers/switch_input.c
@@ -210,12 +210,20 @@ static void switch_input_poll(void *data)
    }
 
    hidGetKeyboardStates(&kbd_state, 1);
-   if (hidKeyboardStateGetKey(&kbd_state, HidKeyboardKey_LeftAlt) || hidKeyboardStateGetKey(&kbd_state, HidKeyboardKey_RightAlt))
+   if (kbd_state.modifiers & (HidKeyboardModifier_LeftAlt | HidKeyboardModifier_RightAlt))
       mod |= RETROKMOD_ALT;
-   if (hidKeyboardStateGetKey(&kbd_state, HidKeyboardKey_LeftControl) || hidKeyboardStateGetKey(&kbd_state, HidKeyboardKey_RightControl))
+   if (kbd_state.modifiers & HidKeyboardModifier_Control)
       mod |= RETROKMOD_CTRL;
-   if (hidKeyboardStateGetKey(&kbd_state, HidKeyboardKey_LeftShift) || hidKeyboardStateGetKey(&kbd_state, HidKeyboardKey_RightShift))
+   if (kbd_state.modifiers & HidKeyboardModifier_Shift)
       mod |= RETROKMOD_SHIFT;
+   if (kbd_state.modifiers & HidKeyboardModifier_Gui)
+      mod |= RETROKMOD_META;
+   if (kbd_state.modifiers & HidKeyboardModifier_CapsLock)
+      mod |= RETROKMOD_CAPSLOCK;
+   if (kbd_state.modifiers & HidKeyboardModifier_ScrollLock)
+      mod |= RETROKMOD_SCROLLOCK;
+   if (kbd_state.modifiers & HidKeyboardModifier_NumLock)
+      mod |= RETROKMOD_NUMLOCK;
 
    for (i = 0; i < SWITCH_NUM_SCANCODES; i++)
    {

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -581,6 +581,8 @@ static LRESULT CALLBACK winraw_callback(
             mod |= RETROKMOD_CAPSLOCK;
          if (GetKeyState(VK_SCROLL)  & 0x81)
             mod |= RETROKMOD_SCROLLOCK;
+         if (GetKeyState(VK_NUMLOCK) & 0x81)
+            mod |= RETROKMOD_NUMLOCK;
          if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x80)
             mod |= RETROKMOD_META;
 

--- a/uwp/uwp_main.cpp
+++ b/uwp/uwp_main.cpp
@@ -636,6 +636,8 @@ void App::OnAcceleratorKey(CoreDispatcher^ sender, AcceleratorKeyEventArgs^ args
       mod |= RETROKMOD_CAPSLOCK;
    if ((window->GetKeyState(VirtualKey::Scroll) & CoreVirtualKeyStates::Locked) == CoreVirtualKeyStates::Locked)
       mod |= RETROKMOD_SCROLLOCK;
+   if ((window->GetKeyState(VirtualKey::NumberKeyLock) & CoreVirtualKeyStates::Locked) == CoreVirtualKeyStates::Locked)
+      mod |= RETROKMOD_NUMLOCK;
    if ((window->GetKeyState(VirtualKey::LeftWindows) & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down ||
          (window->GetKeyState(VirtualKey::RightWindows) & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down)
       mod |= RETROKMOD_META;


### PR DESCRIPTION
## Description

libretro.h describes the enum `retro_mod` with flags for numlock, capslock and scrolllock which are supposed to be the key states (or LED states) of a physical keyboard passed along to a core via the `uint16_t key_modifiers` argument of `retro_keyboard_event_t`. But various keyboard drivers are missing these modifiers so it makes it hard for a computer core like DOSBox Pure to mirror the state of the physical keyboard with the emulated one.

This PR adds the following fixes to the `key_modifiers` reported by these drivers:
- Add missing numlock mod to dinput
- Add missing scrolllock mod to x11
- Add missing capslock, numlock, scrolllock and meta mods to android
- Add missing scrolllock mod to sdl
- Add missing capslock, numlock, scrolllock and meta mods to switch
- Add missing numlock mod to winraw
- Add missing numlock mod to uwp

I was not able to figure out what is needed to fix the wayland or udev because they currently don't seem to handle any of the modifiers at all. Also on the cocoa doesn't seem to have a concept of scroll-lock so that is missing there still (but I think scroll lock is much less important than capslock and numlock).

I have to say that I've only tested this change with dinput and winraw on Windows. The changes I did are all very small and should be correct according to the various documentations I have looked up:
- [Win32 virtual keycodes with VK_NUMLOCK](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
- [Android input.h](https://github.com/innogames/android-ndk/blame/master/platforms/android-15/arch-x86/usr/include/android/input.h)
- [SDL 2 adding KMOD_SCROLL](https://github.com/libsdl-org/SDL/issues/4566)
- [libnx documentation describing HidKeyboardState and HidKeyboardModifier](https://switchbrew.github.io/libnx/hid_8h.html)
- [post describing X11's Mod3Mask as scroll lock](https://stackoverflow.com/questions/4037230/global-hotkey-with-x11-xlib)
- [UWP documentation of VirtualKey enum](https://learn.microsoft.com/en-us/uwp/api/windows.system.virtualkey)

I tried to look up how things are supposed to be handled in wayland but searching for "wl_keyboard" or even "WL_KEYBOARD_KEY_STATE_PRESSED" brings up NO DOCUMENTATION AT ALL. Hello wayland??? I then tried to look at [how SDL does things there](https://github.com/libsdl-org/SDL/blob/f8ad4abe4e3490c68380c507c9f3ee1c22a88639/src/video/wayland/SDL_waylandevents.c#L1290) and still I had no clue what needs to be done. I leave this to someone else who knows about wayland. It seems a mess...

## Related Issues

## Related Pull Requests

## Reviewers
