### PR TITLE
Add sensor function placeholders for all joypad drivers.

### DIFF
--- a/input/drivers_joypad/android_joypad.c
+++ b/input/drivers_joypad/android_joypad.c
@@ -252,7 +252,9 @@ input_device_driver_t android_joypad = {
    android_joypad_axis,
    android_joypad_poll,
    android_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    android_joypad_name,
    "android",
 };

--- a/input/drivers_joypad/ctr_joypad.c
+++ b/input/drivers_joypad/ctr_joypad.c
@@ -212,8 +212,10 @@ input_device_driver_t ctr_joypad = {
    ctr_joypad_get_buttons,
    ctr_joypad_axis,
    ctr_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    ctr_joypad_name,
    "ctr",
 };

--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -56,7 +56,9 @@ input_device_driver_t dinput_joypad = {
    dinput_joypad_axis,
    dinput_joypad_poll,
    dinput_joypad_set_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    dinput_joypad_name,
    "dinput",
 };

--- a/input/drivers_joypad/dos_joypad.c
+++ b/input/drivers_joypad/dos_joypad.c
@@ -254,8 +254,10 @@ input_device_driver_t dos_joypad = {
    NULL,
    dos_joypad_axis,
    dos_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    dos_joypad_name,
    "dos",
 };

--- a/input/drivers_joypad/gx_joypad.c
+++ b/input/drivers_joypad/gx_joypad.c
@@ -672,8 +672,10 @@ input_device_driver_t gx_joypad = {
    gx_joypad_get_buttons,
    gx_joypad_axis,
    gx_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    gx_joypad_name,
    "gx",
 };

--- a/input/drivers_joypad/hid_joypad.c
+++ b/input/drivers_joypad/hid_joypad.c
@@ -130,7 +130,9 @@ input_device_driver_t hid_joypad = {
    hid_joypad_axis,
    hid_joypad_poll,
    hid_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    hid_joypad_name,
    "hid"
 };

--- a/input/drivers_joypad/linuxraw_joypad.c
+++ b/input/drivers_joypad/linuxraw_joypad.c
@@ -405,8 +405,10 @@ input_device_driver_t linuxraw_joypad = {
    linuxraw_joypad_get_buttons,
    linuxraw_joypad_axis,
    linuxraw_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    linuxraw_joypad_name,
    "linuxraw",
 };

--- a/input/drivers_joypad/mfi_joypad.m
+++ b/input/drivers_joypad/mfi_joypad.m
@@ -834,6 +834,8 @@ input_device_driver_t mfi_joypad = {
     apple_gamecontroller_joypad_poll,
     apple_gamecontroller_joypad_set_rumble,
     NULL,
+    NULL,
+    NULL,
     apple_gamecontroller_joypad_name,
     "mfi",
 };

--- a/input/drivers_joypad/parport_joypad.c
+++ b/input/drivers_joypad/parport_joypad.c
@@ -410,8 +410,10 @@ input_device_driver_t parport_joypad = {
    parport_joypad_get_buttons,
    parport_joypad_axis,
    parport_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    parport_joypad_name,
    "parport",
 };

--- a/input/drivers_joypad/ps2_joypad.c
+++ b/input/drivers_joypad/ps2_joypad.c
@@ -264,7 +264,9 @@ input_device_driver_t ps2_joypad = {
    ps2_joypad_axis,
    ps2_joypad_poll,
    ps2_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    ps2_joypad_name,
    "ps2",
 };

--- a/input/drivers_joypad/ps3_joypad.c
+++ b/input/drivers_joypad/ps3_joypad.c
@@ -305,7 +305,9 @@ input_device_driver_t ps3_joypad = {
    ps3_joypad_axis,
    ps3_joypad_poll,
    ps3_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    ps3_joypad_name,
    "ps3",
 };

--- a/input/drivers_joypad/ps4_joypad.c
+++ b/input/drivers_joypad/ps4_joypad.c
@@ -355,7 +355,9 @@ input_device_driver_t ps4_joypad = {
    ps4_joypad_axis,
    ps4_joypad_poll,
    ps4_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    ps4_joypad_name,
    "ps4",
 };

--- a/input/drivers_joypad/psp_joypad.c
+++ b/input/drivers_joypad/psp_joypad.c
@@ -424,7 +424,9 @@ input_device_driver_t psp_joypad = {
    psp_joypad_axis,
    psp_joypad_poll,
    psp_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    psp_joypad_name,
 #ifdef VITA
    "vita",

--- a/input/drivers_joypad/qnx_joypad.c
+++ b/input/drivers_joypad/qnx_joypad.c
@@ -169,8 +169,10 @@ input_device_driver_t qnx_joypad = {
    NULL,
    qnx_joypad_axis,
    qnx_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    qnx_joypad_name,
    "qnx",
 };

--- a/input/drivers_joypad/rwebpad_joypad.c
+++ b/input/drivers_joypad/rwebpad_joypad.c
@@ -210,8 +210,10 @@ input_device_driver_t rwebpad_joypad = {
    rwebpad_joypad_get_buttons,
    rwebpad_joypad_axis,
    rwebpad_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    rwebpad_joypad_name,
    "rwebpad",
 };

--- a/input/drivers_joypad/sdl_dingux_joypad.c
+++ b/input/drivers_joypad/sdl_dingux_joypad.c
@@ -808,6 +808,8 @@ input_device_driver_t sdl_dingux_joypad = {
    NULL,
    NULL,
 #endif
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    sdl_dingux_joypad_name,
    "sdl_dingux",
 };

--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -563,9 +563,11 @@ input_device_driver_t sdl_joypad = {
 #ifdef HAVE_SDL2
    sdl_joypad_set_rumble,
 #else
-   NULL,
+   NULL, /* set_rumble */
 #endif
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    sdl_joypad_name,
 #ifdef HAVE_SDL2
    "sdl2",

--- a/input/drivers_joypad/switch_joypad.c
+++ b/input/drivers_joypad/switch_joypad.c
@@ -465,7 +465,9 @@ input_device_driver_t switch_joypad = {
 #else
    NULL, /* set_rumble */
 #endif
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    switch_joypad_name,
    "switch"
 };

--- a/input/drivers_joypad/test_joypad.c
+++ b/input/drivers_joypad/test_joypad.c
@@ -496,8 +496,10 @@ input_device_driver_t test_joypad = {
    NULL, /* get_buttons */
    test_joypad_axis,
    test_joypad_poll,
-   NULL, /* rumble */
-   NULL, /* rumble_gain */
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    test_joypad_name,
    "test",
 };

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -795,8 +795,10 @@ input_device_driver_t udev_joypad = {
 #ifndef HAVE_LAKKA_SWITCH
    udev_set_rumble_gain,
 #else
-   NULL,
+   NULL, /* set_rumble_gain */
 #endif
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    udev_joypad_name,
    "udev",
 };

--- a/input/drivers_joypad/wiiu/hidpad_driver.c
+++ b/input/drivers_joypad/wiiu/hidpad_driver.c
@@ -117,6 +117,8 @@ input_device_driver_t hidpad_driver =
   hidpad_poll,
   NULL, /* set_rumble */
   NULL, /* set_rumble_gain */
+  NULL, /* set_sensor_state */
+  NULL, /* get_sensor_input */
   hidpad_name,
   "hid"
 };

--- a/input/drivers_joypad/wiiu/kpad_driver.c
+++ b/input/drivers_joypad/wiiu/kpad_driver.c
@@ -292,8 +292,10 @@ input_device_driver_t kpad_driver =
    kpad_get_buttons,
    kpad_axis,
    kpad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    kpad_name,
    "wiimote",
 };

--- a/input/drivers_joypad/wiiu/wpad_driver.c
+++ b/input/drivers_joypad/wiiu/wpad_driver.c
@@ -361,8 +361,10 @@ input_device_driver_t wpad_driver =
   wpad_get_buttons,
   wpad_axis,
   wpad_poll,
-  NULL,
-  NULL,
+  NULL, /* set_rumble */
+  NULL, /* set_rumble_gain */
+  NULL, /* set_sensor_state */
+  NULL, /* get_sensor_input */
   wpad_name,
   "gamepad",
 };

--- a/input/drivers_joypad/wiiu_joypad.c
+++ b/input/drivers_joypad/wiiu_joypad.c
@@ -132,8 +132,10 @@ input_device_driver_t wiiu_joypad =
   wiiu_joypad_get_buttons,
   wiiu_joypad_axis,
   wiiu_joypad_poll,
-  NULL,
-  NULL,
+  NULL, /* set_rumble */
+  NULL, /* set_rumble_gain */
+  NULL, /* set_sensor_state */
+  NULL, /* get_sensor_input */
   wiiu_joypad_name,
   "wiiu",
 };

--- a/input/drivers_joypad/xdk_joypad.c
+++ b/input/drivers_joypad/xdk_joypad.c
@@ -322,8 +322,10 @@ input_device_driver_t xdk_joypad = {
    NULL,
    xdk_joypad_axis,
    xdk_joypad_poll,
-   NULL,
-   NULL,
+   NULL, /* set_rumble */
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    xdk_joypad_name,
    "xdk",
 };

--- a/input/drivers_joypad/xinput_hybrid_joypad.c
+++ b/input/drivers_joypad/xinput_hybrid_joypad.c
@@ -699,7 +699,9 @@ input_device_driver_t xinput_joypad = {
    xinput_joypad_axis,
    xinput_joypad_poll,
    xinput_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    xinput_joypad_name,
    "xinput",
 };

--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -394,7 +394,9 @@ input_device_driver_t xinput_joypad = {
    xinput_joypad_axis,
    xinput_joypad_poll,
    xinput_joypad_rumble,
-   NULL,
+   NULL, /* set_rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    xinput_joypad_name,
    "xinput",
 };

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -170,6 +170,8 @@ static input_device_driver_t null_joypad = {
    NULL, /* poll */
    NULL, /* rumble */
    NULL, /* rumble_gain */
+   NULL, /* set_sensor_state */
+   NULL, /* get_sensor_input */
    NULL, /* name */
    "null",
 };
@@ -518,7 +520,11 @@ bool input_driver_set_sensor(
       return current_driver->set_sensor_state(current_data,
             port, action, rate);
    }
-
+   else if (input_driver_st.primary_joypad && input_driver_st.primary_joypad->set_sensor_state)
+   {
+      return input_driver_st.primary_joypad->set_sensor_state(NULL,
+            port, action, rate);
+   }
    return false;
 }
 
@@ -534,6 +540,12 @@ float input_driver_get_sensor(
       {
          void *current_data = input_driver_st.current_data;
          return current_driver->get_sensor_input(current_data, port, id);
+      }
+      else if (sensors_enable && input_driver_st.primary_joypad && 
+               input_driver_st.primary_joypad->get_sensor_input)
+      {
+         return input_driver_st.primary_joypad->get_sensor_input(NULL,
+               port, id);
       }
    }
 

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -465,6 +465,9 @@ struct rarch_joypad_driver
    void (*poll)(void);
    bool (*set_rumble)(unsigned, enum retro_rumble_effect, uint16_t);
    bool (*set_rumble_gain)(unsigned, unsigned);
+   bool (*set_sensor_state)(void *data, unsigned port,
+         enum retro_sensor_action action, unsigned rate);
+   float (*get_sensor_input)(void *data, unsigned port, unsigned id);
    const char *(*name)(unsigned);
 
    const char *ident;


### PR DESCRIPTION
## Description

In some cases, set_sensor_state and get_sensor_input are more related to the joypad driver, e.g. in desktop platforms where sensors are associated rather with the joypad.

If input driver supports the sensors, it is still preferred. Placeholder inserted for all input drivers, no functionality added yet.

## Related Pull Requests

I wanted to test #16188 but realized that it will not be possible since I am on Wayland... so maybe it can be slightly reworked, extending the usability.
