### PR TITLE
ozone: some fixes for better touchscreen handling

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -739,6 +739,8 @@ static const enum location_driver_enum LOCATION_DEFAULT_DRIVER = LOCATION_NULL;
 
 #if (defined(_3DS) || defined(DINGUX)) && defined(HAVE_RGUI)
 static const enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_RGUI;
+#elif defined(IOS) && !TARGET_OS_TV
+#define MENU_DEFAULT_DRIVER (ios_running_on_ipad() ? MENU_OZONE : MENU_MATERIALUI)
 #elif defined(HAVE_MATERIALUI) && defined(RARCH_MOBILE)
 static const enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_MATERIALUI;
 #elif defined(HAVE_OZONE)

--- a/ui/drivers/cocoa/apple_platform.h
+++ b/ui/drivers/cocoa/apple_platform.h
@@ -12,6 +12,7 @@ extern void update_topshelf(void);
 
 #if TARGET_OS_IOS
 extern void ios_show_file_sheet(void);
+extern bool ios_running_on_ipad(void);
 #endif
 
 #ifdef __OBJC__

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -209,6 +209,11 @@ void get_ios_version(int *major, int *minor)
    if (minor) *minor = savedMinor;
 }
 
+bool ios_running_on_ipad(void)
+{
+   return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
+}
+
 /* Input helpers: This is kept here because it needs ObjC */
 static void handle_touch_event(NSArray* touches)
 {


### PR DESCRIPTION
When tapping on the sidebar from the list, it will take you straight to the item you tapped on. Also fix hiding the fullscreen thumbnails. Also, all the help icons at the bottom right are now actual buttons that can be pressed.

This also makes ozone the default menu driver on iPad.