### PR TITLE
Fix Issue #16776

### DIFF
--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -3696,9 +3696,9 @@ static bool d3d11_gfx_read_viewport(void* data, uint8_t* buffer, bool is_idle)
 
          for (x = 0; x < d3d11->vp.width; x++)
          {
-            bufferRow[3 * x + 2] = BackBufferData[4 * x + 0];
-            bufferRow[3 * x + 1] = BackBufferData[4 * x + 1];
-            bufferRow[3 * x + 0] = BackBufferData[4 * x + 2];
+            bufferRow[3 * x + 2] = BackBufferData[4 * (x + (int)d3d11->frame.viewport.TopLeftX) + 0];
+            bufferRow[3 * x + 1] = BackBufferData[4 * (x + (int)d3d11->frame.viewport.TopLeftX) + 1];
+            bufferRow[3 * x + 0] = BackBufferData[4 * (x + (int)d3d11->frame.viewport.TopLeftX) + 2];
          }
       }
       ret = true;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -3696,9 +3696,9 @@ static bool d3d11_gfx_read_viewport(void* data, uint8_t* buffer, bool is_idle)
 
          for (x = 0; x < d3d11->vp.width; x++)
          {
-            bufferRow[3 * x + 2] = BackBufferData[4 * (x + (int)d3d11->vp.x) + 0];
-            bufferRow[3 * x + 1] = BackBufferData[4 * (x + (int)d3d11->vp.x) + 1];
-            bufferRow[3 * x + 0] = BackBufferData[4 * (x + (int)d3d11->vp.x) + 2];
+            bufferRow[3 * x + 2] = BackBufferData[4 * (x + d3d11->vp.x) + 0];
+            bufferRow[3 * x + 1] = BackBufferData[4 * (x + d3d11->vp.x) + 1];
+            bufferRow[3 * x + 0] = BackBufferData[4 * (x + d3d11->vp.x) + 2];
          }
       }
       ret = true;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -3696,9 +3696,9 @@ static bool d3d11_gfx_read_viewport(void* data, uint8_t* buffer, bool is_idle)
 
          for (x = 0; x < d3d11->vp.width; x++)
          {
-            bufferRow[3 * x + 2] = BackBufferData[4 * (x + (int)d3d11->frame.viewport.TopLeftX) + 0];
-            bufferRow[3 * x + 1] = BackBufferData[4 * (x + (int)d3d11->frame.viewport.TopLeftX) + 1];
-            bufferRow[3 * x + 0] = BackBufferData[4 * (x + (int)d3d11->frame.viewport.TopLeftX) + 2];
+            bufferRow[3 * x + 2] = BackBufferData[4 * (x + (int)d3d11->vp.x) + 0];
+            bufferRow[3 * x + 1] = BackBufferData[4 * (x + (int)d3d11->vp.x) + 1];
+            bufferRow[3 * x + 0] = BackBufferData[4 * (x + (int)d3d11->vp.x) + 2];
          }
       }
       ret = true;
@@ -3713,7 +3713,9 @@ static bool d3d11_gfx_read_viewport(void* data, uint8_t* buffer, bool is_idle)
 
    /* Release the backbuffer staging. */
    BackBufferStaging->lpVtbl->Release(BackBufferStaging);
+   BackBufferResource->lpVtbl->Release(BackBufferResource);
    BackBufferStagingTexture->lpVtbl->Release(BackBufferStagingTexture);
+   BackBuffer->lpVtbl->Release(BackBuffer);
    
    return ret;
 }

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -3690,6 +3690,7 @@ static bool d3d11_gfx_read_viewport(void* data, uint8_t* buffer, bool is_idle)
    /* Assuming format is DXGI_FORMAT_R8G8B8A8_UNORM */
    if (StagingDesc.Format == DXGI_FORMAT_R8G8B8A8_UNORM)
    {
+      BackBufferData += Map.RowPitch * d3d11->vp.y;
       for (y = 0; y < d3d11->vp.height; y++, BackBufferData += Map.RowPitch)
       {
          bufferRow = buffer + 3 * (d3d11->vp.height - y - 1) * d3d11->vp.width;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Fixes issue #16776 .
Additionally fixes a bug where resizing the window would not work correctly after taking a GPU screenshot and could crash RetroArch when attempting to take a screenshot again in this state.

## Related Issues

#16776 

## Related Pull Requests

#16760 

## Reviewers

[If possible @mention all the people that should review your pull request]
