### PR TITLE
Fix autoconf profile saving for devices not in their default port.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -5190,10 +5190,10 @@ bool config_save_autoconf_profile(const
    config_set_string(conf, "input_driver",
          joypad_driver);
    config_set_string(conf, "input_device",
-         input_config_get_device_name(user));
+         input_config_get_device_name(settings->uints.input_joypad_index[user]));
 
-   pid_user = input_config_get_device_pid(user);
-   vid_user = input_config_get_device_vid(user);
+   pid_user = input_config_get_device_pid(settings->uints.input_joypad_index[user]);
+   vid_user = input_config_get_device_vid(settings->uints.input_joypad_index[user]);
 
    if (pid_user && vid_user)
    {


### PR DESCRIPTION
## Description

User slot (player #) and joypad driver port is by default the same, but it can be changed either manually or automatically (reserved device). Use the correct index for detecting values associated with the port.

Fault can be reproduced by manually changing the device to be associated with player 2, and then saving autoconf. 

## Related Issues

Fixes #3578 , thank you for reporting (even if the wait was rather long!)
