### PR TITLE
docs: Add missing command to emscripten docs

### DIFF
--- a/pkg/emscripten/README.md
+++ b/pkg/emscripten/README.md
@@ -26,6 +26,7 @@ cd libretro-fceumm
 emmake make -f Makefile.libretro platform=emscripten
 git clone https://github.com/libretro/RetroArch.git ~/retroarch/RetroArch
 cp ~/retroarch/libretro-fceumm/fceumm_libretro_emscripten.bc ~/retroarch/RetroArch/libretro_emscripten.bc
+cd ~/retroarch
 emmake make -f Makefile.emscripten LIBRETRO=fceumm -j all
 cp fceumm_libretro.{js,wasm} pkg/emscripten/libretro
 ```


### PR DESCRIPTION
## Description

The emscripten docs have commands to build both a core and do final linking in retroarch, but the "cd" command in between those steps is missing.  This adds the missing command.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

I am not familiar with the maintainers of this project.