### PR TITLE
midi: Fix unneeded left shift for MEVT_F_LONG

### DIFF
--- a/midi/drivers/winmm_midi.c
+++ b/midi/drivers/winmm_midi.c
@@ -349,7 +349,7 @@ static bool winmm_midi_write_long_event(winmm_midi_buffer_t *buf,
 
    buf->data[i++] = delta_time;
    buf->data[i++] = 0;
-   buf->data[i++] = MEVT_F_LONG << 24 | MEVT_LONGMSG << 24 | data_size;
+   buf->data[i++] = MEVT_F_LONG | MEVT_LONGMSG << 24 | data_size;
 
    memcpy(&buf->data[i], data, data_size);
    buf->header.dwBytesRecorded += sizeof(DWORD) * 3 + data_size;


### PR DESCRIPTION
MEVT_F_LONG is a DWORD type with a value of 0x80000000, so there is no need to left-shit it.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
