### PR TITLE
iOS fix mouse cursor movement when left click held down or pressed.

### DIFF
--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -875,7 +875,7 @@ enum
                           defaultRegion:(UIPointerRegion *)defaultRegion API_AVAILABLE(ios(13.4))
 {
    cocoa_input_data_t *apple = (cocoa_input_data_t*) input_state_get_ptr()->current_data;
-   if (!apple)
+   if (!apple || apple->mouse_grabbed)
       return nil;
    CGPoint location = [apple_platform.renderView convertPoint:[request location] fromView:nil];
    apple->touches[0].screen_x = (int16_t)(location.x * [[UIScreen mainScreen] scale]);


### PR DESCRIPTION
Suggested fix by @warmenhoven to improve upon #16933. There was a small issue where the mouse cursor would jump or not move when the left/right mouse button was held down. Improves the ability to play mouse driven FPS games like Quake in dosbox-pure and likely other cores that support mouse input.