### PR TITLE
macOS: Update App Store packaging script

### DIFF
--- a/pkg/apple/RetroArch_Metal.xcodeproj/xcshareddata/xcschemes/RetroArch AppStore.xcscheme
+++ b/pkg/apple/RetroArch_Metal.xcodeproj/xcshareddata/xcschemes/RetroArch AppStore.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "07F2BBC32BE83A4700FD1295"
+               BuildableName = "RetroArch.app"
+               BlueprintName = "RetroArch AppStore"
+               ReferencedContainer = "container:RetroArch_Metal.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      disableMainThreadChecker = "YES"
+      disablePerformanceAntipatternChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      viewDebuggingEnabled = "No"
+      queueDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "07F2BBC32BE83A4700FD1295"
+            BuildableName = "RetroArch.app"
+            BlueprintName = "RetroArch AppStore"
+            ReferencedContainer = "container:RetroArch_Metal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "07F2BBC32BE83A4700FD1295"
+            BuildableName = "RetroArch.app"
+            BlueprintName = "RetroArch AppStore"
+            ReferencedContainer = "container:RetroArch_Metal.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/pkg/apple/fastlane/Fastfile
+++ b/pkg/apple/fastlane/Fastfile
@@ -31,9 +31,9 @@ platform :mac do
         "./OSX/Info_AppStore.plist"
       ]
     )
-    # ensure_git_status_clean
-    # git_pull
-    # sh("git log -1")
+    ensure_git_status_clean
+    git_pull
+    sh("git log -1")
     begin
       app_store_build_number(
         app_identifier: "com.libretro.dist.RetroArch",
@@ -77,7 +77,7 @@ platform :mac do
     build_mac_app(
       workspace: "RetroArch.xcworkspace",
       scheme: "RetroArch AppStore",
-      xcodebuild_formatter: 'xcpretty',
+      xcodebuild_formatter: 'xcbeautify --renderer github-actions',
       buildlog_path: "buildlog",
       export_method: "app-store",
       export_options: {


### PR DESCRIPTION
Also needs the `RetroArch AppStore` scheme to be shared, Xcode won't auto-create it on its own.