### PR TITLE
(Vulkan) Prefer IMMEDIATE mode without vsync

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -368,6 +368,8 @@
 
 /* Vulkan specific */
 #define DEFAULT_MAX_SWAPCHAIN_IMAGES 3
+#define MINIMUM_MAX_SWAPCHAIN_IMAGES 2
+#define MAXIMUM_MAX_SWAPCHAIN_IMAGES 4
 
 /* D3D1x specific */
 #if defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
@@ -391,6 +393,8 @@
  * 2: Etc ...
  */
 #define DEFAULT_HARD_SYNC_FRAMES 0
+#define MINIMUM_HARD_SYNC_FRAMES 0
+#define MAXIMUM_HARD_SYNC_FRAMES 3
 
 /* Sets how many milliseconds to delay after VSync before running the core.
  * Can reduce latency at cost of higher risk of stuttering.

--- a/configuration.c
+++ b/configuration.c
@@ -3870,8 +3870,13 @@ static bool config_load_file(global_t *global,
       free(override_username);
    }
 
-   if (settings->uints.video_hard_sync_frames > 3)
-      settings->uints.video_hard_sync_frames = 3;
+   if (settings->uints.video_hard_sync_frames > MAXIMUM_HARD_SYNC_FRAMES)
+      settings->uints.video_hard_sync_frames = MAXIMUM_HARD_SYNC_FRAMES;
+
+   if (settings->uints.video_max_swapchain_images < MINIMUM_MAX_SWAPCHAIN_IMAGES)
+      settings->uints.video_max_swapchain_images = MINIMUM_MAX_SWAPCHAIN_IMAGES;
+   if (settings->uints.video_max_swapchain_images > MAXIMUM_MAX_SWAPCHAIN_IMAGES)
+      settings->uints.video_max_swapchain_images = MAXIMUM_MAX_SWAPCHAIN_IMAGES;
 
    if (settings->uints.video_frame_delay > MAXIMUM_FRAME_DELAY)
       settings->uints.video_frame_delay = MAXIMUM_FRAME_DELAY;

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -456,6 +456,8 @@ typedef struct video_frame_info
    uint32_t video_st_flags;
    uint16_t menu_st_flags;
 
+   uint16_t frame_time_target;
+
    char stat_text[1024];
 
    bool widgets_active;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -14017,8 +14017,8 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            (*list)[list_info->index - 1].offset_by = 2;
-            menu_settings_list_current_add_range(list, list_info, (*list)[list_info->index - 1].offset_by, 4, 1, true, true);
+            (*list)[list_info->index - 1].offset_by = MINIMUM_MAX_SWAPCHAIN_IMAGES;
+            menu_settings_list_current_add_range(list, list_info, (*list)[list_info->index - 1].offset_by, MAXIMUM_MAX_SWAPCHAIN_IMAGES, 1, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
             MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
 
@@ -14089,7 +14089,7 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            menu_settings_list_current_add_range(list, list_info, 0, 3, 1, true, true);
+            menu_settings_list_current_add_range(list, list_info, MINIMUM_HARD_SYNC_FRAMES, MAXIMUM_HARD_SYNC_FRAMES, 1, true, true);
 
             if (video_driver_test_all_flags(GFX_CTX_FLAGS_ADAPTIVE_VSYNC))
             {


### PR DESCRIPTION
## Description

Some Vulkan related corrections:
- Use IMMEDIATE mode if available when vsync is disabled
  - Allows proper tearing and has much less input lag, and thus works properly with external scanline sync
- Add readable debug logging for supported and active presentation modes
- Impose minimum and maximum values for max swapchains, so that program won't freeze if cfg has been edited manually to below allowed 2, and also do the same for gl hard sync frames while at it
- Improve current fastforward frameskip Vulkan hack by not disabling it completely
  - Allows proper fastforward rates with external frame limiting without being totally choppy

Current present mode picking method works only if present modes come in specific order, and they seem to be random based on platform. Here on Windows the order is so that currently MAILBOX will be picked first, which is bad for non-vsync:
```
[DEBUG] [Vulkan]: Swapchain supports present mode: FIFO.
[DEBUG] [Vulkan]: Swapchain supports present mode: FIFO_RELAXED.
[DEBUG] [Vulkan]: Swapchain supports present mode: MAILBOX.
[DEBUG] [Vulkan]: Swapchain supports present mode: IMMEDIATE.
```
