### PR TITLE
Refresh rate switching fixes and cleanups

### DIFF
--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -124,7 +124,9 @@ static void win32_display_server_destroy(void *data)
    if (!dispserv)
       return;
 
-   if (dispserv->orig_width > 0 && dispserv->orig_height > 0)
+   if (     dispserv->orig_width > 0
+         && dispserv->orig_height > 0
+         && dispserv->orig_refresh > 0)
       video_display_server_set_resolution(
             dispserv->orig_width,
             dispserv->orig_height,

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1081,7 +1081,13 @@ const char *video_display_server_get_ident(void)
 void* video_display_server_init(enum rarch_display_type type)
 {
    video_driver_state_t *video_st = &video_driver_st;
-   video_display_server_destroy();
+   runloop_state_t *runloop_st    = runloop_state_get_ptr();
+
+   /* Reuse when already and still running */
+   if (current_display_server && runloop_st->flags & RUNLOOP_FLAG_IS_INITED)
+      return video_st->current_display_server_data;
+   else
+      video_display_server_destroy();
 
    switch (type)
    {
@@ -3279,6 +3285,7 @@ bool video_driver_init_internal(bool *video_is_threaded, bool verbosity_enabled)
       video_st->flags |=  VIDEO_FLAG_STARTED_FULLSCREEN;
    else
       video_st->flags &= ~VIDEO_FLAG_STARTED_FULLSCREEN;
+
    /* Reset video frame count */
    video_st->frame_count             = 0;
    video_st->frame_drop_count        = 0;


### PR DESCRIPTION
## Description

- Fix rate change when changing video driver at the same time, causing the destruction of the display server on reinit, which will reset back to original default rate instead of current content rate
- Fix manual rate change from resolution list and automatic from colliding
- Moved rate adjustments in reinit after content based switching
- Some leftover simplifications
