### PR TITLE
qt fix input panel

### DIFF
--- a/ui/drivers/qt/qt_options.cpp
+++ b/ui/drivers/qt/qt_options.cpp
@@ -254,9 +254,6 @@ QWidget *InputPage::widget()
       menu_file_list_cbs_t *cbs = (menu_file_list_cbs_t*)
          file_list_get_actiondata_at_offset(list, i);
 
-      if (cbs->enum_idx == MENU_ENUM_LABEL_INPUT_HOTKEY_BINDS)
-         break;
-
       layout->add(menu_setting_find_enum(cbs->enum_idx));
    }
 


### PR DESCRIPTION
In the qt ui, settings>input was empty, only the "hotkeys" tab was populating.
It happened between June and October 2023 with the RA archive I have, maybe caused by https://github.com/libretro/RetroArch/pull/15504/files .

Removing the break; it seems to be working fine, not sure why it was there.