### PR TITLE
Fixed warning + allow cli arguments on Haiku

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -4463,9 +4463,9 @@ bool command_event(enum event_command cmd, void *data)
             }
             break;
          }
-#if HAVE_MENU
          case CMD_EVENT_ADD_TO_PLAYLIST:
          {
+#ifdef HAVE_MENU
             struct string_list *str_list = (struct string_list*)data;
             struct menu_state *menu_st     = menu_state_get_ptr();
             settings_t *settings = config_get_ptr();
@@ -4532,9 +4532,9 @@ bool command_event(enum event_command cmd, void *data)
                            NULL, menu_st->userdata);
                }
             }
+#endif
             break;
          }
-#endif
       case CMD_EVENT_RESET_CORE_ASSOCIATION:
          {
             const char *core_name          = "DETECT";

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1432,10 +1432,14 @@ static bool content_load(content_ctx_info_t *info,
    wrap_args->flags          = 0;
    wrap_args->argc           = 0;
 
+   /* The following snippet breaks command-line arguments on Haiku which in turn
+      prevents from using RA without a menu or to start it from a front-end like ES-DE.
+      All things considered, the risk/reward is favorable to just skipping this. */
+#ifndef __HAIKU__
    if (info->environ_get)
       info->environ_get(rarch_argc_ptr,
             rarch_argv_ptr, info->args, wrap_args);
-
+#endif
    if (wrap_args->flags & RARCH_MAIN_WRAP_FLAG_TOUCHED)
    {
       content_load_init_wrap(wrap_args, &rarch_argc, rarch_argv);


### PR DESCRIPTION
## Description

Since RA was ported to Haiku, command-line arguments have been broken and I never took the time to investigate this. It turns out this snippet is the problem: 
```
   if (info->environ_get)
      info->environ_get(rarch_argc_ptr,
            rarch_argv_ptr, info->args, wrap_args);
```
This goes beyond my abilities and just skipping this piece of code (on Haiku that is) solves the immediate issue. Of course if anybody more skilled feels like taking a shot at it, it'll be more then appreciated. The objective is to allow ES-DE to start RA with the appropriate core, now that ES-DE was ported to Haiku.

Also I accidentally caused a new warning in https://github.com/libretro/RetroArch/pull/16881 so the small fix to retroarch.c resolves this.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/16881 caused this warning :
```
CC retroarch.c
retroarch.c: In function ‘command_event’:
retroarch.c:3095:4: warning: enumeration value ‘CMD_EVENT_ADD_TO_PLAYLIST’ not handled in switch [-Wswitch]
 3095 |    switch (cmd)
      |    ^~~~~~
```