### PR TITLE
alsa_midi: Prevent some notes to linger when application is closed

### DIFF
--- a/midi/drivers/alsa_midi.c
+++ b/midi/drivers/alsa_midi.c
@@ -157,7 +157,11 @@ static void alsa_midi_free(void *p)
    if (d)
    {
       if (d->seq)
+      {
+         snd_seq_drain_output(d->seq);
          snd_seq_close(d->seq);
+      }
+
       free(d);
    }
 }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Appears to be enough to silence any lingering notes when midi is playing and core is suddenly closed. Tried adding this on the core side but midi_free comes first before retro_deinit/retro_unload_game so the driver was already closed.

Another way to fix this in the core's side is to call 'flush' immediately after any midi writes, but that doesn't appear to be the api's design, flush is supposed to get called at the end of the retro_run.

Im open for any better methods. but this should work for the issue without causing other problems.

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
@LibretroAdmin @zoltanvb 