### PR TITLE
Replace checkout action, remove upload

### DIFF
--- a/.github/workflows/3DS.yml
+++ b/.github/workflows/3DS.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
     
     - name: Compile Salamander
       run: |
@@ -34,9 +34,3 @@ jobs:
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
-    
-    - uses: actions/upload-artifact@v3
-      with:
-        name: RA-3DS-dummy-${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch_3ds.cia

--- a/.github/workflows/Emscripten.yml
+++ b/.github/workflows/Emscripten.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
 
     - name: Compile RA
       run: |
@@ -31,8 +31,3 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: RA-Emscripten-dummy-${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch.js

--- a/.github/workflows/GameCube.yml
+++ b/.github/workflows/GameCube.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
 
     - name: Compile RA
       run: |
@@ -30,8 +30,3 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: RA-GameCube-dummy-${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch_ngc.dol

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v3
+        uses: taiki-e/checkout-action@v1
 
       - name: Configure Build
         run: |
@@ -35,9 +35,3 @@ jobs:
       - name: Get short SHA
         id: slug
         run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: retroarch_linux_i686${{ steps.slug.outputs.sha8 }}
-          path: |
-            retroarch

--- a/.github/workflows/Wii.yml
+++ b/.github/workflows/Wii.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
 
     - name: Compile Salamander
       run: |
@@ -35,8 +35,3 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: RA-Wii-dummy-${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch_wii.dol

--- a/.github/workflows/WiiU.yml
+++ b/.github/workflows/WiiU.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
 
     - name: Compile Salamander
       run: |
@@ -34,9 +34,3 @@ jobs:
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: RA-WiiU-dummy-${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch.rpx

--- a/.github/workflows/Windows-i686-MXE.yml
+++ b/.github/workflows/Windows-i686-MXE.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
 
     - name: Compile RA
       run: |
@@ -32,9 +32,3 @@ jobs:
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: retroarch${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch.exe

--- a/.github/workflows/Windows-x64-MXE.yml
+++ b/.github/workflows/Windows-x64-MXE.yml
@@ -20,7 +20,7 @@ jobs:
       options: --user root
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: taiki-e/checkout-action@v1
 
     - name: Compile RA
       run: |
@@ -32,9 +32,3 @@ jobs:
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: retroarch${{ steps.slug.outputs.sha8 }}
-        path: |
-          retroarch.exe

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,9 @@ stages:
   - prepare-for-static-cores
   - trigger-static-cores
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 build-retroarch-windows-x64:
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-mxe-win64-cross:gcc10
   stage: build
@@ -880,6 +883,8 @@ build-static-retroarch-ctr:
   stage: prepare-for-static-cores
   before_script:
     - export NUMPROC=$(($(nproc)/3))
+    - export ACTIONS_RUNNER_FORCED_INTERNAL_NODE_VERSION=node16
+    - export ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION=node16
   artifacts:
     paths:
     -  retroarch-precompiled/
@@ -900,6 +905,7 @@ build-static-retroarch-ctr-legacy:
   stage: prepare-for-static-cores
   before_script:
     - export NUMPROC=$(($(nproc)/3))
+    - export ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true
   artifacts:
     paths:
     -  retroarch-precompiled/
@@ -920,6 +926,7 @@ build-static-retroarch-dummy-ctr:
     MEDIA_PATH: .media
   before_script:
     - export NUMPROC=$(($(nproc)/3))
+    - export ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true
   artifacts:
     paths:
     - retroarch_3ds.cia


### PR DESCRIPTION
## Description

Due to node v20 being incompatible with some of the CI images (too old glibc), the checkout action is replaced by an alternative which does not need node. Upload is removed, I did not find a straightforward replacement right now.

Not quite sure this is the best approach, but it is here anyways as a stop-gap, and it does produce green builds. Needless to say, this change also does not address any  of the issues that were discussed on RA Discord `#programming` channel (bandwidth, job maintenance, etc.).