### PR TITLE
Support RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2556,6 +2556,19 @@ enum retro_mod
  */
 #define RETRO_ENVIRONMENT_GET_PLAYLIST_DIRECTORY 79
 
+/**
+ * Returns the "file browser" start directory of the frontend.
+ *
+ * This directory can serve as a start directory for the core in case it
+ * provides an internal way of loading content.
+ *
+ * @param[out] data <tt>const char **</tt>.
+ * May be \c NULL. If so, no such directory is defined, and it's up to the
+ * implementation to find a suitable directory.
+ * @return \c true if the environment call is available.
+ */
+#define RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY 80
+
 /**@}*/
 
 /**

--- a/runloop.c
+++ b/runloop.c
@@ -2639,6 +2639,17 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          break;
       }
 
+      case RETRO_ENVIRONMENT_GET_FILE_BROWSER_START_DIRECTORY:
+      {
+         const char **dir            = (const char**)data;
+         const char *dir_content     = settings->paths.directory_menu_content;
+
+         *dir = *dir_content ? dir_content : NULL;
+         RARCH_LOG("[Environ]: FILE_BROWSER_START_DIRECTORY: \"%s\".\n",
+               dir_content);
+         break;
+      }
+
       case RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO:
       /**
        * Update the system Audio/Video information.


### PR DESCRIPTION
## Description

Add an option to retrieve the file browser start directory, copied from similar playlist directory function.

Tested quickly:
`[INFO] [Environ]: FILE_BROWSER_START_DIRECTORY: "<redacted>".`

while same call before the modification, as expected:
`[INFO] [Environ]: UNSUPPORTED (#80).`

## Related Issues

Closes #16858 
