### PR TITLE
iOS: Fix some minor refresh issues

### DIFF
--- a/gfx/display_servers/dispserv_apple.m
+++ b/gfx/display_servers/dispserv_apple.m
@@ -139,7 +139,10 @@ static void *apple_display_server_get_resolution_list(
    height = bounds.size.height * scale;
 
    UIScreen *mainScreen = [UIScreen mainScreen];
-   currentRate = mainScreen.maximumFramesPerSecond;
+   if (@available(iOS 15, *))
+      currentRate = [CocoaView get].displayLink.preferredFrameRateRange.preferred;
+   else
+      currentRate = [CocoaView get].displayLink.preferredFramesPerSecond;
 #if !TARGET_OS_TV
    if (@available(iOS 15, *))
       [rates addObjectsFromArray:@[@(24), @(30), @(40), @(48), @(60), @(120)]];

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -42,6 +42,7 @@
 #include "../../../content.h"
 #include "../../../core_info.h"
 #include "../../../defaults.h"
+#include "../../../frontend/frontend.h"
 #include "../../../file_path_special.h"
 #include "../../../menu/menu_cbs.h"
 #include "../../../paths.h"
@@ -107,6 +108,25 @@ void cocoa_file_load_with_detect_core(const char *filename);
 #if !defined(OSX) || __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
 -(void)step:(CADisplayLink*)target API_AVAILABLE(macos(14.0), ios(3.1), tvos(3.1))
 {
+#if defined(IOS)
+   if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive)
+      return;
+
+   int ret = runloop_iterate();
+
+   task_queue_check();
+
+   if (ret == -1)
+   {
+      main_exit(NULL);
+      exit(0);
+      return;
+   }
+
+   uint32_t runloop_flags = runloop_get_flags();
+   if (!(runloop_flags & RUNLOOP_FLAG_IDLE))
+      CFRunLoopWakeUp(CFRunLoopGetMain());
+#endif
 }
 #endif
 
@@ -121,7 +141,7 @@ void cocoa_file_load_with_detect_core(const char *filename);
       view.displayLink = [CADisplayLink displayLinkWithTarget:view selector:@selector(step:)];
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 || __TV_OS_VERSION_MAX_ALLOWED >= 150000
       if (@available(iOS 15.0, tvOS 15.0, *))
-         [view.displayLink setPreferredFrameRateRange:CAFrameRateRangeMake(60, 120, 120)];
+         [view.displayLink setPreferredFrameRateRange:CAFrameRateRangeDefault];
 #endif
       [view.displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
 #elif defined(OSX) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -154,8 +154,6 @@ static void rarch_draw_observer(CFRunLoopObserverRef observer,
    uint32_t runloop_flags;
    int          ret   = runloop_iterate();
 
-   task_queue_check();
-
    if (ret == -1)
    {
       ui_companion_cocoatouch_event_command(


### PR DESCRIPTION
This shifts the call to `task_queue_check()` out of the run loop observer to the display link observer, which should cause it to be called slightly less often but still once per frame. Also this leaves the display link refresh rate as default by default.