### PR TITLE
Vulkan: Use separate matrix for menu

### DIFF
--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -573,7 +573,7 @@ typedef struct vk
    video_info_t video;
 
    VkFormat tex_fmt;
-   math_matrix_4x4 mvp, mvp_no_rot; /* float alignment */
+   math_matrix_4x4 mvp, mvp_no_rot, mvp_menu; /* float alignment */
    VkViewport vk_vp;
    VkRenderPass render_pass;
    struct video_viewport vp;

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -3800,7 +3800,7 @@ static void vulkan_set_projection(vk_t *vk,
    matrix_4x4_multiply(vk->mvp, trn, tmp);
 
    /* Required for translate_x+y / negative offsets to also work in RGUI */
-   matrix_4x4_multiply(vk->mvp_no_rot, trn, tmp);
+   matrix_4x4_multiply(vk->mvp_menu, trn, vk->mvp_no_rot);
 }
 
 static void vulkan_set_rotation(void *data, unsigned rotation)
@@ -4737,7 +4737,7 @@ static bool vulkan_frame(void *data, const void *frame,
                quad.sampler = (optimal->flags & VK_TEX_FLAG_MIPMAP)
                   ? vk->samplers.mipmap_nearest : vk->samplers.nearest;
 
-            quad.mvp        = &vk->mvp_no_rot;
+            quad.mvp        = &vk->mvp_menu;
             quad.color.r    = 1.0f;
             quad.color.g    = 1.0f;
             quad.color.b    = 1.0f;


### PR DESCRIPTION
## Description

The use of the default non-rotated matrix for negative screen offset translations in the menu (RGUI only) had unwanted consequences regarding HDR.

## Related Issues

Closes #17125

