### PR TITLE
Draft: CRT SwitchRes Linux EDID PoC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ endif
 HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
 
 ifeq ($(MISSING_DECLS), 1)
-   DEF_FLAGS += -Werror=missing-declarations
+   DEF_FLAGS += -Wno-error
 endif
 
 ifeq ($(HAVE_DYLIB), 1)
@@ -113,7 +113,7 @@ endif
 
 ifneq ($(CXX_BUILD), 1)
    ifneq ($(C89_BUILD),)
-      CFLAGS += -std=c89 -ansi -pedantic -Werror=pedantic -Wno-long-long -Werror=declaration-after-statement -Wno-variadic-macros
+      CFLAGS += -std=c89 -ansi -pedantic -Werror=pedantic -Wno-long-long -Werror=declaration-after-statement -Wno-variadic-macros -Wno-error
    else ifeq ($(HAVE_C99), 1)
       CFLAGS += $(C99_CFLAGS)
    endif

--- a/gfx/temp-hack/swedid-root
+++ b/gfx/temp-hack/swedid-root
@@ -3,18 +3,38 @@
 # This script requires running as root. "sudo" is called from "gfx/video_crt_switch.c", thus requiring a sudoers rule to non-interactively grant root permissions when running "/usr/local/bin/swedid-root" (this script)
 # switchres binary must be in root's PATH
 
-# Hardcoding Display for now as DP-1
+# TODO: Get below values from RetroArch's video output settings instead of hardcoding.
+
+# Hardcode GPU number and Display name. Change these before running.
+_display="DP-1"
+_gpu="1"
+
+# Hardcode ini path or switchres monitor preset. Change this before running
+_sw_args="--ini /home/syboxez/.config/retroarch/config/switchres.ini"
+
+# Change $3 to $5 when no longer hardcoding Display or GPU
 if [ -z "$3" ]; then
-	echo "Usage: $0 [HRes] [VRes] [VFreq] [Display]"
+	echo "Usage: $0 [HRes] [VRes] [VFreq] [GPU Num] [Display]"
 	exit 1
 fi
 
-# Hardcoding Display
+# Change $4 to $6 when no longer hardcoding
 if [ -n "$4" ]; then
 	echo "Too many arguments"
-	echo "Usage: $0 [HRes] [VRes] [VFreq] [Display]"
+	echo "Usage: $0 [HRes] [VRes] [VFreq] [GPU Num] [Display]"
 	exit 1
 fi
+
+# Backup EDID if backup doesn't exist
+# Currently hardcoding GPU number and display name. Change this before running!
+if [ ! -f /tmp/edid.bak ]; then
+	echo "Backing up EDID to /tmp/edid.bak"
+	dd if=/sys/class/drm/card"$_gpu"-"$_display"/edid of=/tmp/edid.bak bs=256
+else
+	echo "EDID already backed up to /tmp/edid.bak. Skipping backup."
+fi
+
+# TODO: Restore EDID after RA closes instead of attempting to use xrandr, which is what happens now.
 
 # Generate temperary working directory to generate EDID binary, then delete after applying
 _tmpdir=$(mktemp -d)
@@ -24,11 +44,10 @@ if [ -z "$_tmpdir" ]; then
 fi
 cd "$_tmpdir"
 
-switchres --ini /home/syboxez/.config/retroarch/config/switchres.ini --edid $1 $2 $3
+switchres $_sw_args --edid $1 $2 $3
 
-#Replace "1" with GPU number, replace "DP-1" with display
-cat "$_tmpdir"/custom.bin > /sys/kernel/debug/dri/1/DP-1/edid_override
-echo 1 > /sys/kernel/debug/dri/1/DP-1/trigger_hotplug
+cat "$_tmpdir"/custom.bin > /sys/kernel/debug/dri/"$_gpu"/"$_display"/edid_override
+echo 1 > /sys/kernel/debug/dri/"$_gpu"/"$_display"/trigger_hotplug
 
 cd /tmp
 rm -rf "$_tmpdir"

--- a/gfx/temp-hack/swedid-root
+++ b/gfx/temp-hack/swedid-root
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script requires running as root. "sudo" is called from "gfx/video_crt_switch.c", thus requiring a sudoers rule to non-interactively grant root permissions when running "/usr/local/bin/swedid-root" (this script)
+# switchres binary must be in root's PATH
+
+# Hardcoding Display for now as DP-1
+if [ -z "$3" ]; then
+	echo "Usage: $0 [HRes] [VRes] [VFreq] [Display]"
+	exit 1
+fi
+
+# Hardcoding Display
+if [ -n "$4" ]; then
+	echo "Too many arguments"
+	echo "Usage: $0 [HRes] [VRes] [VFreq] [Display]"
+	exit 1
+fi
+
+# Generate temperary working directory to generate EDID binary, then delete after applying
+_tmpdir=$(mktemp -d)
+if [ -z "$_tmpdir" ]; then
+        echo "_tmpdir doesn't exist"
+        exit 1
+fi
+cd "$_tmpdir"
+
+switchres --ini /home/syboxez/.config/retroarch/config/switchres.ini --edid $1 $2 $3
+
+#Replace "1" with GPU number, replace "DP-1" with display
+cat "$_tmpdir"/custom.bin > /sys/kernel/debug/dri/1/DP-1/edid_override
+echo 1 > /sys/kernel/debug/dri/1/DP-1/trigger_hotplug
+
+cd /tmp
+rm -rf "$_tmpdir"

--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -300,6 +300,7 @@ static void switch_res_crt(
 {
    int w                   = native_width;
    int h                   = height;
+   char commandbuffer[256];
 
    /* Check if SR2 is loaded, if not, load it */
    if (crt_sr2_init(p_switch, monitor_index, crt_mode, super_width))
@@ -382,16 +383,11 @@ static void switch_res_crt(
       RARCH_DBG("[CRT] %dx%d rotation: %d rotated: %d core rotation:%d\n", w, h, p_switch->rotated, flags & SR_MODE_ROTATED, retroarch_get_rotation());
       ret = sr_add_mode(w, h, rr, flags, &srm);
       if (!ret)
-         RARCH_ERR("[CRT] SR failed to add mode.\n");
-      if (p_switch->kms_ctx)
-      {
-         get_modeline_for_kms(p_switch, &srm);
-         video_driver_set_video_mode(srm.width, srm.height, true);
-      }
-      else if (p_switch->khr_ctx)
-         RARCH_WARN("[CRT] Vulkan -> Can't modeswitch for now.\n");
-      else
-         ret = sr_set_mode(srm.id);
+         RARCH_ERR("[CRT]: SR failed to add mode\n");
+
+      snprintf(commandbuffer, sizeof(commandbuffer), "/usr/bin/sudo /usr/local/bin/swedid-root %d %d %d", srm.width, srm.height, srm.vfreq);
+      ret = system(commandbuffer);
+
       if (!p_switch->kms_ctx && !ret)
          RARCH_ERR("[CRT] SR failed to switch mode.\n");
       p_switch->sr_core_hz = (float)srm.vfreq;

--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -385,7 +385,8 @@ static void switch_res_crt(
       if (!ret)
          RARCH_ERR("[CRT]: SR failed to add mode\n");
 
-      snprintf(commandbuffer, sizeof(commandbuffer), "/usr/bin/sudo /usr/local/bin/swedid-root %d %d %d", srm.width, srm.height, srm.vfreq);
+      snprintf(commandbuffer, sizeof(commandbuffer), "/usr/bin/sudo /usr/local/bin/swedid-root %d %d %f", srm.width, srm.height, srm.vfreq);
+      printf("%s\n", commandbuffer);
       ret = system(commandbuffer);
 
       if (!p_switch->kms_ctx && !ret)


### PR DESCRIPTION
Discussion about specific implementation ideas in `switchres` here: https://github.com/antonioginer/switchres/issues/102

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Extremely hacky PoC for using CRT CwitchRes to generate a single-use EDID and apply that EDID as root to a specific display. Very inelegant, some hardcoding going on, overwrites KMS and X11 modesetting with EDID overwrites (to test the PoC in multiple environments, such as KMS, Wayland, and X11)

## Related Issues

Currently, RetroArch does not support CRT SwitchRes in Wayland environments and may or may not have support for DRM/KMS environments.

Currently RetroArch will set standard video modes in KMS but will not generate new modes, and switchres has WIP support for DRM/KMS modeswitching that relies on a kernel patch.

This commit does not require a kernel patch and will use an external switchres binary to generate a single-use EDID binary containing a single modeline (switchres does not support generating EDID binaries when running as a library from what I've seen).

## Related Pull Requests

Potentially a future PR for switchres to add support for generating an edid in the API

## Reviewers

@hunterk @antonioginer @alphanu1 

I am expecting to have to completely delete this commit and redo it with a much cleaner strategy. Would appreciate comments.
