### PR TITLE
Stay on previous CI image for Android.

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -7,7 +7,6 @@ on:
   repository_dispatch:
     types: [run_build]
 
-
 permissions:
   contents: read
 
@@ -16,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Prevent moving forward to Ubuntu 24.04, as the associated changes (probably the default Java 17) cause the Android CI job with the fixed gradle version to fail. We have 2 years to work out a solution.

Ref: https://github.com/actions/runner-images/issues/10636

Error with current ubuntu-latest image, for easier lookup:

```
Run cd pkg/android/phoenix
Downloading https://services.gradle.org/distributions/gradle-6.7.1-bin.zip
..................................................................................................
Unzipping /home/runner/.gradle/wrapper/dists/gradle-6.7.1-bin/bwlcbys1h7rz3272sye1xwiv6/gradle-6.7.1-bin.zip to /home/runner/.gradle/wrapper/dists/gradle-6.7.1-bin/bwlcbys1h7rz3272sye1xwiv6
Set executable permissions for: /home/runner/.gradle/wrapper/dists/gradle-6.7.1-bin/bwlcbys1h7rz3272sye1xwiv6/gradle-6.7.1/bin/gradle

Welcome to Gradle 6.7.1!

Here are the highlights of this release:
 - File system watching is ready for production use
 - Declare the version of Java your build requires
 - Java 15 support

For more details see https://docs.gradle.org/6.7.1/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/home/runner/work/RetroArch/RetroArch/pkg/android/phoenix/build.gradle'

* What went wrong:
Could not compile build file '/home/runner/work/RetroArch/RetroArch/pkg/android/phoenix/build.gradle'.
> startup failed:
  General error during semantic analysis: Unsupported class file major version 61
  
  java.lang.IllegalArgumentException: Unsupported class file major version 61
```