### PR TITLE
fix segfault with vulkan shaders

### DIFF
--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2592,10 +2592,10 @@ Framebuffer::Framebuffer(
       unsigned max_levels) :
    size(max_size),
    format(format),
+   max_levels(MAX(max_levels, 1u)),
    memory_properties(mem_props),
    device(device)
 {
-   max_levels = MAX(max_levels, 1u);
    RARCH_LOG("[Vulkan filter chain]: Creating framebuffer %ux%u (max %u level(s)).\n",
          max_size.width, max_size.height, max_levels);
    vulkan_initialize_render_pass(device, format, &render_pass);


### PR DESCRIPTION
## Description

This commit caused segfaults with vulkan when shaders were loaded: https://github.com/libretro/RetroArch/commit/b4e5a8fb70caf427f6143d3b6ce91ac7e97d2b38

Moving the line back up seems to fix it here without needing to switch back to to std::max().

## Related Issues

I don't think anyone made an issue for it yet.

## Related Pull Requests

none

## Reviewers

@LibretroAdmin 
