### PR TITLE
Fix quick shift key presses getting ignored on dinput driver

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -1354,14 +1354,17 @@ static LRESULT CALLBACK wnd_proc_common_dinput_internal(HWND hwnd,
             if (extended)
                keysym |= 0x80;
 
-            keycode = input_keymaps_translate_keysym_to_rk(keysym);
-            switch (keycode)
+            /* tell the driver about shift and alt key events */
+            if (keysym == 0x2A/*DIK_LSHIFT*/ || keysym == 0x36/*DIK_RSHIFT*/
+                     || keysym == 0x38/*DIK_LMENU*/ || keysym == 0xB8/*DIK_RMENU*/)
             {
-               /* L+R Shift handling done in dinput_poll */
-               case RETROK_LSHIFT:
-               case RETROK_RSHIFT:
-                  return 0;
+               void* input_data = (void*)(LONG_PTR)GetWindowLongPtr(main_window.hwnd, GWLP_USERDATA);
+               if (input_data && dinput_handle_message(input_data,
+                        message, wparam, lparam))
+                  return 0; /* key up already handled by the driver */
             }
+
+            keycode = input_keymaps_translate_keysym_to_rk(keysym);
 
             if (GetKeyState(VK_SHIFT)   & 0x80)
                mod |= RETROKMOD_SHIFT;


### PR DESCRIPTION
## Description

The main issue with shift keys in the dinput driver on Windows is that when both shift keys are pressed simultaneously, the OS will not issue a WM_KEYUP for the one first pressed down. 4 years ago the PR #11543 fixed this by moving shift key event handling out of the windows message handler into the dinput polling function.

But because shift keys were now ignored in the event message handler and only issued during polling, a quick key press and release between two polls would get missed. This PR fixes this by having the event message handler still issue these key presses and only do the very special issuing of the missing shift key up event in the dinput polling upon simultaneous pressing of both shift keys. This way all key presses are caught no matter how quick they are.

This PR also fixes left alt up key events getting sent to the core twice.

One remaining issue is that the ALT-TAB handling is not yet perfect. If a user holds down any other key before pressing ALT-TAB, no up event will get issued for the keys already pressed before ALT until pressed and then released again while the window has focus again. A core can still work around this by manually querying any pressed keys during `retro_run` with `input_state_cb` to see if they are actually still down. DOSBox Pure does this. This should be rather rare though so fixing it doesn't have high priority.

## Related Issues

## Related Pull Requests

#11543

## Reviewers

@sonninnos