### PR TITLE
Skip core unload when Quit on Close Content is set

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -5598,9 +5598,10 @@ int action_ok_close_content(const char *path, const char *label, unsigned type, 
    menu_st->selection_ptr       = 0;
 
    /* Check if we need to quit */
-   check_quit_on_close();
+   if (should_quit_on_close())
+      return generic_action_ok_command(CMD_EVENT_QUIT);
 
-   /* Unload core */
+   /* Otherwise, unload core */
    ret = generic_action_ok_command(CMD_EVENT_UNLOAD_CORE);
 
    /* If close content was selected via any means other than

--- a/retroarch.c
+++ b/retroarch.c
@@ -3723,6 +3723,12 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_CLOSE_CONTENT:
 #ifdef HAVE_MENU
+         /* If we need to quit, skip unloading the core to avoid performing
+          * cleanup actions (like writing autosave state) twice. */
+         if (should_quit_on_close()) {
+            command_event(CMD_EVENT_QUIT, NULL);
+            break;
+         }
          /* Closing content via hotkey requires toggling menu
           * and resetting the position later on to prevent
           * going to empty Quick Menu */
@@ -3731,8 +3737,6 @@ bool command_event(enum event_command cmd, void *data)
             menu_state_get_ptr()->flags |= MENU_ST_FLAG_PENDING_CLOSE_CONTENT;
             command_event(CMD_EVENT_MENU_TOGGLE, NULL);
          }
-         /* Check if we need to quit Retroarch */
-         check_quit_on_close();
 #else
          command_event(CMD_EVENT_QUIT, NULL);
 #endif
@@ -8212,7 +8216,7 @@ void retroarch_fail(int error_code, const char *error)
 }
 
 /* Called on close content, checks if we need to also exit retroarch */
-void check_quit_on_close(void)
+bool should_quit_on_close(void)
 {
 #ifdef HAVE_MENU
    settings_t *settings   = config_get_ptr();
@@ -8223,8 +8227,9 @@ void check_quit_on_close(void)
             || (settings->uints.quit_on_close_content ==
                QUIT_ON_CLOSE_CONTENT_ENABLED)
       )
-      command_event(CMD_EVENT_QUIT, NULL);
+      return true;
 #endif
+   return false;
 }
 
 /*

--- a/retroarch.h
+++ b/retroarch.h
@@ -206,7 +206,7 @@ void core_options_flush(void);
  **/
 void retroarch_fail(int error_code, const char *error);
 
-void check_quit_on_close(void);
+bool should_quit_on_close(void);
 
 uint16_t retroarch_get_flags(void);
 


### PR DESCRIPTION
## Description

Currently, when RetroArch's "Quit on Close Content" option is enabled and "Close Content" is activated (either through the menu or a hotkey), RetroArch first unloads the current core (`CMD_EVENT_UNLOAD_CORE`) and then quits (`CMD_EVENT_QUIT`). Firing these events performs some duplicate cleanup tasks, including writing the autosave state twice. This leads to some unfortunate consequences, including writing the autosave state to the wrong directory the second time when per-core state directories are enabled. (See #15793 for more details.)

In practice, it seems fine to quit without unloading the core. Indeed, this is exactly what the Quit hotkey does by firing `CMD_EVENT_QUIT` directly. This PR removes the event firing behavior from `check_quit_on_close` and renames it to `should_quit_on_close` for clarity, then updates the two call sites (one for Close Content via menu and the other via hotkey) to call `should_quit_on_close` before firing any events. After that, we fire one only event: `CMD_EVENT_QUIT` if quit-on-close is enabled, and `CMD_EVENT_UNLOAD_CORE` if not.

I've done some basic testing and it appears this PR fixes the autosave bug without introducing any obvious new issues. More help testing is much appreciated, though.

Here's a log snippet of the quit-on-close behavior with this PR applied (note the autosave is only written once, vs. the logs in the bug report where it's written twice):

```
[INFO] Auto save state to "C:\msys64\home\bcat\retroarch\states\Snes9x\240p Test Suite (1.061).state.auto" succeeded.
[INFO] [Config]: Loading config: "C:\msys64\home\bcat\retroarch\retroarch.cfg".
[INFO] [Overrides]: Configuration overrides unloaded, original configuration restored.
[INFO] [Config]: Saved new config to "C:\msys64\home\bcat\retroarch\retroarch.cfg".
[INFO] [Core]: Content ran for a total of: 00 hours, 00 minutes, 07 seconds.
[INFO] [Runtime]: Saving runtime log file: "C:\msys64\home\bcat\retroarch\playlists\logs\Snes9x\240p Test Suite (1.061).lrtl".
[INFO] [Core]: Unloading game..
[INFO] [Core]: Unloading core..
[INFO] [Core]: Unloading core symbols..
[INFO] [Core]: Saved core options file to "C:\msys64\home\bcat\retroarch\config\Snes9x\Snes9x.opt".
```

## Related Issues

Fixes #15793.

## Related Pull Requests

N/A

## Reviewers

@hizzlekizzle (since we were talking about this on the issue, apologies if this isn't appropriate)