### PR TITLE
fake negative x/y viewport positions under vulkan

### DIFF
--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -577,6 +577,8 @@ typedef struct vk
    VkViewport vk_vp;
    VkRenderPass render_pass;
    struct video_viewport vp;
+   float translate_x;
+   float translate_y;
    struct vk_per_frame swapchain[VULKAN_MAX_SWAPCHAIN_IMAGES];
    struct vk_image backbuffers[VULKAN_MAX_SWAPCHAIN_IMAGES];
    struct vk_texture default_texture;


### PR DESCRIPTION
When integer overscale is in use, Vulkan can either show a blank screen or improper viewport positioning when the correct position would require that the viewport be shifted left of or above the top left corner of the window.

Since Vulkan doesn't support negative x or y viewport positions, this patch concatenates a translation matrix to the projection matrix used in Vulkan rendering. In this way, if a negative x or y coordinate would be necessary, we can instead use a 0 coordinate and a leftwards/upwards translation to achieve the same effect.  This seems to work alright with overlays, so as far as I can tell this patch seems sufficient to get the behavior we want.

This fixes a bug noticed by @sonninnos on Discord.