### PR TITLE
Vulkan: Negative viewport position correction

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -3862,14 +3862,14 @@ static void vulkan_set_viewport(void *data, unsigned viewport_width,
 
    if (vk->vp.x < 0)
    {
-      vk->translate_x = (float)vk->vp.x;
+      vk->translate_x = (float)vk->vp.x * 2;
       vk->vp.x = 0.0;
    }
    else
       vk->translate_x = 0.0;
    if (vk->vp.y < 0)
    {
-      vk->translate_y = (float)vk->vp.y;
+      vk->translate_y = (float)vk->vp.y * 2;
       vk->vp.y = 0.0;
    }
    else


### PR DESCRIPTION
## Description

Here on Windows 0.5 viewport will not center properly if output is bigger than screen:
![retroarch_2024_09_29_19_49_47_436](https://github.com/user-attachments/assets/61fc0b56-c3f2-4231-b762-64932d3a95ba)

But simply doing this does:
![retroarch_2024_09_29_19_50_35_788](https://github.com/user-attachments/assets/d7dd9d37-d368-4361-a169-e467f7df2606)

I see no ill behavior on Windows, but how about other platforms?


## Related Pull Requests

https://github.com/libretro/RetroArch/pull/16773

