### PR TITLE
Report replay frame number for active_replay stdout api

### DIFF
--- a/command.c
+++ b/command.c
@@ -408,12 +408,15 @@ bool command_get_config_param(command_t *cmd, const char* arg)
       input_driver_state_t *input_st = input_state_get_ptr();
       value            = value_dynamic;
       value_dynamic[0] = '\0';
-      if(input_st->bsv_movie_state_handle)
-         snprintf(value_dynamic, sizeof(value_dynamic), "%lld %u",
-               (long long)(input_st->bsv_movie_state_handle->identifier),
-               input_st->bsv_movie_state.flags);
+      if(input_st->bsv_movie_state_handle) {
+         bsv_movie_t *movie = input_st->bsv_movie_state_handle;
+         snprintf(value_dynamic, sizeof(value_dynamic), "%lld %u %lld",
+               (long long)(movie->identifier),
+                  input_st->bsv_movie_state.flags,
+                  (long long)(movie->frame_counter));
+      }
       else
-         strlcpy(value_dynamic, "0 0", sizeof(value_dynamic));
+         strlcpy(value_dynamic, "0 0 0", sizeof(value_dynamic));
    }
    #endif
    /* TODO: query any string */

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -201,7 +201,7 @@ struct bsv_movie
    size_t *frame_pos;
    int64_t identifier;
    size_t frame_mask;
-   size_t frame_ptr;
+   uint64_t frame_counter;
    size_t min_file_pos;
    size_t state_size;
    bsv_key_data_t key_events[NAME_MAX_LENGTH]; /* uint32_t alignment */


### PR DESCRIPTION
This changes the replay movie's `frame_ptr` (a 20-bit number used to point to a log of file offsets) into a frame counter, which is masked against the 20-bit pattern for use in the file offset log but also functions as a time index into the replay.  Right now that is reported in `GET_CONFIG_PARAM active_replay` but in the future it could be used to show how far into the replay we are during playback or how long the replay is during recording.