### PR TITLE
macOS: optional library inclusion

### DIFF
--- a/pkg/apple/BaseConfig.xcconfig
+++ b/pkg/apple/BaseConfig.xcconfig
@@ -106,3 +106,5 @@ HEADER_SEARCH_PATHS = $(inherited) $(SRCBASE) $(SRCBASE)/gfx/include $(SRCBASE)/
 CLANG_CXX_LANGUAGE_STANDARD=c++11
 CLANG_ENABLE_OBJC_ARC=YES
 INFOPLIST_FILE = $(SRCROOT)/OSX/Info_Metal.plist
+
+#include? "/usr/local/share/retroarch-apple-deps/deps.xcconfig"


### PR DESCRIPTION
I've set up a [git repo](https://github.com/warmenhoven/retroarch-apple-deps) to store prebuilt binaries for optional libraries where it doesn't make sense to include either the binaries or the source in the retroarch repo (e.g. libraries that would normally be provided by the platform). Rather than include it as a git submodule, this makes an assumption that it's installed in /usr/local/share; if it's not it will be silently ignored, similar to ./configure not finding the library. (I've already put it on the buildbots.) The repo is also set up in a way where it is easy to have in a different location, though that does require passing additional flags to xcodebuild.

The current repo includes sdl2 for macOS, so this also fixes #16838, and as a result, #16136.