### PR TITLE
Bring the Chuncheon relay server back into `intl`

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -7496,6 +7496,10 @@ MSG_HASH(
    "Southeast Asia"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_VALUE_NETPLAY_MITM_SERVER_LOCATION_5,
+   "East Asia (Chuncheon, South Korea)"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_VALUE_NETPLAY_MITM_SERVER_LOCATION_CUSTOM,
    "Custom"
    )


### PR DESCRIPTION
## Description

The server was added to the derived files as a result [lost](https://github.com/libretro/RetroArch/commit/b112b5b9cc61d3860e04ec4b75676d264e0dbeec#diff-d84b3369632d09bf346bed876d4de2e8c92ee402344f4c9a786257b444a6d539) when regenerating. 


## Related Pull Requests

#17055