### PR TITLE
Fine-tune device reservation.

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5624,8 +5624,9 @@ static int menu_displaylist_parse_input_select_reserved_device_list(
                                     0, menu_index, NULL))
             {
                 /* Add checkmark if input is currently
-                 * mapped to this entry */
-                if (string_is_equal(device_label, &reserved_device_name[10]))
+                 * mapped to this entry - with or without vid:pid prefix */
+                if (string_is_equal(device_label, &reserved_device_name[10]) ||
+                    string_is_equal(device_label, reserved_device_name))
                 {
                     menu_file_list_cbs_t *cbs = (menu_file_list_cbs_t*)info_list->list[menu_index].actiondata;
                     if (cbs)

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -367,7 +367,7 @@ static bool input_autoconfigure_scan_config_files_internal(
  *      (not even the assignment to first free player port)
  */
 static void reallocate_port_if_needed(unsigned detected_port, int vendor_id,
-      int product_id, const char *device_name)
+      int product_id, const char *device_name, const char *device_display_name)
 {
    settings_t *settings = config_get_ptr();
 
@@ -429,7 +429,9 @@ static void reallocate_port_if_needed(unsigned detected_port, int vendor_id,
          {
             strlcpy(settings_value_device_name, settings_value, 
                     sizeof(settings_value_device_name));
-            device_has_reserved_slot = string_is_equal(device_name, settings_value_device_name);
+            device_has_reserved_slot = 
+               string_is_equal(device_name, settings_value_device_name) || 
+               string_is_equal(device_display_name, settings_value_device_name);
          }
          else
             device_has_reserved_slot = (vendor_id == settings_value_vendor_id &&
@@ -590,7 +592,9 @@ static void cb_input_autoconfigure_connect(
       input_config_set_autoconfig_binds(port,
             autoconfig_handle->autoconfig_file);
 
-   reallocate_port_if_needed(port,autoconfig_handle->device_info.vid, autoconfig_handle->device_info.pid,autoconfig_handle->device_info.name);
+   reallocate_port_if_needed(port,autoconfig_handle->device_info.vid, autoconfig_handle->device_info.pid,
+      autoconfig_handle->device_info.name,
+      autoconfig_handle->device_info.display_name);
 
 }
 

--- a/tests-other/testinput_device_reservation_test2.cfg
+++ b/tests-other/testinput_device_reservation_test2.cfg
@@ -2,7 +2,7 @@
 # Sets up joypad driver, test input file for the joypad driver,
 # logging and autoconfig dir, and prevents saving.
 # Usage:
-#   retroarch --appendconfig tests-other/testinput_device_reservation_test.cfg\|tests-other/all_binds_empty.cfg
+#   retroarch --appendconfig tests-other/testinput_device_reservation_test2.cfg\|tests-other/all_binds_empty.cfg
 
 # Test scenario:
 # - Player 1 through 4 has preferred device C


### PR DESCRIPTION
## Description

- add reserved device check against device display name as well
(this is especially useful if the autoconfig file has different display name than device name, because setting it from menu will put the display name as the reserved device)
- selected device name matching in menu with or without vid:pid
- cosmetical change in test input file

Tested with existing tests and some manual reservation.

## Related Pull Requests
#16647 
