### PR TITLE
Allow building RetroArch with menu disabled

### DIFF
--- a/cheevos/cheevos_menu.c
+++ b/cheevos/cheevos_menu.c
@@ -22,16 +22,18 @@
 #include "../gfx/gfx_display.h"
 #include "../file_path_special.h"
 
-#ifdef HAVE_MENU
-
 #include "cheevos.h"
 
 #include "../deps/rcheevos/include/rc_runtime_types.h"
 #include "../deps/rcheevos/include/rc_api_runtime.h"
 #include "../deps/rcheevos/src/rc_client_internal.h"
 
+#if HAVE_MENU
+
 #include "../menu/menu_driver.h"
 #include "../menu/menu_entries.h"
+
+#endif
 
 #include <features/features_cpu.h>
 #include <retro_assert.h>
@@ -42,6 +44,8 @@
 #define MENU_BADGE_RETRY_RELOAD_FRAMES 64
 
 #ifdef HAVE_RC_CLIENT
+
+#if HAVE_MENU
 
 bool rcheevos_menu_get_state(unsigned menu_offset, char* buffer, size_t buffer_size)
 {
@@ -512,6 +516,7 @@ void rcheevos_menu_populate(void* data)
    }
 }
 
+#endif /* HAVE_MENU */
 
 uintptr_t rcheevos_get_badge_texture(const char* badge, bool locked, bool download_if_missing)
 {
@@ -573,6 +578,8 @@ uintptr_t rcheevos_get_badge_texture(const char* badge, bool locked, bool downlo
 }
 
 #else /* !HAVE_RC_CLIENT */
+
+#if HAVE_MENU
 
 enum rcheevos_menuitem_bucket
 {
@@ -1193,6 +1200,8 @@ void rcheevos_menu_populate(void* data)
    }
 }
 
+#endif /* HAVE_MENU */
+
 uintptr_t rcheevos_get_badge_texture(const char *badge, bool locked, bool download_if_missing)
 {
    if (badge)
@@ -1222,5 +1231,3 @@ uintptr_t rcheevos_get_badge_texture(const char *badge, bool locked, bool downlo
 }
 
 #endif /* HAVE_RC_CLIENT */
-
-#endif /* HAVE_MENU */

--- a/configuration.c
+++ b/configuration.c
@@ -1747,7 +1747,9 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("run_ahead_hide_warnings",       &settings->bools.run_ahead_hide_warnings, true, DEFAULT_RUN_AHEAD_HIDE_WARNINGS, false);
    SETTING_BOOL("preemptive_frames_enable",      &settings->bools.preemptive_frames_enable, true, false, false);
    SETTING_BOOL("preemptive_frames_hide_warnings", &settings->bools.preemptive_frames_hide_warnings, true, DEFAULT_PREEMPT_HIDE_WARNINGS, false);
+#if HAVE_MENU
    SETTING_BOOL("kiosk_mode_enable",             &settings->bools.kiosk_mode_enable, true, DEFAULT_KIOSK_MODE_ENABLE, false);
+#endif
    SETTING_BOOL("block_sram_overwrite",          &settings->bools.block_sram_overwrite, true, DEFAULT_BLOCK_SRAM_OVERWRITE, false);
    SETTING_BOOL("replay_auto_index",             &settings->bools.replay_auto_index, true, DEFAULT_REPLAY_AUTO_INDEX, false);
    SETTING_BOOL("savestate_auto_index",          &settings->bools.savestate_auto_index, true, DEFAULT_SAVESTATE_AUTO_INDEX, false);

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3473,10 +3473,15 @@ void video_driver_frame(const void *data, unsigned width,
     *   current frame is not (i.e. if core was
     *   previously sending duped frames, ensure
     *   that the next frame update is captured) */
+#if HAVE_MENU
    if (   video_info.input_driver_nonblock_state
        && video_info.fastforward_frameskip
        &&  !((video_info.menu_st_flags & MENU_ST_FLAG_ALIVE)
        ||   (last_frame_duped && !!data)))
+#else
+   if (   video_info.input_driver_nonblock_state
+       && video_info.fastforward_frameskip)
+#endif
    {
       retro_time_t frame_time_accumulator_prev = frame_time_accumulator;
       retro_time_t frame_time_delta            = new_time - last_time;
@@ -3788,7 +3793,11 @@ void video_driver_frame(const void *data, unsigned width,
                   msg_entry.category,
                   msg_entry.prio,
                   false,
+#if HAVE_MENU
                   (video_info.menu_st_flags & MENU_ST_FLAG_ALIVE) ? true : false
+#else
+                  false
+#endif
             );
       }
       /* ...otherwise, just output message via
@@ -3972,8 +3981,12 @@ void video_driver_frame(const void *data, unsigned width,
       if (video_st->current_video->frame(
                video_st->data, data, width, height,
                video_st->frame_count, (unsigned)pitch,
+#if HAVE_MENU
                   ((video_info.menu_st_flags & MENU_ST_FLAG_SCREENSAVER_ACTIVE) > 0)
                || video_info.notifications_hidden ? "" : video_driver_msg,
+#else
+               video_info.notifications_hidden ? "" : video_driver_msg,
+#endif
                &video_info))
          video_st->flags |=  VIDEO_FLAG_ACTIVE;
       else
@@ -3988,7 +4001,9 @@ void video_driver_frame(const void *data, unsigned width,
           || video_info.memory_show
           || video_info.core_status_msg_show
          )
+#if HAVE_MENU
        && !((video_info.menu_st_flags & MENU_ST_FLAG_SCREENSAVER_ACTIVE))
+#endif
        && !video_info.notifications_hidden
       )
    {

--- a/gfx/widgets/gfx_widget_achievement_popup.c
+++ b/gfx/widgets/gfx_widget_achievement_popup.c
@@ -18,7 +18,7 @@
 #include "../gfx_display.h"
 #include "../gfx_widgets.h"
 
-#include "../cheevos/cheevos.h"
+#include "../../cheevos/cheevos.h"
 
 #define CHEEVO_NOTIFICATION_DURATION      4000
 

--- a/gfx/widgets/gfx_widget_leaderboard_display.c
+++ b/gfx/widgets/gfx_widget_leaderboard_display.c
@@ -18,7 +18,7 @@
 #include "../gfx_display.h"
 #include "../gfx_widgets.h"
 
-#include "../cheevos/cheevos.h"
+#include "../../cheevos/cheevos.h"
 #include <features/features_cpu.h>
 
 #define CHEEVO_LBOARD_ARRAY_SIZE 4

--- a/retroarch.c
+++ b/retroarch.c
@@ -4463,6 +4463,7 @@ bool command_event(enum event_command cmd, void *data)
             }
             break;
          }
+#if HAVE_MENU
          case CMD_EVENT_ADD_TO_PLAYLIST:
          {
             struct string_list *str_list = (struct string_list*)data;
@@ -4533,6 +4534,7 @@ bool command_event(enum event_command cmd, void *data)
             }
             break;
          }
+#endif
       case CMD_EVENT_RESET_CORE_ASSOCIATION:
          {
             const char *core_name          = "DETECT";

--- a/runloop.c
+++ b/runloop.c
@@ -6814,10 +6814,10 @@ static enum runloop_state_enum runloop_check_state(
       cbs->poll_cb();
       return RUNLOOP_STATE_PAUSE;
    }
-
+#if HAVE_MENU
    if (menu_was_alive)
       return RUNLOOP_STATE_MENU;
-
+#endif
    return RUNLOOP_STATE_ITERATE;
 }
 

--- a/tasks/task_pl_thumbnail_download.c
+++ b/tasks/task_pl_thumbnail_download.c
@@ -39,6 +39,8 @@
 #ifdef HAVE_MENU
 #include "../menu/menu_cbs.h"
 #include "../menu/menu_driver.h"
+#else
+#include <queues/message_queue.h>
 #endif
 #endif
 


### PR DESCRIPTION
## Description

This will allow compiling a RetroArch build with the menu disabled, HOWEVER it still requires disabling QT and Achievements (ie. it won't build with just `--disable-menu` and also needs `--disable-menu --disable-cheevos --disable-qt`)

Normal builds that don't invoke `--disable-menu` should be unaffected. 

## Related Issues

Workaround but not definitive fix for : https://github.com/libretro/RetroArch/issues/16880

## Reviewers

@Autechre64 @sonninnos 
