### PR TITLE
Hotfix for savestate thumbnail cleanup

### DIFF
--- a/command.c
+++ b/command.c
@@ -1564,6 +1564,7 @@ void command_event_set_savestate_garbage_collect(
        * and delete that one as well. */
       i = strlcpy(state_dir,oldest_save,PATH_MAX_LENGTH);
       strlcpy(state_dir + i,".png",STRLEN_CONST(".png")+1);
+      filestream_delete(state_dir);
    }
 
    dir_list_free(dir_list);


### PR DESCRIPTION
Hotfix for #16836 
Missed a tiny bit of detail from the PR: actually deleting the file. When cleaned the debug logs I added during development, I removed the actual deletion line as well...
Tested again.