### PR TITLE
improve GLES version directive granularity

### DIFF
--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -366,13 +366,22 @@ static bool gl_glsl_compile_shader(glsl_shader_data_t *glsl,
          strtoul(existing_version + 8, (char**)&program, 10);
 
 #ifdef HAVE_OPENGLES
-      if (version_no < 130)
-         version_no    = 100;
-      else
+      if (version_no >= 130 && version_no < 330)
       {
          version_extra = " es";
          version_no    = 300;
       }
+      else if (version_no == 330)
+      {
+         version_extra = " es";
+         version_no    = 310;
+      }
+      else if (version_no > 330)
+      {
+         version_extra = " es";
+         version_no    = 320;
+      }
+      else version_no  = 100;
 #endif
       snprintf(version,
             sizeof(version), "#version %u%s\n", version_no, version_extra);


### PR DESCRIPTION
when translating from non-ES OpenGL version directive numbers.

## Description

fishku was working on a shader that uses textureGather, which was added to GLES with version 310 es, while our existing version directives only allowed up to version 300 es. So, while the shader works fine on desktop platforms, it fails on mobile/embedded GPUs because we have no way of requesting higher GLSL versions. This change corrects that deficiency and lets authors use these newer features when needed.

## Related Issues

none that I know of

## Related Pull Requests

none (yet)

## Reviewers

Anyone who cares to check it out. I'm hoping that the CI jobs will create a binary that @fishcu  can test on his chinese handheld. Let's hold off on merging until we can hear whether this actually gets him fixed up.
