### PR TITLE
Use the correct case for Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ following dependencies come as recommended:
    - GL headers / Vulkan headers
    - X11 headers and libs, or EGL/KMS/GBM
 
-OSX port of RetroArch requires latest versions of XCode to build.
+OSX port of RetroArch requires latest versions of Xcode to build.
 
 RetroArch can utilize these libraries if enabled:
 

--- a/pkg/apple/iOS/BUILDING
+++ b/pkg/apple/iOS/BUILDING
@@ -1,4 +1,4 @@
-The following instructions will only work if building from OS X, using latest XCode with fake signing enabled.
+The following instructions will only work if building from OS X, using latest Xcode with fake signing enabled.
 
 To build RetroArch:
     Open $(root)/ios/RetroArch.xcodeproj, change build type to iOSDevice then choose Product->Build For->Archiving.


### PR DESCRIPTION
## Description

This PR fixes mentions of the application `Xcode` to use the correct case.

Source: https://developer.apple.com/xcode/
