### PR TITLE
Invoke menu icon thumbnail loading only if needed.

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2958,7 +2958,7 @@ static void xmb_populate_entries(void *data,
 
    xmb_set_title(xmb);
 
-   if(xmb->is_playlist)
+   if(xmb->is_playlist && settings->uints.menu_icon_thumbnails)
    {
       xmb_populate_dynamic_icons(xmb);
    }


### PR DESCRIPTION
## Description
Workaround for a crash in the linked issue. Not a complete solution, but this change is reasonable in any case.

## Related Issues

#16951 (does not fix it completely, but at least limits the effect to only when both icon thumbnails and non-PNG thumbnails are enabled)

## Related Pull Requests

#16758 

## Reviewers

@sonninnos 
@jbreitweiser 
