### PR TITLE
Fix a crash when switchres is used with videocore drivers.

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -133,12 +133,14 @@ static void crt_switch_set_aspect(
       patched_height           = height;
    }
 
+#if !defined(HAVE_VIDEOCORE)
    sr_get_state(&state);
 
    if ((int)srm_width >= state.super_width && !srm_isstretched)
       RARCH_LOG("[CRT]: Super resolution detected. Fractal scaling @ X:%f Y:%f \n", srm_xscale, srm_yscale);
    else if (srm_isstretched && srm_width > 0 )
       RARCH_LOG("[CRT]: Resolution is stretched. Fractal scaling @ X:%f Y:%f \n", srm_xscale, srm_yscale);
+#endif
 
    scaled_width  = roundf(patched_width  * srm_xscale);
    scaled_height = roundf(patched_height * srm_yscale);


### PR DESCRIPTION
## Description

While testing #15972 , a crash was found, so I guess that can be merged irrespectively of the userland removal. Due to the different codepath of initializing when videocore is used, sr_get_state will have some missing parts, but since it is only used for a log here, it can be omitted.

