### PR TITLE
Use frame cache size in integer scaling instead of av info geometry

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2354,12 +2354,8 @@ void video_viewport_get_scaled_integer(struct video_viewport *vp,
    int padding_y                   = 0;
    float viewport_bias_x           = settings->floats.video_viewport_bias_x;
    float viewport_bias_y           = settings->floats.video_viewport_bias_y;
-   /* Use system reported sizes as these define the
-    * geometry for the "normal" case. */
-   unsigned content_width          =
-      video_st->av_info.geometry.base_width;
-   unsigned content_height         =
-      video_st->av_info.geometry.base_height;
+   unsigned content_width          = video_st->frame_cache_width;
+   unsigned content_height         = video_st->frame_cache_height;
    unsigned int rotation           = retroarch_get_rotation();
 #if defined(RARCH_MOBILE)
    if (width < height)
@@ -2373,7 +2369,7 @@ void video_viewport_get_scaled_integer(struct video_viewport *vp,
       viewport_bias_y = 1.0 - viewport_bias_y;
 
    if (rotation % 2)
-      content_height     = video_st->av_info.geometry.base_width;
+      content_height  = content_width;
 
    if (content_height == 0)
       content_height     = 1;


### PR DESCRIPTION
## Description

Since it is not guaranteed that cores output exactly at base size, using it in integer scaling calculation will not produce optimal results.

For example here with Mupen64 which outputs really at 640x240 instead of reported 640x480:

Huge borders without integer:
![retroarch_2024_09_28_01_04_29_691](https://github.com/user-attachments/assets/483f665c-7006-4423-ac09-6d70004f9bb7)

And for comparison integer not-overscaled:
![retroarch_2024_09_28_01_14_25_444](https://github.com/user-attachments/assets/b0542e75-df83-47d8-a96a-b8adb2a5d421)

Current integer overscale next step jumps badly overboard:
![retroarch_2024_09_28_01_04_32_411](https://github.com/user-attachments/assets/36dddc29-e38d-420b-b9b5-2c055b5b5017)

Fixed to use current cached frame size instead to get the missing step:
![retroarch_2024_09_28_01_03_37_660](https://github.com/user-attachments/assets/799144c6-f426-4bf6-b64b-ac3ce92078d7)

Are there any downsides to this that I'm not seeing?

## Related Pull Requests

#17056

