### PR TITLE
slang shaders: add support for __has_include like C++17 macro.

### DIFF
--- a/gfx/drivers_shader/glslang_util.c
+++ b/gfx/drivers_shader/glslang_util.c
@@ -98,7 +98,7 @@ enum slang_texture_semantic slang_name_to_texture_semantic_array(
 }
 
 bool glslang_read_shader_file(const char *path,
-      struct string_list *output, bool root_file)
+      struct string_list *output, bool root_file, bool is_optional)
 {
    size_t i;
    char tmp[PATH_MAX_LENGTH];
@@ -124,7 +124,8 @@ bool glslang_read_shader_file(const char *path,
    /* Read file contents */
    if (!filestream_read_file(path, (void**)&buf, &buf_len))
    {
-      RARCH_ERR("[slang]: Failed to open shader file: \"%s\".\n", path);
+      if (!is_optional)
+         RARCH_ERR("[slang]: Failed to open shader file: \"%s\".\n", path);
       return false;
    }
 
@@ -182,14 +183,21 @@ bool glslang_read_shader_file(const char *path,
    if (!string_list_append(output, tmp, attr))
       goto error;
 
+   
+   /* Add defines about supported retroarch features */
+   if (!string_list_append(output, "#define _RARCH_SUPPORTS_INCLUDE_OPTIONAL", attr))
+      goto error;
+   
    /* Loop through lines of file */
    for (i = root_file ? 1 : 0; i < lines.size; i++)
    {
       const char *line   = lines.elems[i].data;
-
+   
       /* Check for 'include' statements */
-      if (!strncmp("#include ", line, STRLEN_CONST("#include ")))
+      bool include_optional = !strncmp("#pragma include_optional ", line, STRLEN_CONST("#pragma include_optional "));
+      if ( !strncmp("#include ", line, STRLEN_CONST("#include ")) || include_optional )
       {
+
          char include_file[PATH_MAX_LENGTH];
          char include_path[PATH_MAX_LENGTH];
 
@@ -209,8 +217,12 @@ bool glslang_read_shader_file(const char *path,
                include_path, path, include_file, sizeof(include_path));
 
          /* Parse include file */
-         if (!glslang_read_shader_file(include_path, output, false))
-            goto error;
+         if (!glslang_read_shader_file(include_path, output, false, include_optional)) {
+            if (include_optional)
+               RARCH_LOG("[slang]: Optional include not found \"%s\".\n", include_path);
+            else
+               goto error;
+         }
 
          /* After including a file, use line directive
           * to pull it back to current file. */

--- a/gfx/drivers_shader/glslang_util.c
+++ b/gfx/drivers_shader/glslang_util.c
@@ -182,11 +182,6 @@ bool glslang_read_shader_file(const char *path,
    snprintf(tmp, sizeof(tmp), "#line %u \"%s\"", root_file ? 2 : 1, basename);
    if (!string_list_append(output, tmp, attr))
       goto error;
-
-   
-   /* Add defines about supported retroarch features */
-   if (!string_list_append(output, "#define _RARCH_SUPPORTS_INCLUDE_OPTIONAL", attr))
-      goto error;
    
    /* Loop through lines of file */
    for (i = root_file ? 1 : 0; i < lines.size; i++)

--- a/gfx/drivers_shader/glslang_util.h
+++ b/gfx/drivers_shader/glslang_util.h
@@ -129,7 +129,7 @@ enum glslang_format glslang_find_format(const char *fmt);
    Returns a Bool indicating if parsing was successful.
  */
 bool glslang_read_shader_file(const char *path,
-      struct string_list *output, bool root_file);
+      struct string_list *output, bool root_file, bool is_optional);
 
 bool slang_texture_semantic_is_array(enum slang_texture_semantic sem);
 

--- a/gfx/drivers_shader/glslang_util_cxx.cpp
+++ b/gfx/drivers_shader/glslang_util_cxx.cpp
@@ -220,7 +220,7 @@ bool glslang_compile_shader(const char *shader_path, glslang_output *output)
 
    RARCH_LOG("[slang]: Compiling shader: \"%s\".\n", shader_path);
 
-   if (!glslang_read_shader_file(shader_path, &lines, true))
+   if (!glslang_read_shader_file(shader_path, &lines, true, false))
       goto error;
    output->meta = glslang_meta{};
    if (!glslang_parse_meta(&lines, &output->meta))

--- a/gfx/drivers_shader/slang_process.cpp
+++ b/gfx/drivers_shader/slang_process.cpp
@@ -397,7 +397,7 @@ bool slang_preprocess_parse_parameters(const char *shader_path,
    if (!string_list_initialize(&lines))
       goto error;
 
-   if (!glslang_read_shader_file(shader_path, &lines, true))
+   if (!glslang_read_shader_file(shader_path, &lines, true, false))
       goto error;
    meta = glslang_meta{};
    if (!glslang_parse_meta(&lines, &meta))


### PR DESCRIPTION
## Description

This adds a new #pragma include_if_exist "filename" directive that acts like #include statements, but does not return error if the file does not exists.
