### PR TITLE
Add Redox OS to the list of supported operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ RetroArch has been ported to the following platforms:
    - PlayStation Vita
    - Raspberry Pi
    - ReactOS
+   - Redox OS
    - RetroFW
    - RS90
    - SerenityOS


### PR DESCRIPTION
Source : [Upstream build recipe](https://gitlab.redox-os.org/redox-os/cookbook/-/blob/master/recipes/emulators/retroarch/recipe.toml?ref_type=heads) which uses this [repository](https://github.com/jackpot51/retroarch).