### PR TITLE
Update the checkout and upload artifact Actions

### DIFF
--- a/.github/workflows/3DS.yml
+++ b/.github/workflows/3DS.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Compile Salamander
       run: |
@@ -35,7 +35,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RA-3DS-dummy-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/3DS.yml
+++ b/.github/workflows/3DS.yml
@@ -20,6 +20,16 @@ jobs:
       options: --user root
 
     steps:
+    - name: Run on old node
+      run: |
+        apt update && apt -y install wget
+        touch "$HOME/.bashrc"
+        wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+        nvm install 16
+        # node 16 is now available.
+        
     - uses: actions/checkout@v4
     
     - name: Compile Salamander

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +18,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Build
         run: |
@@ -36,7 +33,7 @@ jobs:
         id: slug
         run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: retroarch_linux_i686${{ steps.slug.outputs.sha8 }}
           path: |


### PR DESCRIPTION
Some workflows started failing today, and [the NodeJS upgrade is why](https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/); that took effect today. This PR will update older Actions on failing workflows, assuming that doing so for the first one I tried works out.