### PR TITLE
Flip default y positive direction for viewport calc

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2358,7 +2358,7 @@ void video_viewport_get_scaled_integer(struct video_viewport *vp,
          video_st->av_info.geometry.base_height;
       unsigned int rotation = retroarch_get_rotation();
 #if defined(RARCH_MOBILE)
-      if (aspect_ratio < 1.0f)
+      if (width < height)
       {
          viewport_bias_x = settings->floats.video_viewport_bias_portrait_x;
          viewport_bias_y = settings->floats.video_viewport_bias_portrait_y;

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2128,11 +2128,9 @@ void video_driver_update_viewport(
             vp,
             vp->full_width,
             vp->full_height,
-            video_driver_aspect_ratio, keep_aspect, false);
+            video_driver_aspect_ratio, keep_aspect, true);
    else if (keep_aspect && !force_full)
-   {
-      video_viewport_get_scaled_aspect(vp, vp->full_width, vp->full_height, false);
-   }
+      video_viewport_get_scaled_aspect(vp, vp->full_width, vp->full_height, true);
 }
 
 void video_driver_restore_cached(void *settings_data)


### PR DESCRIPTION
This should fix metal and maybe some directx resizes, following on #16716 .
