### PR TITLE
Fix pthread support

### DIFF
--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -117,7 +117,11 @@ run:
 	ps2client -h $(PS2_IP) execee host:$(EE_BIN)
 
 sim:
-	PCSX2 --elf=$(PWD)/$(EE_BIN) --nogui
+ifeq ($(shell uname), Darwin)
+	/Applications/PCSX2.app/Contents/MacOS/PCSX2 -elf $(PWD)/$(EE_BIN)
+else
+	PCSX2 -elf $(PWD)/$(EE_BIN) -nogui
+endif
 
 debug: clean all run
 

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -50,9 +50,6 @@
 #define DEFAULT_PARTITION "hdd0:__common:pfs"
 #endif
 
-// Disable pthread functionality
-PS2_DISABLE_AUTOSTART_PTHREAD();
-
 static enum frontend_fork ps2_fork_mode      = FRONTEND_FORK_NONE;
 static char cwd[FILENAME_MAX]                = {0};
 static char mountString[10]                  = {0};

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -340,6 +340,7 @@ static void frontend_ps2_exec(const char *path, bool should_load_game)
    RARCH_LOG("Attempt to load executable: [%s], partition [%s].\n", path, mountPoint);
 
    /* Reload IOP drivers for saving IOP ram */
+   deinit_drivers(true, true);
    reset_IOP();
    common_init_drivers(false);
    waitUntilDeviceIsReady(path);


### PR DESCRIPTION
## Description

This PR is to enable `pthread` usage in the PS2 port.
It was disabled because I thought we weren't using it, however, there are several cpp cores that are using it as `stella2014` or `Gearcoleco`.
Some other minor improvements have been made

## Related Issues

Fixes: #16122

Cheers