### PR TITLE
Revert "wayland: Commit viewport resizes (#16419)"

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -130,13 +130,8 @@ void xdg_toplevel_handle_configure_common(gfx_ctx_wayland_data_t *wl,
       wl->buffer_height = wl->fractional_scale ?
          FRACTIONAL_SCALE_MULT(wl->height, wl->fractional_scale_num) : wl->height * wl->buffer_scale;
       wl->resize        = true;
-      if (wl->viewport)
-      {
-         /* Stretch old buffer to fill new size, commit/roundtrip to apply */
+      if (wl->viewport) /* Update viewport */
          wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
-         wl_surface_commit(wl->surface);
-         wl_display_roundtrip(wl->input.dpy);
-      }
    }
 
    if (floating)
@@ -203,13 +198,8 @@ void libdecor_frame_handle_configure_common(struct libdecor_frame *frame,
       wl->buffer_height = wl->fractional_scale ?
          FRACTIONAL_SCALE_MULT(height, wl->fractional_scale_num) : height * wl->buffer_scale;
       wl->resize        = true;
-      if (wl->viewport)
-      {
-         /* Stretch old buffer to fill new size, commit/roundtrip to apply */
+      if (wl->viewport) /* Update viewport */
          wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
-         wl_surface_commit(wl->surface);
-         wl_display_roundtrip(wl->input.dpy);
-      }
    }
 
    state = wl->libdecor_state_new(wl->width, wl->height);
@@ -852,13 +842,8 @@ bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
       wl->buffer_height        = wl->fractional_scale ?
          FRACTIONAL_SCALE_MULT(wl->buffer_height, wl->fractional_scale_num) : wl->buffer_height * wl->buffer_scale;
    }
-   if (wl->viewport)
-   {
-      /* Stretch old buffer to fill new size, commit/roundtrip to apply */
+   if (wl->viewport) /* Update viewport */
       wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
-      wl_surface_commit(wl->surface);
-      wl_display_roundtrip(wl->input.dpy);
-   }
 
 #ifdef HAVE_LIBDECOR_H
    if (wl->libdecor)


### PR DESCRIPTION
This reverts commit 08496b302c7a9e4a080542df6b4a1e294a2a668a (#16419), fixing #17020.