### PR TITLE
Update input_driver.c to improve the classic toggle turbo function

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1563,25 +1563,32 @@ static int16_t input_state_device(
                {
                   /* Works pretty much the same as classic mode above
                    * but with a toggle mechanic */
+
+                  /* Check if it's to enable the turbo func, if we're still holding
+                   * the button from previous toggle then ignore */
+                  if (   (res)
+                      && (input_st->turbo_btns.frame_enable[port]))
+                  {
+                     if (!(input_st->turbo_btns.turbo_pressed[port] & (1 << id)))
+                     {
+                        input_st->turbo_btns.enable[port] ^= (1 << id);
+                        /* Remember for the toggle check */
+                        input_st->turbo_btns.turbo_pressed[port] |= (1 << id);
+                     }
+                  }
+                  else
+                  {
+                     input_st->turbo_btns.turbo_pressed[port] &= ~(1 << id);
+                  }
+
                   if (res)
                   {
-                     /* Check if it's a new press, if we're still holding
-                      * the button from previous toggle then ignore */
-                     if (     input_st->turbo_btns.frame_enable[port]
-                           && !(input_st->turbo_btns.turbo_pressed[port] & (1 << id)))
-                        input_st->turbo_btns.enable[port] ^= (1 << id);
-
                      if (input_st->turbo_btns.enable[port] & (1 << id))
                         /* If turbo button is enabled for this key ID */
                         res = ((   input_st->turbo_btns.count
                                  % settings->uints.input_turbo_period)
                               < settings->uints.input_turbo_duty_cycle);
-                  }
-                  /* Remember for the toggle check */
-                  if (input_st->turbo_btns.frame_enable[port])
-                     input_st->turbo_btns.turbo_pressed[port] |= (1 << id);
-                  else
-                     input_st->turbo_btns.turbo_pressed[port] &= ~(1 << id);
+                  }  
                }
             }
          }


### PR DESCRIPTION
Changed the logic of the classic toggle turbo mode code such that the pressing order of the turbo button and the button to enable/disable does not matter.

## Description

The classic turbo toggle mode works by pressing a button, then the turbo button to enable the turbo function for it. And to disable turbo, press the button then the turbo button to toggle the function. It does not work in the reverse order. That is, pressing the turbo button following by the button the user intends to "turbo" will not do anything, which may lead to confusions. This modification improves this.

## Related Issues

NA

## Related Pull Requests

NA

## Reviewers

NA
