### PR TITLE
apple: minor cleanup of Xcode project files

### DIFF
--- a/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_Metal.xcodeproj/project.pbxproj
@@ -181,39 +181,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		05132C6621A74D7A00379846 /* ozone_texture.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ozone_texture.c; sourceTree = "<group>"; };
-		05132C6721A74D7B00379846 /* ozone_theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ozone_theme.h; sourceTree = "<group>"; };
-		05132C6821A74D7B00379846 /* ozone.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ozone.h; sourceTree = "<group>"; };
-		05132C6921A74D7B00379846 /* ozone_entries.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ozone_entries.c; sourceTree = "<group>"; };
-		05132C6A21A74D7B00379846 /* ozone.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ozone.c; sourceTree = "<group>"; };
-		05132C6B21A74D7B00379846 /* ozone_theme.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ozone_theme.c; sourceTree = "<group>"; };
-		05132C6C21A74D7B00379846 /* ozone_sidebar.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ozone_sidebar.c; sourceTree = "<group>"; };
-		05132C6D21A74D7B00379846 /* ozone_sidebar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ozone_sidebar.h; sourceTree = "<group>"; };
-		05132C6E21A74D7B00379846 /* ozone_display.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ozone_display.c; sourceTree = "<group>"; };
-		05132C6F21A74D7B00379846 /* ozone_texture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ozone_texture.h; sourceTree = "<group>"; };
-		05132C7021A74D7B00379846 /* ozone_display.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ozone_display.h; sourceTree = "<group>"; };
 		05269A6120ABF20500C29F1E /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
-		05366512213F8BE5007E7EA0 /* thumbnailpackdownload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = thumbnailpackdownload.cpp; sourceTree = "<group>"; };
-		05366514213F8BE5007E7EA0 /* coreoptionsdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coreoptionsdialog.h; sourceTree = "<group>"; };
-		05366515213F8BE5007E7EA0 /* viewoptionsdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = viewoptionsdialog.h; sourceTree = "<group>"; };
-		05366516213F8BE5007E7EA0 /* filedropwidget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filedropwidget.h; sourceTree = "<group>"; };
-		05366517213F8BE5007E7EA0 /* ui_qt_load_core_window.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ui_qt_load_core_window.cpp; sourceTree = "<group>"; };
-		05366518213F8BE5007E7EA0 /* playlistentrydialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = playlistentrydialog.cpp; sourceTree = "<group>"; };
 		05366519213F8BE5007E7EA0 /* ui_qt_load_core_window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ui_qt_load_core_window.h; sourceTree = "<group>"; };
-		0536651A213F8BE5007E7EA0 /* shaderparamsdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shaderparamsdialog.cpp; sourceTree = "<group>"; };
-		0536651D213F8BE5007E7EA0 /* flowlayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flowlayout.h; sourceTree = "<group>"; };
-		0536651E213F8BE5007E7EA0 /* playlistthumbnaildownload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = playlistthumbnaildownload.cpp; sourceTree = "<group>"; };
-		0536651F213F8BE5007E7EA0 /* playlistentrydialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playlistentrydialog.h; sourceTree = "<group>"; };
-		05366520213F8BE5007E7EA0 /* coreinfodialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = coreinfodialog.cpp; sourceTree = "<group>"; };
-		05366521213F8BE5007E7EA0 /* filedropwidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = filedropwidget.cpp; sourceTree = "<group>"; };
-		05366522213F8BE5007E7EA0 /* thumbnaildownload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = thumbnaildownload.cpp; sourceTree = "<group>"; };
-		05366523213F8BE5007E7EA0 /* playlist.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = playlist.cpp; sourceTree = "<group>"; };
-		05366525213F8BE5007E7EA0 /* shaderparamsdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shaderparamsdialog.h; sourceTree = "<group>"; };
-		05366526213F8BE5007E7EA0 /* flowlayout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flowlayout.cpp; sourceTree = "<group>"; };
-		05366527213F8BE5007E7EA0 /* viewoptionsdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = viewoptionsdialog.cpp; sourceTree = "<group>"; };
-		05366528213F8BE5007E7EA0 /* coreoptionsdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = coreoptionsdialog.cpp; sourceTree = "<group>"; };
-		0536652B213F8BE5007E7EA0 /* coreinfodialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coreinfodialog.h; sourceTree = "<group>"; };
-		0536652C213F8BE5007E7EA0 /* updateretroarch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = updateretroarch.cpp; sourceTree = "<group>"; };
 		0538874D20DDD5C600769232 /* dxgi_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dxgi_common.c; sourceTree = "<group>"; };
 		0538874E20DDD5C600769232 /* dxgi_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dxgi_common.h; sourceTree = "<group>"; };
 		0538875120DE11D200769232 /* retro_common_api.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = retro_common_api.h; sourceTree = "<group>"; };
@@ -232,12 +201,10 @@
 		053FC25721433F1800D98D46 /* QtWidgets.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QtWidgets.framework; path = /usr/local/opt/qt/lib/QtWidgets.framework; sourceTree = "<group>"; };
 		05422E592140C8DB00F09961 /* RetroArch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RetroArch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		05422E5C2140CFC500F09961 /* Metal.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Metal.xcconfig; sourceTree = "<group>"; };
-		0548E2B320F976E10094A083 /* dynamic.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = dynamic.c; path = ../../dynamic.c; sourceTree = "<group>"; };
 		0548E2B420F976E10094A083 /* dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = dynamic.h; path = ../../dynamic.h; sourceTree = "<group>"; };
 		0548E2B520F976E20094A083 /* driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = driver.h; path = ../../driver.h; sourceTree = "<group>"; };
 		0548E2B620F977060094A083 /* playlist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = playlist.h; path = ../../playlist.h; sourceTree = "<group>"; };
 		0548E2B720F977060094A083 /* performance_counters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = performance_counters.h; path = ../../performance_counters.h; sourceTree = "<group>"; };
-		0548E2B820F977060094A083 /* performance_counters.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = performance_counters.c; path = ../../performance_counters.c; sourceTree = "<group>"; };
 		0548E2B920F977060094A083 /* playlist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = playlist.c; path = ../../playlist.c; sourceTree = "<group>"; };
 		055312AB20DE130A00C4D7F4 /* gl_capabilities.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gl_capabilities.c; sourceTree = "<group>"; };
 		055312AD20DE130A00C4D7F4 /* scaler_int.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scaler_int.c; sourceTree = "<group>"; };
@@ -260,7 +227,6 @@
 		05A8C51D20DB72F000FF7857 /* menu_cbs_get_value.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_get_value.c; sourceTree = "<group>"; };
 		05A8C51E20DB72F000FF7857 /* menu_cbs_sublabel.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_sublabel.c; sourceTree = "<group>"; };
 		05A8C51F20DB72F000FF7857 /* menu_cbs_cancel.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_cancel.c; sourceTree = "<group>"; };
-		05A8C52020DB72F000FF7857 /* menu_cbs_down.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_down.c; sourceTree = "<group>"; };
 		05A8C52120DB72F000FF7857 /* menu_cbs_scan.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_scan.c; sourceTree = "<group>"; };
 		05A8C52220DB72F000FF7857 /* menu_cbs_select.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_select.c; sourceTree = "<group>"; };
 		05A8C52320DB72F000FF7857 /* menu_cbs_ok.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_ok.c; sourceTree = "<group>"; };
@@ -268,69 +234,40 @@
 		05A8C52520DB72F000FF7857 /* menu_cbs_left.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_left.c; sourceTree = "<group>"; };
 		05A8C52620DB72F000FF7857 /* menu_cbs_right.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_right.c; sourceTree = "<group>"; };
 		05A8C52720DB72F000FF7857 /* menu_cbs_deferred_push.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_deferred_push.c; sourceTree = "<group>"; };
-		05A8C52820DB72F000FF7857 /* menu_cbs_refresh.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_refresh.c; sourceTree = "<group>"; };
 		05A8C52920DB72F000FF7857 /* menu_cbs_start.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_start.c; sourceTree = "<group>"; };
-		05A8C52A20DB72F000FF7857 /* menu_cbs_contentlist_switch.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_contentlist_switch.c; sourceTree = "<group>"; };
 		05A8C52B20DB72F000FF7857 /* menu_cbs_label.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_label.c; sourceTree = "<group>"; };
 		05A8C52C20DB72F000FF7857 /* menu_cbs_title.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_title.c; sourceTree = "<group>"; };
-		05A8C52D20DB72F000FF7857 /* menu_cbs_up.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_cbs_up.c; sourceTree = "<group>"; };
-		05A8C52E20DB72F000FF7857 /* gfx_animation.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gfx_animation.c; sourceTree = "<group>"; };
 		05A8C52F20DB72F000FF7857 /* menu_displaylist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_displaylist.h; sourceTree = "<group>"; };
 		05A8C53220DB72F000FF7857 /* xmb.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xmb.c; sourceTree = "<group>"; };
-		05A8C53B20DB72F000FF7857 /* xui.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = xui.cpp; sourceTree = "<group>"; };
 		05A8C53C20DB72F000FF7857 /* rgui.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rgui.c; sourceTree = "<group>"; };
-		05A8C53E20DB72F000FF7857 /* null.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = null.c; sourceTree = "<group>"; };
 		05A8C54020DB72F000FF7857 /* materialui.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = materialui.c; sourceTree = "<group>"; };
 		05A8C54320DB72F000FF7857 /* menu_driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_driver.h; sourceTree = "<group>"; };
 		05A8C54620DB72F000FF7857 /* menu_setting.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_setting.c; sourceTree = "<group>"; };
 		05A8C54920DB72F000FF7857 /* menu_displaylist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_displaylist.c; sourceTree = "<group>"; };
-		05A8C54B20DB72F000FF7857 /* gfx_animation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gfx_animation.h; sourceTree = "<group>"; };
 		05A8C54C20DB72F000FF7857 /* menu_cbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_cbs.h; sourceTree = "<group>"; };
 		05A8C54D20DB72F000FF7857 /* menu_driver.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = menu_driver.c; sourceTree = "<group>"; };
 		05A8C55020DB72F000FF7857 /* menu_input.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_input.h; sourceTree = "<group>"; };
 		05A8C55120DB72F000FF7857 /* menu_setting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_setting.h; sourceTree = "<group>"; };
-		05A8C55E20DB72F000FF7857 /* menu_osk_utf8_pages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_osk_utf8_pages.h; sourceTree = "<group>"; };
-		05A8C56120DB72F000FF7857 /* gfx_display_vulkan.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gfx_display_vulkan.c; sourceTree = "<group>"; };
-		05A8C56320DB72F000FF7857 /* gfx_display_gl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gfx_display_gl.c; sourceTree = "<group>"; };
-		05A8C56420DB72F000FF7857 /* gfx_display_d3d10.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gfx_display_d3d10.c; sourceTree = "<group>"; };
-		05A8C56F20DB72F000FF7857 /* gfx_display_metal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = gfx_display_metal.m; sourceTree = "<group>"; };
 		05A8C57020DB72F000FF7857 /* menu_entries.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = menu_entries.h; sourceTree = "<group>"; };
 		05A8C57220DB72F000FF7857 /* msg_hash_pl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_pl.h; sourceTree = "<group>"; };
-		05A8C57320DB72F000FF7857 /* msg_hash_pt_br.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_pt_br.c; sourceTree = "<group>"; };
 		05A8C57420DB72F000FF7857 /* msg_hash_it.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_it.h; sourceTree = "<group>"; };
 		05A8C57520DB72F000FF7857 /* msg_hash_ar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_ar.h; sourceTree = "<group>"; };
-		05A8C57620DB72F000FF7857 /* msg_hash_ja.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_ja.c; sourceTree = "<group>"; };
 		05A8C57720DB72F000FF7857 /* msg_hash_lbl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_lbl.h; sourceTree = "<group>"; };
 		05A8C57820DB72F000FF7857 /* msg_hash_ru.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_ru.h; sourceTree = "<group>"; };
-		05A8C57920DB72F000FF7857 /* msg_hash_cht.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_cht.c; sourceTree = "<group>"; };
-		05A8C57A20DB72F000FF7857 /* msg_hash_ko.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_ko.c; sourceTree = "<group>"; };
 		05A8C57B20DB72F000FF7857 /* msg_hash_pt_pt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_pt_pt.h; sourceTree = "<group>"; };
 		05A8C57C20DB72F000FF7857 /* msg_hash_vn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_vn.h; sourceTree = "<group>"; };
-		05A8C57D20DB72F000FF7857 /* msg_hash_nl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_nl.c; sourceTree = "<group>"; };
 		05A8C57E20DB72F000FF7857 /* msg_hash_us.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_us.h; sourceTree = "<group>"; };
-		05A8C57F20DB72F000FF7857 /* msg_hash_es.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_es.c; sourceTree = "<group>"; };
-		05A8C58020DB72F000FF7857 /* msg_hash_de.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_de.c; sourceTree = "<group>"; };
-		05A8C58120DB72F000FF7857 /* msg_hash_eo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_eo.c; sourceTree = "<group>"; };
-		05A8C58220DB72F000FF7857 /* msg_hash_chs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_chs.c; sourceTree = "<group>"; };
-		05A8C58320DB72F000FF7857 /* msg_hash_fr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_fr.c; sourceTree = "<group>"; };
-		05A8C58420DB72F000FF7857 /* msg_hash_it.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_it.c; sourceTree = "<group>"; };
-		05A8C58520DB72F000FF7857 /* msg_hash_ar.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_ar.c; sourceTree = "<group>"; };
 		05A8C58620DB72F000FF7857 /* msg_hash_ja.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_ja.h; sourceTree = "<group>"; };
 		05A8C58720DB72F000FF7857 /* msg_hash_pt_br.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_pt_br.h; sourceTree = "<group>"; };
-		05A8C58820DB72F000FF7857 /* msg_hash_pl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_pl.c; sourceTree = "<group>"; };
 		05A8C58920DB72F000FF7857 /* msg_hash_cht.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_cht.h; sourceTree = "<group>"; };
-		05A8C58A20DB72F000FF7857 /* msg_hash_ru.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_ru.c; sourceTree = "<group>"; };
 		05A8C58B20DB72F000FF7857 /* msg_hash_ko.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_ko.h; sourceTree = "<group>"; };
 		05A8C58C20DB72F000FF7857 /* msg_hash_es.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_es.h; sourceTree = "<group>"; };
 		05A8C58D20DB72F000FF7857 /* msg_hash_us.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_us.c; sourceTree = "<group>"; };
 		05A8C58E20DB72F000FF7857 /* msg_hash_de.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_de.h; sourceTree = "<group>"; };
 		05A8C58F20DB72F000FF7857 /* msg_hash_nl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_nl.h; sourceTree = "<group>"; };
-		05A8C59020DB72F000FF7857 /* msg_hash_pt_pt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_pt_pt.c; sourceTree = "<group>"; };
-		05A8C59120DB72F000FF7857 /* msg_hash_vn.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = msg_hash_vn.c; sourceTree = "<group>"; };
 		05A8C59220DB72F000FF7857 /* msg_hash_fr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_fr.h; sourceTree = "<group>"; };
 		05A8C59320DB72F000FF7857 /* msg_hash_eo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_eo.h; sourceTree = "<group>"; };
 		05A8C59420DB72F000FF7857 /* msg_hash_chs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = msg_hash_chs.h; sourceTree = "<group>"; };
-		05A8C59620DB72F000FF7857 /* frontend.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = frontend.c; sourceTree = "<group>"; };
 		05A8C59B20DB72F000FF7857 /* platform_darwin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = platform_darwin.m; sourceTree = "<group>"; };
 		05A8C5A920DB72F000FF7857 /* frontend_driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = frontend_driver.h; sourceTree = "<group>"; };
 		05A8C5AA20DB72F000FF7857 /* frontend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = frontend.h; sourceTree = "<group>"; };
@@ -339,11 +276,7 @@
 		05A8C5AF20DB72F000FF7857 /* ui_win32.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ui_win32.c; sourceTree = "<group>"; };
 		05A8C5B820DB72F000FF7857 /* ui_win32_resource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ui_win32_resource.h; sourceTree = "<group>"; };
 		05A8C5BA20DB72F000FF7857 /* ui_cocoa.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa.m; sourceTree = "<group>"; };
-		05A8C5BC20DB72F000FF7857 /* ui_cocoa_msg_window.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_msg_window.m; sourceTree = "<group>"; };
 		05A8C5BD20DB72F000FF7857 /* cocoa_common.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = cocoa_common.m; sourceTree = "<group>"; };
-		05A8C5BF20DB72F000FF7857 /* ui_cocoa_browser_window.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_browser_window.m; sourceTree = "<group>"; };
-		05A8C5C020DB72F000FF7857 /* ui_cocoa_window.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_window.m; sourceTree = "<group>"; };
-		05A8C5C120DB72F000FF7857 /* ui_cocoa_application.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_application.m; sourceTree = "<group>"; };
 		05A8C5C220DB72F000FF7857 /* cocoa_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cocoa_common.h; sourceTree = "<group>"; };
 		05A8C5C820DB72F000FF7857 /* ui_qt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ui_qt.h; sourceTree = "<group>"; };
 		05A8C5CE20DB72F000FF7857 /* ui_cocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ui_cocoa.h; sourceTree = "<group>"; };
@@ -352,9 +285,7 @@
 		05A8C5D120DB72F000FF7857 /* ui_win32.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ui_win32.h; sourceTree = "<group>"; };
 		05A8C5D220DB72F000FF7857 /* ui_companion_driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ui_companion_driver.h; sourceTree = "<group>"; };
 		05A8C5D320DB72F000FF7857 /* ui_companion_driver.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ui_companion_driver.c; sourceTree = "<group>"; };
-		05A8C5D520DB72F000FF7857 /* video_display_server.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = video_display_server.c; sourceTree = "<group>"; };
 		05A8C5E720DB72F000FF7857 /* cocoa_gl_ctx.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = cocoa_gl_ctx.m; sourceTree = "<group>"; };
-		05A8C5F020DB72F000FF7857 /* gl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gl.c; sourceTree = "<group>"; };
 		05A8C5F720DB72F000FF7857 /* metal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = metal.m; sourceTree = "<group>"; };
 		05A8C5FF20DB72F000FF7857 /* vulkan.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vulkan.c; sourceTree = "<group>"; };
 		05A8C60120DB72F000FF7857 /* pipeline_xmb_ribbon.glsl.frag.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pipeline_xmb_ribbon.glsl.frag.h; sourceTree = "<group>"; };
@@ -371,7 +302,6 @@
 		05A8C60C20DB72F000FF7857 /* opaque.cg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opaque.cg.h; sourceTree = "<group>"; };
 		05A8C60F20DB72F000FF7857 /* modern_opaque.glsl.vert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = modern_opaque.glsl.vert.h; sourceTree = "<group>"; };
 		05A8C61020DB72F000FF7857 /* modern_opaque.glsl.frag.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = modern_opaque.glsl.frag.h; sourceTree = "<group>"; };
-		05A8C61220DB72F000FF7857 /* modern_pipeline_snow.glsl.vert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = modern_pipeline_snow.glsl.vert.h; sourceTree = "<group>"; };
 		05A8C61320DB72F000FF7857 /* pipeline_snowflake.glsl.frag.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pipeline_snowflake.glsl.frag.h; sourceTree = "<group>"; };
 		05A8C61420DB72F000FF7857 /* modern_pipeline_xmb_ribbon.glsl.vert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = modern_pipeline_xmb_ribbon.glsl.vert.h; sourceTree = "<group>"; };
 		05A8C61520DB72F000FF7857 /* core_opaque.glsl.vert.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = core_opaque.glsl.vert.h; sourceTree = "<group>"; };
@@ -439,17 +369,11 @@
 		05A8C75420DB72F100FF7857 /* metal_renderer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = metal_renderer.m; sourceTree = "<group>"; };
 		05A8C75D20DB72F100FF7857 /* gl_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gl_common.c; sourceTree = "<group>"; };
 		05A8C75E20DB72F100FF7857 /* d3d_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = d3d_common.c; sourceTree = "<group>"; };
-		05A8C76320DB72F100FF7857 /* d3d10_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = d3d10_common.h; sourceTree = "<group>"; };
 		05A8C76820DB72F100FF7857 /* vulkan_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = vulkan_common.h; sourceTree = "<group>"; };
 		05A8C76F20DB72F100FF7857 /* gl_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gl_common.h; sourceTree = "<group>"; };
 		05A8C77020DB72F100FF7857 /* d3d_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = d3d_common.h; sourceTree = "<group>"; };
 		05A8C77720DB72F100FF7857 /* d3d10_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = d3d10_common.c; sourceTree = "<group>"; };
 		05A8C77A20DB72F100FF7857 /* video_display_server.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = video_display_server.h; sourceTree = "<group>"; };
-		05A8C77D20DB72F100FF7857 /* vga_font.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vga_font.c; sourceTree = "<group>"; };
-		05A8C78120DB72F100FF7857 /* d3d10_font.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = d3d10_font.c; sourceTree = "<group>"; };
-		05A8C78320DB72F100FF7857 /* metal_raster_font.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = metal_raster_font.m; sourceTree = "<group>"; };
-		05A8C78820DB72F100FF7857 /* gl_raster_font.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = gl_raster_font.c; sourceTree = "<group>"; };
-		05A8C78920DB72F100FF7857 /* vulkan_raster_font.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = vulkan_raster_font.c; sourceTree = "<group>"; };
 		05A8C78D20DB72F100FF7857 /* video_filter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = video_filter.c; sourceTree = "<group>"; };
 		05A8C79020DB72F100FF7857 /* glslang_util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = glslang_util.h; sourceTree = "<group>"; };
 		05A8C79120DB72F100FF7857 /* shader_glsl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = shader_glsl.c; sourceTree = "<group>"; };
@@ -484,7 +408,6 @@
 		05B5F91120ED6AAE009C521F /* retroarch.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = retroarch.c; path = ../../retroarch.c; sourceTree = "<group>"; };
 		05B5F91220ED6AAF009C521F /* retroarch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = retroarch.h; path = ../../retroarch.h; sourceTree = "<group>"; };
 		05BF821420ED69D100D95B19 /* config.def.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.def.h; path = ../../config.def.h; sourceTree = "<group>"; };
-		05BF821520ED69D100D95B19 /* core_impl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = core_impl.c; path = ../../core_impl.c; sourceTree = "<group>"; };
 		05BF821620ED69D100D95B19 /* config.features.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.features.h; path = ../../config.features.h; sourceTree = "<group>"; };
 		05BF821720ED69D100D95B19 /* command.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = command.h; path = ../../command.h; sourceTree = "<group>"; };
 		05BF821820ED69D100D95B19 /* core_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = core_info.c; path = ../../core_info.c; sourceTree = "<group>"; };
@@ -512,7 +435,6 @@
 		05C5D55F20E3DD0900654EE4 /* hid_driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hid_driver.h; sourceTree = "<group>"; };
 		05C5D56020E3DD0900654EE4 /* gamepad.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = gamepad.h; sourceTree = "<group>"; };
 		05C5D56120E3DD0900654EE4 /* input_driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input_driver.h; sourceTree = "<group>"; };
-		05C5D56320E3DD0900654EE4 /* keyboard_event_apple.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = keyboard_event_apple.c; sourceTree = "<group>"; };
 		05C5D56620E3DD0900654EE4 /* keyboard_event_apple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = keyboard_event_apple.h; sourceTree = "<group>"; };
 		05C5D56A20E3DD0900654EE4 /* input_remapping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input_remapping.h; sourceTree = "<group>"; };
 		05C5D56C20E3DD0900654EE4 /* input_overlay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input_overlay.h; sourceTree = "<group>"; };
@@ -522,12 +444,6 @@
 		05C5D57620E3DD0900654EE4 /* input_hid_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = input_hid_common.c; sourceTree = "<group>"; };
 		05C5D57720E3DD0900654EE4 /* input_x11_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = input_x11_common.c; sourceTree = "<group>"; };
 		05C5D57820E3DD0900654EE4 /* linux_common.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = linux_common.c; sourceTree = "<group>"; };
-		05C5D57A20E3DD0900654EE4 /* hid_device_driver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = hid_device_driver.h; sourceTree = "<group>"; };
-		05C5D57B20E3DD0900654EE4 /* device_ds3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = device_ds3.c; sourceTree = "<group>"; };
-		05C5D57C20E3DD0900654EE4 /* device_ds4.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = device_ds4.c; sourceTree = "<group>"; };
-		05C5D57D20E3DD0900654EE4 /* hid_device_driver.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = hid_device_driver.c; sourceTree = "<group>"; };
-		05C5D57E20E3DD0900654EE4 /* device_wiiu_gca.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = device_wiiu_gca.c; sourceTree = "<group>"; };
-		05C5D57F20E3DD0900654EE4 /* device_null.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = device_null.c; sourceTree = "<group>"; };
 		05C5D58020E3DD0900654EE4 /* linux_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = linux_common.h; sourceTree = "<group>"; };
 		05C5D58120E3DD0900654EE4 /* input_x11_common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = input_x11_common.h; sourceTree = "<group>"; };
 		05C5D58220E3DD0900654EE4 /* input_autodetect_builtin.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = input_autodetect_builtin.c; sourceTree = "<group>"; };
@@ -539,7 +455,6 @@
 		05D7753120A55D2700646447 /* BaseConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BaseConfig.xcconfig; sourceTree = "<group>"; };
 		05D7753320A5678300646447 /* griffin_cpp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = griffin_cpp.cpp; path = ../../griffin/griffin_cpp.cpp; sourceTree = "<group>"; };
 		05D7753420A5678400646447 /* griffin_glslang.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = griffin_glslang.cpp; path = ../../griffin/griffin_glslang.cpp; sourceTree = "<group>"; };
-		05EFAFC22191D64200D27059 /* stripes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = stripes.c; sourceTree = "<group>"; };
 		05F2872F20F2BEEA00632D47 /* task_autodetect.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = task_autodetect.c; sourceTree = "<group>"; };
 		05F2873020F2BEEA00632D47 /* task_netplay_find_content.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = task_netplay_find_content.c; sourceTree = "<group>"; };
 		05F2873120F2BEEA00632D47 /* task_netplay_nat_traversal.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = task_netplay_nat_traversal.c; sourceTree = "<group>"; };
@@ -592,14 +507,6 @@
 		A90205FD4D5979BD8B7E4DD6 /* Info_Metal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.info; name = Info_Metal.plist; path = OSX/Info_Metal.plist; sourceTree = "<group>"; };
 		A902065A41AEBECE594908C7 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = OSX/en.lproj/MainMenu_Metal.xib; sourceTree = "<group>"; };
 		A90207489289602F593626D5 /* QTConfig.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = QTConfig.xcconfig; sourceTree = "<group>"; };
-		A90208A05A895029CEC32C14 /* ui_cocoa_msg_window_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_msg_window_metal.m; sourceTree = "<group>"; };
-		A9020AF14B9A73364C6CDDA5 /* cocoa_common_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cocoa_common_metal.m; sourceTree = "<group>"; };
-		A9020BD6594399DDAB0E2563 /* ui_cocoatouch_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ui_cocoatouch_metal.m; sourceTree = "<group>"; };
-		A9020C55D864F0E0C6E7DFF9 /* ui_cocoa_window_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_window_metal.m; sourceTree = "<group>"; };
-		A9020EE4BE2C6A15024A32E0 /* ui_cocoa_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_metal.m; sourceTree = "<group>"; };
-		A9020F2EEF870903107B0EA7 /* ui_cocoa_application_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_application_metal.m; sourceTree = "<group>"; };
-		A9020F48BA562B13D4789292 /* ui_cocoa_browser_window_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ui_cocoa_browser_window_metal.m; sourceTree = "<group>"; };
-		A9020FA64527ED74C836B41D /* cocoa_gl_ctx_metal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cocoa_gl_ctx_metal.m; sourceTree = "<group>"; };
 		D27C50872228360000113BC0 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		D27C50892228360D00113BC0 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		E8EE1E942A2C6A26003C73F6 /* cocoa_input.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = cocoa_input.m; sourceTree = "<group>"; };
@@ -708,48 +615,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		05132C6521A74D5100379846 /* ozone */ = {
-			isa = PBXGroup;
-			children = (
-				05132C6E21A74D7B00379846 /* ozone_display.c */,
-				05132C7021A74D7B00379846 /* ozone_display.h */,
-				05132C6921A74D7B00379846 /* ozone_entries.c */,
-				05132C6C21A74D7B00379846 /* ozone_sidebar.c */,
-				05132C6D21A74D7B00379846 /* ozone_sidebar.h */,
-				05132C6621A74D7A00379846 /* ozone_texture.c */,
-				05132C6F21A74D7B00379846 /* ozone_texture.h */,
-				05132C6B21A74D7B00379846 /* ozone_theme.c */,
-				05132C6721A74D7B00379846 /* ozone_theme.h */,
-				05132C6A21A74D7B00379846 /* ozone.c */,
-				05132C6821A74D7B00379846 /* ozone.h */,
-			);
-			path = ozone;
-			sourceTree = "<group>";
-		};
 		05366511213F8BE5007E7EA0 /* qt */ = {
 			isa = PBXGroup;
 			children = (
-				05366520213F8BE5007E7EA0 /* coreinfodialog.cpp */,
-				0536652B213F8BE5007E7EA0 /* coreinfodialog.h */,
-				05366528213F8BE5007E7EA0 /* coreoptionsdialog.cpp */,
-				05366514213F8BE5007E7EA0 /* coreoptionsdialog.h */,
-				05366521213F8BE5007E7EA0 /* filedropwidget.cpp */,
-				05366516213F8BE5007E7EA0 /* filedropwidget.h */,
-				05366526213F8BE5007E7EA0 /* flowlayout.cpp */,
-				0536651D213F8BE5007E7EA0 /* flowlayout.h */,
-				05366523213F8BE5007E7EA0 /* playlist.cpp */,
-				05366518213F8BE5007E7EA0 /* playlistentrydialog.cpp */,
-				0536651F213F8BE5007E7EA0 /* playlistentrydialog.h */,
-				0536651E213F8BE5007E7EA0 /* playlistthumbnaildownload.cpp */,
-				0536651A213F8BE5007E7EA0 /* shaderparamsdialog.cpp */,
-				05366525213F8BE5007E7EA0 /* shaderparamsdialog.h */,
-				05366522213F8BE5007E7EA0 /* thumbnaildownload.cpp */,
-				05366512213F8BE5007E7EA0 /* thumbnailpackdownload.cpp */,
-				05366517213F8BE5007E7EA0 /* ui_qt_load_core_window.cpp */,
 				05366519213F8BE5007E7EA0 /* ui_qt_load_core_window.h */,
-				0536652C213F8BE5007E7EA0 /* updateretroarch.cpp */,
-				05366527213F8BE5007E7EA0 /* viewoptionsdialog.cpp */,
-				05366515213F8BE5007E7EA0 /* viewoptionsdialog.h */,
 			);
 			path = qt;
 			sourceTree = "<group>";
@@ -856,9 +725,6 @@
 			children = (
 				05A8C51C20DB72F000FF7857 /* cbs */,
 				05A8C53120DB72F000FF7857 /* drivers */,
-				05A8C56020DB72F000FF7857 /* drivers_display */,
-				05A8C52E20DB72F000FF7857 /* gfx_animation.c */,
-				05A8C54B20DB72F000FF7857 /* gfx_animation.h */,
 				05A8C54C20DB72F000FF7857 /* menu_cbs.h */,
 				05A8C54920DB72F000FF7857 /* menu_displaylist.c */,
 				05A8C52F20DB72F000FF7857 /* menu_displaylist.h */,
@@ -869,7 +735,6 @@
 				05A8C54620DB72F000FF7857 /* menu_setting.c */,
 				05A8C55120DB72F000FF7857 /* menu_setting.h */,
 				05A8C51B20DB72F000FF7857 /* menu_shader.h */,
-				05A8C55220DB72F000FF7857 /* widgets */,
 			);
 			name = menu;
 			path = ../../menu;
@@ -881,7 +746,6 @@
 				05A8C51D20DB72F000FF7857 /* menu_cbs_get_value.c */,
 				05A8C51E20DB72F000FF7857 /* menu_cbs_sublabel.c */,
 				05A8C51F20DB72F000FF7857 /* menu_cbs_cancel.c */,
-				05A8C52020DB72F000FF7857 /* menu_cbs_down.c */,
 				05A8C52120DB72F000FF7857 /* menu_cbs_scan.c */,
 				05A8C52220DB72F000FF7857 /* menu_cbs_select.c */,
 				05A8C52320DB72F000FF7857 /* menu_cbs_ok.c */,
@@ -889,12 +753,9 @@
 				05A8C52520DB72F000FF7857 /* menu_cbs_left.c */,
 				05A8C52620DB72F000FF7857 /* menu_cbs_right.c */,
 				05A8C52720DB72F000FF7857 /* menu_cbs_deferred_push.c */,
-				05A8C52820DB72F000FF7857 /* menu_cbs_refresh.c */,
 				05A8C52920DB72F000FF7857 /* menu_cbs_start.c */,
-				05A8C52A20DB72F000FF7857 /* menu_cbs_contentlist_switch.c */,
 				05A8C52B20DB72F000FF7857 /* menu_cbs_label.c */,
 				05A8C52C20DB72F000FF7857 /* menu_cbs_title.c */,
-				05A8C52D20DB72F000FF7857 /* menu_cbs_up.c */,
 			);
 			path = cbs;
 			sourceTree = "<group>";
@@ -902,73 +763,34 @@
 		05A8C53120DB72F000FF7857 /* drivers */ = {
 			isa = PBXGroup;
 			children = (
-				05132C6521A74D5100379846 /* ozone */,
 				05A8C54020DB72F000FF7857 /* materialui.c */,
-				05A8C53E20DB72F000FF7857 /* null.c */,
 				05A8C53C20DB72F000FF7857 /* rgui.c */,
-				05EFAFC22191D64200D27059 /* stripes.c */,
 				05A8C53220DB72F000FF7857 /* xmb.c */,
-				05A8C53B20DB72F000FF7857 /* xui.cpp */,
 			);
 			path = drivers;
-			sourceTree = "<group>";
-		};
-		05A8C55220DB72F000FF7857 /* widgets */ = {
-			isa = PBXGroup;
-			children = (
-				05A8C55E20DB72F000FF7857 /* menu_osk_utf8_pages.h */,
-			);
-			path = widgets;
-			sourceTree = "<group>";
-		};
-		05A8C56020DB72F000FF7857 /* drivers_display */ = {
-			isa = PBXGroup;
-			children = (
-				05A8C56420DB72F000FF7857 /* gfx_display_d3d10.c */,
-				05A8C56320DB72F000FF7857 /* gfx_display_gl.c */,
-				05A8C56F20DB72F000FF7857 /* gfx_display_metal.m */,
-				05A8C56120DB72F000FF7857 /* gfx_display_vulkan.c */,
-			);
-			path = drivers_display;
 			sourceTree = "<group>";
 		};
 		05A8C57120DB72F000FF7857 /* intl */ = {
 			isa = PBXGroup;
 			children = (
-				05A8C58520DB72F000FF7857 /* msg_hash_ar.c */,
 				05A8C57520DB72F000FF7857 /* msg_hash_ar.h */,
-				05A8C58220DB72F000FF7857 /* msg_hash_chs.c */,
 				05A8C59420DB72F000FF7857 /* msg_hash_chs.h */,
-				05A8C57920DB72F000FF7857 /* msg_hash_cht.c */,
 				05A8C58920DB72F000FF7857 /* msg_hash_cht.h */,
-				05A8C58020DB72F000FF7857 /* msg_hash_de.c */,
 				05A8C58E20DB72F000FF7857 /* msg_hash_de.h */,
-				05A8C58120DB72F000FF7857 /* msg_hash_eo.c */,
 				05A8C59320DB72F000FF7857 /* msg_hash_eo.h */,
-				05A8C57F20DB72F000FF7857 /* msg_hash_es.c */,
 				05A8C58C20DB72F000FF7857 /* msg_hash_es.h */,
-				05A8C58320DB72F000FF7857 /* msg_hash_fr.c */,
 				05A8C59220DB72F000FF7857 /* msg_hash_fr.h */,
-				05A8C58420DB72F000FF7857 /* msg_hash_it.c */,
 				05A8C57420DB72F000FF7857 /* msg_hash_it.h */,
-				05A8C57620DB72F000FF7857 /* msg_hash_ja.c */,
 				05A8C58620DB72F000FF7857 /* msg_hash_ja.h */,
-				05A8C57A20DB72F000FF7857 /* msg_hash_ko.c */,
 				05A8C58B20DB72F000FF7857 /* msg_hash_ko.h */,
 				05A8C57720DB72F000FF7857 /* msg_hash_lbl.h */,
-				05A8C57D20DB72F000FF7857 /* msg_hash_nl.c */,
 				05A8C58F20DB72F000FF7857 /* msg_hash_nl.h */,
-				05A8C58820DB72F000FF7857 /* msg_hash_pl.c */,
 				05A8C57220DB72F000FF7857 /* msg_hash_pl.h */,
-				05A8C57320DB72F000FF7857 /* msg_hash_pt_br.c */,
 				05A8C58720DB72F000FF7857 /* msg_hash_pt_br.h */,
-				05A8C59020DB72F000FF7857 /* msg_hash_pt_pt.c */,
 				05A8C57B20DB72F000FF7857 /* msg_hash_pt_pt.h */,
-				05A8C58A20DB72F000FF7857 /* msg_hash_ru.c */,
 				05A8C57820DB72F000FF7857 /* msg_hash_ru.h */,
 				05A8C58D20DB72F000FF7857 /* msg_hash_us.c */,
 				05A8C57E20DB72F000FF7857 /* msg_hash_us.h */,
-				05A8C59120DB72F000FF7857 /* msg_hash_vn.c */,
 				05A8C57C20DB72F000FF7857 /* msg_hash_vn.h */,
 			);
 			name = intl;
@@ -979,7 +801,6 @@
 			isa = PBXGroup;
 			children = (
 				05A8C59720DB72F000FF7857 /* drivers */,
-				05A8C59620DB72F000FF7857 /* frontend.c */,
 				05A8C5A920DB72F000FF7857 /* frontend_driver.h */,
 				05A8C5AA20DB72F000FF7857 /* frontend.h */,
 				05A8C5AB20DB72F000FF7857 /* frontend_driver.c */,
@@ -1015,8 +836,6 @@
 				05366511213F8BE5007E7EA0 /* qt */,
 				05A8C5CE20DB72F000FF7857 /* ui_cocoa.h */,
 				05A8C5BA20DB72F000FF7857 /* ui_cocoa.m */,
-				A9020EE4BE2C6A15024A32E0 /* ui_cocoa_metal.m */,
-				A9020BD6594399DDAB0E2563 /* ui_cocoatouch_metal.m */,
 				05A8C5CF20DB72F000FF7857 /* ui_cocoatouch.m */,
 				05A8C5D020DB72F000FF7857 /* ui_qt.cpp */,
 				05A8C5C820DB72F000FF7857 /* ui_qt.h */,
@@ -1030,17 +849,8 @@
 		05A8C5BB20DB72F000FF7857 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
-				A9020AF14B9A73364C6CDDA5 /* cocoa_common_metal.m */,
 				05A8C5C220DB72F000FF7857 /* cocoa_common.h */,
 				05A8C5BD20DB72F000FF7857 /* cocoa_common.m */,
-				A9020F2EEF870903107B0EA7 /* ui_cocoa_application_metal.m */,
-				05A8C5C120DB72F000FF7857 /* ui_cocoa_application.m */,
-				A9020F48BA562B13D4789292 /* ui_cocoa_browser_window_metal.m */,
-				05A8C5BF20DB72F000FF7857 /* ui_cocoa_browser_window.m */,
-				A90208A05A895029CEC32C14 /* ui_cocoa_msg_window_metal.m */,
-				05A8C5BC20DB72F000FF7857 /* ui_cocoa_msg_window.m */,
-				A9020C55D864F0E0C6E7DFF9 /* ui_cocoa_window_metal.m */,
-				05A8C5C020DB72F000FF7857 /* ui_cocoa_window.m */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";
@@ -1051,7 +861,6 @@
 				05A8C73A20DB72F100FF7857 /* common */,
 				05A8C5EC20DB72F000FF7857 /* drivers */,
 				05A8C5D620DB72F000FF7857 /* drivers_context */,
-				05A8C77C20DB72F100FF7857 /* drivers_font */,
 				05A8C7AA20DB72F100FF7857 /* drivers_font_renderer */,
 				05A8C78E20DB72F100FF7857 /* drivers_shader */,
 				05A8C73920DB72F100FF7857 /* font_driver.c */,
@@ -1059,7 +868,6 @@
 				05A8C67720DB72F000FF7857 /* video_crt_switch.c */,
 				05A8C79D20DB72F100FF7857 /* video_crt_switch.h */,
 				05A8C7A820DB72F100FF7857 /* video_defines.h */,
-				05A8C5D520DB72F000FF7857 /* video_display_server.c */,
 				05A8C77A20DB72F100FF7857 /* video_display_server.h */,
 				05A8C67620DB72F000FF7857 /* video_driver.c */,
 				05A8C79F20DB72F100FF7857 /* video_driver.h */,
@@ -1078,7 +886,6 @@
 			isa = PBXGroup;
 			children = (
 				05A8C5E720DB72F000FF7857 /* cocoa_gl_ctx.m */,
-				A9020FA64527ED74C836B41D /* cocoa_gl_ctx_metal.m */,
 			);
 			path = drivers_context;
 			sourceTree = "<group>";
@@ -1090,7 +897,6 @@
 				05A8C60020DB72F000FF7857 /* gl_shaders */,
 				05A8C62220DB72F000FF7857 /* vulkan_shaders */,
 				05A8C63E20DB72F000FF7857 /* d3d10.c */,
-				05A8C5F020DB72F000FF7857 /* gl.c */,
 				05A8C5F720DB72F000FF7857 /* metal.m */,
 				05A8C5FF20DB72F000FF7857 /* vulkan.c */,
 			);
@@ -1114,7 +920,6 @@
 				05A8C60C20DB72F000FF7857 /* opaque.cg.h */,
 				05A8C60F20DB72F000FF7857 /* modern_opaque.glsl.vert.h */,
 				05A8C61020DB72F000FF7857 /* modern_opaque.glsl.frag.h */,
-				05A8C61220DB72F000FF7857 /* modern_pipeline_snow.glsl.vert.h */,
 				05A8C61320DB72F000FF7857 /* pipeline_snowflake.glsl.frag.h */,
 				05A8C61420DB72F000FF7857 /* modern_pipeline_xmb_ribbon.glsl.vert.h */,
 				05A8C61520DB72F000FF7857 /* core_opaque.glsl.vert.h */,
@@ -1192,7 +997,6 @@
 				05A8C75E20DB72F100FF7857 /* d3d_common.c */,
 				05A8C77020DB72F100FF7857 /* d3d_common.h */,
 				05A8C77720DB72F100FF7857 /* d3d10_common.c */,
-				05A8C76320DB72F100FF7857 /* d3d10_common.h */,
 				0538874D20DDD5C600769232 /* dxgi_common.c */,
 				0538874E20DDD5C600769232 /* dxgi_common.h */,
 				05A8C75D20DB72F100FF7857 /* gl_common.c */,
@@ -1214,18 +1018,6 @@
 				05A8C75120DB72F100FF7857 /* metal_shader_types.h */,
 			);
 			path = metal;
-			sourceTree = "<group>";
-		};
-		05A8C77C20DB72F100FF7857 /* drivers_font */ = {
-			isa = PBXGroup;
-			children = (
-				05A8C78120DB72F100FF7857 /* d3d10_font.c */,
-				05A8C78820DB72F100FF7857 /* gl_raster_font.c */,
-				05A8C78320DB72F100FF7857 /* metal_raster_font.m */,
-				05A8C77D20DB72F100FF7857 /* vga_font.c */,
-				05A8C78920DB72F100FF7857 /* vulkan_raster_font.c */,
-			);
-			path = drivers_font;
 			sourceTree = "<group>";
 		};
 		05A8C78E20DB72F100FF7857 /* drivers_shader */ = {
@@ -1272,14 +1064,11 @@
 				05BF821A20ED69D100D95B19 /* configuration.c */,
 				05BF821D20ED69D100D95B19 /* configuration.h */,
 				05B5F90D20ED6A03009C521F /* content.h */,
-				05BF821520ED69D100D95B19 /* core_impl.c */,
 				05BF821820ED69D100D95B19 /* core_info.c */,
 				05BF821B20ED69D100D95B19 /* core_info.h */,
 				05BF821920ED69D100D95B19 /* core.h */,
 				0548E2B520F976E20094A083 /* driver.h */,
-				0548E2B320F976E10094A083 /* dynamic.c */,
 				0548E2B420F976E10094A083 /* dynamic.h */,
-				0548E2B820F977060094A083 /* performance_counters.c */,
 				0548E2B720F977060094A083 /* performance_counters.h */,
 				0548E2B920F977060094A083 /* playlist.c */,
 				0548E2B620F977060094A083 /* playlist.h */,
@@ -1355,7 +1144,6 @@
 		05C5D56220E3DD0900654EE4 /* drivers_keyboard */ = {
 			isa = PBXGroup;
 			children = (
-				05C5D56320E3DD0900654EE4 /* keyboard_event_apple.c */,
 				05C5D56620E3DD0900654EE4 /* keyboard_event_apple.h */,
 			);
 			path = drivers_keyboard;
@@ -1373,7 +1161,6 @@
 		05C5D57520E3DD0900654EE4 /* common */ = {
 			isa = PBXGroup;
 			children = (
-				05C5D57920E3DD0900654EE4 /* hid */,
 				05C5D57620E3DD0900654EE4 /* input_hid_common.c */,
 				05C5D57720E3DD0900654EE4 /* input_x11_common.c */,
 				05C5D58120E3DD0900654EE4 /* input_x11_common.h */,
@@ -1381,19 +1168,6 @@
 				05C5D58020E3DD0900654EE4 /* linux_common.h */,
 			);
 			path = common;
-			sourceTree = "<group>";
-		};
-		05C5D57920E3DD0900654EE4 /* hid */ = {
-			isa = PBXGroup;
-			children = (
-				05C5D57B20E3DD0900654EE4 /* device_ds3.c */,
-				05C5D57C20E3DD0900654EE4 /* device_ds4.c */,
-				05C5D57F20E3DD0900654EE4 /* device_null.c */,
-				05C5D57E20E3DD0900654EE4 /* device_wiiu_gca.c */,
-				05C5D57D20E3DD0900654EE4 /* hid_device_driver.c */,
-				05C5D57A20E3DD0900654EE4 /* hid_device_driver.h */,
-			);
-			path = hid;
 			sourceTree = "<group>";
 		};
 		05C5D58420E3DD0900654EE4 /* drivers_joypad */ = {

--- a/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
@@ -378,7 +378,6 @@
 		92B9EC9824E0537500E6CFB2 /* config.def.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.def.h; path = ../../config.def.h; sourceTree = "<group>"; };
 		92B9EC9924E0537500E6CFB2 /* config.features.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = config.features.h; path = ../../config.features.h; sourceTree = "<group>"; };
 		92B9EC9A24E0537500E6CFB2 /* content.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = content.h; path = ../../content.h; sourceTree = "<group>"; };
-		92B9EC9B24E0539000E6CFB2 /* core_type.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core_type.h; path = ../../core_type.h; sourceTree = "<group>"; };
 		92B9EC9C24E0539000E6CFB2 /* core_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = core_info.c; path = ../../core_info.c; sourceTree = "<group>"; };
 		92B9EC9D24E0539000E6CFB2 /* core_info.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core_info.h; path = ../../core_info.h; sourceTree = "<group>"; };
 		92B9EC9E24E0539000E6CFB2 /* core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = core.h; path = ../../core.h; sourceTree = "<group>"; };
@@ -1067,7 +1066,6 @@
 				92B9ECBF24E054B500E6CFB2 /* core_backup.h */,
 				92B9EC9C24E0539000E6CFB2 /* core_info.c */,
 				92B9EC9D24E0539000E6CFB2 /* core_info.h */,
-				92B9EC9B24E0539000E6CFB2 /* core_type.h */,
 				92B9ECB024E054B400E6CFB2 /* core_updater_list.c */,
 				92B9ECB624E054B500E6CFB2 /* core_updater_list.h */,
 				92B9EC9E24E0539000E6CFB2 /* core.h */,


### PR DESCRIPTION
This doesn't actually change the compilation at all; it just removes a bunch of references to files that no longer exist, so Xcode will stop thinking I'm trying to jump to the now missing file.