### PR TITLE
Explicitly cast to a pointer in wayland builds

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -407,7 +407,7 @@ static bool gfx_ctx_wl_set_video_mode(void *data,
       goto error;
    }
 
-   if (!egl_create_surface(&wl->egl, (EGLNativeWindowType)wl->win))
+   if (!egl_create_surface(&wl->egl, (void*)wl->win))
       goto error;
    egl_set_swap_interval(&wl->egl, wl->egl.interval);
 #endif


### PR DESCRIPTION
## Description

The build with `--enable-wayland --disable-kms` on linux has a part where an unsigned long is passed as a void*, but GCC 14 enforces -Werror=int-conversion, causing the build to fail.
https://gcc.gnu.org/gcc-14/porting_to.html#int-conversion

The build with `--enable-kms` does not fail because EGLNativeWindowType is defined as void*.

Downstream bug: https://bugs.gentoo.org/936962