### PR TITLE
Input reserved device menu item cleanup

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5625,7 +5625,7 @@ static int menu_displaylist_parse_input_select_reserved_device_list(
             {
                 /* Add checkmark if input is currently
                  * mapped to this entry */
-                if (string_is_equal(device_label, reserved_device_name))
+                if (string_is_equal(device_label, &reserved_device_name[10]))
                 {
                     menu_file_list_cbs_t *cbs = (menu_file_list_cbs_t*)info_list->list[menu_index].actiondata;
                     if (cbs)

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -2780,7 +2780,9 @@ static int setting_action_ok_select_reserved_device(
     char enum_idx[16];
     if (!setting)
         return -1;
+
     snprintf(enum_idx, sizeof(enum_idx), "%d", setting->enum_idx);
+
     generic_action_ok_displaylist_push(
             enum_idx, /* we will pass the enumeration index of the string as a path */
             NULL, NULL, 0, idx, 0,
@@ -7785,6 +7787,8 @@ static int setting_action_start_input_device_reserved_device_name(rarch_setting_
    configuration_set_string(settings,
          settings->arrays.input_reserved_devices[setting->index_offset],
          "");
+
+   command_event(CMD_EVENT_REINIT, NULL);
    return 0;
 }
 
@@ -8189,17 +8193,11 @@ static void get_string_representation_input_device_reservation_type(
    map = settings->uints.input_device_reservation_type[setting->index_offset];
 
    if (map == INPUT_DEVICE_RESERVATION_NONE)
-   {
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DEVICE_RESERVATION_NONE), len);
-   }
    else if (map == INPUT_DEVICE_RESERVATION_PREFERRED)
-   {
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DEVICE_RESERVATION_PREFERRED), len);
-   }
    else if (map == INPUT_DEVICE_RESERVATION_RESERVED)
-   {
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DEVICE_RESERVATION_RESERVED), len);
-   }
    else
       strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DISABLED), len);
 }
@@ -8214,7 +8212,9 @@ static void setting_get_string_representation_input_device_reserved_device_name(
     if (!setting)
         return;
 
-    if (sscanf(setting->value.target.string, "%04x:%04x ", &dev_vendor_id, &dev_product_id) != 2)
+    if (string_is_empty(setting->value.target.string))
+        strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NONE), len);
+    else if (sscanf(setting->value.target.string, "%04x:%04x ", &dev_vendor_id, &dev_product_id) != 2)
         strlcpy(s, setting->value.target.string, len);
     else
         strlcpy(s, &setting->value.target.string[10], len);
@@ -9731,7 +9731,6 @@ static bool setting_append_list_input_player_options(
       (*list)[list_info->index - 1].get_string_representation =
             &setting_get_string_representation_input_device_reserved_device_name;
       (*list)[list_info->index - 1].action_start  = &setting_action_start_input_device_reserved_device_name;
-
       MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_IDX_PTR(list, list_info,
             (enum msg_hash_enums)(MENU_ENUM_LABEL_INPUT_DEVICE_RESERVED_DEVICE_NAME + user));
       MENU_SETTINGS_LIST_CURRENT_ADD_ENUM_VALUE_IDX(list, list_info,


### PR DESCRIPTION
## Description

- Changed the empty option value to "None" like in the dropdown, because it looks confusing otherwise
- Fixed dropdown current selection detection
- Added reinit also to option reset just like in option change
- Trivial nits

The option is also missing left+right change, but decided to not add those since they will trigger reinit, which makes it rather annoying.
