### PR TITLE
iOS: Use BaseConfig xcconfig file, shared with macOS

### DIFF
--- a/pkg/apple/BaseConfig.xcconfig
+++ b/pkg/apple/BaseConfig.xcconfig
@@ -4,7 +4,6 @@
 //
 //
 
-OTHER_CFLAGS = $(inherited) -DFLAC__HAS_OGG=0
 OTHER_CFLAGS = $(inherited) -DGLSLANG_OSINCLUDE_UNIX
 OTHER_CFLAGS = $(inherited) -DHAVE_7ZIP
 OTHER_CFLAGS = $(inherited) -DHAVE_ACCESSIBILITY
@@ -19,20 +18,12 @@ OTHER_CFLAGS = $(inherited) -DHAVE_CHEATS
 OTHER_CFLAGS = $(inherited) -DHAVE_CHEEVOS
 OTHER_CFLAGS = $(inherited) -DHAVE_CLOUDSYNC
 OTHER_CFLAGS = $(inherited) -DHAVE_COCOA_METAL
-OTHER_CFLAGS = $(inherited) -DHAVE_COMMAND
 OTHER_CFLAGS = $(inherited) -DHAVE_CONFIGFILE
 OTHER_CFLAGS = $(inherited) -DHAVE_COREAUDIO
-OTHER_CFLAGS = $(inherited) -DHAVE_COREAUDIO3
-OTHER_CFLAGS = $(inherited) -DHAVE_DISCORD
-OTHER_CFLAGS = $(inherited) -DHAVE_DR_FLAC
-OTHER_CFLAGS = $(inherited) -DHAVE_DR_MP3
 OTHER_CFLAGS = $(inherited) -DHAVE_DSP_FILTER
-OTHER_CFLAGS = $(inherited) -DHAVE_DYLIB
 OTHER_CFLAGS = $(inherited) -DHAVE_DYNAMIC
 OTHER_CFLAGS = $(inherited) -DHAVE_EASTEREGG
 OTHER_CFLAGS = $(inherited) -DHAVE_FILTERS_BUILTIN
-OTHER_CFLAGS = $(inherited) -DHAVE_FLAC
-OTHER_CFLAGS = $(inherited) -DHAVE_GETOPT_LONG
 OTHER_CFLAGS = $(inherited) -DHAVE_GFX_WIDGETS
 OTHER_CFLAGS = $(inherited) -DHAVE_GIT_VERSION
 OTHER_CFLAGS = $(inherited) -DHAVE_GLSL
@@ -41,27 +32,20 @@ OTHER_CFLAGS = $(inherited) -DHAVE_GRIFFIN
 OTHER_CFLAGS = $(inherited) -DHAVE_HID
 OTHER_CFLAGS = $(inherited) -DHAVE_IFINFO
 OTHER_CFLAGS = $(inherited) -DHAVE_IMAGEVIEWER
-OTHER_CFLAGS = $(inherited) -DHAVE_IOHIDMANAGER
 OTHER_CFLAGS = $(inherited) -DHAVE_LANGEXTRA
 OTHER_CFLAGS = $(inherited) -DHAVE_LIBRETRODB
-OTHER_CFLAGS = $(inherited) -DHAVE_LROUND
-OTHER_CFLAGS = $(inherited) -DHAVE_MATERIALUI
 OTHER_CFLAGS = $(inherited) -DHAVE_MENU
 OTHER_CFLAGS = $(inherited) -DHAVE_METAL
 OTHER_CFLAGS = $(inherited) -DHAVE_MFI
-OTHER_CFLAGS = $(inherited) -DHAVE_MMAP
 OTHER_CFLAGS = $(inherited) -DHAVE_NETPLAYDISCOVERY
 OTHER_CFLAGS = $(inherited) -DHAVE_NETPLAYDISCOVERY_NSNET
 OTHER_CFLAGS = $(inherited) -DHAVE_NETWORKGAMEPAD
 OTHER_CFLAGS = $(inherited) -DHAVE_NETWORKING
-OTHER_CFLAGS = $(inherited) -DHAVE_NETWORK_CMD
 OTHER_CFLAGS = $(inherited) -DHAVE_NO_BUILTINZLIB
 OTHER_CFLAGS = $(inherited) -DHAVE_OPENGL
-OTHER_CFLAGS = $(inherited) -DHAVE_OPENGL_CORE
 OTHER_CFLAGS = $(inherited) -DHAVE_OVERLAY
 OTHER_CFLAGS = $(inherited) -DHAVE_OZONE
 OTHER_CFLAGS = $(inherited) -DHAVE_PATCH
-OTHER_CFLAGS = $(inherited) -DHAVE_PRESENCE
 OTHER_CFLAGS = $(inherited) -DHAVE_RBMP
 OTHER_CFLAGS = $(inherited) -DHAVE_REWIND
 OTHER_CFLAGS = $(inherited) -DHAVE_RGUI
@@ -77,20 +61,16 @@ OTHER_CFLAGS = $(inherited) -DHAVE_SPIRV_CROSS
 OTHER_CFLAGS = $(inherited) -DHAVE_SSL
 OTHER_CFLAGS = $(inherited) -DHAVE_STB_FONT
 OTHER_CFLAGS = $(inherited) -DHAVE_STB_VORBIS
-OTHER_CFLAGS = $(inherited) -DHAVE_STDIN_CMD
 OTHER_CFLAGS = $(inherited) -DHAVE_THREADS
 OTHER_CFLAGS = $(inherited) -DHAVE_TRANSLATE
 OTHER_CFLAGS = $(inherited) -DHAVE_UPDATE_ASSETS
 OTHER_CFLAGS = $(inherited) -DHAVE_UPDATE_CORE_INFO
 OTHER_CFLAGS = $(inherited) -DHAVE_VIDEO_FILTER
-OTHER_CFLAGS = $(inherited) -DHAVE_VIDEO_LAYOUT
 OTHER_CFLAGS = $(inherited) -DHAVE_VULKAN
 OTHER_CFLAGS = $(inherited) -DHAVE_XDELTA
 OTHER_CFLAGS = $(inherited) -DHAVE_XMB
 OTHER_CFLAGS = $(inherited) -DHAVE_ZLIB
 OTHER_CFLAGS = $(inherited) -DINLINE=inline
-OTHER_CFLAGS = $(inherited) -DMETAL_DEBUG
-OTHER_CFLAGS = $(inherited) -DOSX
 OTHER_CFLAGS = $(inherited) -DRARCH_INTERNAL
 OTHER_CFLAGS = $(inherited) -DRC_DISABLE_LUA
 OTHER_CFLAGS = $(inherited) -DWANT_GLSLANG
@@ -98,13 +78,67 @@ OTHER_CFLAGS = $(inherited) -D_7ZIP_ST
 OTHER_CFLAGS = $(inherited) -D__LIBRETRO__
 
 OTHER_CFLAGS[arch=x86_64] = $(inherited) -DHAVE_SSE
-OTHER_CFLAGS[arch=arm64] = $(inherited) -D__ARM_NEON__ -DHAVE_NEON
+OTHER_CFLAGS[arch=arm64*] = $(inherited) -D__ARM_NEON__ -DHAVE_NEON
+
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DFLAC__HAS_OGG=0
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_COMMAND
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_COREAUDIO3
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_DISCORD
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_DR_FLAC
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_DR_MP3
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_DYLIB
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_FLAC
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_GETOPT_LONG
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_IOHIDMANAGER
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_LROUND
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_MATERIALUI
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_MMAP
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_NETWORK_CMD
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_OPENGL_CORE
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_PRESENCE
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_STDIN_CMD
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DHAVE_VIDEO_LAYOUT
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DMETAL_DEBUG
+OTHER_CFLAGS[sdk=macosx*] = $(inherited) -DOSX
+
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DGLES_SILENCE_DEPRECATION
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_ALTKIT
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_BTSTACK
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_BUILTINMINIUPNPC
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_COCOATOUCH
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_KEYMAPPER
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_MAIN
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_MINIUPNPC
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_ONLINE_UPDATER
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_OPENGLES
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DHAVE_OPENGLES3
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DIOS
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DPACKAGE_VERSION=\"$(MARKETING_VERSION)\"
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -DRARCH_MOBILE
+OTHER_CFLAGS_IOS_TVOS_SHARE = $(inherited) -D_LZMA_UINT32_IS_ULONG
+
+OTHER_CFLAGS[sdk=iphoneos*] = $(inherited) $(OTHER_CFLAGS_IOS_TVOS_SHARE)
+OTHER_CFLAGS[sdk=iphonesimulator*] = $(inherited) $(OTHER_CFLAGS_IOS_TVOS_SHARE)
+OTHER_CFLAGS[sdk=appletvos*] = $(inherited) $(OTHER_CFLAGS_IOS_TVOS_SHARE)
+OTHER_CFLAGS[sdk=appletvsimulator*] = $(inherited) $(OTHER_CFLAGS_IOS_TVOS_SHARE)
+
+OTHER_CFLAGS_IOS = $(inherited) -DHAVE_COREMOTION
+OTHER_CFLAGS_IOS = $(inherited) -DHAVE_IOS_CUSTOMKEYBOARD
+OTHER_CFLAGS_IOS = $(inherited) -DHAVE_IOS_SWIFT
+OTHER_CFLAGS_IOS = $(inherited) -DHAVE_IOS_TOUCHMOUSE
+OTHER_CFLAGS_IOS = $(inherited) -DHAVE_MATERIALUI
+
+OTHER_CFLAGS[sdk=iphoneos*] = $(inherited) $(OTHER_CFLAGS_IOS)
+OTHER_CFLAGS[sdk=iphonesimulator*] = $(inherited) $(OTHER_CFLAGS_IOS)
+
+OTHER_CFLAGS[config=Debug] = $(inherited) -DDEBUG=1
+OTHER_CFLAGS[config=Release] = $(inherited) -DNDEBUG -DNS_BLOCK_ASSERTIONS=1
 
 SRCBASE  = $(SRCROOT)/../..
 DEPS_DIR = $(SRCBASE)/deps
-HEADER_SEARCH_PATHS = $(inherited) $(SRCBASE) $(SRCBASE)/gfx/include $(SRCBASE)/libretro-common/include $(DEPS_DIR)/libFLAC/include $(DEPS_DIR)/7zip $(DEPS_DIR)/stb $(DEPS_DIR) $(DEPS_DIR)/SPIRV-Cross $(DEPS_DIR)/glslang $(DEPS_DIR)/glslang/glslang/glslang/Public $(DEPS_DIR)/glslang/glslang/glslang/MachineIndependent $(DEPS_DIR)/glslang/glslang/SPIRV $(DEPS_DIR)/glslang/glslang/glslang/OSDependent/Unix
+HEADER_SEARCH_PATHS = $(inherited) $(SRCBASE) $(SRCBASE)/gfx/include $(SRCBASE)/libretro-common/include $(DEPS_DIR)/libFLAC/include $(DEPS_DIR)/rcheevos/include $(DEPS_DIR)/7zip $(DEPS_DIR)/stb $(DEPS_DIR) $(DEPS_DIR)/SPIRV-Cross $(DEPS_DIR)/glslang $(DEPS_DIR)/glslang/glslang/glslang/Public $(DEPS_DIR)/glslang/glslang/glslang/MachineIndependent $(DEPS_DIR)/glslang/glslang/SPIRV $(DEPS_DIR)/glslang/glslang/glslang/OSDependent/Unix
 CLANG_CXX_LANGUAGE_STANDARD=c++11
 CLANG_ENABLE_OBJC_ARC=YES
-INFOPLIST_FILE = $(SRCROOT)/OSX/Info_Metal.plist
+INFOPLIST_FILE[sdk=macosx*] = $(SRCROOT)/OSX/Info_Metal.plist
 
 #include? "/usr/local/share/retroarch-apple-deps/deps.xcconfig"

--- a/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		0718BC632ABBAFB6001F2CBE /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0718BC5F2ABBA807001F2CBE /* Network.framework */; };
 		073734A42A093A5700BF7397 /* JITSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 92A1F81727006CAE00DEAD2A /* JITSupport.m */; };
 		073734A62A093ACA00BF7397 /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = 073734A52A093ACA00BF7397 /* AltKit */; };
+		0753AD192C86144200874A42 /* BaseConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0753AD182C86144200874A42 /* BaseConfig.xcconfig */; };
+		0753AD1A2C86144200874A42 /* BaseConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0753AD182C86144200874A42 /* BaseConfig.xcconfig */; };
 		076CA50D2B695C2C00840EA5 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 076CA50C2B695C2C00840EA5 /* libz.tbd */; };
 		0789FC302A07847E00D042B7 /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0789FC2F2A07847E00D042B7 /* AltKit */; };
 		07B7872D29E8FE8F0088B74F /* filters in Resources */ = {isa = PBXBuildFile; fileRef = 07B7872C29E8FE8F0088B74F /* filters */; };
@@ -203,6 +205,7 @@
 		0712A7772B807AE400C9765F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0718BC5F2ABBA807001F2CBE /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS17.0.sdk/System/Library/Frameworks/Network.framework; sourceTree = DEVELOPER_DIR; };
 		073DB2892B8706490001BA32 /* RetroArchTV.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RetroArchTV.entitlements; sourceTree = "<group>"; };
+		0753AD182C86144200874A42 /* BaseConfig.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = BaseConfig.xcconfig; sourceTree = "<group>"; };
 		076A9EAF2C438E1D00504BDF /* RetroArchiOS.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; name = RetroArchiOS.entitlements; path = iOS/RetroArchiOS.entitlements; sourceTree = SOURCE_ROOT; };
 		076CA50C2B695C2C00840EA5 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS17.2.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 		077AB2C82BFB0E28002BBE2F /* AppStore.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = AppStore.xcconfig; path = iOS/AppStore.xcconfig; sourceTree = "<group>"; };
@@ -1217,6 +1220,7 @@
 		96AFAE1A16C1D4EA009DE44C = {
 			isa = PBXGroup;
 			children = (
+				0753AD182C86144200874A42 /* BaseConfig.xcconfig */,
 				077AB2C82BFB0E28002BBE2F /* AppStore.xcconfig */,
 				0789FC2D2A07845300D042B7 /* Packages */,
 				96AFAE9C16C1D976009DE44C /* Main Entry Core */,
@@ -1466,6 +1470,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07F7FB022A2DA8B800037C04 /* filters in Resources */,
+				0753AD192C86144200874A42 /* BaseConfig.xcconfig in Resources */,
 				9222F2092315DAD50097C0FD /* Launch Screen.storyboard in Resources */,
 				9204BE231D319EF300BD49DB /* InfoPlist.strings in Resources */,
 				9222F20B2315DD3D0097C0FD /* retroarch_logo.png in Resources */,
@@ -1480,6 +1485,7 @@
 			files = (
 				07B7872D29E8FE8F0088B74F /* filters in Resources */,
 				92CC05BD21FE3C1700FF79F0 /* GCDWebUploader.bundle in Resources */,
+				0753AD1A2C86144200874A42 /* BaseConfig.xcconfig in Resources */,
 				9222F2002314BA7C0097C0FD /* assets.zip in Resources */,
 				926C77E321FD1E6700103EDE /* Assets.xcassets in Resources */,
 			);
@@ -1788,26 +1794,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = Default;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "$(IOS_CODE_SIGN_ENTITLEMENTS)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/iOS/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					../../,
-					"../../libretro-common/include",
-					"../../libretro-common/include/compat/zlib",
-					../../deps/stb,
-					../../deps/rcheevos/include,
-					../../deps/7zip,
-					../../deps,
-					"$(DEPS_DIR)/glslang",
-					"$(DEPS_DIR)/SPIRV-Cross",
-					"$(DEPS_DIR)/glslang/glslang/glslang/Public",
-					"$(DEPS_DIR)/glslang/glslang/glslang/OSDependent/Unix",
-					"$(DEPS_DIR)/glslang/glslang/SPIRV",
-					"$(DEPS_DIR)/glslang/glslang/glslang/MachineIndependent",
-					../../gfx/include,
-				);
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = "$(RA_IPHONEOS_DEPLOYMENT_TARGET:default=13.0)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1816,16 +1802,6 @@
 					"@executable_path/Frameworks/MoltenVK.framework",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/iOS/modules";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DHAVE_COREMOTION",
-					"-DHAVE_IOS_CUSTOMKEYBOARD",
-					"-DHAVE_IOS_SWIFT",
-					"-DHAVE_IOS_TOUCHMOUSE",
-					"-DHAVE_MATERIALUI",
-				);
-				"OTHER_CFLAGS[sdk=iphoneos*]" = "$(inherited)";
-				"OTHER_CFLAGS[sdk=iphonesimulator*]" = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(IOS_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = RetroArch;
 				SWIFT_OBJC_BRIDGING_HEADER = "RetroArch-Bridging-Header.h";
@@ -1838,26 +1814,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = Default;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "$(IOS_CODE_SIGN_ENTITLEMENTS)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/iOS/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					../../,
-					"../../libretro-common/include",
-					"../../libretro-common/include/compat/zlib",
-					../../deps/stb,
-					../../deps/rcheevos/include,
-					../../deps/7zip,
-					../../deps,
-					"$(DEPS_DIR)/glslang",
-					"$(DEPS_DIR)/SPIRV-Cross",
-					"$(DEPS_DIR)/glslang/glslang/glslang/Public",
-					"$(DEPS_DIR)/glslang/glslang/glslang/OSDependent/Unix",
-					"$(DEPS_DIR)/glslang/glslang/SPIRV",
-					"$(DEPS_DIR)/glslang/glslang/glslang/MachineIndependent",
-					../../gfx/include,
-				);
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = "$(RA_IPHONEOS_DEPLOYMENT_TARGET:default=13.0)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1866,16 +1822,6 @@
 					"@executable_path/Frameworks/MoltenVK.framework",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/iOS/modules";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-DHAVE_COREMOTION",
-					"-DHAVE_IOS_CUSTOMKEYBOARD",
-					"-DHAVE_IOS_SWIFT",
-					"-DHAVE_IOS_TOUCHMOUSE",
-					"-DHAVE_MATERIALUI",
-				);
-				"OTHER_CFLAGS[sdk=iphoneos*]" = "$(inherited)";
-				"OTHER_CFLAGS[sdk=iphonesimulator*]" = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "$(IOS_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = RetroArch;
 				SWIFT_OBJC_BRIDGING_HEADER = "RetroArch-Bridging-Header.h";
@@ -1891,22 +1837,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/tvOS/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					../../,
-					"../../libretro-common/include",
-					"../../libretro-common/include/compat/zlib",
-					../../deps/stb,
-					../../deps/rcheevos/include,
-					../../deps,
-					../../deps/7zip,
-					"$(DEPS_DIR)/glslang",
-					"$(DEPS_DIR)/SPIRV-Cross",
-					"$(DEPS_DIR)/glslang/glslang/glslang/Public",
-					"$(DEPS_DIR)/glslang/glslang/glslang/OSDependent/Unix",
-					"$(DEPS_DIR)/glslang/glslang/SPIRV",
-					"$(DEPS_DIR)/glslang/glslang/glslang/MachineIndependent",
-					../../gfx/include,
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1934,22 +1864,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/tvOS/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					../../,
-					"../../libretro-common/include",
-					"../../libretro-common/include/compat/zlib",
-					../../deps/stb,
-					../../deps/rcheevos/include,
-					../../deps,
-					../../deps/7zip,
-					"$(DEPS_DIR)/glslang",
-					"$(DEPS_DIR)/SPIRV-Cross",
-					"$(DEPS_DIR)/glslang/glslang/glslang/Public",
-					"$(DEPS_DIR)/glslang/glslang/glslang/OSDependent/Unix",
-					"$(DEPS_DIR)/glslang/glslang/SPIRV",
-					"$(DEPS_DIR)/glslang/glslang/glslang/MachineIndependent",
-					../../gfx/include,
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2020,12 +1934,11 @@
 		};
 		96AFAE5216C1D4EA009DE44C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0753AD182C86144200874A42 /* BaseConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -2051,17 +1964,13 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = ../;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_KEY_CFBundleDisplayName = RetroArch;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				IOS_BUNDLE_IDENTIFIER = com.libretro.RetroArchiOS11;
@@ -2073,99 +1982,8 @@
 				MARKETING_VERSION = 1.19.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				OTHER_CFLAGS = (
-					"-DGLES_SILENCE_DEPRECATION",
-					"-DGLSLANG_OSINCLUDE_UNIX",
-					"-DHAVE_7ZIP",
-					"-DHAVE_ACCESSIBILITY",
-					"-DHAVE_AL",
-					"-DHAVE_ALTKIT",
-					"-DHAVE_AUDIOMIXER",
-					"-DHAVE_BTSTACK",
-					"-DHAVE_BUILTINGLSLANG",
-					"-DHAVE_BUILTINMBEDTLS",
-					"-DHAVE_BUILTINMINIUPNPC",
-					"-DHAVE_CC_RESAMPLER",
-					"-DHAVE_CHD",
-					"-DHAVE_CHEATS",
-					"-DHAVE_CHEEVOS",
-					"-DHAVE_CLOUDSYNC",
-					"-DHAVE_COCOATOUCH",
-					"-DHAVE_COCOA_METAL",
-					"-DHAVE_CONFIGFILE",
-					"-DHAVE_COREAUDIO",
-					"-DHAVE_DSP_FILTER",
-					"-DHAVE_DYNAMIC",
-					"-DHAVE_FILTERS_BUILTIN",
-					"-DHAVE_GFX_WIDGETS",
-					"-DHAVE_GIT_VERSION",
-					"-DHAVE_GLSL",
-					"-DHAVE_GLSLANG",
-					"-DHAVE_GRIFFIN",
-					"-DHAVE_VULKAN",
-					"-DHAVE_HID",
-					"-DHAVE_IFINFO",
-					"-DHAVE_IMAGEVIEWER",
-					"-DHAVE_KEYMAPPER",
-					"-DHAVE_LANGEXTRA",
-					"-DHAVE_LIBRETRODB",
-					"-DHAVE_MAIN",
-					"-DHAVE_MENU",
-					"-DHAVE_METAL",
-					"-DHAVE_MFI",
-					"-DHAVE_MINIUPNPC",
-					"-DHAVE_NEON",
-					"-DHAVE_NETPLAYDISCOVERY",
-					"-DHAVE_NETPLAYDISCOVERY_NSNET",
-					"-DHAVE_NETWORKGAMEPAD",
-					"-DHAVE_NETWORKING",
-					"-DHAVE_NO_BUILTINZLIB",
-					"-DHAVE_ONLINE_UPDATER",
-					"-DHAVE_OPENGL",
-					"-DHAVE_OPENGLES",
-					"-DHAVE_OPENGLES3",
-					"-DHAVE_OVERLAY",
-					"-DHAVE_OZONE",
-					"-DHAVE_PATCH",
-					"-DHAVE_RBMP",
-					"-DHAVE_REWIND",
-					"-DHAVE_RGUI",
-					"-DHAVE_RJPEG",
-					"-DHAVE_RPNG",
-					"-DHAVE_RTGA",
-					"-DHAVE_BSV_MOVIE",
-					"-DHAVE_RUNAHEAD",
-					"-DHAVE_RWAV",
-					"-DHAVE_SCREENSHOTS",
-					"-DHAVE_SHADERPIPELINE",
-					"-DHAVE_SLANG",
-					"-DHAVE_SPIRV_CROSS",
-					"-DHAVE_SSL",
-					"-DHAVE_STB_FONT",
-					"-DHAVE_STB_VORBIS",
-					"-DHAVE_THREADS",
-					"-DHAVE_TRANSLATE",
-					"-DHAVE_UPDATE_ASSETS",
-					"-DHAVE_UPDATE_CORE_INFO",
-					"-DHAVE_VIDEO_FILTER",
-					"-DHAVE_XDELTA",
-					"-DHAVE_XMB",
-					"-DHAVE_ZLIB",
-					"-DINLINE=inline",
-					"-DIOS",
-					"-DPACKAGE_VERSION=\\\"$(MARKETING_VERSION)\\\"",
-					"-DRARCH_INTERNAL",
-					"-DRARCH_MOBILE",
-					"-DRC_DISABLE_LUA",
-					"-DWANT_GLSLANG",
-					"-D_7ZIP_ST",
-					"-D_LZMA_UINT32_IS_ULONG",
-					"-D__ARM_NEON__",
-					"-D__LIBRETRO__",
-				);
-				"OTHER_LDFLAGS[arch=*]" = "-Wl,-segalign,4000";
+				OTHER_CFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
-				SRCBASE = "$(SRCROOT)/../..";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2177,12 +1995,11 @@
 		};
 		96AFAE5316C1D4EA009DE44C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0753AD182C86144200874A42 /* BaseConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -2208,16 +2025,12 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					NDEBUG,
-					"NS_BLOCK_ASSERTIONS=1",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = ../;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_KEY_CFBundleDisplayName = RetroArch;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				IOS_BUNDLE_IDENTIFIER = com.libretro.RetroArchiOS11;
@@ -2230,99 +2043,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				MTL_IGNORE_WARNINGS = YES;
-				OTHER_CFLAGS = (
-					"-DGLES_SILENCE_DEPRECATION",
-					"-DGLSLANG_OSINCLUDE_UNIX",
-					"-DHAVE_7ZIP",
-					"-DHAVE_ACCESSIBILITY",
-					"-DHAVE_AL",
-					"-DHAVE_ALTKIT",
-					"-DHAVE_AUDIOMIXER",
-					"-DHAVE_BTSTACK",
-					"-DHAVE_BUILTINGLSLANG",
-					"-DHAVE_BUILTINMBEDTLS",
-					"-DHAVE_BUILTINMINIUPNPC",
-					"-DHAVE_CC_RESAMPLER",
-					"-DHAVE_CHD",
-					"-DHAVE_CHEATS",
-					"-DHAVE_CHEEVOS",
-					"-DHAVE_CLOUDSYNC",
-					"-DHAVE_COCOATOUCH",
-					"-DHAVE_COCOA_METAL",
-					"-DHAVE_CONFIGFILE",
-					"-DHAVE_COREAUDIO",
-					"-DHAVE_DSP_FILTER",
-					"-DHAVE_DYNAMIC",
-					"-DHAVE_FILTERS_BUILTIN",
-					"-DHAVE_GFX_WIDGETS",
-					"-DHAVE_GIT_VERSION",
-					"-DHAVE_GLSL",
-					"-DHAVE_GLSLANG",
-					"-DHAVE_GRIFFIN",
-					"-DHAVE_VULKAN",
-					"-DHAVE_HID",
-					"-DHAVE_IFINFO",
-					"-DHAVE_IMAGEVIEWER",
-					"-DHAVE_KEYMAPPER",
-					"-DHAVE_LANGEXTRA",
-					"-DHAVE_LIBRETRODB",
-					"-DHAVE_MAIN",
-					"-DHAVE_MENU",
-					"-DHAVE_METAL",
-					"-DHAVE_MFI",
-					"-DHAVE_MINIUPNPC",
-					"-DHAVE_NEON",
-					"-DHAVE_NETPLAYDISCOVERY",
-					"-DHAVE_NETPLAYDISCOVERY_NSNET",
-					"-DHAVE_NETWORKGAMEPAD",
-					"-DHAVE_NETWORKING",
-					"-DHAVE_NO_BUILTINZLIB",
-					"-DHAVE_ONLINE_UPDATER",
-					"-DHAVE_OPENGL",
-					"-DHAVE_OPENGLES",
-					"-DHAVE_OPENGLES3",
-					"-DHAVE_OVERLAY",
-					"-DHAVE_OZONE",
-					"-DHAVE_PATCH",
-					"-DHAVE_RBMP",
-					"-DHAVE_REWIND",
-					"-DHAVE_RGUI",
-					"-DHAVE_RJPEG",
-					"-DHAVE_RPNG",
-					"-DHAVE_RTGA",
-					"-DHAVE_BSV_MOVIE",
-					"-DHAVE_RUNAHEAD",
-					"-DHAVE_RWAV",
-					"-DHAVE_SCREENSHOTS",
-					"-DHAVE_SHADERPIPELINE",
-					"-DHAVE_SLANG",
-					"-DHAVE_SPIRV_CROSS",
-					"-DHAVE_SSL",
-					"-DHAVE_STB_FONT",
-					"-DHAVE_STB_VORBIS",
-					"-DHAVE_THREADS",
-					"-DHAVE_TRANSLATE",
-					"-DHAVE_UPDATE_ASSETS",
-					"-DHAVE_UPDATE_CORE_INFO",
-					"-DHAVE_VIDEO_FILTER",
-					"-DHAVE_XDELTA",
-					"-DHAVE_XMB",
-					"-DHAVE_ZLIB",
-					"-DINLINE=inline",
-					"-DIOS",
-					"-DPACKAGE_VERSION=\\\"$(MARKETING_VERSION)\\\"",
-					"-DRARCH_INTERNAL",
-					"-DRARCH_MOBILE",
-					"-DRC_DISABLE_LUA",
-					"-DWANT_GLSLANG",
-					"-D_7ZIP_ST",
-					"-D_LZMA_UINT32_IS_ULONG",
-					"-D__ARM_NEON__",
-					"-D__LIBRETRO__",
-				);
-				"OTHER_LDFLAGS[arch=*]" = "-Wl,-segalign,4000";
+				OTHER_CFLAGS = "$(inherited)";
 				SDKROOT = iphoneos;
-				SRCBASE = "$(SRCROOT)/../..";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_BUNDLE_IDENTIFIER = com.libretro.dist.tvos.RetroArch;


### PR DESCRIPTION
Several reasons:
* This fixes the iOS/tvOS simulator builds, as it restricts the NEON defines to arm64
* This enables the retroarch-apple-deps libraries. iOS will now link against SDL, which will provide a microphone driver
* It's easier to manage a bunch of build flags through the xcconfig file than inside of Xcode
* It's easier to spot differences between macOS/iOS/tvOS this way

Other than bringing in retroarch-apple-deps, this does not result in any functional change.