### PR TITLE
winmm_midi: Fix midi_write_long_event unable to send sysex correctly

### DIFF
--- a/midi/drivers/winmm_midi.c
+++ b/midi/drivers/winmm_midi.c
@@ -343,6 +343,9 @@ static bool winmm_midi_write_long_event(winmm_midi_buffer_t *buf,
 {
    DWORD i = buf->header.dwBytesRecorded / sizeof(DWORD);
 
+   /* data size has to be DWORD aligned */
+   data_size = (data_size + (sizeof(DWORD) - 1)) & ~(sizeof(DWORD) - 1);
+
    if (buf->header.dwBytesRecorded + sizeof(DWORD) * 3 + data_size >
          sizeof(DWORD) * WINMM_MIDI_BUF_LEN)
       return false;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Data size of buffer in midi_write_long_msg() has to be DWORD aligned (is that the correct term?)

## Related Issues

Fix https://github.com/libretro/RetroArch/issues/16790
Fix https://github.com/libretro/px68k-libretro/issues/164

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

review before merge for confirmation/corrections:
@LibretroAdmin @zoltanvb and others
