### PR TITLE
Fix typos

### DIFF
--- a/README-mali_fbdev_r4p0.md
+++ b/README-mali_fbdev_r4p0.md
@@ -6,7 +6,7 @@ good fbdev implementation. It is derived from the old Android GLES driver.
 
 It was meant to be used on Cubieboard/Cubieboard2/Cubietruck, but it should not
 be used on an Odroid X2/U2/U3 where a superior solution (RetroArch exynos video driver) is available.
-Fbdev implementation on Odroid harware is missing WAITFORVSYNC ioctl, so use Exynos driver there.
+Fbdev implementation on Odroid hardware is missing WAITFORVSYNC ioctl, so use Exynos driver there.
 
 This driver requires MALI r4p0 binary blobs for fbdev, and a kernel compatible with r4p0 binaries.
 

--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -611,7 +611,7 @@ bool audio_driver_init_internal(
 #ifdef HAVE_REWIND
    int16_t *rewind_buf            = NULL;
 #endif
-   /* Accomodate rewind since at some point we might have two full buffers. */
+   /* Accommodate rewind since at some point we might have two full buffers. */
    size_t outsamples_max          = AUDIO_CHUNK_SIZE_NONBLOCKING * 2 * AUDIO_MAX_RATIO * slowmotion_ratio;
    int16_t *out_conv_buf          = (int16_t*)memalign_alloc(64, outsamples_max * sizeof(int16_t));
    size_t audio_buf_length        = AUDIO_CHUNK_SIZE_NONBLOCKING * 2 * sizeof(float);

--- a/audio/common/alsa.c
+++ b/audio/common/alsa.c
@@ -460,7 +460,7 @@ struct string_list *alsa_device_list_type_new(const char* type)
       char *io   = snd_device_name_get_hint(*n, "IOID");
       char *desc = snd_device_name_get_hint(*n, "DESC");
 
-      /* description of device IOID - input / output identifcation
+      /* description of device IOID - input / output identification
        * ("Input" or "Output"), NULL means both) */
 
       if (!io || (string_is_equal(io, type)))

--- a/audio/drivers/rsound.h
+++ b/audio/drivers/rsound.h
@@ -257,9 +257,9 @@ int rsd_set_param (rsound_t *rd, enum rsd_settings option, void* param);
 
 void rsd_set_callback (rsound_t *rd, rsd_audio_callback_t callback, rsd_error_callback_t err_callback, size_t max_size, void *userdata);
 
-/* Lock and unlock the callback. When the callback lock is aquired, the callback is guaranteed to not be executing.
+/* Lock and unlock the callback. When the callback lock is acquired, the callback is guaranteed to not be executing.
    The lock has to be unlocked afterwards.
-   Attemping to call several rsd_callback_lock() in succession might cause a deadlock.
+   Attempting to call several rsd_callback_lock() in succession might cause a deadlock.
    The lock should be held for as short period as possible.
    Try to avoid calling code that may block when holding the lock. */
 void rsd_callback_lock (rsound_t *rd);
@@ -294,10 +294,10 @@ size_t rsd_write (rsound_t *rd, const void* buf, size_t size);
  *NOTE* This function is deprecated, it should not be used in new applications. */
 size_t rsd_pointer (rsound_t *rd);
 
-/* Aquires how much data can be written to the buffer without blocking */
+/* Acquires how much data can be written to the buffer without blocking */
 size_t rsd_get_avail (rsound_t *rd);
 
-/* Aquires the latency at the moment for the audio stream. It is measured in bytes. Useful for syncing video and audio. */
+/* Acquires the latency at the moment for the audio stream. It is measured in bytes. Useful for syncing video and audio. */
 size_t rsd_delay (rsound_t *rd);
 
 /* Utility for returning latency in milliseconds. */

--- a/audio/drivers/tinyalsa.c
+++ b/audio/drivers/tinyalsa.c
@@ -121,8 +121,8 @@
  */
 #define	PCM_STATE_RUNNING	0x03
 
-/** For inputs, this means an overrun occured.
- * For outputs, this means an underrun occured.
+/** For inputs, this means an overrun occurred.
+ * For outputs, this means an underrun occurred.
  */
 #define	PCM_STATE_XRUN 0x04
 
@@ -755,13 +755,13 @@ struct pcm
    unsigned int running:1;
    /** Whether or not the PCM has been prepared */
    unsigned int prepared:1;
-   /** The number of underruns that have occured */
+   /** The number of underruns that have occurred */
    int underruns;
    /** Size of the buffer */
    unsigned int buffer_size;
    /** The boundary for ring buffer pointers */
    unsigned int boundary;
-   /** Description of the last error that occured */
+   /** Description of the last error that occurred */
    char error[PCM_ERROR_MAX];
    /** Configuration that was passed to @ref pcm_open */
    struct pcm_config config;
@@ -845,10 +845,10 @@ static int pcm_get_file_descriptor(const struct pcm *pcm)
    return pcm->fd;
 }
 
-/** Gets the error message for the last error that occured.
- * If no error occured and this function is called, the results are undefined.
+/** Gets the error message for the last error that occurred.
+ * If no error occurred and this function is called, the results are undefined.
  * @param pcm A PCM handle.
- * @return The error message of the last error that occured.
+ * @return The error message of the last error that occurred.
  * @ingroup libtinyalsa-pcm
  */
 static const char* pcm_get_error(const struct pcm *pcm)
@@ -1195,7 +1195,7 @@ static int pcm_mmap_begin(struct pcm *pcm, void **areas, unsigned int *offset,
       avail = pcm->buffer_size;
    continuous = pcm->buffer_size - *offset;
 
-   /* we can only copy frames if the are availabale and continuos */
+   /* we can only copy frames if the are available and continuous */
    copy_frames = *frames;
    if (copy_frames > avail)
       copy_frames = avail;
@@ -1939,8 +1939,8 @@ static int pcm_state(struct pcm *pcm)
  * @param pcm A PCM handle.
  * @param timeout The maximum amount of time to wait for, in terms of milliseconds.
  * @returns If frames became available, one is returned.
- *  If a timeout occured, zero is returned.
- *  If an error occured, a negative number is returned.
+ *  If a timeout occurred, zero is returned.
+ *  If an error occurred, a negative number is returned.
  * @ingroup libtinyalsa-pcm
  */
 static int pcm_wait(struct pcm *pcm, int timeout)

--- a/audio/drivers_resampler/cc_resampler.c
+++ b/audio/drivers_resampler/cc_resampler.c
@@ -33,7 +33,7 @@
  * we approximate those with polynoms
  *
  * CC_RESAMPLER_PRECISION defines how accurate the approximation is
- * a setting of 5 or more means full precison.
+ * a setting of 5 or more means full precision.
  * setting 0 doesn't use a polynom
  * setting 1 uses P(X) = X - (3/4)*X^3 + (1/4)*X^5
  *

--- a/audio/librsound.c
+++ b/audio/librsound.c
@@ -441,7 +441,7 @@ static int rsnd_send_header_info(rsound_t *rd)
    return 0;
 }
 
-/* Recieves backend info from server that is of interest to the client. (This mini-protocol might be extended later on.) */
+/* Receives backend info from server that is of interest to the client. (This mini-protocol might be extended later on.) */
 static int rsnd_get_backend_info ( rsound_t *rd )
 {
 #define RSND_HEADER_SIZE 8
@@ -563,7 +563,7 @@ static int rsnd_create_connection(rsound_t *rd)
    {
       /* Part of the uber simple protocol.
          1. Send wave header.
-         2. Recieve backend info like latency and preferred packet size.
+         2. Receive backend info like latency and preferred packet size.
          3. Starts the playback thread. */
 
       rc = rsnd_send_header_info(rd);
@@ -602,7 +602,7 @@ static int rsnd_create_connection(rsound_t *rd)
 }
 
 /* Sends a chunk over the network. Makes sure that everything is sent if blocking. Returns -1 if connection is lost, non-negative if success.
- * If blocking, and not enough data is recieved, it will return -1. */
+ * If blocking, and not enough data is received, it will return -1. */
 static ssize_t rsnd_send_chunk(int socket, const void* buf, size_t size, int blocking)
 {
    ssize_t rc = 0;
@@ -652,8 +652,8 @@ static ssize_t rsnd_send_chunk(int socket, const void* buf, size_t size, int blo
    return (ssize_t)wrote;
 }
 
-/* Recieved chunk. Makes sure that everything is recieved if blocking. Returns -1 if connection is lost, non-negative if success.
- * If blocking, and not enough data is recieved, it will return -1. */
+/* Received chunk. Makes sure that everything is received if blocking. Returns -1 if connection is lost, non-negative if success.
+ * If blocking, and not enough data is received, it will return -1. */
 static ssize_t rsnd_recv_chunk(int socket, void *buf, size_t size, int blocking)
 {
    ssize_t rc = 0;
@@ -960,7 +960,7 @@ static int rsnd_close_ctl(rsound_t *rd)
       if (fd.revents & POLLIN)
       {
          const char *subchar;
-         /* We just read everything in large chunks until we find 
+         /* We just read everything in large chunks until we find
           * what we're looking for */
          int rc = net_recv(rd->conn.ctl_socket, buf + index, RSD_PROTO_MAXSIZE*2 - 1 - index, 0);
 
@@ -991,7 +991,7 @@ static int rsnd_close_ctl(rsound_t *rd)
    return 0;
 }
 
-/* Sends delay info request to server on the ctl socket. 
+/* Sends delay info request to server on the ctl socket.
  * This code section isn't critical, and will work if it works.
  * It will never block. */
 static int rsnd_send_info_query(rsound_t *rd)
@@ -1026,7 +1026,7 @@ static int rsnd_update_server_info(rsound_t *rd)
       char *tmpstr;
       memset(temp, 0, sizeof(temp));
 
-      /* We first recieve the small header. We just use the larger buffer as it is disposable. */
+      /* We first receive the small header. We just use the larger buffer as it is disposable. */
       rc = rsnd_recv_chunk(rd->conn.ctl_socket, temp, RSD_PROTO_CHUNKSIZE, 0);
       if ( rc == 0 )
          break;
@@ -1044,7 +1044,7 @@ static int rsnd_update_server_info(rsound_t *rd)
       /* The length of the argument message is stored in the small 8 byte header. */
       long int len = strtol(substr, NULL, 0);
 
-      /* Recieve the rest of the data. */
+      /* Receive the rest of the data. */
       if ( rsnd_recv_chunk(rd->conn.ctl_socket, temp, len, 0) < len )
          return -1;
 

--- a/bootstrap/vita/sbrk.c
+++ b/bootstrap/vita/sbrk.c
@@ -52,8 +52,8 @@ void _init_vita_heap(void) {
 	if (sceKernelCreateLwMutex((struct SceKernelLwMutexWork*)_newlib_sbrk_mutex, "sbrk mutex", 0, 0, 0) < 0) {
 		goto failure;
 	}
-	
-	// Always allocating the max avaliable USER_RW mem on the system
+
+	// Always allocating the max available USER_RW mem on the system
 	SceKernelFreeMemorySizeInfo info;
 	info.size = sizeof(SceKernelFreeMemorySizeInfo);
 	sceKernelGetFreeMemorySize(&info);

--- a/cheat_manager.h
+++ b/cheat_manager.h
@@ -87,8 +87,8 @@ enum cheat_rumble_type
 struct item_cheat
 {
    /* Clock value for when rumbling should stop */
-   retro_time_t rumble_primary_end_time; 
-   retro_time_t rumble_secondary_end_time; 
+   retro_time_t rumble_primary_end_time;
+   retro_time_t rumble_secondary_end_time;
 
    char *desc;
    char *code;
@@ -128,7 +128,7 @@ struct item_cheat
    unsigned int rumble_prev_value;
    unsigned int rumble_initialized;
    /* 0-15 for specific port, anything else means "all ports" */
-   unsigned int rumble_port; 
+   unsigned int rumble_port;
    unsigned int rumble_primary_strength; /* 0-65535 */
    unsigned int rumble_primary_duration; /* in milliseconds */
    unsigned int rumble_secondary_strength; /* 0-65535 */
@@ -141,7 +141,7 @@ struct item_cheat
     * repeat_add_to_address - every iteration of repeat_count will have this amount added to item_cheat.address
     *
     * Note that repeat_add_to_address represents the number of "memory_search_size" blocks to add to
-    * item_cheat.address.  If memory_seach_size is 16-bits and repeat_add_to_address is 2, then item_cheat.address
+    * item_cheat.address.  If memory_search_size is 16-bits and repeat_add_to_address is 2, then item_cheat.address
     * will be increased by 4 bytes 2*(16-bits) for every iteration.
     *
     * This is a cheating structure used for codes like unlocking all levels, giving yourself 1 of every item,etc.

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -782,7 +782,7 @@ void rcheevos_award_achievement(rcheevos_locals_t* locals,
    if (!cheevo)
       return;
 
-   /* Deactivates the acheivement. */
+   /* Deactivates the achievement. */
    rc_runtime_deactivate_achievement(&locals->runtime, cheevo->id);
 
    cheevo->active &= ~RCHEEVOS_ACTIVE_SOFTCORE;

--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -1552,7 +1552,7 @@ void rcheevos_client_initialize_runtime(unsigned game_id,
 
    if (!data)
    {
-      CHEEVOS_LOG(RCHEEVOS_TAG "Failed to allocate runtime initalization data\n");
+      CHEEVOS_LOG(RCHEEVOS_TAG "Failed to allocate runtime initialization data\n");
       return;
    }
 

--- a/config.def.h
+++ b/config.def.h
@@ -245,8 +245,8 @@
 /* Do not use windowed mode for WinRT and Winapi Family builds on the Xbox UWP with fixed resolution shrinks the image into the left top corner of the screen with some libretro cores */
 #define DEFAULT_WINDOWED_FULLSCREEN false
 #else
-#define DEFAULT_WINDOWED_FULLSCREEN true 
-#endif 
+#define DEFAULT_WINDOWED_FULLSCREEN true
+#endif
 
 /* Enable automatic switching of the screen refresh rate when using the specified screen mode(s),
  * based on running core/content */
@@ -410,20 +410,20 @@
  */
 #define DEFAULT_SHADER_SUBFRAMES 1
 
-/* Divides implements basic rolling scanning of sub frames - does this simply by scrolling a 
- * a scissor rect down the screen according to how many sub frames there are  
+/* Divides implements basic rolling scanning of sub frames - does this simply by scrolling a
+ * a scissor rect down the screen according to how many sub frames there are
  */
 #define DEFAULT_SCAN_SUBFRAMES false
 
 /* Inserts black frame(s) inbetween frames.
- * Useful for Higher Hz monitors (set to multiples of 60 Hz) who want to play 60 Hz 
+ * Useful for Higher Hz monitors (set to multiples of 60 Hz) who want to play 60 Hz
  * material with CRT-like motion clarity.
  */
 #define DEFAULT_BLACK_FRAME_INSERTION 0
 
 /* Black Frame Insertion Dark Frames.
  * Increase for more clarity at the cost of lower brightness. Adjusting can also eliminate
- * any temporary image retention if noticed. Only useful at 180hz or higher 60hz multiples, 
+ * any temporary image retention if noticed. Only useful at 180hz or higher 60hz multiples,
  * as 120hz only has one total extra frame for BFI to work with.
  */
 #define DEFAULT_BFI_DARK_FRAMES 1
@@ -508,7 +508,7 @@
 /* Should we expand the colour gamut when using hdr */
 #define DEFAULT_VIDEO_HDR_EXPAND_GAMUT true
 
-/* When presets are saved they will be saved using the #reference 
+/* When presets are saved they will be saved using the #reference
  * directive by default */
 #define DEFAULT_VIDEO_SHADER_PRESET_SAVE_REFERENCE_ENABLE true
 
@@ -1121,7 +1121,7 @@
 /*Desired duration of the screenshot notification*/
 #define DEFAULT_NOTIFICATION_SHOW_SCREENSHOT_DURATION 0
 
-/* Display a white flashing effect with the desired 
+/* Display a white flashing effect with the desired
  * duration when taking a screenshot*/
 #define DEFAULT_NOTIFICATION_SHOW_SCREENSHOT_FLASH 0
 #endif
@@ -1262,9 +1262,9 @@
 
 
 #if defined(RETROFW) || defined(MIYOO)
-/*RETROFW jz4760 has signficant slowdown with default settings */
+/*RETROFW jz4760 has significant slowdown with default settings */
 #define DEFAULT_REWIND_BUFFER_SIZE (1 << 20)
-#define DEFAULT_REWIND_BUFFER_SIZE_STEP 1 
+#define DEFAULT_REWIND_BUFFER_SIZE_STEP 1
 #define DEFAULT_REWIND_GRANULARITY 6
 #else
 /* The buffer size for the rewind buffer. This needs to be about
@@ -1517,7 +1517,7 @@
 /* Show Menu start-up screen on boot. */
 #define DEFAULT_MENU_SHOW_START_SCREEN true
 
-/* Default scale factor for non-frambuffer-based display
+/* Default scale factor for non-framebuffer-based display
  * drivers and display widgets */
 #if defined(VITA)
 #define DEFAULT_MENU_SCALE_FACTOR 1.5f
@@ -1666,7 +1666,7 @@
 #define DEFAULT_CONTENT_RUNTIME_LOG true
 #endif
 
-/* Keep track of how long each content has been running 
+/* Keep track of how long each content has been running
  * for over time (ignores core) */
 #define DEFAULT_CONTENT_RUNTIME_LOG_AGGREGATE false
 

--- a/configuration.c
+++ b/configuration.c
@@ -2978,7 +2978,7 @@ void config_set_defaults(void *data)
    for (i = 0; i < MAX_USERS; i++)
    {
       settings->uints.input_joypad_index[i] = (unsigned)i;
-#ifdef SWITCH /* Switch prefered default dpad mode */
+#ifdef SWITCH /* Switch preferred default dpad mode */
       settings->uints.input_analog_dpad_mode[i] = ANALOG_DPAD_LSTICK;
 #else
       settings->uints.input_analog_dpad_mode[i] = ANALOG_DPAD_NONE;
@@ -4645,13 +4645,13 @@ bool config_load_remap(const char *directory_input_remapping,
        || string_is_empty(directory_input_remapping))
       return false;
 
-   if (   sort_remaps_by_controller 
-       && input_device_name != NULL 
+   if (   sort_remaps_by_controller
+       && input_device_name != NULL
        && !string_is_empty(input_device_name))
    {
-      /* Ensure directory does not contain special chars */ 
+      /* Ensure directory does not contain special chars */
       input_device_dir = sanitize_path_part(input_device_name, strlen(input_device_name));
-      
+
       /* Allocate memory for the new path */
       remap_path_total_len = strlen(core_name) + strlen(input_device_dir) + 2;
       remap_path = (char *)malloc(remap_path_total_len);
@@ -4661,7 +4661,7 @@ bool config_load_remap(const char *directory_input_remapping,
       _len += strlcpy(remap_path + _len, PATH_DEFAULT_SLASH(), remap_path_total_len - _len);
       _len += strlcpy(remap_path + _len, input_device_dir, remap_path_total_len - _len);
 
-      /* Deallocate as we no longer this */ 
+      /* Deallocate as we no longer this */
       free((char*)input_device_dir);
       input_device_dir = NULL;
    }

--- a/cores/libretro-ffmpeg/ffmpeg_core.c
+++ b/cores/libretro-ffmpeg/ffmpeg_core.c
@@ -982,7 +982,7 @@ void CORE_PREFIX(retro_run)(void)
 #if ENABLE_HW_ACCEL
 /*
  * Try to initialize a specific HW decoder defined by type.
- * Optionaly tests the pixel format list for a compatible pixel format.
+ * Optionally tests the pixel format list for a compatible pixel format.
  */
 static enum AVPixelFormat init_hw_decoder(struct AVCodecContext *ctx,
                                     const enum AVHWDeviceType type,

--- a/cores/libretro-mpv/mpv-libretro.c
+++ b/cores/libretro-mpv/mpv-libretro.c
@@ -56,7 +56,7 @@ static mpv_render_context *mpv_gl;
 /* Save the current playback time for context changes */
 static int64_t playback_time = 0;
 
-/* filepath required globaly as mpv is reopened on context change */
+/* filepath required globally as mpv is reopened on context change */
 static char *filepath = NULL;
 
 static volatile int frame_queue = 0;

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -769,7 +769,7 @@ void processing_heal(uint8_t *src, int width, int height) {
    int i;
    for (i = 0; i < width * height; i+=1, src += 3, ++fp1) {
       /* Tries to filter a bunch of blanked out scanline sections my capture cards spits out with this crazy hack
-       * Since the blanked out scanlines are set to a black value bellow anything that can be captued, it's quite
+       * Since the blanked out scanlines are set to a black value bellow anything that can be captured, it's quite
        * easy to select the scanlines...
        */
       if (src[0] <= 0 && src[1] <= 0 && src[2] <= 0 && i >= width && i <= width * height - width) {
@@ -895,7 +895,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &outputmode);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &frametimes);
       /* Video or Audio device(s) has(ve) been changed
-       * TODO We may get away without reseting devices when changing output mode...
+       * TODO We may get away without resetting devices when changing output mode...
        */
       if ((videodev.value    && (strcmp(video_device, videodev.value) != 0)) ||\
           (audiodev.value    && (strcmp(audio_device, audiodev.value) != 0)) ||\
@@ -915,7 +915,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
 
    /* printf("%d %d %d %s\n", video_cap_width, video_cap_height, video_buf.field, video_output_mode);
     * TODO pass frame_curr to source_* functions
-    * half_feed_rate allows interlaced intput to be fed at half the calls to this function
+    * half_feed_rate allows interlaced input to be fed at half the calls to this function
     * where the same frame is then read by the deinterlacer twice, for each field
     */
    if (video_half_feed_rate == 0) {
@@ -943,7 +943,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
     */
    if (strcmp(video_output_mode, "deinterlaced") == 0) {
       processing_bgr_xrgb(frame_cap, frame_curr, video_cap_width, video_cap_height);
-      /* When deinterlacing a interlaced intput, we need to process both fields of a frame,
+      /* When deinterlacing a interlaced input, we need to process both fields of a frame,
        * one at a time (retro_run needs to be called twice, vide_half_feed_rate prevents the
        * source from being read twice...
        */
@@ -1260,7 +1260,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
       if (strcmp(video_capture_mode, "interlaced") == 0) {
          video_out_height = video_cap_height;
       } else {
-         printf("WARNING: Capture mode %s with output mode %s is not properly supported yet... (Is this even usefull?)\n", \
+         printf("WARNING: Capture mode %s with output mode %s is not properly supported yet... (Is this even useful?)\n", \
                  video_capture_mode, video_output_mode);
          video_out_height = video_cap_height*2;
       }

--- a/dist-scripts/wiiu-rpx-upload.sh
+++ b/dist-scripts/wiiu-rpx-upload.sh
@@ -4,7 +4,7 @@
 # This script will upload the packaged RetroArch cores to a WiiU running
 # FTPiiU or FTPiiU Anywhere
 #
-# IMPORTANT: This script assumes the following structur
+# IMPORTANT: This script assumes the following structure
 #
 # WARNING: I experienced corrupt uploads when using Dimok's FTPiiU. You
 # probably want to use FIX94's FTPiiU Anywhere.

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -106,7 +106,7 @@ typedef enum
 {
    CFUserDomainMask     = 1,       /* user's home directory --- place to install user's personal items (~) */
    CFLocalDomainMask    = 2,       /* local to the current machine --- place to install items available to everyone on this machine (/Library) */
-   CFNetworkDomainMask  = 4,       /* publically available location in the local area network --- place to install items available on the network (/Network) */
+   CFNetworkDomainMask  = 4,       /* publicly available location in the local area network --- place to install items available on the network (/Network) */
    CFSystemDomainMask   = 8,       /* provided by Apple, unmodifiable (/System) */
    CFAllDomainsMask     = 0x0ffff  /* All domains: all of the above and future items */
 } CFDomainMask;

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -201,7 +201,7 @@ static void mount_partition(void)
 
    if (getMountInfo(mount_path, mountString, mountPoint, new_cwd) != 1)
    {
-      RARCH_WARN("Partition info not readed\n");
+      RARCH_WARN("Partition info not read\n");
       return;
    }
 
@@ -212,7 +212,7 @@ static void mount_partition(void)
       return;
    }
 
-   /* If we're booting from HDD, we must update the cwd variable 
+   /* If we're booting from HDD, we must update the cwd variable
     * and add : to the mount point */
    if (bootDeviceID == BOOT_DEVICE_HDD || bootDeviceID == BOOT_DEVICE_HDD0)
    {
@@ -221,7 +221,7 @@ static void mount_partition(void)
    }
    else
    {
-      /* We MUST put mountPoint as empty to avoid wrong results 
+      /* We MUST put mountPoint as empty to avoid wrong results
          with LoadELFFromFileWithPartition */
       strlcpy(mountPoint, "", sizeof(mountPoint));
    }
@@ -295,7 +295,7 @@ static void frontend_ps2_get_env(int *argc, char *argv[],
 #endif
 }
 
-static void common_init_drivers(bool extra_drivers) 
+static void common_init_drivers(bool extra_drivers)
 {
    init_drivers(extra_drivers);
 
@@ -303,11 +303,11 @@ static void common_init_drivers(bool extra_drivers)
 
    getcwd(cwd, sizeof(cwd));
 #if !defined(IS_SALAMANDER) && !defined(DEBUG)
-   /* If it is not Salamander, we need to go one level 
+   /* If it is not Salamander, we need to go one level
     * up for setting the CWD. */
    path_parent_dir(cwd, strlen(cwd));
 #endif
-   
+
    mount_partition();
 
    waitUntilDeviceIsReady(cwd);

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1599,7 +1599,7 @@ static void frontend_unix_get_env(int *argc,
                   sizeof(g_defaults.dirs[DEFAULT_DIR_WALLPAPERS]));
 
             /* This switch tries to handle the different locations for devices with
-               weird write permissions. Should be largelly unnecesary nowadays. Most
+               weird write permissions. Should be largelly unnecessary nowadays. Most
                devices I have tested are INTERNAL_STORAGE_WRITABLE but better safe than sorry */
 
             switch (storage_permissions)

--- a/gfx/common/angle_common.h
+++ b/gfx/common/angle_common.h
@@ -17,7 +17,7 @@
 #define __ANGLE_COMMON_H
 
 #ifdef HAVE_GBM
-/* presense or absense of this include makes egl.h change NativeWindowType between gbm_device* and _XDisplay* */
+/* presence or absence of this include makes egl.h change NativeWindowType between gbm_device* and _XDisplay* */
 #include <gbm.h>
 #endif
 #include <EGL/egl.h>

--- a/gfx/common/d3d12_defines.h
+++ b/gfx/common/d3d12_defines.h
@@ -201,7 +201,7 @@ typedef struct
 #endif
    DXGIAdapter adapter;
    D3D12Device device;
- 
+
 #ifdef DEVICE_DEBUG
 #ifdef DEBUG
    D3D12DebugDevice debug_device;
@@ -232,8 +232,8 @@ typedef struct
       D3D12RootSignature      cs_rootSignature; /* descriptor layout */
       D3D12RootSignature      sl_rootSignature; /* descriptor layout */
       D3D12RootSignature      rootSignature;    /* descriptor layout */
-      d3d12_descriptor_heap_t srv_heap;         /* ShaderResouceView descritor heap */
-      d3d12_descriptor_heap_t rtv_heap;         /* RenderTargetView descritor heap */
+      d3d12_descriptor_heap_t srv_heap;         /* ShaderResourceView descriptor heap */
+      d3d12_descriptor_heap_t rtv_heap;         /* RenderTargetView descriptor heap */
       d3d12_descriptor_heap_t sampler_heap;
    } desc;
 

--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -542,7 +542,7 @@ bool egl_init_context_common(
 
    if (i == *count)
    {
-      RARCH_ERR("[EGL]: No EGL config found which satifies requirements.\n");
+      RARCH_ERR("[EGL]: No EGL config found which satisfies requirements.\n");
       return false;
    }
 

--- a/gfx/common/egl_common.h
+++ b/gfx/common/egl_common.h
@@ -17,7 +17,7 @@
 #define __EGL_COMMON_H
 
 #ifdef HAVE_GBM
-/* presense or absense of this include makes egl.h change NativeWindowType between gbm_device* and _XDisplay* */
+/* presence or absence of this include makes egl.h change NativeWindowType between gbm_device* and _XDisplay* */
 #include <gbm.h>
 #endif
 #include <EGL/egl.h>

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -210,7 +210,7 @@ static void vulkan_emulated_mailbox_loop(void *userdata)
       /* VK_SUBOPTIMAL_KHR can be returned on Android 10
        * when prerotate is not dealt with.
        * It can also be returned by WSI when the surface
-       * is _temorarily_ suboptimal.
+       * is _temporarily_ suboptimal.
        * This is not an error we need to care about,
        * and we'll treat it as SUCCESS. */
       if (mailbox->result == VK_SUBOPTIMAL_KHR)
@@ -2218,7 +2218,7 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    /* We don't clamp the number of images requested to what is reported
     * as supported by the implementation in surface_properties.minImageCount,
     * because MESA always reports a minImageCount of 4, but 3 and 2 work
-    * pefectly well, even if it's out of spec. */
+    * perfectly well, even if it's out of spec. */
 
    if (     (surface_properties.maxImageCount > 0)
          && (desired_swapchain_images > surface_properties.maxImageCount))
@@ -2613,7 +2613,7 @@ void vulkan_present(gfx_ctx_vulkan_data_t *vk, unsigned index)
    /* VK_SUBOPTIMAL_KHR can be returned on
     * Android 10 when prerotate is not dealt with.
     * It can also be returned by WSI when the surface
-    * is _temorarily_ suboptimal.
+    * is _temporarily_ suboptimal.
     * This is not an error we need to care about,
     * and we'll treat it as SUCCESS. */
    if (result == VK_SUBOPTIMAL_KHR)

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -775,7 +775,7 @@ bool gfx_ctx_wl_init_common(
 
    /* Bind SHM based wl_buffer to wl_surface until the vulkan surface is ready.
     * This shows the window which assigns us a display (wl_output)
-    *  which is usefull for HiDPI and auto selecting a display for fullscreen. */
+    * which is useful for HiDPI and auto selecting a display for fullscreen. */
    if (video_monitor_index == 0 && wl_list_length (&wl->all_outputs) > 1)
    {
       if (!wl_draw_splash_screen(wl))

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -25,7 +25,7 @@
 #define COBJMACROS
 #define COBJMACROS_DEFINED
 #endif
-/* We really just want shobjidl.h, but there's no way to detect its existance at compile time (especially with mingw). however shlobj happens to include it for us when it's supported, which is easier. */
+/* We really just want shobjidl.h, but there's no way to detect its existence at compile time (especially with mingw). however shlobj happens to include it for us when it's supported, which is easier. */
 #include <shlobj.h>
 #ifdef COBJMACROS_DEFINED
 #undef COBJMACROS

--- a/gfx/drivers/dispmanx_gfx.c
+++ b/gfx/drivers/dispmanx_gfx.c
@@ -55,7 +55,7 @@ struct dispmanx_surface
    struct dispmanx_page *pages;
    /* the page that's currently on screen */
    struct dispmanx_page *current_page;
-   /*The page to wich we will dump the render. We need to know this
+   /* The page where we will dump the render. We need to know this
     * already when we enter the surface update function. No time to wait
     * for free pages before blitting and showing the just rendered frame! */
    struct dispmanx_page *next_page;
@@ -156,7 +156,7 @@ static struct dispmanx_page *dispmanx_get_free_page(struct dispmanx_video *_disp
       }
    }
 
-   /* We mark the choosen page as used */
+   /* We mark the chosen page as used */
    slock_lock(page->page_used_mutex);
    page->used = true;
    slock_unlock(page->page_used_mutex);
@@ -202,7 +202,7 @@ static void dispmanx_surface_free(struct dispmanx_video *_dispvars,
    struct dispmanx_surface *surface = *sp;
 
    /* What if we run into the vsync cb code after freeing the surface?
-    * We could be trying to get non-existant lock, signal non-existant condition..
+    * We could be trying to get non-existent lock, signal non-existent condition..
     * So we wait for any pending flips to complete before freeing any surface. */
    slock_lock(_dispvars->pending_mutex);
    if (_dispvars->pageflip_pending > 0)
@@ -276,7 +276,7 @@ static void dispmanx_surface_setup(struct dispmanx_video *_dispvars,
    dst_height = _dispvars->dispmanx_height;
 
    /* If we obtain a scaled image width that is bigger than the physical screen width,
-    * then we keep the physical screen width as our maximun width. */
+    * then we keep the physical screen width as our maximum width. */
    if (dst_width > _dispvars->dispmanx_width)
       dst_width = _dispvars->dispmanx_width;
 
@@ -376,7 +376,7 @@ static void dispmanx_blank_console (struct dispmanx_video *_dispvars)
          -1,
          &_dispvars->back_surface);
 
-   /* Updating 1-page surface synchronously asks for truble, since the 1st CB will
+   /* Updating 1-page surface synchronously causes problems, since the 1st CB will
     * signal but not free because the only page is on screen, so get_free will wait forever. */
    dispmanx_surface_update_async(image, _dispvars->back_surface);
 }

--- a/gfx/drivers/drm_gfx.c
+++ b/gfx/drivers/drm_gfx.c
@@ -272,7 +272,7 @@ static void drm_surface_setup(void *data,  int src_width, int src_height,
 
 static void drm_page_flip(struct drm_surface *surface)
 {
-   /* We alredy have the id of the FB_ID property of
+   /* We already have the id of the FB_ID property of
     * the plane on which we are going to do a pageflip:
     * we got it back in drm_plane_setup()  */
    static drmModeAtomicReqPtr req = NULL;
@@ -517,7 +517,7 @@ static void drm_plane_setup(struct drm_surface *surface)
    uint32_t plane_w = drm.current_mode->vdisplay * surface->aspect;
    uint32_t plane_h = drm.current_mode->vdisplay;
    /* If we obtain a scaled image width that is bigger than the physical screen width,
-    * then we keep the physical screen width as our maximun width. */
+    * then we keep the physical screen width as our maximum width. */
    if (plane_w > drm.current_mode->hdisplay)
       plane_w = drm.current_mode->hdisplay;
 
@@ -796,7 +796,7 @@ static void drm_set_texture_enable(void *data, bool state, bool full_screen)
    /* If menu was active but it's not anymore... */
    if (!state && _drmvars->menu_active)
    {
-      /* We tell ony the plane we have to read from the main surface again */
+      /* We tell only the plane we have to read from the main surface again */
       drm_plane_setup(_drmvars->main_surface);
       /* We free the menu surface buffers */
       drm_surface_free(_drmvars, &_drmvars->menu_surface);

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -3447,7 +3447,7 @@ static bool gl2_frame(void *data, const void *frame,
                if (     (img_width  > fbo_rect->width)
                      || (img_height > fbo_rect->height))
                {
-                  /* Check proactively since we might suddently
+                  /* Check proactively since we might suddenly
                    * get sizes of tex_w width or tex_h height. */
                   unsigned max                    = img_width > img_height ? img_width : img_height;
                   unsigned pow2_size              = next_pow2(max);

--- a/gfx/drivers/oga_gfx.c
+++ b/gfx/drivers/oga_gfx.c
@@ -141,7 +141,7 @@ static bool oga_create_display(oga_video_t* vid)
 
    vid->connector_id = connector->connector_id;
 
-   /* Find prefered mode */
+   /* Find preferred mode */
    for (i = 0; i < connector->count_modes; i++)
    {
       drmModeModeInfo *current_mode = &connector->modes[i];

--- a/gfx/drivers/rsx_gfx.c
+++ b/gfx/drivers/rsx_gfx.c
@@ -214,7 +214,7 @@ static void gfx_display_rsx_draw(gfx_display_ctx_draw_t *draw,
          texture->wrap_t, GCM_TEXTURE_CLAMP_TO_EDGE, 0, GCM_TEXTURE_ZFUNC_LESS, 0);
 
 #if RSX_MAX_TEXTURE_VERTICES > 0
-   /* Using preallocated texture vertices uses better memory managment but may cause more flickering */
+   /* Using preallocated texture vertices uses better memory management but may cause more flickering */
    end_vert_idx             = rsx->texture_vert_idx + draw->coords->vertices;
    if (end_vert_idx > RSX_MAX_TEXTURE_VERTICES)
    {
@@ -1154,7 +1154,7 @@ static gcmContextData *rsx_init_screen(rsx_t* gcm)
 
    if (!saved_context)
    {
-      /* Allocate a 1MB buffer, alligned to a 1MB boundary
+      /* Allocate a 1MB buffer, aligned to a 1MB boundary
        * to be our shared I/O memory with the RSX. */
       void *host_addr = memalign(1024*1024, HOST_SIZE);
 

--- a/gfx/drivers/sunxi_gfx.c
+++ b/gfx/drivers/sunxi_gfx.c
@@ -493,7 +493,7 @@ void pixman_composite_src_8888_8888_asm_neon(int width,
    uint16_t *src,
    int src_stride_pixels);
 
-/* Pointer to the blitting function. Will be asigned
+/* Pointer to the blitting function. Will be assigned
  * when we find out what bpp the core uses. */
 void (*pixman_blit) (int width,
    int height,

--- a/gfx/drivers/switch_nx_gfx.c
+++ b/gfx/drivers/switch_nx_gfx.c
@@ -471,7 +471,7 @@ static void gfx_cpy_dsp_buf(uint32_t *buffer, uint32_t *image, int w, int h, uin
     }
 }
 
-/* needed to clear surface completely as hw scaling doesn't always scale to full resoution perflectly */
+/* needed to clear surface completely as hw scaling doesn't always scale to full resolution perflectly */
 static void clear_screen(switch_video_t *sw)
 {
     nwindowSetDimensions(sw->win, sw->vp.full_width, sw->vp.full_height);

--- a/gfx/drivers/vulkan_shaders/hdr_common.glsl
+++ b/gfx/drivers/vulkan_shaders/hdr_common.glsl
@@ -122,7 +122,7 @@ const mat3 k2020toExpanded709 = mat3 (
  * by normalizing the values using the defined nits for paper white. According to SDR specs, paper white
  * is 80 nits, but that is paper white in a cinema with a dark environment, and is perceived as grey on
  * a display in office and living room environments. This value should be tuned according to the nits
- * that the consumer perceives as white in his living room, e.g. 200 nits. As refernce, PC monitors is
+ * that the consumer perceives as white in his living room, e.g. 200 nits. As reference, PC monitors is
  * normally in the range 200-300 nits, SDR TVs 150-250 nits.
  */
 vec3 NormalizeHDRSceneValue(vec3 hdrSceneValue)

--- a/gfx/drivers/vulkan_shaders/rgb565_to_rgba8888.comp
+++ b/gfx/drivers/vulkan_shaders/rgb565_to_rgba8888.comp
@@ -21,7 +21,7 @@ vec3 rgb565_to_rgb888(uint word)
 
 void main()
 {
-	// We work on two horizonal pixels in parallel since we cannot rely on 16-bit storage.
+	// We work on two horizontal pixels in parallel since we cannot rely on 16-bit storage.
 	uvec2 first_input_pixel = gl_GlobalInvocationID.xy;
 	uvec2 first_output_pixel = first_input_pixel * uvec2(2, 1);
 

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -599,7 +599,7 @@ static void xv_calc_out_rect(bool keep_aspect,
    vp->full_width       = vp_width;
    vp->full_height      = vp_height;
 
-   /* TODO: Does xvideo have its origin in top left or bottom-left? Assuming top left. */ 
+   /* TODO: Does xvideo have its origin in top left or bottom-left? Assuming top left. */
    if (scale_integer)
       video_viewport_get_scaled_integer(vp, vp_width, vp_height,
            video_driver_get_aspect_ratio(), keep_aspect, true);
@@ -676,7 +676,7 @@ static void *xv_init(const video_info_t *video,
       else if (ret == XvBadAlloc)
          RARCH_ERR("[XVideo]: XvQueryAdaptors() failed to allocate memory.\n");
       else
-         RARCH_ERR("[XVideo]: Unkown error in XvQueryAdaptors().\n");
+         RARCH_ERR("[XVideo]: Unknown error in XvQueryAdaptors().\n");
 
       goto error;
    }

--- a/gfx/drivers_font_renderer/freetype.c
+++ b/gfx/drivers_font_renderer/freetype.c
@@ -216,9 +216,9 @@ static bool font_renderer_create_atlas(ft_font_renderer_t *handle, float font_si
    unsigned i, x, y;
    freetype_atlas_slot_t* slot = NULL;
 
-   unsigned max_width          = round((handle->face->bbox.xMax - handle->face->bbox.xMin) 
+   unsigned max_width          = round((handle->face->bbox.xMax - handle->face->bbox.xMin)
          * font_size / handle->face->units_per_EM);
-   unsigned max_height         = round((handle->face->bbox.yMax - handle->face->bbox.yMin) 
+   unsigned max_height         = round((handle->face->bbox.yMax - handle->face->bbox.yMin)
          * font_size / handle->face->units_per_EM);
 
    unsigned atlas_width        = (max_width  + FT_ATLAS_PADDING) * FT_ATLAS_COLS;
@@ -306,13 +306,13 @@ static void *font_renderer_ft_init(const char *font_path, float font_size)
       int face_index         = 0;
       /* select Sans fonts */
       FcPattern* pattern     = FcNameParse((const FcChar8*)"Sans");
-      /* since fontconfig uses LL-TT style, we need to normalize 
+      /* since fontconfig uses LL-TT style, we need to normalize
        * locale names */
       FcChar8* locale        = FcLangNormalize((const FcChar8*)get_user_language_iso639_1(false));
-      /* configure fontconfig substitute policies, this 
+      /* configure fontconfig substitute policies, this
        * will increase the search scope */
       FcConfigSubstitute(config, pattern, FcMatchPattern);
-      /* pull in system-wide defaults, so the 
+      /* pull in system-wide defaults, so the
        * font selection respects system (or user) configurations */
       FcDefaultSubstitute(pattern);
 
@@ -320,7 +320,7 @@ static void *font_renderer_ft_init(const char *font_path, float font_size)
       locale_boxed.type = FcTypeString;
       locale_boxed.u.s  = locale;
 
-      /* Override locale settins, since we are not using the system locale */
+      /* Override locale settings, since we are not using the system locale */
       FcPatternAdd(pattern, FC_LANG, locale_boxed, false);
 
       /* Let's find the best matching font given our search criteria */
@@ -349,7 +349,7 @@ static void *font_renderer_ft_init(const char *font_path, float font_size)
       FcPatternDestroy(found);
       FcStrFree(locale);
       FcConfigDestroy(config);
-      
+
       if (err)
          goto error;
       handle->file_data = font_data;

--- a/gfx/gfx_animation.c
+++ b/gfx/gfx_animation.c
@@ -1148,7 +1148,7 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
    }
 
    /* Note: If we reach this point then str_len > ticker->len
-    * (previously had an unecessary 'if (str_len > ticker->len)'
+    * (previously had an unnecessary 'if (str_len > ticker->len)'
     * check here...) */
    switch (ticker->type_enum)
    {

--- a/gfx/gfx_display.c
+++ b/gfx/gfx_display.c
@@ -677,8 +677,8 @@ void gfx_display_draw_texture_slice(
    draw.x                   = 0;
    draw.y                   = 0;
 
-   /* vertex coords are specfied bottom-up in this order: BL BR TL TR */
-   /* texture coords are specfied top-down in this order: BL BR TL TR */
+   /* vertex coords are specified bottom-up in this order: BL BR TL TR */
+   /* texture coords are specified top-down in this order: BL BR TL TR */
 
    /* If someone wants to change this to not draw several times, the
     * coordinates will need to be modified because of the triangle strip usage. */

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -576,7 +576,7 @@ typedef struct gfx_ctx_driver
    gfx_ctx_proc_t (*get_proc_address)(const char*);
 
    /* Returns true if this context supports EGLImage buffers for
-    * screen drawing and was initalized correctly. */
+    * screen drawing and was initialized correctly. */
    bool (*image_buffer_init)(void*, const video_info_t*);
 
    /* Writes the frame to the EGLImage and sets image_handle to it.

--- a/gfx/video_filter.c
+++ b/gfx/video_filter.c
@@ -450,7 +450,7 @@ rarch_softfilter_t *rarch_softfilter_new(const char *filter_config,
 #endif
    if (!append_softfilter_plugs(filt, plugs))
    {
-      RARCH_ERR("[SoftFitler]: Failed to append softfilter plugins...\n");
+      RARCH_ERR("[SoftFilter]: Failed to append softfilter plugins...\n");
       goto error;
    }
 
@@ -461,7 +461,7 @@ rarch_softfilter_t *rarch_softfilter_new(const char *filter_config,
    if (!create_softfilter_graph(filt, in_pixel_format,
             max_width, max_height, cpu_features, threads))
    {
-      RARCH_ERR("[SoftFitler]: Failed to create softfilter graph...\n");
+      RARCH_ERR("[SoftFilter]: Failed to create softfilter graph...\n");
       goto error;
    }
 

--- a/gfx/video_filters/snes_ntsc/snes_ntsc_impl.h
+++ b/gfx/video_filters/snes_ntsc/snes_ntsc_impl.h
@@ -225,7 +225,7 @@ static void init( init_t* impl, snes_ntsc_setup_t const* setup )
 					(float) pow( i * to_float, gamma ) * impl->contrast + impl->brightness;
 	}
 
-	/* setup decoder matricies */
+	/* setup decoder matrices */
 	{
 		float hue = (float) setup->hue * PI + PI / 180 * ext_decoder_hue;
 		float sat = (float) setup->saturation + 1;

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -478,7 +478,7 @@ static void wl_touch_handle_frame(void *data, struct wl_touch *wl_touch) { }
 static void wl_touch_handle_cancel(void *data, struct wl_touch *wl_touch)
 {
    /* If i understand the spec correctly we have to reset all touches here
-    * since they were not ment for us anyway */
+    * since they were not meant for us anyway */
    int i;
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
@@ -924,7 +924,7 @@ static void wl_data_device_handle_enter(void *data,
 {
    data_offer_ctx *offer_data;
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   enum wl_data_device_manager_dnd_action dnd_action = 
+   enum wl_data_device_manager_dnd_action dnd_action =
       WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE;
 
    if (!offer)
@@ -936,11 +936,11 @@ static void wl_data_device_handle_enter(void *data,
    wl_data_offer_accept(offer, serial,
       offer_data->is_file_mime_type ? FILE_MIME : NULL);
 
-   if (     offer_data->is_file_mime_type 
+   if (     offer_data->is_file_mime_type
          && offer_data->supported_actions & DND_ACTION)
       dnd_action = DND_ACTION;
 
-   if (     wl_data_offer_get_version(offer) 
+   if (     wl_data_offer_get_version(offer)
          >= WL_DATA_OFFER_SET_ACTIONS_SINCE_VERSION)
      wl_data_offer_set_actions(offer, dnd_action, dnd_action);
 }

--- a/input/connect/connect_wii.c
+++ b/input/connect/connect_wii.c
@@ -398,7 +398,7 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
       {
          case 0:
             /* no ha habido nunca handshake, debemos forzar un
-             * mensaje de staus para ver que pasa. */
+             * mensaje de status para ver que pasa. */
 
             WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE);
             wiimote_set_leds(wm, WIIMOTE_LED_NONE);
@@ -439,7 +439,7 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
 
                      WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE_COMPLETE);
                      /* forzamos un handshake por si venimos
-                      * de un hanshake completo. */
+                      * de un handshake completo. */
                      WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE);
                   }
 
@@ -478,7 +478,7 @@ static int wiimote_handshake(struct connect_wii_wiimote_t* wm,
                   {
                      WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE_COMPLETE);
                      /* forzamos un handshake por si venimos
-                      * de un hanshake completo. */
+                      * de un handshake completo. */
                      WIIMOTE_ENABLE_STATE(wm, WIIMOTE_STATE_HANDSHAKE);
                   }
                }

--- a/input/connect/connect_wiiugca.c
+++ b/input/connect/connect_wiiugca.c
@@ -87,7 +87,7 @@ static void* hidpad_wiiugca_init(void *data, uint32_t slot, hid_driver_t *driver
       device->pad_data[i].joypad      = NULL;
       device->pad_data[i].pad_index   = i;
    }
-   
+
    device->driver                     = driver;
 
    device->driver->send_control(device->handle, magic_data, sizeof(magic_data));
@@ -175,7 +175,7 @@ static void update_analog_state(gca_pad_data_t *pad)
    int pad_axis;
 
    /* GameCube analog axis are 8-bit unsigned, where 128/128 is center.
-    * So, we subtract 128 to get a signed, 0-based value and then mulitply
+    * So, we subtract 128 to get a signed, 0-based value and then multiply
     * by 256 to get the 16-bit range RetroArch expects. */
    for (pad_axis = 0; pad_axis < 4; pad_axis++)
    {

--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -81,7 +81,7 @@ typedef struct rwebinput_input
 } rwebinput_input_t;
 
 /* KeyboardEvent.keyCode has been deprecated for a while and doesn't have
- * separate left/right modifer codes, so we have to map string labels from
+ * separate left/right modifier codes, so we have to map string labels from
  * KeyboardEvent.code to retro keys */
 static const rwebinput_key_to_code_map_entry_t rwebinput_key_to_code_map[] =
 {
@@ -489,7 +489,7 @@ static int16_t rwebinput_input_state(
             }
             if (id_minus_valid && id_minus_key && id_minus_key < RETROK_LAST)
             {
-               if (rwebinput_is_pressed(rwebinput, 
+               if (rwebinput_is_pressed(rwebinput,
                         binds[port], idx, id_minus,
                         keyboard_mapping_blocked))
                   ret += -0x7fff;
@@ -508,10 +508,10 @@ static int16_t rwebinput_input_state(
          if (idx == 0)
          {
             struct video_viewport vp;
-            rwebinput_mouse_state_t 
+            rwebinput_mouse_state_t
                *mouse                   = &rwebinput->mouse;
             const int edge_detect       = 32700;
-            bool screen                 = device == 
+            bool screen                 = device ==
                RARCH_DEVICE_POINTER_SCREEN;
             bool inside                 = false;
             int16_t res_x               = 0;
@@ -537,7 +537,7 @@ static int16_t rwebinput_input_state(
                res_y = res_screen_y;
             }
 
-            inside =    (res_x >= -edge_detect) 
+            inside =    (res_x >= -edge_detect)
                && (res_y >= -edge_detect)
                && (res_x <= edge_detect)
                && (res_y <= edge_detect);
@@ -586,7 +586,7 @@ static void rwebinput_process_keyboard_events(
    uint32_t character                       = 0;
    uint16_t mod                             = 0;
    const EmscriptenKeyboardEvent *key_event = &event->event;
-   bool keydown                             = 
+   bool keydown                             =
       event->type == EMSCRIPTEN_EVENT_KEYDOWN;
 
    /* a printable key: populate character field */
@@ -620,8 +620,8 @@ static void rwebinput_process_keyboard_events(
    if (translated_keycode != RETROK_UNKNOWN)
       input_keyboard_event(keydown, translated_keycode, character, mod,
          RETRO_DEVICE_KEYBOARD);
-   
-   if (     translated_keycode  < RETROK_LAST 
+
+   if (     translated_keycode  < RETROK_LAST
          && translated_keycode != RETROK_UNKNOWN)
       rwebinput->keys[translated_keycode] = keydown;
 }

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -96,7 +96,7 @@
 
 /* Define this to use direct printf debug messages. */
 /*#define UDEV_TOUCH_PRINTF_DEBUG*/
-/* Define this to add more deep debugging messages - performace will suffer... */
+/* Define this to add more deep debugging messages - performance will suffer... */
 /*#define UDEV_TOUCH_DEEP_DEBUG*/
 
 /* TODO - Temporary debugging using direct printf */
@@ -401,7 +401,7 @@ typedef struct
    udev_slot_state_t *current;
    uint16_t current_active;
 
-   /* Timestamp of when the last touch state update ocurred */
+   /* Timestamp of when the last touch state update occurred */
    udev_touch_ts_t last_state_update;
 
    /* Simulated pointer / touchscreen */
@@ -1884,7 +1884,7 @@ static bool udev_translate_touch_pos(
    /*
     * TODO - This keeps the precision, but might result in +-1 pixel difference
     *   One way to fix this is to add or remove 0.5, but this needs floating
-    *   point operations which might not be desireable.
+    *   point operations which might not be desirable.
     */
    int32_t ma_pos_x   = (((((pointer_pos_x + src_touch->info_x_limits.min) * 0x7fff) / src_touch->info_x_limits.range) * target_vp->full_width) / 0x7fff);
    int32_t ma_pos_y   = (((((pointer_pos_y + src_touch->info_y_limits.min) * 0x7fff) / src_touch->info_y_limits.range) * target_vp->full_height) / 0x7fff);
@@ -2420,10 +2420,10 @@ static void udev_report_touch(udev_input_t *udev, udev_input_device_t *dev)
                RARCH_ERR("[udev] Cannot report touch up since there are no active points!\n");
             }
 
-            /* Letting go of the primary gesture point -> Wait for full relese */
+            /* Letting go of the primary gesture point -> Wait for full release */
             if (iii == touch->gest_primary_slot)
                touch->gest_primary_slot = UDEV_INPUT_TOUCH_TRACKING_ID_NONE;
-            /* Letting go of the secondary gesture point -> Wait for full relese */
+            /* Letting go of the secondary gesture point -> Wait for full release */
             if (iii == touch->gest_secondary_slot)
                touch->gest_secondary_slot = UDEV_INPUT_TOUCH_TRACKING_ID_NONE;
 
@@ -3237,7 +3237,7 @@ static int udev_input_add_device(udev_input_t *udev,
             mouse = 1;
 
             if (!test_bit(keycaps, BTN_MOUSE))
-               RARCH_DBG("[udev]: Waring REL pointer device (%s) has no mouse button\n",device->ident);
+               RARCH_DBG("[udev]: Warning REL pointer device (%s) has no mouse button\n",device->ident);
          }
       }
 

--- a/input/drivers/wiiu_input.c
+++ b/input/drivers/wiiu_input.c
@@ -111,9 +111,9 @@ static int16_t wiiu_input_state(
          break;
       case RETRO_DEVICE_POINTER:
       case RARCH_DEVICE_POINTER_SCREEN:
-         /* TODO: Emulate a relative mouse. 
-          * This is suprisingly hard to get working nicely.
-            */
+         /* TODO: Emulate a relative mouse.
+          * This is surprisingly hard to get working nicely.
+          */
          switch (id)
          {
             case RETRO_DEVICE_ID_POINTER_PRESSED:

--- a/input/drivers_hid/btstack_hid.c
+++ b/input/drivers_hid/btstack_hid.c
@@ -454,7 +454,7 @@ extern const hci_cmd_t rfcomm_register_service;
 extern const hci_cmd_t rfcomm_register_service_with_initial_credits;
 /* unregister rfcomm service, @param service_channel(16) */
 extern const hci_cmd_t rfcomm_unregister_service;
-/* request persisten rfcomm channel for service name: serive name (char*)  */
+/* request persistent rfcomm channel for service name: serive name (char*)  */
 extern const hci_cmd_t rfcomm_persistent_channel_for_service;
 
 /* linked_list.h */
@@ -1425,11 +1425,11 @@ static int16_t btstack_hid_joypad_state(
       const uint32_t joyaxis = (binds[i].joyaxis != AXIS_NONE)
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
-               (uint16_t)joykey != NO_BTN 
+               (uint16_t)joykey != NO_BTN
             && btstack_hid_joypad_button(data, port_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(btstack_hid_joypad_axis(data, port_idx, joyaxis)) 
+            ((float)abs(btstack_hid_joypad_axis(data, port_idx, joyaxis))
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -261,7 +261,7 @@ static int udev_add_pad(struct udev_device *dev, unsigned p, int fd, const char 
                by testing if the axis initial value is negative, allowing for
                for some slop (1300 =~ 4%) in an axis centred around 0.
                The actual work is done in udev_joypad_axis.
-               All bets are off if you're sitting on it. Reinitailise it by unpluging
+               All bets are off if you're sitting on it. Reinitialise it by unpluging
                and plugging back in. */
             if (udev_compute_axis(abs, abs->value) < -1300)
               pad->neg_trigger[i] = true;

--- a/input/drivers_joypad/xinput_hybrid_joypad.c
+++ b/input/drivers_joypad/xinput_hybrid_joypad.c
@@ -16,14 +16,14 @@
 
 /* Support 360 controllers on Windows.
  * Said controllers do show under DInput but they have limitations in this mode;
- * The triggers are combined rather than seperate and it is not possible to use
+ * The triggers are combined rather than separate and it is not possible to use
  * the guide button.
  *
  * Some wrappers for other controllers also simulate xinput (as it is easier to implement)
  * so this may be useful for those also.
  **/
 
-/* Specialized version of xinput_joypad.c, 
+/* Specialized version of xinput_joypad.c,
  * has both DirectInput and XInput codepaths */
 
 /* TODO/FIXME - integrate dinput_joypad into this version */
@@ -92,9 +92,9 @@ static XINPUT_VIBRATION    g_xinput_rumble_states[4];
 static xinput_joypad_state g_xinput_states[4];
 
 /* Buttons are provided by XInput as bits of a uint16.
- * Map from rarch button index (0..10) to a mask to 
+ * Map from rarch button index (0..10) to a mask to
  * bitwise-& the buttons against.
- * dpad is handled seperately. */
+ * dpad is handled separately. */
 static const uint16_t button_index_to_bitmap_code[] =  {
    XINPUT_GAMEPAD_A,
    XINPUT_GAMEPAD_B,
@@ -170,7 +170,7 @@ static bool guid_is_xinput_device(const GUID* product_guid)
 
       rdi.cbSize      = rdi_size;
 
-      /* 
+      /*
        * Step 1 -
        * Check if device type is HID
        * Step 2 -
@@ -182,7 +182,7 @@ static bool guid_is_xinput_device(const GUID* product_guid)
        * Step 5 -
        * Check if the device ID contains "IG_".
        * If it does, then it's an XInput device
-       * This information can not be found from DirectInput 
+       * This information can not be found from DirectInput
        */
       if (
                (raw_devs[i].dwType == RIM_TYPEHID)                    /* 1 */
@@ -242,7 +242,7 @@ static BOOL CALLBACK enum_joypad_cb_hybrid(
    if (g_joypad_cnt == MAX_USERS)
       return DIENUM_STOP;
 
-   while (!g_xinput_states[g_last_xinput_pad_idx].connected && g_last_xinput_pad_idx < 3) 
+   while (!g_xinput_states[g_last_xinput_pad_idx].connected && g_last_xinput_pad_idx < 3)
    {
       g_last_xinput_pad_idx++;
    }
@@ -258,9 +258,9 @@ static BOOL CALLBACK enum_joypad_cb_hybrid(
 #endif
       return DIENUM_CONTINUE;
 
-   g_pads[g_joypad_cnt].joy_name          = 
+   g_pads[g_joypad_cnt].joy_name          =
       strdup((const char*)inst->tszProductName);
-   g_pads[g_joypad_cnt].joy_friendly_name = 
+   g_pads[g_joypad_cnt].joy_friendly_name =
       strdup((const char*)inst->tszInstanceName);
 
    /* there may be more useful info in the GUID,
@@ -420,7 +420,7 @@ static void *xinput_joypad_init(void *data)
       g_xinput_states[i].xstate.Gamepad.sThumbLY      = 0;
       g_xinput_states[i].xstate.Gamepad.sThumbRX      = 0;
       g_xinput_states[i].xstate.Gamepad.sThumbRY      = 0;
-      g_xinput_states[i].connected                    = 
+      g_xinput_states[i].connected                    =
          !(g_XInputGetStateEx(i, &dummy_state) == ERROR_DEVICE_NOT_CONNECTED);
    }
 
@@ -480,7 +480,7 @@ succeeded:
 error:
    /* non-hat button. */
    g_xinput_num_buttons = g_xinput_guide_button_supported ? 11 : 10;
-   
+
    return NULL;
 }
 
@@ -543,12 +543,12 @@ static int16_t xinput_joypad_state_func(
       const uint32_t joyaxis = (binds[i].joyaxis != AXIS_NONE)
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
-               (uint16_t)joykey != NO_BTN 
+               (uint16_t)joykey != NO_BTN
             && xinput_joypad_button_state(
                xuser, btn_word, port_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(xinput_joypad_axis_state(pad, port_idx, joyaxis)) 
+            ((float)abs(xinput_joypad_axis_state(pad, port_idx, joyaxis))
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }

--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -16,7 +16,7 @@
 
 /* Support 360 controllers on Windows.
  * Said controllers do show under DInput but they have limitations in this mode;
- * The triggers are combined rather than seperate and it is not possible to use
+ * The triggers are combined rather than separate and it is not possible to use
  * the guide button.
  *
  * Some wrappers for other controllers also simulate xinput (as it is easier to implement)
@@ -73,9 +73,9 @@ static XINPUT_VIBRATION    g_xinput_rumble_states[4];
 static xinput_joypad_state g_xinput_states[4];
 
 /* Buttons are provided by XInput as bits of a uint16.
- * Map from rarch button index (0..10) to a mask to 
+ * Map from rarch button index (0..10) to a mask to
  * bitwise-& the buttons against.
- * dpad is handled seperately. */
+ * dpad is handled separately. */
 static const uint16_t button_index_to_bitmap_code[] =  {
    XINPUT_GAMEPAD_A,
    XINPUT_GAMEPAD_B,
@@ -97,7 +97,7 @@ static const uint16_t button_index_to_bitmap_code[] =  {
 
 static INLINE int pad_index_to_xuser_index(unsigned pad)
 {
-   return pad < DEFAULT_MAX_PADS 
+   return pad < DEFAULT_MAX_PADS
       && g_xinput_states[pad].connected ? pad : -1;
 }
 
@@ -190,7 +190,7 @@ static void *xinput_joypad_init(void *data)
       g_xinput_states[i].xstate.Gamepad.sThumbLY      = 0;
       g_xinput_states[i].xstate.Gamepad.sThumbRX      = 0;
       g_xinput_states[i].xstate.Gamepad.sThumbRY      = 0;
-      g_xinput_states[i].connected                    = 
+      g_xinput_states[i].connected                    =
          !(g_XInputGetStateEx(i, &dummy_state) == ERROR_DEVICE_NOT_CONNECTED);
    }
 
@@ -317,12 +317,12 @@ static int16_t xinput_joypad_state_func(
       const uint32_t joyaxis = (binds[i].joyaxis != AXIS_NONE)
          ? binds[i].joyaxis : joypad_info->auto_binds[i].joyaxis;
       if (
-               (uint16_t)joykey != NO_BTN 
+               (uint16_t)joykey != NO_BTN
             && xinput_joypad_button_state(
                xuser, btn_word, port_idx, (uint16_t)joykey))
          ret |= ( 1 << i);
       else if (joyaxis != AXIS_NONE &&
-            ((float)abs(xinput_joypad_axis_state(pad, port_idx, joyaxis)) 
+            ((float)abs(xinput_joypad_axis_state(pad, port_idx, joyaxis))
              / 0x8000) > joypad_info->axis_threshold)
          ret |= (1 << i);
    }
@@ -336,7 +336,7 @@ static void xinput_joypad_poll(void)
 
    for (i = 0; i < 4; ++i)
    {
-      xinput_joypad_state 
+      xinput_joypad_state
          *state          = &g_xinput_states[i];
       DWORD status       = g_XInputGetStateEx(i, &state->xstate);
       bool success       = status == ERROR_SUCCESS;

--- a/input/drivers_joypad/xinput_joypad_inl.h
+++ b/input/drivers_joypad/xinput_joypad_inl.h
@@ -31,7 +31,7 @@ static bool load_xinput_dll(void)
     * wrapper DLL (such as x360ce); support these by checking
     * the working directory first.
     *
-    * No need to check for existance as we will be checking dylib_load's
+    * No need to check for existence as we will be checking dylib_load's
     * success anyway.
     */
 

--- a/input/drivers_keyboard/keyboard_event_android.h
+++ b/input/drivers_keyboard/keyboard_event_android.h
@@ -16,7 +16,7 @@
 #ifndef _KEYBOARD_EVENT_ANDROID_H
 #define _KEYBOARD_EVENT_ANDROID_H
 
-/* The list of defined Android keycodes is incomplete in SDK version 12 
+/* The list of defined Android keycodes is incomplete in SDK version 12
  * and lower.
  * If using an SDK lower than 13, add missing keycodes here */
 #if __ANDROID_API__ < 13
@@ -121,7 +121,7 @@ enum {
 };
 
 /*
- * Meta key / modifer state.
+ * Meta key / modifier state.
  */
 enum {
     AMETA_CTRL_ON = 0x1000,

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4344,7 +4344,7 @@ bool input_set_rumble_state(unsigned port,
    unsigned joy_idx                       = settings->uints.input_joypad_index[port];
    uint16_t scaled_strength               = strength;
 
-   /* If gain setting is not suported, do software gain control */
+   /* If gain setting is not supported, do software gain control */
    if (input_driver_st.primary_joypad)
    {
       if (!input_driver_st.primary_joypad->set_rumble_gain)
@@ -5700,7 +5700,7 @@ void bsv_movie_frame_rewind(void)
        * However, playing back that frame caused us to read data, and push
        * data to the ring buffer.
        *
-       * Sucessively rewinding frames, we need to rewind past the read data,
+       * Successively rewinding frames, we need to rewind past the read data,
        * plus another. */
       uint8_t delta = handle->first_rewind ? 1 : 2;
       if (handle->frame_counter >= delta)

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -333,7 +333,7 @@ struct input_driver
    /**
     * Queries state for a specified control on a specified input port. This
     * function pointer can be set to NULL if not supported by the input driver,
-    * for example if a joypad driver is responsible for quering state for a
+    * for example if a joypad driver is responsible for querying state for a
     * particular driver/platform.
     *
     * @param joypad_data      Input state struct, defined by the input driver
@@ -395,7 +395,7 @@ struct input_driver
 
    /**
     * Retrieves the sensor state associated with the provided port and ID. This
-    * function pointer may be set to NULL if retreiving sensor state is not
+    * function pointer may be set to NULL if retrieving sensor state is not
     * supported.
     *
     * @param data

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -10274,7 +10274,7 @@ MSG_HASH(
 )
 MSG_HASH(
    MENU_ENUM_LABEL_CHEEVOS_SERVER_RECONNECTED,
-   "All pending requests have succesfully been synced to the RetroAchievements server."
+   "All pending requests have successfully been synced to the RetroAchievements server."
 )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CHEEVOS_IDENTIFYING_GAME,

--- a/libretro-common/audio/dsp_filters/eq.c
+++ b/libretro-common/audio/dsp_filters/eq.c
@@ -222,7 +222,7 @@ static void create_filter(struct eq_data *eq, unsigned size_log2,
       time_filter[i] = tmp;
    }
 
-   /* Apply a window to smooth out the frequency repsonse. */
+   /* Apply a window to smooth out the frequency response. */
    for (i = 0; i < (int)eq->block_size; i++)
    {
       /* Kaiser window. */

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -650,7 +650,7 @@ void path_parent_dir(char *path, size_t len)
          /* We removed the only slash from what used to be an absolute path.
           * On Linux, this goes from "/" to an empty string and everything works fine,
           * but on Windows, we went from C:\ to C:, which is not a valid path and that later
-          * gets errornously treated as a relative one by path_basedir and returns "./".
+          * gets erroneously treated as a relative one by path_basedir and returns "./".
           * What we really wanted is an empty string. */
          path[0] = '\0';
          return;
@@ -722,8 +722,8 @@ bool path_is_absolute(const char *path)
             || string_starts_with_size(path + 1, ":\\",  STRLEN_CONST(":\\")));
 #elif defined(__wiiu__) || defined(VITA)
       {
-         const char *seperator = strchr(path, ':');
-         return (seperator && (seperator[1] == '/'));
+         const char *separator = strchr(path, ':');
+         return (separator && (separator[1] == '/'));
       }
 #endif
    }
@@ -746,7 +746,7 @@ bool path_is_absolute(const char *path)
  * Note: Symlinks are only resolved on Unix-likes
  * Note: The current working dir might not be what you expect,
  *       e.g. on Android it is "/"
- *       Use of fill_pathname_resolve_relative() should be prefered
+ *       Use of fill_pathname_resolve_relative() should be preferred
  **/
 char *path_resolve_realpath(char *buf, size_t size, bool resolve_symlinks)
 {

--- a/libretro-common/formats/jpeg/rjpeg.c
+++ b/libretro-common/formats/jpeg/rjpeg.c
@@ -823,9 +823,9 @@ static void rjpeg_idct_block(uint8_t *out, int out_stride, short data[64])
    for (i = 0; i < 8; ++i,++d, ++v)
    {
       /* if all zeroes, shortcut -- this avoids dequantizing 0s and IDCTing */
-      if (     d[ 8] == 0 
-            && d[16] == 0 
-            && d[24] == 0 
+      if (     d[ 8] == 0
+            && d[16] == 0
+            && d[24] == 0
             && d[32] == 0
             && d[40] == 0
             && d[48] == 0
@@ -870,7 +870,7 @@ static void rjpeg_idct_block(uint8_t *out, int out_stride, short data[64])
        * we've got an extra 1<<3, so 1<<17 total we need to remove.
        * so we want to round that, which means adding 0.5 * 1<<17,
        * aka 65536. Also, we'll end up with -128 to 127 that we want
-       * to encode as 0..255 by adding 128, so we'll add that before the shift 
+       * to encode as 0..255 by adding 128, so we'll add that before the shift
        */
       x0 += 65536 + (128<<17);
       x1 += 65536 + (128<<17);
@@ -1322,7 +1322,7 @@ static void rjpeg_jpeg_reset(rjpeg_jpeg *j)
    j->todo                = j->restart_interval ? j->restart_interval : 0x7fffffff;
    j->eob_run             = 0;
 
-   /* no more than 1<<31 MCUs if no restart_interal? that's plenty safe,
+   /* no more than 1<<31 MCUs if no restart_interval? that's plenty safe,
     * since we don't even allow 1<<30 pixels */
 }
 

--- a/libretro-common/formats/libchdr/libchdr_cdrom.c
+++ b/libretro-common/formats/libchdr/libchdr_cdrom.c
@@ -4,7 +4,7 @@
 
     cdrom.c
 
-    Generic MAME CD-ROM utilties - build IDE and SCSI CD-ROMs on top of this
+    Generic MAME CD-ROM utilities - build IDE and SCSI CD-ROMs on top of this
 
 ****************************************************************************
 

--- a/libretro-common/include/compat/zlib/zlib.h
+++ b/libretro-common/include/compat/zlib/zlib.h
@@ -485,7 +485,7 @@ typedef gz_header FAR *gz_headerp;
   instead use raw inflate, see inflateInit2() below, or inflateBack() and
   perform their own processing of the gzip header and trailer.  When processing
   gzip-wrapped deflate data, strm->adler32 is set to the CRC-32 of the output
-  producted so far.  The CRC-32 is checked against the gzip trailer.
+  produced so far.  The CRC-32 is checked against the gzip trailer.
 
     inflate() returns Z_OK if some progress has been made (more input processed
   or more output produced), Z_STREAM_END if the end of the compressed data has
@@ -844,7 +844,7 @@ typedef gz_header FAR *gz_headerp;
    to dictionary.  dictionary must have enough space, where 32768 bytes is
    always enough.  If inflateGetDictionary() is called with dictionary equal to
    Z_NULL, then only the dictionary length is returned, and nothing is copied.
-   Similary, if dictLength is Z_NULL, then it is not set.
+   Similarly, if dictLength is Z_NULL, then it is not set.
 
      inflateGetDictionary returns Z_OK on success, or Z_STREAM_ERROR if the
    stream state is inconsistent.
@@ -1414,7 +1414,7 @@ typedef struct gzFile_s *gzFile;    /* semi-opaque gzip file descriptor */
      If the flush parameter is Z_FINISH, the remaining data is written and the
    gzip stream is completed in the output.  If gzwrite() is called again, a new
    gzip stream will be started in the output.  gzread() is able to read such
-   concatented gzip streams.
+   concatenated gzip streams.
 
      gzflush should be called only when strictly necessary because it will
    degrade compression if called too often.

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -222,7 +222,7 @@ void path_parent_dir(char *path, size_t len);
  * Note: Symlinks are only resolved on Unix-likes
  * Note: The current working dir might not be what you expect,
  *       e.g. on Android it is "/"
- *       Use of fill_pathname_resolve_relative() should be prefered
+ *       Use of fill_pathname_resolve_relative() should be preferred
  **/
 char *path_resolve_realpath(char *buf, size_t size, bool resolve_symlinks);
 
@@ -556,11 +556,11 @@ size_t fill_pathname_abbreviated_or_relative(char *out_path,
  *
  * @path_part          : directory or filename
  * @size               : length of path_part
- * 
- * Takes single part of a path eg. single filename 
+ *
+ * Takes single part of a path eg. single filename
  * or directory, and removes any special chars that are
  * unavailable.
- * 
+ *
  * @returns new string that has been sanitized
  **/
 const char *sanitize_path_part(const char *path_part, size_t size);

--- a/libretro-common/include/formats/rjson.h
+++ b/libretro-common/include/formats/rjson.h
@@ -106,7 +106,7 @@ const char *rjson_get_error(rjson_t *json);
 void rjson_set_error(rjson_t *json, const char* error);
 
 /* Functions to get the current position in the source stream as well as */
-/* a bit of source json arround the current position for additional detail
+/* a bit of source json around the current position for additional detail
  * when parsing has failed with RJSON_ERROR.
  * Intended to be used with printf style formatting like:
  * printf("Invalid JSON at line %d, column %d - %s - Source: ...%.*s...\n",
@@ -127,7 +127,7 @@ bool rjson_check_context(rjson_t *json, unsigned int depth, ...);
 unsigned int rjson_get_context_depth(rjson_t *json);
 
 /* Return the current parsing context, that is, RJSON_OBJECT if we are inside
- * an object, RJSON_ARRAY if we are inside an array, and RJSON_DONE or 
+ * an object, RJSON_ARRAY if we are inside an array, and RJSON_DONE or
  * RJSON_ERROR if we are not yet/anymore in either. */
 enum rjson_type rjson_get_context_type(rjson_t *json);
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -219,7 +219,7 @@ extern "C" {
 #define RETRO_DEVICE_KEYBOARD     3
 
 /**
- * An abstraction around a light gun, simular to the PlayStation's Guncon.
+ * An abstraction around a light gun, similar to the PlayStation's Guncon.
  *
  * When provided as the \c device argument to \c retro_input_state_t,
  * the \c id argument denotes one of several possible inputs.
@@ -1094,7 +1094,7 @@ enum retro_mod
  * to write audio. The audio callbacks must be called from within the
  * notification callback.
  * The amount of audio data to write is up to the core.
- * Generally, the audio callback will be called continously in a loop.
+ * Generally, the audio callback will be called continuously in a loop.
  *
  * A frontend may disable this callback in certain situations.
  * The core must be able to render audio with the "normal" interface.
@@ -1332,7 +1332,7 @@ enum retro_mod
  * <li>Changing the emulated system's internal resolution,
  * within the limits defined by the existing values of \c max_width and \c max_height.
  * Use \c RETRO_ENVIRONMENT_SET_GEOMETRY instead,
- * and adjust \c retro_get_system_av_info to account fo
+ * and adjust \c retro_get_system_av_info to account for
  * supported scale factors and screen layouts
  * when computing \c max_width and \c max_height.
  * Only use this environment call if \c max_width or \c max_height needs to increase.
@@ -5174,14 +5174,14 @@ struct retro_hw_render_callback
  * character is the text character of the pressed key. (UTF-32).
  * key_modifiers is a set of RETROKMOD values or'ed together.
  *
- * The pressed/keycode state can be indepedent of the character.
+ * The pressed/keycode state can be independent of the character.
  * It is also possible that multiple characters are generated from a
  * single keypress.
  * Keycode events should be treated separately from character events.
  * However, when possible, the frontend should try to synchronize these.
  * If only a character is posted, keycode should be RETROK_UNKNOWN.
  *
- * Similarily if only a keycode event is generated with no corresponding
+ * Similarly if only a keycode event is generated with no corresponding
  * character, character should be 0.
  */
 typedef void (RETRO_CALLCONV *retro_keyboard_event_t)(bool down, unsigned keycode,
@@ -5732,7 +5732,7 @@ struct retro_message
 enum retro_message_target
 {
    /**
-    * Indicates that the frontent should display the given message
+    * Indicates that the frontend should display the given message
     * using all other targets defined by \c retro_message_target at once.
     */
    RETRO_MESSAGE_TARGET_ALL = 0,
@@ -5923,7 +5923,7 @@ struct retro_message_ext
    /**
     * The progress of an asynchronous task.
     *
-    * A value betwen 0 and 100 (inclusive) indicates the task's percentage,
+    * A value between 0 and 100 (inclusive) indicates the task's percentage,
     * and a value of -1 indicates a task of unknown completion.
     *
     * @note Since message type is a hint, a frontend may ignore progress values.

--- a/libretro-common/include/libretro_vulkan.h
+++ b/libretro-common/include/libretro_vulkan.h
@@ -172,8 +172,8 @@ struct retro_hw_render_context_negotiation_interface_vulkan
     * of the frontend is destroyed if create_device was called successfully so that the core has a chance of
     * tearing down its own device resources.
     *
-    * Only auxillary resources should be freed here, i.e. resources which are not part of retro_vulkan_context.
-    * v2: Auxillary instance resources created during create_instance can also be freed here.
+    * Only auxiliary resources should be freed here, i.e. resources which are not part of retro_vulkan_context.
+    * v2: Auxiliary instance resources created during create_instance can also be freed here.
     */
    retro_vulkan_destroy_device_t destroy_device;
 
@@ -373,7 +373,7 @@ struct retro_hw_render_interface_vulkan
     * The frontend will always release ownership back to src_queue_family.
     * Waiting for frontend to complete with wait_sync_index() ensures that
     * the frontend has released ownership back to the application.
-    * Note that in Vulkan, transfering ownership is a two-part process.
+    * Note that in Vulkan, transferring ownership is a two-part process.
     *
     * Example frame:
     *  - core releases ownership from src_queue_index to queue_index with VkImageMemoryBarrier.
@@ -431,7 +431,7 @@ struct retro_hw_render_interface_vulkan
     *
     * While this value will typically remain constant throughout the
     * applications lifecycle, it may for example change if the frontend
-    * suddently changes fullscreen state and/or latency.
+    * suddenly changes fullscreen state and/or latency.
     *
     * If this value ever changes, it is safe to assume that the device
     * is completely idle and all synchronization objects can be deleted

--- a/libretro-common/include/lists/linked_list.h
+++ b/libretro-common/include/lists/linked_list.h
@@ -50,7 +50,7 @@ linked_list_t *linked_list_new(void);
 
 /**
  * @brief frees the memory used by the linked list
- * 
+ *
  * Frees all of the memory used by this linked list. The values of all
  * remaining elements are freed using the "free_value" function. Does
  * nothing if "list" is NULL.
@@ -62,7 +62,7 @@ void linked_list_free(linked_list_t *list, void (*free_value)(void *value));
 
 /**
  * @brief adds an element to the linked list
- * 
+ *
  * Add a new element to the end of this linked list. Does nothing if
  * "list" is NULL.
  *
@@ -285,7 +285,7 @@ void linked_list_iterator_free(linked_list_iterator_t *iterator);
 /**
  * @brief Apply the provided function to all values in the linked list
  *
- * Apply the provied function to all values in the linked list. The values are applied
+ * Apply the provided function to all values in the linked list. The values are applied
  * in the forward direction. Does nothing if "list" is NULL.
  *
  * @param list linked list to apply the function to

--- a/libretro-common/include/retro_common_api.h
+++ b/libretro-common/include/retro_common_api.h
@@ -125,7 +125,7 @@ or obscure compilers */
 I would like to see retro_inline.h moved in here; possibly boolean too.
 
 rationale: these are used in public APIs, and it is easier to find problems
-and write code that works the first time portably when theyre included uniformly
+and write code that works the first time portably when they are included uniformly
 than to do the analysis from scratch each time you think you need it, for each feature.
 
 Moreover it helps force you to make hard decisions: if you EVER bring in boolean.h,

--- a/libretro-common/include/rthreads/tpool.h
+++ b/libretro-common/include/rthreads/tpool.h
@@ -5,17 +5,17 @@
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this file (tpool.h).
  * ---------------------------------------------------------------------------------------
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -40,10 +40,10 @@ RETRO_BEGIN_DECLS
 struct tpool;
 typedef struct tpool tpool_t;
 
-/** 
+/**
  * (*thread_func_t):
  * @arg           : Argument.
- * 
+ *
  * Callback function that the pool will call to do work.
  **/
 typedef void (*thread_func_t)(void *arg);
@@ -54,29 +54,29 @@ typedef void (*thread_func_t)(void *arg);
  *                  If 0 defaults to 2.
  *
  * Create a thread pool.
- * 
+ *
  * Returns: pool.
  */
 tpool_t *tpool_create(size_t num);
 
-/** 
+/**
  * tpool_destroy:
  * @tp            : Thread pool.
- * 
- * Destory a thread pool
+ *
+ * Destroy a thread pool
  * The pool can be destroyed while there is outstanding work to process. All
- * outstanding unprocessed work will be discareded. There may be a delay before
+ * outstanding unprocessed work will be discarded. There may be a delay before
  * this function returns because it will block for work that is processing to
  * complete.
  **/
 void tpool_destroy(tpool_t *tp);
 
-/** 
+/**
  * tpool_add_work:
  * @tp         : Thread pool.
  * @func       : Function the pool should call.
  * @arg        : Argument to pass to func.
- * 
+ *
  * Add work to a thread pool.
  *
  * Returns: true if work was added, otherwise false.
@@ -86,7 +86,7 @@ bool tpool_add_work(tpool_t *tp, thread_func_t func, void *arg);
 /**
  * tpool_wait:
  * @tp Thread pool.
- * 
+ *
  * Wait for all work in the pool to be completed.
  */
 void tpool_wait(tpool_t *tp);

--- a/libretro-common/include/string/stdstring.h
+++ b/libretro-common/include/string/stdstring.h
@@ -250,7 +250,7 @@ size_t word_wrap_wideglyph(
 /**
  * string_tokenize:
  *
- * Splits string into tokens seperated by @delim
+ * Splits string into tokens separated by @delim
  * > Returned token string must be free()'d
  * > Returns NULL if token is not found
  * > After each call, @str is set to the position after the

--- a/libretro-common/net/net_compat.c
+++ b/libretro-common/net/net_compat.c
@@ -389,7 +389,7 @@ bool addr_6to4(struct sockaddr_storage *addr)
 {
 #ifdef HAVE_INET6
    /* ::ffff:a.b.c.d */
-   static const uint16_t preffix[] = {0,0,0,0,0,0xffff};
+   static const uint16_t prefix[] = {0,0,0,0,0,0xffff};
    uint32_t address;
    uint16_t port;
    struct sockaddr_in6 *addr6 = (struct sockaddr_in6*)addr;
@@ -402,14 +402,14 @@ bool addr_6to4(struct sockaddr_storage *addr)
          return true;
       case AF_INET6:
          /* Is the address provided an IPv4? */
-         if (!memcmp(&addr6->sin6_addr, preffix, sizeof(preffix)))
+         if (!memcmp(&addr6->sin6_addr, prefix, sizeof(prefix)))
             break;
       default:
          /* We don't know how to handle this. */
          return false;
    }
 
-   memcpy(&address, ((uint8_t*)&addr6->sin6_addr) + sizeof(preffix),
+   memcpy(&address, ((uint8_t*)&addr6->sin6_addr) + sizeof(prefix),
       sizeof(address));
    port = addr6->sin6_port;
 

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -684,7 +684,7 @@ bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us)
     * of the minimum length */
    /* The implementation of a 0 timeout here with pthreads is sketchy.
     * It isn't clear what happens if pthread_cond_timedwait is called with NOW.
-    * Moreover, it is possible that this thread gets pre-empted after the
+    * Moreover, it is possible that this thread gets preempted after the
     * clock_gettime but before the pthread_cond_timedwait.
     * In order to help smoke out problems caused by this strange usage,
     * let's treat a 0 timeout as always timing out.

--- a/libretro-common/samples/core_options/example_categories/conversion_scripts/v1_to_v2_converter.py
+++ b/libretro-common/samples/core_options/example_categories/conversion_scripts/v1_to_v2_converter.py
@@ -410,7 +410,7 @@ if __name__ == '__main__':
                         print('Your file looks like it already is v2? (' + file + ')')
                         continue
                     if 0 > test:
-                        print('An error occured! Please make sure to use the complete v1 struct! (' + file + ')')
+                        print('An error occurred! Please make sure to use the complete v1 struct! (' + file + ')')
                         continue
             else:
                 print(file + ' not found.')

--- a/libretro-common/samples/core_options/example_translation/translation scripts/intl/v1_to_v2_converter.py
+++ b/libretro-common/samples/core_options/example_translation/translation scripts/intl/v1_to_v2_converter.py
@@ -453,7 +453,7 @@ if __name__ == '__main__':
                     print('Your file looks like it already is v2? (' + file + ')')
                     continue
                 if 0 > test:
-                    print('An error occured! Please make sure to use the complete v1 struct! (' + file + ')')
+                    print('An error occurred! Please make sure to use the complete v1 struct! (' + file + ')')
                     continue
         else:
             print(file + ' not found.')

--- a/libretro-common/samples/streams/rzip/Makefile
+++ b/libretro-common/samples/streams/rzip/Makefile
@@ -47,7 +47,7 @@ SOURCES := \
 ifneq ($(wildcard $(LIBRETRO_DEPS_DIR)/*),)
 	# If we are building from inside the RetroArch
 	# directory (i.e. if an 'external' deps directory
-	# is avaiable), bake in zlib support
+	# is available), bake in zlib support
 	SOURCES += \
 		$(LIBRETRO_DEPS_DIR)/libz/adler32.c \
 		$(LIBRETRO_DEPS_DIR)/libz/libz-crc32.c \

--- a/libretro-common/string/stdstring.c
+++ b/libretro-common/string/stdstring.c
@@ -425,7 +425,7 @@ size_t word_wrap_wideglyph(char *dst, size_t dst_size,
 /**
  * string_tokenize:
  *
- * Splits string into tokens seperated by @delim
+ * Splits string into tokens separated by @delim
  * > Returned token string must be free()'d
  * > Returns NULL if token is not found
  * > After each call, @str is set to the position after the

--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -55,9 +55,9 @@
 
 namespace
 {
-   /* UWP deals with paths containing / instead of 
+   /* UWP deals with paths containing / instead of
     * \ way worse than normal Windows */
-   /* and RetroArch may sometimes mix them 
+   /* and RetroArch may sometimes mix them
     * (e.g. on archive extraction) */
    static void windowsize_path(wchar_t* path)
    {
@@ -336,7 +336,7 @@ libretro_vfs_implementation_file* retro_vfs_file_open_impl(
     if (mode == RETRO_VFS_FILE_ACCESS_READ)
         creationDisposition = OPEN_EXISTING;
     else
-        creationDisposition = (mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING) != 0 
+        creationDisposition = (mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING) != 0
            ? OPEN_ALWAYS
            : CREATE_ALWAYS;
 
@@ -434,9 +434,9 @@ int retro_vfs_mkdir_impl(const char* dir)
     return uwp_mkdir_impl(std::filesystem::path(dir));
 }
 
-/* The first run paramater is used to avoid error checking 
+/* The first run parameter is used to avoid error checking
  * when doing recursion.
- * Unlike the initial implementation, this can move folders 
+ * Unlike the initial implementation, this can move folders
  * even empty ones when you want to move a directory structure.
  *
  * This will fail even if a single file cannot be moved.
@@ -460,8 +460,8 @@ static int uwp_move_path(
                  GetFileExInfoStandard, &lpFileInfo))
         {
             /* Check that the files attributes are not null or empty */
-            if (     lpFileInfo.dwFileAttributes 
-                  != INVALID_FILE_ATTRIBUTES 
+            if (     lpFileInfo.dwFileAttributes
+                  != INVALID_FILE_ATTRIBUTES
                   && lpFileInfo.dwFileAttributes != 0)
             {
                /* Parent path doesn't exist, so we gotta create it  */
@@ -474,7 +474,7 @@ static int uwp_move_path(
         if (GetFileAttributesExFromAppW(old_path.wstring().c_str(), GetFileExInfoStandard, &lpFileInfo))
         {
             /* Check that the files attributes are not null or empty */
-            if (     lpFileInfo.dwFileAttributes != INVALID_FILE_ATTRIBUTES 
+            if (     lpFileInfo.dwFileAttributes != INVALID_FILE_ATTRIBUTES
                   && lpFileInfo.dwFileAttributes != 0)
             {
                 /* Check if source path is a dir */
@@ -534,14 +534,14 @@ static int uwp_move_path(
           bool fail = false;
           do
           {
-             if (     wcscmp(findDataResult.cFileName, L".")  != 0 
+             if (     wcscmp(findDataResult.cFileName, L".")  != 0
                    && wcscmp(findDataResult.cFileName, L"..") != 0)
              {
                 std::filesystem::path temp_old = old_path;
                 std::filesystem::path temp_new = new_path;
                 temp_old /= findDataResult.cFileName;
                 temp_new /= findDataResult.cFileName;
-                if (    findDataResult.dwFileAttributes 
+                if (    findDataResult.dwFileAttributes
                       & FILE_ATTRIBUTE_DIRECTORY)
                 {
                    CreateDirectoryFromAppW(temp_new.wstring().c_str(), NULL);
@@ -561,7 +561,7 @@ static int uwp_move_path(
                                (targetfileinfo.dwFileAttributes !=
                                 INVALID_FILE_ATTRIBUTES)
                             && (targetfileinfo.dwFileAttributes != 0)
-                            && (!(targetfileinfo.dwFileAttributes 
+                            && (!(targetfileinfo.dwFileAttributes
                                   & FILE_ATTRIBUTE_DIRECTORY)))
                       {
                          if (DeleteFileFromAppW(temp_new.wstring().c_str()))
@@ -572,7 +572,7 @@ static int uwp_move_path(
                    if (!MoveFileFromAppW(temp_old.wstring().c_str(),
                             temp_new.wstring().c_str()))
                       fail = true;
-                   /* Set ACL - this step sucks or at least used to 
+                   /* Set ACL - this step sucks or at least used to
                     * before I made a whole function
                     * Don't know if we actually "need" to set the ACL
                     * though */
@@ -589,7 +589,7 @@ static int uwp_move_path(
     return 0;
 }
 
-/* C doesn't support default arguments so we wrap it up in a shell to enable 
+/* C doesn't support default arguments so we wrap it up in a shell to enable
  * us to use default arguments.
  * Default arguments mean that we can do better recursion */
 int retro_vfs_file_rename_impl(const char* old_path, const char* new_path)
@@ -634,8 +634,8 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
                }
            }
            free(path_wide);
-           return (attribdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) 
-              ? RETRO_VFS_STAT_IS_VALID | RETRO_VFS_STAT_IS_DIRECTORY 
+           return (attribdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+              ? RETRO_VFS_STAT_IS_VALID | RETRO_VFS_STAT_IS_DIRECTORY
               : RETRO_VFS_STAT_IS_VALID;
        }
    }

--- a/memory/wii/mem2_manager.c
+++ b/memory/wii/mem2_manager.c
@@ -84,7 +84,7 @@ bool gx_init_mem2(void)
     * reserve about 256KB for stuff like network and USB to work correctly.
     * However, other sources says these functions need at least 0xE0000 bytes,
     * 7/8 of a megabyte, of reserved memory to do this. My initial testing
-    * shows that we can work with only 128KB, but we use 256KB becuse testing
+    * shows that we can work with only 128KB, but we use 256KB because testing
     * has shown some stuff being iffy with only 128KB, mainly Wiimote stuff.
     * If some stuff mysteriously stops working, try fiddling with this size.
     */

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3666,33 +3666,33 @@ static int generic_action_ok_remap_file_operation(const char *path,
    if (string_is_empty(core_name))
       return -1;
 
-   if (   sort_remaps_by_controller 
-       && input_device_name != NULL 
+   if (   sort_remaps_by_controller
+       && input_device_name != NULL
        && !string_is_empty(input_device_name))
    {
       /* Ensure directory does not contain special chars */
       input_device_dir = sanitize_path_part(input_device_name, strlen(input_device_name));
-      
-      /* Allocate memory for the new path */ 
+
+      /* Allocate memory for the new path */
       remap_path_total_len = strlen(core_name) + strlen(input_device_dir) + 2;
       remap_path = (char *)malloc(remap_path_total_len);
 
-      /* Build the new path with the controller name */ 
+      /* Build the new path with the controller name */
       _len  = strlcpy(remap_path, core_name, remap_path_total_len);
       _len += strlcpy(remap_path + _len, PATH_DEFAULT_SLASH(), remap_path_total_len - _len);
       _len += strlcpy(remap_path + _len, input_device_dir, remap_path_total_len - _len);
 
-      /* Deallocate as we no longer this */ 
+      /* Deallocate as we no longer this */
       free((char*)input_device_dir);
       input_device_dir = NULL;
    }
    else
    {
-      /* Allocate memory for the new path */ 
+      /* Allocate memory for the new path */
       remap_path_total_len = strlen(core_name) + 1;
       remap_path = (char *)malloc(remap_path_total_len);
 
-      /* We're not using controller path, just use core name */ 
+      /* We're not using controller path, just use core name */
       strlcpy(remap_path, core_name, remap_path_total_len);
    }
 
@@ -5145,7 +5145,7 @@ void cb_generic_download(retro_task_t *task,
 
    output_path[0] = '\0';
 
-   /* we have to determine dir_path at the time of writting or else
+   /* we have to determine dir_path at the time of writing or else
     * we'd run into races when the user changes the setting during an
     * http transfer. */
    switch (transf->enum_idx)

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -3910,7 +3910,7 @@ static enum materialui_entry_value_type materialui_get_entry_value_type(
                /* Note that we have to perform a backup check here,
                 * since the 'manual content scan - file extensions'
                 * setting may have a value of 'zip' or '7z' etc, which
-                * means it would otherwise get incorreclty identified as
+                * means it would otherwise get incorrectly identified as
                 * an archive file... */
                if (entry_type != FILE_TYPE_CARCHIVE)
                   value_type = MUI_ENTRY_VALUE_TEXT;
@@ -5637,14 +5637,14 @@ static void materialui_render_entry_touch_feedback(
     * touch feedback highlight */
    if (mui->touch_feedback_alpha > 0.0f)
    {
-      float higlight_color[16];
+      float highlight_color[16];
       float shadow_top_color[16];
       float shadow_bottom_color[16];
 
       /* Set highlight colour */
-      memcpy(higlight_color, mui->colors.list_highlighted_background,
-            sizeof(higlight_color));
-      gfx_display_set_alpha(higlight_color,
+      memcpy(highlight_color, mui->colors.list_highlighted_background,
+            sizeof(highlight_color));
+      gfx_display_set_alpha(highlight_color,
             mui->transition_alpha * mui->touch_feedback_alpha);
 
       /* Set shadow colour (if required) */
@@ -5670,7 +5670,7 @@ static void materialui_render_entry_touch_feedback(
             mui, p_disp, userdata, video_width, video_height,
             header_height, x_offset,
             mui->touch_feedback_selection,
-            higlight_color,
+            highlight_color,
             shadow_top_color, shadow_bottom_color);
    }
 }

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -7906,7 +7906,7 @@ static bool ozone_is_current_entry_settings(size_t current_selection)
                /* Note that we have to perform a backup check here,
                 * since the 'manual content scan - file extensions'
                 * setting may have a value of 'zip' or '7z' etc, which
-                * means it would otherwise get incorreclty identified as
+                * means it would otherwise get incorrectly identified as
                 * an archive file... */
                if (entry_type != FILE_TYPE_CARCHIVE)
                   return true;
@@ -10408,7 +10408,7 @@ static void ozone_draw_header(
    unsigned logo_icon_size                  = 60 * scale_factor;
    unsigned status_icon_size                = 92 * scale_factor;
    unsigned status_row_size                 = 160 * scale_factor;
-   unsigned seperator_margin                = 30 * scale_factor;
+   unsigned separator_margin                = 30 * scale_factor;
    enum gfx_animation_ticker_type
          menu_ticker_type                   = (enum gfx_animation_ticker_type)settings->uints.menu_ticker_type;
    gfx_display_ctx_driver_t *dispctx        = p_disp->dispctx;
@@ -10436,9 +10436,9 @@ static void ozone_draw_header(
          userdata,
          video_width,
          video_height,
-         seperator_margin,
+         separator_margin,
          ozone->dimensions.header_height,
-         video_width - seperator_margin * 2,
+         video_width - separator_margin * 2,
          ozone->dimensions.spacer_1px,
          video_width,
          video_height,
@@ -10670,7 +10670,7 @@ static void ozone_draw_footer(
    bool search_enabled                    = !settings->bools.menu_disable_search_button;
    size_t selection                       = ozone->selection;
    float scale_factor                     = ozone->last_scale_factor;
-   unsigned seperator_margin              = 30 * scale_factor;
+   unsigned separator_margin              = 30 * scale_factor;
    float footer_margin                    = 42 * scale_factor;
    float footer_text_y                    = (float)video_height
          - (ozone->dimensions.footer_height / 2.0f)
@@ -10766,9 +10766,9 @@ static void ozone_draw_footer(
          userdata,
          video_width,
          video_height,
-         seperator_margin,
+         separator_margin,
          video_height - ozone->dimensions.footer_height,
-         video_width - seperator_margin * 2,
+         video_width - separator_margin * 2,
          ozone->dimensions.spacer_1px,
          video_width,
          video_height,

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5487,7 +5487,7 @@ static void rgui_render(
             /* Note:
              * - 'Right' thumbnail is drawn at the top
              * - 'Left' thumbnail is drawn at the bottom
-             * ...unless thumbnail postions are swapped.
+             * ...unless thumbnail positions are swapped.
              * (legacy naming, unfortunately...) */
 
             /* An annoyance - cannot assume terminal will have a
@@ -6579,7 +6579,7 @@ static void *rgui_init(void **userdata, bool video_is_threaded)
    rgui->prev_savestate_thumbnail_file_path[0] = '\0';
 
    /* Ensure that pointer device starts with well defined
-    * values (shoult not be necessary, but some platforms may
+    * values (should not be necessary, but some platforms may
     * not handle struct initialisation correctly...) */
    memset(&rgui->pointer, 0, sizeof(menu_input_pointer_t));
 

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -628,7 +628,7 @@ static void xmb_free_node(xmb_node_t *node)
 /**
  * @brief frees all xmb_node_t in a file_list_t
  *
- * file_list_t asumes userdata holds a simple structure and
+ * file_list_t assumes userdata holds a simple structure and
  * free()'s it. Can't change this at the time because other
  * code depends on this behavior.
  *
@@ -5518,7 +5518,7 @@ static bool xmb_load_dynamic_icon(const char *icon_path,
    gfx_thumbnail_t *icon)
 {
    unsigned width, height;
-   /* Wierd unwanted state */
+   /* Weird unwanted state */
    if(icon->status == GFX_THUMBNAIL_STATUS_UNKNOWN &&
          icon->texture > 0)
       gfx_thumbnail_reset(icon);

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -6948,7 +6948,7 @@ clear:
  * menu_shader_manager_append_preset:
  * @shader                   : current shader
  * @preset_path              : path to the preset to append
- * @dir_video_shader         : temporary diretory
+ * @dir_video_shader         : temporary directory
  *
  * combine current shader with a shader preset on disk
  **/

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -1391,7 +1391,7 @@ static rarch_setting_t setting_action_setting(const char* name,
 
 /**
  * setting_group_setting:
- * @type               : type of settting.
+ * @type               : type of setting.
  * @name               : name of setting.
  *
  * Initializes a setting of type ST_GROUP.
@@ -1891,7 +1891,7 @@ static rarch_setting_t setting_string_setting(enum setting_type type,
 
 /**
  * setting_string_setting_options:
- * @type               : type of settting.
+ * @type               : type of setting.
  * @name               : name of setting.
  * @short_description  : Short description of setting.
  * @target             : Target of bind setting.
@@ -1930,7 +1930,7 @@ static rarch_setting_t setting_string_setting_options(enum setting_type type,
 
 /**
  * setting_subgroup_setting:
- * @type               : type of settting.
+ * @type               : type of setting.
  * @name               : name of setting.
  * @parent_name        : group that the subgroup setting belongs to.
  *
@@ -3391,7 +3391,7 @@ static void setting_get_string_representation_uint_menu_icon_thumbnails(
    }
 }
 
-static void setting_set_string_representation_timedate_date_seperator(char *s)
+static void setting_set_string_representation_timedate_date_separator(char *s)
 {
    settings_t *settings                  = config_get_ptr();
    unsigned menu_timedate_date_separator = settings ?
@@ -3550,7 +3550,7 @@ static void setting_get_string_representation_uint_menu_timedate_style(
    }
 
    /* Change date separator, if required */
-   setting_set_string_representation_timedate_date_seperator(s);
+   setting_set_string_representation_timedate_date_separator(s);
 }
 
 static void setting_get_string_representation_uint_menu_timedate_date_separator(
@@ -5248,7 +5248,7 @@ static void setting_get_string_representation_uint_playlist_sublabel_last_played
    }
 
    /* Change date separator, if required */
-   setting_set_string_representation_timedate_date_seperator(s);
+   setting_set_string_representation_timedate_date_separator(s);
 }
 
 static void setting_get_string_representation_uint_playlist_inline_core_display_type(
@@ -21771,7 +21771,7 @@ static bool setting_append_list(
 
          START_SUB_GROUP(list, list_info, "Playlist", &group_info, &subgroup_info, parent_group);
 
-         /* Favourites size is traditionally associtated with
+         /* Favourites size is traditionally associated with
           * history size, but they are in fact unrelated. We
           * therefore place this entry outside the "History"
           * sub group. */

--- a/menu/menu_shader.h
+++ b/menu/menu_shader.h
@@ -66,7 +66,7 @@ bool menu_shader_manager_set_preset(
  * menu_shader_manager_append_preset:
  * @shader                   : current shader
  * @preset_path              : path to the preset to append
- * @dir_video_shader         : temporary diretory
+ * @dir_video_shader         : temporary directory
  *
  * combine current shader with a shader preset on disk
  **/

--- a/network/drivers_wifi/connmanctl.c
+++ b/network/drivers_wifi/connmanctl.c
@@ -148,7 +148,7 @@ static bool connmanctl_tether_status(connman_t *connman)
 
    /* Following command lists 'technologies' of connman,
     * greps the wifi + 10 following lines, then first
-    * occurance of 'Tethering', then 'True' and counts
+    * occurrence of 'Tethering', then 'True' and counts
     * the matching lines.
     * Expected result is either 1 (active) or 0 (not active)
     */

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -3232,10 +3232,10 @@ static int handle_connection(netplay_t *netplay, netplay_address_t *addr,
 
 #define INET_TO_NETPLAY(in_addr, out_addr) \
    { \
-      uint16_t *preffix = (uint16_t*)&(out_addr)->addr[10]; \
+      uint16_t *prefix = (uint16_t*)&(out_addr)->addr[10]; \
       uint32_t *addr4   = (uint32_t*)&(out_addr)->addr[12]; \
       memset(&(out_addr)->addr[0], 0, 10); \
-      *preffix = 0xffff; \
+      *prefix = 0xffff; \
       memcpy(addr4, &((struct sockaddr_in*)(in_addr))->sin_addr, \
          sizeof(*addr4)); \
    }

--- a/network/netplay/netplay_private.h
+++ b/network/netplay/netplay_private.h
@@ -95,10 +95,10 @@ enum netplay_cmd
 {
    /* Basic commands */
 
-   /* Acknowlegement response */
+   /* Acknowledgement response */
    NETPLAY_CMD_ACK            = 0x0000,
 
-   /* Failed acknowlegement response */
+   /* Failed acknowledgement response */
    NETPLAY_CMD_NAK            = 0x0001,
 
    /* Gracefully disconnects from host */
@@ -179,7 +179,7 @@ enum netplay_cmd
    /* Chat commands */
 
    /* Sends a player chat message.
-    * The server is responsible for formatting/truncating 
+    * The server is responsible for formatting/truncating
     * the message and relaying it to all playing clients,
     * including the one that sent the message. */
    NETPLAY_CMD_PLAYER_CHAT    = 0x1000,
@@ -227,7 +227,7 @@ enum netplay_cmd_mode_reasons
 /* Real preferences for sharing devices */
 enum rarch_netplay_share_preference
 {
-   /* Prefer not to share, shouldn't be set 
+   /* Prefer not to share, shouldn't be set
       as a sharing mode for an shared device */
    NETPLAY_SHARE_NO_SHARING     = 0x00,
 
@@ -252,15 +252,15 @@ enum rarch_netplay_stall_reason
 {
    NETPLAY_STALL_NONE = 0,
 
-   /* We're so far ahead that we can't read 
+   /* We're so far ahead that we can't read
       more data without overflowing the buffer */
    NETPLAY_STALL_RUNNING_FAST,
 
-   /* We're in spectator or slave mode 
+   /* We're in spectator or slave mode
       and are running ahead at all */
    NETPLAY_STALL_SPECTATOR_WAIT,
 
-   /* Our actual execution is catching up 
+   /* Our actual execution is catching up
       with latency-adjusted input frames */
    NETPLAY_STALL_INPUT_LATENCY,
 
@@ -296,17 +296,17 @@ typedef struct netplay_input_state
    /* Is this a buffer with real data? */
    bool used;
 
-   /* The input data itself (note: should expand 
+   /* The input data itself (note: should expand
       beyond 1 by overallocating). */
    uint32_t data[1];
 
-   /* Warning: No members allowed past this point, 
+   /* Warning: No members allowed past this point,
       due to dynamic resizing. */
 } *netplay_input_state_t;
 
 struct delta_frame
 {
-   /* The resolved input, i.e., what's actually 
+   /* The resolved input, i.e., what's actually
       going to the core. One input per device. */
    netplay_input_state_t resolved_input[MAX_INPUT_DEVICES]; /* ptr alignment */
 
@@ -389,14 +389,14 @@ struct netplay_connection
    /* Which netplay protocol is this connection running? */
    uint32_t netplay_protocol;
 
-   /* If the mode is a DELAYED_DISCONNECT or SPECTATOR, 
-    * the transmission of the mode change may have to 
+   /* If the mode is a DELAYED_DISCONNECT or SPECTATOR,
+    * the transmission of the mode change may have to
     * wait for data to be forwarded.
-    * This is the frame to wait for, or 0 if no delay 
+    * This is the frame to wait for, or 0 if no delay
     * is active. */
    uint32_t delay_frame;
 
-   /* For the server: When was the last time we requested 
+   /* For the server: When was the last time we requested
     * this client to stall?
     * For the client: How many frames of stall do we have left? */
    uint32_t stall_frame;
@@ -405,7 +405,7 @@ struct netplay_connection
       too slow? */
    uint32_t stall_slow;
 
-   /* What latency is this connection running on? 
+   /* What latency is this connection running on?
     * Network latency has limited precision as we estimate it
     * once every pre-frame. */
    int32_t ping;
@@ -578,7 +578,7 @@ struct netplay
    /* Our own device bitmap */
    uint32_t self_devices;
 
-   /* The device types for every connected device. 
+   /* The device types for every connected device.
     * We store them and ignore any menu changes,
     * as netplay needs fixed devices. */
    uint32_t config_devices[MAX_INPUT_DEVICES];
@@ -597,7 +597,7 @@ struct netplay
    /* How far behind did we fall? */
    uint32_t catch_up_behind;
 
-   /* Number of desync operations we're currently performing. 
+   /* Number of desync operations we're currently performing.
     * If set, we don't attempt to stay in sync. */
    uint32_t desync;
 
@@ -610,7 +610,7 @@ struct netplay
 
    int frame_run_time_ptr;
 
-   /* Latency frames; positive to hide network latency, 
+   /* Latency frames; positive to hide network latency,
     * negative to hide input latency */
    int input_latency_frames;
 
@@ -637,11 +637,11 @@ struct netplay
    /* Our nickname */
    char nick[NETPLAY_NICK_LEN];
 
-   /* Set to true if we have a device that most cores 
+   /* Set to true if we have a device that most cores
     * translate to "up/down" actions, typically a keyboard.
     * We need to keep track of this because with such a device,
     * we need to "fix" the input state to the frame BEFORE a
-    * state load, then perform the state load, and the 
+    * state load, then perform the state load, and the
     * up/down states will proceed as expected. */
    bool have_updown_device;
 
@@ -666,8 +666,8 @@ struct netplay
    /* Opposite of stalling, should we be catching up? */
    bool catch_up;
 
-   /* Force a rewind to other_frame_count/other_ptr. 
-    * This is for synchronized events, such as restarting 
+   /* Force a rewind to other_frame_count/other_ptr.
+    * This is for synchronized events, such as restarting
     * or savestate loading. */
    bool force_rewind;
 
@@ -707,7 +707,7 @@ bool netplay_send(struct socket_buffer *sbuf,
 /**
  * netplay_send_flush
  *
- * Flush unsent data in the given socket buffer, 
+ * Flush unsent data in the given socket buffer,
  * blocking to do so if requested.
  *
  * Returns false only on socket failures, true otherwise.
@@ -728,7 +728,7 @@ ssize_t netplay_recv(struct socket_buffer *sbuf, int sockfd,
 /**
  * netplay_recv_reset
  *
- * Reset our recv buffer so that future netplay_recvs 
+ * Reset our recv buffer so that future netplay_recvs
  * will read the same data again.
  */
 void netplay_recv_reset(struct socket_buffer *sbuf);
@@ -736,7 +736,7 @@ void netplay_recv_reset(struct socket_buffer *sbuf);
 /**
  * netplay_recv_flush
  *
- * Flush our recv buffer, so a future netplay_recv_reset 
+ * Flush our recv buffer, so a future netplay_recv_reset
  * will reset to this point.
  */
 void netplay_recv_flush(struct socket_buffer *sbuf);
@@ -748,10 +748,10 @@ void netplay_recv_flush(struct socket_buffer *sbuf);
 /**
  * netplay_delta_frame_ready
  *
- * Prepares, if possible, a delta frame for input, and reports 
+ * Prepares, if possible, a delta frame for input, and reports
  * whether it is ready.
  *
- * Returns: True if the delta frame is ready for input at 
+ * Returns: True if the delta frame is ready for input at
  * the given frame, false otherwise.
  */
 bool netplay_delta_frame_ready(netplay_t *netplay,
@@ -777,7 +777,7 @@ void input_poll_net(netplay_t *netplay);
 /**
  * netplay_wait_and_init_serialization
  *
- * Try very hard to initialize serialization, simulating 
+ * Try very hard to initialize serialization, simulating
  * multiple frames if necessary. For quirky cores.
  *
  * Returns true if serialization is now ready, false otherwise.
@@ -812,7 +812,7 @@ bool netplay_send_raw_cmd(netplay_t *netplay,
 /**
  * netplay_send_raw_cmd_all
  *
- * Send a raw Netplay command to all connections, 
+ * Send a raw Netplay command to all connections,
  * optionally excluding one
  * (typically the client that the relevant command came from)
  */
@@ -823,7 +823,7 @@ void netplay_send_raw_cmd_all(netplay_t *netplay,
 /**
  * netplay_cmd_mode
  *
- * Send a mode change request. As a server, 
+ * Send a mode change request. As a server,
  * the request is to ourself, and so honored instantly.
  */
 bool netplay_cmd_mode(netplay_t *netplay,

--- a/record/record_driver.c
+++ b/record/record_driver.c
@@ -132,7 +132,7 @@ static void recording_driver_free_state(void)
    recording_state.gpu_width     = 0;
    recording_state.gpu_height    = 0;
    recording_state.width         = 0;
-   recording_stte.height         = 0;
+   recording_state.height        = 0;
 }
 #endif
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -4474,7 +4474,7 @@ bool command_event(enum event_command cmd, void *data)
                   playlist_config_set_path(&playlist_config, str_list->elems[6].data);
                   playlist = playlist_init(&playlist_config);
 
-                  /* Check whether favourties playlist is at capacity */
+                  /* Check whether favourites playlist is at capacity */
                   if (playlist_size(playlist) >=
                         playlist_capacity(playlist))
                   {
@@ -6407,7 +6407,7 @@ static void retroarch_print_help(const char *arg0)
 #ifdef HAVE_ACCESSIBILITY
    _len += strlcpy(buf + _len,
          "      --accessibility            "
-         "Enables accessibilty for blind users using text-to-speech.\n"
+         "Enables accessibility for blind users using text-to-speech.\n"
          , sizeof(buf) - _len);
 #endif
 
@@ -8231,7 +8231,7 @@ bool retroarch_main_quit(void)
 
 #if !defined(HAVE_DYNAMIC)
    {
-      /* Salamander sets RUNLOOP_FLAG_SHUTDOWN_INITIATED prior, so we need to handle it seperately */
+      /* Salamander sets RUNLOOP_FLAG_SHUTDOWN_INITIATED prior, so we need to handle it separately */
       /* config_save_file_salamander() must be called independent of config_save_on_exit */
       config_save_file_salamander();
       if (config_save_on_exit)

--- a/steam/steam.c
+++ b/steam/steam.c
@@ -175,7 +175,7 @@ core_info_t* steam_find_core_info_for_dlc(const char* name)
 }
 
 /* Generate a list with core dlcs
- * Needs to be called after initializion because it uses core info */
+ * Needs to be called after initialization because it uses core info */
 MistResult steam_generate_core_dlcs_list(steam_core_dlc_list_t **list)
 {
    int count, i;

--- a/tasks/task_cloudsync.c
+++ b/tasks/task_cloudsync.c
@@ -969,7 +969,7 @@ static RFILE *task_cloud_sync_write_updated_manifest(file_list_t *manifest, char
       return NULL;
    }
 
-   /* since we may be transfering files at the same time,
+   /* since we may be transferring files at the same time,
     * the newly created manifest might be out of order */
    file_list_sort_on_alt(manifest);
 

--- a/tasks/task_core_updater.c
+++ b/tasks/task_core_updater.c
@@ -272,7 +272,7 @@ static void free_core_updater_list_handle(
 {
    if (list_handle->http_data)
    {
-      /* since we took onwership, we have to destroy it ourself */
+      /* since we took ownership, we have to destroy it ourself */
       if (list_handle->http_data->data)
          free(list_handle->http_data->data);
 

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -493,7 +493,7 @@ int detect_gc_game(intfstream_t *fd, char *s, size_t len, const char *filename)
    /** convert raw gamecube serial to redump serial.
    not enough is known about the disc data to properly
    convert every raw serial to redump serial.  it will
-   only fail with the following excpetions: the
+   only fail with the following exceptions: the
    subregions of europe P-UKV, P-AUS, X-UKV, X-EUU
    will not match redump.**/
 

--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -1067,7 +1067,7 @@ bool task_push_overlay_load_default(
 
    if (!config_get_uint(conf, "overlays", &loader->size))
    {
-      /* Error - overlays varaible not defined in config. */
+      /* Error - overlays variable not defined in config. */
       config_file_free(conf);
       free(loader);
       return false;

--- a/tasks/task_translation.c
+++ b/tasks/task_translation.c
@@ -1088,7 +1088,7 @@ bool run_translation_service(settings_t *settings, bool paused)
       /* mode */
       {
          unsigned ai_service_mode   = settings->uints.ai_service_mode;
-         /*"image" is included for backwards compatability with
+         /*"image" is included for backwards compatibility with
           * vgtranslate < 1.04 */
 
          new_ai_service_url[  _len] = separator;

--- a/tools/com-parser/com-parse.cpp
+++ b/tools/com-parser/com-parse.cpp
@@ -29,8 +29,8 @@ AstBase<Annotation> AstBase<Annotation>::empty = AstBase<Annotation>("", 0, 0, "
 //bool use_typedefs = false;
 bool use_typedefs = true;
 
-//const char* prefix_seperator = "_";
-const char* prefix_seperator = "";
+//const char* prefix_separator = "_";
+const char* prefix_separator = "";
 
 vector<string> ignored_fn_prefixes_list =
 {
@@ -452,7 +452,7 @@ public:
 
       }
 
-      name = prefix + prefix_seperator;
+      name = prefix + prefix_separator;
 
       if(overloaded && !this_.base)
       {
@@ -676,7 +676,7 @@ public:
             break;
          else
          {
-//           cout << "Unexcpected node " << node->name << endl;
+//           cout << "Unexpected node " << node->name << endl;
          }
       }
 

--- a/tools/gas-preprocessor.pl
+++ b/tools/gas-preprocessor.pl
@@ -289,7 +289,7 @@ sub expand_macros {
         # parameters can be blank
         my @arglist = split(/,/, $3);
         my @args;
-        my @args_seperator;
+        my @args_separator;
 
         my $comma_sep_required = 0;
         foreach (@arglist) {
@@ -299,14 +299,14 @@ sub expand_macros {
             my @whitespace_split = split(/\s+/, $_);
             if (!@whitespace_split) {
                 push(@args, '');
-                push(@args_seperator, '');
+                push(@args_separator, '');
             } else {
                 foreach (@whitespace_split) {
                         #print ("arglist = \"$_\"\n");
                     if (length($_)) {
                         push(@args, $_);
                         my $sep = $comma_sep_required ? "," : " ";
-                        push(@args_seperator, $sep);
+                        push(@args_separator, $sep);
                         #print ("sep = \"$sep\", arg = \"$_\"\n");
                         $comma_sep_required = 0;
                     }
@@ -336,9 +336,9 @@ sub expand_macros {
                 # XXX: is vararg allowed on arguments before the last?
                 $argname = $macro_args{$macro}[-1];
                 if ($argname =~ s/:vararg$//) {
-                    #print "macro = $macro, args[$i] = $args[$i], args_seperator=@args_seperator, argname = $argname, arglist[$i] = $arglist[$i], arglist = @arglist, args=@args, macro_args=@macro_args\n";
+                    #print "macro = $macro, args[$i] = $args[$i], args_separator=@args_separator, argname = $argname, arglist[$i] = $arglist[$i], arglist = @arglist, args=@args, macro_args=@macro_args\n";
                     #$replacements{$argname} .= ", $args[$i]";
-                    $replacements{$argname} .= "$args_seperator[$i] $args[$i]";
+                    $replacements{$argname} .= "$args_separator[$i] $args[$i]";
                 } else {
                     die "Too many arguments to macro $macro";
                 }

--- a/ui/drivers/qt/qt_downloads.cpp
+++ b/ui/drivers/qt/qt_downloads.cpp
@@ -77,7 +77,7 @@ void MainWindow::onThumbnailPackDownloadNetworkError(QNetworkReply::NetworkError
          code, errorStringData);
 
 #if 0
-   /* Deleting the reply here seems to cause a strange 
+   /* Deleting the reply here seems to cause a strange
     * heap-use-after-free crash. */
    reply->disconnect();
    reply->abort();
@@ -96,10 +96,10 @@ void MainWindow::onThumbnailPackDownloadNetworkSslErrors(const QList<QSslError> 
    for (i = 0; i < errors.count(); i++)
    {
       const QSslError &error = errors.at(i);
-      QString string         = 
-           QString("Ignoring SSL error code ") 
-         + QString::number(error.error()) 
-         + ": " 
+      QString string         =
+           QString("Ignoring SSL error code ")
+         + QString::number(error.error())
+         + ": "
          + error.errorString();
       QByteArray stringArray = string.toUtf8();
       const char *stringData = stringArray.constData();
@@ -124,10 +124,10 @@ void MainWindow::onThumbnailPackDownloadFinished()
 
    m_thumbnailPackDownloadProgressDialog->cancel();
 
-   /* At least on Linux, the progress dialog will refuse 
-    * to hide itself and will stay on screen in a corrupted 
-    * way if we happen to show an error message in this function. 
-    * processEvents() will sometimes fix it, other times not... 
+   /* At least on Linux, the progress dialog will refuse
+    * to hide itself and will stay on screen in a corrupted
+    * way if we happen to show an error message in this function.
+    * processEvents() will sometimes fix it, other times not...
     * seems random. */
    qApp->processEvents();
 
@@ -249,9 +249,9 @@ void MainWindow::downloadAllThumbnails(QString system, QUrl url)
    if (!settings)
       return;
 
-   urlString            = 
-      QString(THUMBNAILPACK_URL_HEADER) 
-      + system 
+   urlString            =
+      QString(THUMBNAILPACK_URL_HEADER)
+      + system
       + THUMBNAILPACK_EXTENSION;
 
    if (url.isEmpty())
@@ -272,11 +272,11 @@ void MainWindow::downloadAllThumbnails(QString system, QUrl url)
       QDir dir;
       const char *path_dir_thumbnails = settings->paths.directory_thumbnails;
       QString dirString               = QString(path_dir_thumbnails);
-      QString fileName                = 
-         dirString 
-         + "/" 
-         + system 
-         + THUMBNAILPACK_EXTENSION 
+      QString fileName                =
+         dirString
+         + "/"
+         + system
+         + THUMBNAILPACK_EXTENSION
          + PARTIAL_EXTENSION;
       QByteArray fileNameArray        = fileName.toUtf8();
       const char *fileNameData        = fileNameArray.constData();
@@ -368,7 +368,7 @@ void MainWindow::onThumbnailDownloadNetworkError(QNetworkReply::NetworkError cod
          code, errorStringData);
 
 #if 0
-   /* Deleting the reply here seems to cause a strange 
+   /* Deleting the reply here seems to cause a strange
     * heap-use-after-free crash. */
    reply->disconnect();
    reply->abort();
@@ -388,10 +388,10 @@ void MainWindow::onThumbnailDownloadNetworkSslErrors(
    for (i = 0; i < errors.count(); i++)
    {
       const QSslError &error = errors.at(i);
-      QString         string = 
-           QString("Ignoring SSL error code ") 
-         + QString::number(error.error()) 
-         + ": " 
+      QString         string =
+           QString("Ignoring SSL error code ")
+         + QString::number(error.error())
+         + ": "
          + error.errorString();
       QByteArray stringArray = string.toUtf8();
       const char *stringData = stringArray.constData();
@@ -418,10 +418,10 @@ void MainWindow::onThumbnailDownloadFinished()
 
    m_thumbnailDownloadProgressDialog->cancel();
 
-   /* At least on Linux, the progress dialog will refuse 
-    * to hide itself and will stay on screen in a corrupted 
-    * way if we happen to show an error message in this 
-    * function. processEvents() will sometimes fix it, 
+   /* At least on Linux, the progress dialog will refuse
+    * to hide itself and will stay on screen in a corrupted
+    * way if we happen to show an error message in this
+    * function. processEvents() will sometimes fix it,
     * other times not... seems random. */
    qApp->processEvents();
 
@@ -441,7 +441,7 @@ void MainWindow::onThumbnailDownloadFinished()
 
    if (code != 200)
    {
-      QUrl redirectUrl               = 
+      QUrl redirectUrl               =
          reply->attribute(
                QNetworkRequest::RedirectionTargetAttribute).toUrl();
 
@@ -513,10 +513,10 @@ void MainWindow::onThumbnailDownloadFinished()
 
       RARCH_ERR("[Qt]: Thumbnail download ended prematurely: %s\n", errorData);
       emit showErrorMessageDeferred(
-              QString(msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QT_NETWORK_ERROR)) 
-            + ": Code " 
-            + QString::number(code) 
-            + ": " 
+              QString(msg_hash_to_str(MENU_ENUM_LABEL_VALUE_QT_NETWORK_ERROR))
+            + ": Code "
+            + QString::number(code)
+            + ": "
             + errorData);
    }
 
@@ -568,10 +568,10 @@ void MainWindow::downloadThumbnail(QString system, QString title, QUrl url)
 
    title                    = getScrubbedString(title);
    downloadType             = m_pendingThumbnailDownloadTypes.takeFirst();
-   urlString                = QString(THUMBNAIL_URL_HEADER) 
+   urlString                = QString(THUMBNAIL_URL_HEADER)
       + system + "/"
-      + downloadType + "/" 
-      + title 
+      + downloadType + "/"
+      + title
       + THUMBNAIL_IMAGE_EXTENSION;
 
    if (url.isEmpty())
@@ -592,10 +592,10 @@ void MainWindow::downloadThumbnail(QString system, QString title, QUrl url)
       QDir dir;
       const char *path_dir_thumbnails = settings->paths.directory_thumbnails;
       QString               dirString = QString(path_dir_thumbnails) + "/" + system + "/" + downloadType;
-      QString fileName                = dirString 
-         + "/" 
-         + title 
-         + THUMBNAIL_IMAGE_EXTENSION 
+      QString fileName                = dirString
+         + "/"
+         + title
+         + THUMBNAIL_IMAGE_EXTENSION
          + PARTIAL_EXTENSION;
       QByteArray fileNameArray        = fileName.toUtf8();
       const char *fileNameData        = fileNameArray.constData();
@@ -674,10 +674,10 @@ void MainWindow::onPlaylistThumbnailDownloadNetworkSslErrors(const QList<QSslErr
    for (i = 0; i < errors.count(); i++)
    {
       const QSslError &error = errors.at(i);
-      QString string         = 
-           QString("Ignoring SSL error code ") 
-         + QString::number(error.error()) 
-         + ": " 
+      QString string         =
+           QString("Ignoring SSL error code ")
+         + QString::number(error.error())
+         + ": "
          + error.errorString();
       QByteArray stringArray = string.toUtf8();
       const char *stringData = stringArray.constData();
@@ -749,7 +749,7 @@ void MainWindow::onPlaylistThumbnailDownloadFinished()
       }
       else
       {
-         /* Thumbnail download finished succesfully? */
+         /* Thumbnail download finished successfully? */
          if (m_playlistThumbnailDownloadFile.rename(newFileName))
             m_downloadedThumbnails++;
          else
@@ -815,12 +815,12 @@ void MainWindow::downloadNextPlaylistThumbnail(
 
    title                = getScrubbedString(title);
 
-   urlString            = 
-        QString(THUMBNAIL_URL_HEADER) 
+   urlString            =
+        QString(THUMBNAIL_URL_HEADER)
       + system  + "/"
-      + type 
-      + "/" 
-      + title 
+      + type
+      + "/"
+      + title
       + THUMBNAIL_IMAGE_EXTENSION;
 
    if (url.isEmpty())
@@ -951,7 +951,7 @@ void MainWindow::downloadPlaylistThumbnails(QString playlistPath)
    {
       QHash<QString, QString> firstThumbnail = m_pendingPlaylistThumbnails.takeAt(0);
 
-      /* Start downloading the first thumbnail, 
+      /* Start downloading the first thumbnail,
        * the rest will download as each one finishes. */
       downloadNextPlaylistThumbnail(firstThumbnail.value("db_name"), firstThumbnail.value("label_noext"), firstThumbnail.value("type"));
    }

--- a/uwp/std_filesystem_compat.h
+++ b/uwp/std_filesystem_compat.h
@@ -52,7 +52,7 @@
 #       error Could not find system header "<filesystem>" or "<experimental/filesystem>"
 #   endif
 
-// We priously determined that we need the exprimental version
+// We priously determined that we need the experimental version
 #   if INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
 // Include it
 #       include <experimental/filesystem>

--- a/wiiu/slang/slang-parse.cpp
+++ b/wiiu/slang/slang-parse.cpp
@@ -260,7 +260,7 @@ int main(int argc, const char** argv)
       else if (node->name == "Line")
          *out << node->token << std::endl;
       else
-         std::cout << "Unexcpected node " << node->name << std::endl;
+         std::cout << "Unexpected node " << node->name << std::endl;
    }
 
    {


### PR DESCRIPTION
## Description

Fix typos in comments, log messages, and names of the local variables. Caught by [typos](https://github.com/crate-ci/typos).
Some third party includes have been skipped because PR is already too large.


