### PR TITLE
Introduce video_driver_translate_coord_viewport_wrap clamping variant.

### DIFF
--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -1071,7 +1071,10 @@ bool video_monitor_fps_statistics(double *refresh_rate,
       double *deviation, unsigned *sample_points);
 
 #define video_driver_translate_coord_viewport_wrap(vp, mouse_x, mouse_y, res_x, res_y, res_screen_x, res_screen_y) \
-   (video_driver_get_viewport_info(vp) ? video_driver_translate_coord_viewport(vp, mouse_x, mouse_y, res_x, res_y, res_screen_x, res_screen_y) : false)
+   (video_driver_get_viewport_info(vp) ? video_driver_translate_coord_viewport(vp, mouse_x, mouse_y, res_x, res_y, res_screen_x, res_screen_y, true) : false)
+
+#define video_driver_translate_coord_viewport_confined_wrap(vp, mouse_x, mouse_y, res_x, res_y, res_screen_x, res_screen_y) \
+   (video_driver_get_viewport_info(vp) ? video_driver_translate_coord_viewport(vp, mouse_x, mouse_y, res_x, res_y, res_screen_x, res_screen_y, false) : false)
 
 /**
  * video_driver_translate_coord_viewport:
@@ -1081,9 +1084,12 @@ bool video_monitor_fps_statistics(double *refresh_rate,
  * @res_y                          : Scaled  Y coordinate.
  * @res_screen_x                   : Scaled screen X coordinate.
  * @res_screen_y                   : Scaled screen Y coordinate.
+ * @report_oob                     : Out-of-bounds report mode
  *
  * Translates pointer [X,Y] coordinates into scaled screen
- * coordinates based on viewport info.
+ * coordinates based on viewport info. If report_oob is true,
+ * -0x8000 will be returned for the coordinate which is offscreen,
+ * otherwise offscreen coordinate is clamped to 0x7fff / -0x7fff.
  *
  * Returns: true (1) if successful, false if video driver doesn't support
  * viewport info.
@@ -1092,7 +1098,7 @@ bool video_driver_translate_coord_viewport(
       struct video_viewport *vp,
       int mouse_x, int mouse_y,
       int16_t *res_x, int16_t *res_y, int16_t *res_screen_x,
-      int16_t *res_screen_y);
+      int16_t *res_screen_y, bool report_oob);
 
 uintptr_t video_driver_display_userdata_get(void);
 

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -1898,7 +1898,7 @@ static bool udev_translate_touch_pos(
    *pointer_ma_pos_y  = ma_pos_y;
 
    /* Main panel -> Screen and Viewport */
-   return video_driver_translate_coord_viewport(
+   return video_driver_translate_coord_viewport_wrap(
       target_vp,
       *pointer_ma_pos_x,
       *pointer_ma_pos_y,
@@ -2569,7 +2569,7 @@ static void udev_report_touch(udev_input_t *udev, udev_input_device_t *dev)
                   touch->mouse_pos_y = (int32_t) touch->touchpad_pos_y;
 
                   /* Translate the panel coordinates into normalized coordinates. */
-                  video_driver_translate_coord_viewport(
+                  video_driver_translate_coord_viewport_wrap(
                      &vp, touch->mouse_pos_x, touch->mouse_pos_y,
                      &touch->mouse_vp_pos_x, &touch->mouse_vp_pos_y,
                      &touch->mouse_scr_pos_x, &touch->mouse_scr_pos_y
@@ -2873,7 +2873,7 @@ static void udev_input_touch_state_trackball(
          /* Get current viewport information */
          video_driver_get_viewport_info(&vp);
          /* Translate the raw coordinates into normalized coordinates. */
-         video_driver_translate_coord_viewport(
+         video_driver_translate_coord_viewport_wrap(
             &vp, touch->mouse_pos_x, touch->mouse_pos_y,
             &touch->mouse_vp_pos_x, &touch->mouse_vp_pos_y,
             &touch->mouse_scr_pos_x, &touch->mouse_scr_pos_y


### PR DESCRIPTION
## Description

Add another version of the coordinate translation that will not report `-0x8000` for offscreen values, but instead map the position to the respective edge. Not yet in use.

Udev driver updated to use the (old) wrapper, as all other input drivers do already.

This is a preparation for "sensible pointer handling". The current situation was described at:
https://github.com/libretro/RetroArch/pull/17169#issuecomment-2480050754

My proposal for the "sensible pointer handling" is to aim for the following in all input drivers including overlay:

- Querying `RETRO_DEVICE_ID_POINTER_X` or `RETRO_DEVICE_ID_POINTER_Y` would always return a value that is within `[-0x7FFF,0x7FFF]`. If the pointer is out-of-bounds compared to the viewport (for example, in the black area surrounding the content), the edge position is reported.
- Querying `RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X` or `RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X` would return `-0x8000` if the pointer/lightgun is out-of-bounds.
- Querying offscreen state for lightgun returns true if pointer is out-of-bounds or near the edge `]32700 / -32700[`
- Introduce a new parameter for pointer offscreen handling: `#define RETRO_DEVICE_ID_POINTER_IS_OFFSCREEN    15` . This is to cover any legacy code which uses lightgun offscreen detection with pointer type, some input drivers have it implemented. This would return true using the same logic as lightgun.
- Document these in `libretro.h` accordingly.

This will need changes in several input drivers, but the actual changes will be small, in most cases just changing the wrapper function for the pointer case and getting rid of the extra checks for -0x8000. I am leaving this PR in draft to allow any discussion to happen.

## Related Pull Requests

#17169 (was reverted in the meantime)

## Reviewers

@schellingb @JesseTG 
