### PR TITLE
show rcheevos game image in discord rich presence

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -766,6 +766,15 @@ int rcheevos_get_richpresence(char* s, size_t len)
    return (int)rc_client_get_rich_presence_message(rcheevos_locals.client, s, (size_t)len);
 }
 
+int rcheevos_get_game_badge_url(char* s, size_t len)
+{
+   const rc_client_game_t* game = rc_client_get_game_info(rcheevos_locals.client);
+   if (!game || !game->id || !game->badge_name || !game->badge_name[0])
+      return 0;
+
+   return (rc_client_game_get_image_url(game, s, len) == RC_OK);
+}
+
 #else /* !HAVE_RC_CLIENT */
 
 void rcheevos_award_achievement(rcheevos_locals_t* locals,

--- a/cheevos/cheevos.h
+++ b/cheevos/cheevos.h
@@ -57,6 +57,7 @@ bool rcheevos_get_support_cheevos(void);
 
 const char* rcheevos_get_hash(void);
 int rcheevos_get_richpresence(char *s, size_t len);
+int rcheevos_get_game_badge_url(char *s, size_t len);
 uintptr_t rcheevos_get_badge_texture(const char* badge, bool locked, bool download_if_missing);
 
 uint8_t* rcheevos_patch_address(unsigned address);

--- a/network/discord.c
+++ b/network/discord.c
@@ -277,6 +277,7 @@ void discord_update(enum presence presence)
    discord_state_t *discord_st = &discord_state_st;
 #ifdef HAVE_CHEEVOS
    char cheevos_richpresence[256];
+   char cheevos_badge_url[256];
 #endif
 
    if (presence == discord_st->status)
@@ -361,11 +362,14 @@ void discord_update(enum presence presence)
                discord_st->presence.startTimestamp = discord_st->start_time;
 
 #ifdef HAVE_CHEEVOS
+               if (rcheevos_get_game_badge_url(cheevos_badge_url, sizeof(cheevos_badge_url)))
+                  discord_st->presence.largeImageKey = cheevos_badge_url;
+
                if (rcheevos_get_richpresence(cheevos_richpresence, sizeof(cheevos_richpresence)) > 0)
                   discord_st->presence.details     = cheevos_richpresence;
                else
 #endif
-                   discord_st->presence.details    = msg_hash_to_str(
+                  discord_st->presence.details     = msg_hash_to_str(
                      MENU_ENUM_LABEL_VALUE_DISCORD_IN_GAME);
 
                discord_st->presence.state          = label;
@@ -426,6 +430,9 @@ void discord_update(enum presence presence)
       case PRESENCE_RETROACHIEVEMENTS:
          if (discord_st->pause_time)
             return;
+
+         if (rcheevos_get_game_badge_url(cheevos_badge_url, sizeof(cheevos_badge_url)))
+            discord_st->presence.largeImageKey = cheevos_badge_url;
 
          if (rcheevos_get_richpresence(cheevos_richpresence, sizeof(cheevos_richpresence)) > 0)
             discord_st->presence.details = cheevos_richpresence;


### PR DESCRIPTION
## Description

Adds the RetroAchievements game icon to the discord rich presence when updating the discord rich presence with the RetroAchievements rich presence.

When a game is loaded, the discord rich presence says "In-Game [filename]" and shows the system icon associated to the loaded core. This is not changed.
![image](https://github.com/user-attachments/assets/e30e9dd0-87fc-4b04-b44b-d8e1f5a2f239)

If RetroAchievements are enabled, and the game is recognized by RetroAchievements, the RetroAchievements icon will be applied when the RetroAchievements rich presence is evaluated and applied to the discord rich presence:
![image](https://github.com/user-attachments/assets/1fd89019-40a7-4173-9655-72cd8b480aa2)

If RetroAchievements is not eabled, or the game is not recognized, it will continue to display the console icon and filename (in this case, I actually have a filename called `Unknown.nes` - it's not just reporting that the game could not be identified):
![image](https://github.com/user-attachments/assets/00e37992-124d-4439-8e9a-90c105304dc5)

Note that this behavior still requires an actual discord client be present on the user's machine - just like the basic Discord rich presence support.

## Related Issues

See suggestion here: https://discord.com/channels/184109094070779904/434713532341288961/1276704982439166044

## Related Pull Requests

n/a

## Reviewers

@Sanaki
