### PR TITLE
Avoid calling strlcpy when copying string onto itself

### DIFF
--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -3033,8 +3033,9 @@ bool video_shader_apply_shader(
          configuration_set_bool(settings, settings->bools.video_shader_enable, true);
          if (!string_is_empty(preset_path))
          {
-            strlcpy(runloop_st->runtime_shader_preset_path, preset_path,
-                  sizeof(runloop_st->runtime_shader_preset_path));
+            if (runloop_st->runtime_shader_preset_path != preset_path)
+               strlcpy(runloop_st->runtime_shader_preset_path, preset_path,
+                     sizeof(runloop_st->runtime_shader_preset_path));
 #ifdef HAVE_MENU
             /* reflect in shader manager */
             if (menu_shader_manager_set_preset(


### PR DESCRIPTION
In `runloop_check_state`, it calls `video_shader_get_current_shader_preset` to get the shader which returns `runloop_st->runtime_shader_preset_path`; `runloop_check_state` passes that to `video_shader_apply_shader` which calls `strlcpy(runloop_st->runtime_shader_preset_path)` with that value. Mac really doesn't like strlcpy() when the src and dst overlap; and in this case since they're the same pointer, it's better to just avoid the strlcpy entirely.