### PR TITLE
Support for analog L2/R2 when a DS3 controller is used with PSVita

### DIFF
--- a/libretro-common/include/defines/psp_defines.h
+++ b/libretro-common/include/defines/psp_defines.h
@@ -100,6 +100,8 @@ int sceClibPrintf ( const char * format, ... );
 #define PSP_CTRL_R2 SCE_CTRL_RTRIGGER
 #define PSP_CTRL_L3 SCE_CTRL_L3
 #define PSP_CTRL_R3 SCE_CTRL_R3
+#define STATE_ANALOGL2(state) ((state).lt)
+#define STATE_ANALOGR2(state) ((state).rt)
 #else
 #define DEFAULT_SAMPLING_MODE (SCE_CTRL_MODE_DIGITALANALOG)
 


### PR DESCRIPTION
## Description

Enable analog trigger values. The SDK [has the support](https://docs.vitasdk.org/group__SceCtrlUser.html#structSceCtrlData), so the change is straightforward. L2 is mapped to axis 4, R2 is mapped to axis 5.

## Related Issues

Closes #17162 
