### PR TITLE
Remove trailing whitespace to prevent whitespace in translations.

### DIFF
--- a/intl/msg_hash_en.h
+++ b/intl/msg_hash_en.h
@@ -500,11 +500,11 @@ MSG_HASH(
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_REMAP_SORT_BY_CONTROLLER_ENABLE,
    "Sort Remaps By Gamepad"
-   )   
+   )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_INPUT_REMAP_SORT_BY_CONTROLLER_ENABLE,
    "Remaps will only apply to the active gamepad in which they were saved."
-   )   
+   )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_AUTODETECT_ENABLE,
    "Autoconfiguration"


### PR DESCRIPTION
Whitespace characters were inadvertantly added in previous PR and now appear in translations. This PR simply just removes the offending whitespace characters.