### PR TITLE
Menu support for loading directories as content if a core indicates support for that

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -310,6 +310,14 @@ static int filebrowser_parse(
                FILE_TYPE_USE_DIRECTORY, 0 ,0);
          break;
       default:
+         /* if a core has / in its list of supported extensions, the core
+            supports loading of directories on the host file system */
+         if (exts && strchr(exts, '/'))
+            menu_entries_prepend(info_list,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_USE_THIS_DIRECTORY),
+                  msg_hash_to_str(MENU_ENUM_LABEL_USE_THIS_DIRECTORY),
+                  MSG_UNKNOWN,
+                  FILE_TYPE_PLAIN, 0, FILE_TYPE_USE_DIRECTORY);
          break;
    }
 


### PR DESCRIPTION
## Description

DOSBox Pure is a core that supports loading a directory as content and will mount that directory as a file system inside DOS.
The other DOSBox cores (SVN and Core) as well as ScummVM also already support loading a directory directly.

Currently in RetroArch a directory can only be loaded by manually writing a playlist file or by launching RetroArch with `-L "core.so" "/directory/path"`, but not via the menu. Partially this was because a core couldn't tell the frontend that it supports loading directories.

This PR adds support for a core to have "/" in its list of supported extensions to indicate support for loading directories. If such a core is installed, the content browser will list an entry with `<Use This Directory>` at the top.

For example in DOSBox Pure it looks like this in the info file:
```sh
supported_extensions = "zip|dosz|exe|com|bat|iso|chd|cue|ins|img|ima|vhd|jrc|tc|m3u|m3u8|conf|/"
```

And like this in the `retro_get_system_info` function:
```c
	info->valid_extensions = "zip|dosz|exe|com|bat|iso|chd|cue|ins|img|ima|vhd|jrc|tc|m3u|m3u8|conf|/";
```

If a core additionally supports the disk control interface, as is the case with DOSBox Pure, this PR also adds support for loading directories as disk images.

If this PR is merged, the cores mentioned above (dosbox_pure, dosbox_svn, dosbox_core and scummvm) should have their info files as well as their return value of `valid_extensions` from `retro_get_system_info` updated to actually indicate support for directories to make use of it.

## Related Issues

## Related Pull Requests

## Reviewers