### PR TITLE
Preemptive Frames updates

### DIFF
--- a/runahead.h
+++ b/runahead.h
@@ -56,7 +56,9 @@ typedef struct preemptive_frames_data
    int16_t ptrdev_state[MAX_USERS][4];
 
    /* Pointing device requested */
-   uint8_t ptr_dev[MAX_USERS];
+   uint8_t ptr_dev_needed[MAX_USERS];
+   /* Device ID of ptrdev_state */
+   uint8_t ptr_dev_polled[MAX_USERS];
    /* Buffer indexes for replays */
    uint8_t start_ptr;
    uint8_t replay_ptr;

--- a/ui/drivers/qt/qt_options.cpp
+++ b/ui/drivers/qt/qt_options.cpp
@@ -385,9 +385,10 @@ LatencyPage::LatencyPage(QObject *parent) :
 
 QWidget *LatencyPage::widget()
 {
-   QWidget                         *widget = new QWidget;
-   FormLayout                      *layout = new FormLayout;
-   CheckableSettingsGroup *runAheadGpuSync = new CheckableSettingsGroup(MENU_ENUM_LABEL_RUN_AHEAD_ENABLED);
+   QWidget                       *widget = new QWidget;
+   FormLayout                    *layout = new FormLayout;
+   CheckableSettingsGroup *runAheadGroup = new CheckableSettingsGroup(MENU_ENUM_LABEL_RUN_AHEAD_ENABLED);
+   CheckableSettingsGroup  *preemptGroup = new CheckableSettingsGroup(MENU_ENUM_LABEL_PREEMPT_ENABLE);
 
    rarch_setting_t *hardSyncSetting        = menu_setting_find_enum(MENU_ENUM_LABEL_VIDEO_HARD_SYNC);
 
@@ -408,10 +409,14 @@ QWidget *LatencyPage::widget()
    layout->add(menu_setting_find_enum(MENU_ENUM_LABEL_AUDIO_LATENCY));
    layout->add(menu_setting_find_enum(MENU_ENUM_LABEL_INPUT_POLL_TYPE_BEHAVIOR));
 
-   runAheadGpuSync->add(menu_setting_find_enum(MENU_ENUM_LABEL_RUN_AHEAD_FRAMES));
-   runAheadGpuSync->add(menu_setting_find_enum(MENU_ENUM_LABEL_RUN_AHEAD_SECONDARY_INSTANCE));
-   runAheadGpuSync->add(menu_setting_find_enum(MENU_ENUM_LABEL_RUN_AHEAD_HIDE_WARNINGS));
-   layout->addRow(runAheadGpuSync);
+   runAheadGroup->add(menu_setting_find_enum(MENU_ENUM_LABEL_RUN_AHEAD_FRAMES));
+   runAheadGroup->add(menu_setting_find_enum(MENU_ENUM_LABEL_RUN_AHEAD_SECONDARY_INSTANCE));
+   runAheadGroup->add(menu_setting_find_enum(MENU_ENUM_LABEL_RUN_AHEAD_HIDE_WARNINGS));
+   layout->addRow(runAheadGroup);
+
+   preemptGroup->add(menu_setting_find_enum(MENU_ENUM_LABEL_PREEMPT_FRAMES));
+   preemptGroup->add(menu_setting_find_enum(MENU_ENUM_LABEL_PREEMPT_HIDE_WARNINGS));
+   layout->addRow(preemptGroup);
 
    widget->setLayout(layout);
 


### PR DESCRIPTION
Relatively minor improvements, the biggest being that a pointing device will trigger preemptive frames if used by the core, even if not selected as a device type.

- Check pointing devices when used by core; ignore `input_libretro_device`
- Use stored mouse x,y input state (lower level call might flush deltas)
- Remove port mapping code (unnecessary now)
- Fewer memsets
- Add to Qt menu