### PR TITLE
iOS/tvOS: flush save files on backgrounding

### DIFF
--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -757,6 +757,7 @@ enum
    update_topshelf();
 #endif
    rarch_stop_draw_observer();
+   command_event(CMD_EVENT_SAVE_FILES, NULL);
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application


### PR DESCRIPTION
People make progress and then background without closing and lose their progress.