### PR TITLE
Show also current frame cache size in stats

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3939,7 +3939,8 @@ void video_driver_frame(const void *data, unsigned width,
             sizeof(video_info.stat_text),
             "CORE AV_INFO\n"
             " Size:        %u x %u\n"
-            " Max Size:    %u x %u\n"
+            " - Base:      %u x %u\n"
+            " - Max:       %u x %u\n"
             " Aspect:      %3.3f\n"
             " FPS:         %3.2f\n"
             " Sample Rate: %6.2f\n"
@@ -3958,6 +3959,8 @@ void video_driver_frame(const void *data, unsigned width,
             " Blocking:    %5.2f %%\n"
             " Samples:  %8d\n"
             "%s",
+            video_st->frame_cache_width,
+            video_st->frame_cache_height,
             av_info->geometry.base_width,
             av_info->geometry.base_height,
             av_info->geometry.max_width,


### PR DESCRIPTION
## Description

Since some cores output at different sizes than exactly base or max, let's show them all:
![retroarch_2024_09_28_00_47_36_851](https://github.com/user-attachments/assets/72924515-a706-4e2d-b176-34bf96c53f38)
