### PR TITLE
Ignore other hotkeys with menu toggle

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5642,6 +5642,10 @@ static void input_keys_pressed(
             }
 
             BIT256_SET_PTR(p_new_state, i);
+
+            /* Ignore all other hotkeys if menu toggle is pressed */
+            if (i == RARCH_MENU_TOGGLE)
+               break;
          }
       }
    }


### PR DESCRIPTION
## Description

There is no need to continue checking any other hotkey on the same frame when menu toggle is triggered, which also gets rid of the Game Focus toggle issue.

## Related Issues

Closes #16550

