### PR TITLE
Disallow Cloud Sync with HTTPs when HAVE_SSL is disabled

### DIFF
--- a/network/cloud_sync/webdav.c
+++ b/network/cloud_sync/webdav.c
@@ -506,6 +506,10 @@ static bool webdav_sync_begin(cloud_sync_complete_handler_t cb, void *user_data)
    if (string_is_empty(url))
       return false;
 
+#ifndef HAVE_SSL
+   if (strncmp(url, "https", 5) == 0)
+      return false;
+#endif
    /* TODO: LOCK? */
 
    if (!strstr(url, "://"))


### PR DESCRIPTION
## Description

Some platforms do not have SSL enabled, which would cause CloudSync to crash by attempting to handle HTTPs traffic as HTTP. Fail the sync immediately if such a scenario happens.

## Related Issues

https://github.com/libretro/RetroArch/issues/6875

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/15548

## Reviewers

@warmenhoven 
