### PR TITLE
Fix exclusive fullscreen condition

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1248,7 +1248,7 @@ void video_switch_refresh_rate_maybe(
    unsigned video_bfi                 = settings->uints.video_black_frame_insertion;
    unsigned shader_subframes          = settings->uints.video_shader_subframes;
    bool vrr_runloop_enable            = settings->bools.vrr_runloop_enable;
-   bool exclusive_fullscreen          = (video_st->flags | VIDEO_FLAG_FORCE_FULLSCREEN) || (
+   bool exclusive_fullscreen          = (video_st->flags & VIDEO_FLAG_FORCE_FULLSCREEN) || (
                                         settings->bools.video_fullscreen && !settings->bools.video_windowed_fullscreen);
    bool windowed_fullscreen           = settings->bools.video_fullscreen && settings->bools.video_windowed_fullscreen;
    bool all_fullscreen                = settings->bools.video_fullscreen || settings->bools.video_windowed_fullscreen;


### PR DESCRIPTION
Spotted in Android compilation:
warning: bitwise or with non-zero value always evaluates to true [-Wtautological-bitwise-compare]

## Related Pull Requests
Introduced in #16689 

