### PR TITLE
Simplified Parameter Parsing to have all all shader formats use the same slang method

### DIFF
--- a/gfx/drivers_shader/glslang_util.c
+++ b/gfx/drivers_shader/glslang_util.c
@@ -97,6 +97,19 @@ enum slang_texture_semantic slang_name_to_texture_semantic_array(
    return SLANG_INVALID_TEXTURE_SEMANTIC;
 }
 
+/* Reads a shader file and outputs its contents as a string list.
+
+   Takes the path of the shader file and appends each line of the file
+   to the output string list.
+
+   If the root_file argument is set to true, it expects the first line of the file
+   to be a valid '#version' string
+
+   Handles '#include' statements by recursively parsing included files and appending their contents.
+
+   Returns a Bool indicating if parsing was successful.
+ */
+
 bool glslang_read_shader_file(const char *path,
       struct string_list *output, bool root_file)
 {
@@ -150,9 +163,9 @@ bool glslang_read_shader_file(const char *path,
    if (lines.size < 1)
       goto error;
 
-   /* If this is the 'parent' shader file, ensure that first
-    * line is a 'VERSION' string */
-   if (root_file)
+   /* If this is the 'parent' shader file and a slang file,
+    * ensure that first line is a 'VERSION' string */
+   if (root_file && (strcmp(path_get_extension(path), "slang") == 0))
    {
       const char *line = lines.elems[0].data;
 
@@ -166,9 +179,9 @@ bool glslang_read_shader_file(const char *path,
       if (!string_list_append(output, line, attr))
          goto error;
 
-      /* Allows us to use #line to make dealing with shader 
+      /* Allows us to use #line to make dealing with shader
        * errors easier.
-       * This is supported by glslang, but since we always 
+       * This is supported by glslang, but since we always
        * use glslang statically, this is fine. */
       if (!string_list_append(output,
                "#extension GL_GOOGLE_cpp_style_line_directive : require",


### PR DESCRIPTION
Cleanup/Simplification of shader parameter resolution process

Originally if the parameter resolution was a different code path if it was a slang shader or not even though the parameter resolution was actually supposed to be the same. 

This PR removes one of the two paths so that the same parameter resolution is used for both. 

Tested with both slang and glsl shaders

## Reviewers

@hizzlekizzle
