### PR TITLE
Reduce calls to path_remove_extension - use fill_pathname instead

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -1404,8 +1404,8 @@ void audio_driver_load_system_sounds(void)
       if (audio_driver_mixer_extension_supported(ext))
       {
          basename_noext[0] = '\0';
-         fill_pathname_base(basename_noext, path, sizeof(basename_noext));
-         path_remove_extension(basename_noext);
+         fill_pathname(basename_noext, path_basename(path), "",
+               sizeof(basename_noext));
 
          if (string_is_equal_noncase(basename_noext, "ok"))
             path_ok = path;

--- a/command.c
+++ b/command.c
@@ -1908,8 +1908,8 @@ bool command_event_save_core_config(
       char tmp[PATH_MAX_LENGTH + 8];
       RARCH_LOG("[Config]: %s\n", msg_hash_to_str(MSG_USING_CORE_NAME_FOR_NEW_CONFIG));
 
-      fill_pathname_base(config_name, core_path, sizeof(config_name));
-      path_remove_extension(config_name);
+      fill_pathname(config_name, path_basename(core_path), "",
+            sizeof(config_name));
       fill_pathname_join_special(config_path, config_dir, config_name,
             sizeof(config_path));
 

--- a/core_backup.c
+++ b/core_backup.c
@@ -62,11 +62,8 @@ static bool core_backup_get_backup_dir(
        || (len < 1))
       return false;
 
-   strlcpy(core_file_id, core_filename, sizeof(core_file_id));
-
-   /* > Remove file extension */
-   path_remove_extension(core_file_id);
-
+   fill_pathname(core_file_id, core_filename, "",
+         sizeof(core_file_id));
    if (string_is_empty(core_file_id))
       return false;
 

--- a/core_info.c
+++ b/core_info.c
@@ -1567,8 +1567,7 @@ static bool core_info_get_file_id(const char *core_filename,
     * or platform-specific suffix */
 
    /* > Remove extension */
-   strlcpy(core_file_id, core_filename, len);
-   path_remove_extension(core_file_id);
+   fill_pathname(core_file_id, core_filename, "", len);
 #if defined(IOS) || defined(OSX)
    /* iOS framework names, to quote Apple:
     * "must contain only alphanumerics, dots, hyphens and must not end with a dot."

--- a/disk_index_file.c
+++ b/disk_index_file.c
@@ -205,7 +205,6 @@ bool disk_index_file_init(
       const char *dir_savefile)
 {
    size_t len;
-   const char *content_file = NULL;
    char content_name[NAME_MAX_LENGTH];
    char disk_index_file_dir[DIR_MAX_LENGTH];
 
@@ -220,14 +219,8 @@ bool disk_index_file_init(
       goto error;
 
    /* Build disk index file path */
-
-   /* > Get content name */
-   content_file = path_basename(content_path);
-   if (string_is_empty(content_file))
-      goto error;
-
-   strlcpy(content_name, content_file, sizeof(content_name));
-   path_remove_extension(content_name);
+   fill_pathname(content_name, path_basename(content_path), "",
+         sizeof(content_name));
    if (string_is_empty(content_name))
       goto error;
 

--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -334,8 +334,6 @@ bool gfx_thumbnail_set_content_image(
       gfx_thumbnail_path_data_t *path_data,
       const char *img_dir, const char *img_name)
 {
-   char *content_img_no_ext = NULL;
-
    if (!path_data)
       return false;
 
@@ -368,14 +366,9 @@ bool gfx_thumbnail_set_content_image(
    strlcpy(path_data->content_img,
             img_name, sizeof(path_data->content_img));
 
-   /* Get image label */
-   content_img_no_ext = path_remove_extension(path_data->content_img);
-   if (!string_is_empty(content_img_no_ext))
-      strlcpy(path_data->content_label,
-            content_img_no_ext, sizeof(path_data->content_label));
-   else
-      strlcpy(path_data->content_label,
-            path_data->content_img, sizeof(path_data->content_label));
+   fill_pathname(path_data->content_label,
+         path_data->content_img, "",
+         sizeof(path_data->content_label));
 
    /* Set file path */
    fill_pathname_join_special(path_data->content_path,
@@ -519,27 +512,17 @@ bool gfx_thumbnail_set_content_playlist(
       else
       {
          char tmp_buf[NAME_MAX_LENGTH];
-         char *db_name_no_ext = NULL;
          const char *pos      = strchr(db_name, '|');
-
          /* If db_name comes from core info, and there are multiple
           * databases mentioned separated by |, use only first one */
          if (pos && (size_t) (pos - db_name) + 1 < sizeof(tmp_buf))
             strlcpy(tmp_buf, db_name, (size_t)(pos - db_name) + 1);
          else
-            /* Remove .lpl extension
-             * > path_remove_extension() requires a char * (not const)
-             *   so have to use a temporary buffer... */
             strlcpy(tmp_buf, db_name, sizeof(tmp_buf));
 
-         db_name_no_ext = path_remove_extension(tmp_buf);
-
-         if (!string_is_empty(db_name_no_ext))
-            strlcpy(path_data->content_db_name,
-                  db_name_no_ext, sizeof(path_data->content_db_name));
-         else
-            strlcpy(path_data->content_db_name,
-                  tmp_buf, sizeof(path_data->content_db_name));
+         fill_pathname(path_data->content_db_name,
+               tmp_buf, "",
+               sizeof(path_data->content_db_name));
       }
    }
 
@@ -669,7 +652,6 @@ bool gfx_thumbnail_set_icon_playlist(
       else
       {
          char tmp_buf[NAME_MAX_LENGTH];
-         char *db_name_no_ext = NULL;
          const char* pos      = strchr(db_name, '|');
 
          /* If db_name comes from core info, and there are multiple
@@ -677,18 +659,11 @@ bool gfx_thumbnail_set_icon_playlist(
          if (pos && (size_t) (pos - db_name)+1 < sizeof(tmp_buf))
             strlcpy(tmp_buf, db_name, (size_t) (pos - db_name)+1);
          else
-            /* Remove .lpl extension
-             * > path_remove_extension() requires a char * (not const)
-             *   so have to use a temporary buffer... */
             strlcpy(tmp_buf, db_name, sizeof(tmp_buf));
-         db_name_no_ext = path_remove_extension(tmp_buf);
 
-         if (!string_is_empty(db_name_no_ext))
-            strlcpy(path_data->content_db_name,
-                  db_name_no_ext, sizeof(path_data->content_db_name));
-         else
-            strlcpy(path_data->content_db_name,
-                  tmp_buf, sizeof(path_data->content_db_name));
+         fill_pathname(path_data->content_db_name,
+               tmp_buf, "",
+               sizeof(path_data->content_db_name));
       }
    }
 

--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -257,15 +257,13 @@ bool gfx_thumbnail_set_system(gfx_thumbnail_path_data_t *path_data,
                 && string_is_equal(playlist_file,
                    FILE_PATH_CONTENT_FAVORITES));
 
+            /* This means we have to work a little harder
+             * i.e. check whether the cached playlist file
+             * matches the database name */
             if (!playlist_valid)
             {
-               /* This means we have to work a little harder
-                * i.e. check whether the cached playlist file
-                * matches the database name */
-               char *playlist_name = NULL;
-               char tmp[NAME_MAX_LENGTH];
-               strlcpy(tmp, playlist_file, sizeof(tmp));
-               playlist_name  = path_remove_extension(tmp);
+               char playlist_name[NAME_MAX_LENGTH];
+               fill_pathname(playlist_name, playlist_file, "", sizeof(playlist_name));
                playlist_valid = string_is_equal(playlist_name, system);
             }
 
@@ -479,20 +477,12 @@ bool gfx_thumbnail_set_content_playlist(
 
    /* Determine content image name */
    {
-      char* content_name_no_ext = NULL;
       char tmp_buf[NAME_MAX_LENGTH];
-      /* Remove rom file extension
-       * > path_remove_extension() requires a char * (not const)
-       *   so have to use a temporary buffer... */
-
-      const char* base_name = path_basename(path_data->content_path);
-      strlcpy(tmp_buf, base_name, sizeof(tmp_buf));
-      content_name_no_ext = path_remove_extension(tmp_buf);
-      if (!content_name_no_ext)
-         content_name_no_ext = tmp_buf;
+      fill_pathname(tmp_buf, path_basename(path_data->content_path),
+            "", sizeof(tmp_buf));
 
       gfx_thumbnail_fill_content_img(path_data->content_img_full,
-         sizeof(path_data->content_img_full), content_name_no_ext,false);
+         sizeof(path_data->content_img_full), tmp_buf, false);
       gfx_thumbnail_fill_content_img(path_data->content_img,
          sizeof(path_data->content_img), path_data->content_label,false);
 
@@ -638,18 +628,11 @@ bool gfx_thumbnail_set_icon_playlist(
    /* Determine content image name */
    {
       char tmp_buf[NAME_MAX_LENGTH];
-      char* content_name_no_ext = NULL;
-      /* Remove rom file extension
-       * > path_remove_extension() requires a char * (not const)
-       *   so have to use a temporary buffer... */
-      const char* base_name     = path_basename(path_data->content_path);
-      strlcpy(tmp_buf, base_name, sizeof(tmp_buf));
-      content_name_no_ext = path_remove_extension(tmp_buf);
-      if (!content_name_no_ext)
-         content_name_no_ext = tmp_buf;
+      fill_pathname(tmp_buf, path_basename(path_data->content_path), "",
+            sizeof(tmp_buf));
 
       gfx_thumbnail_fill_content_img(path_data->content_img_full,
-         sizeof(path_data->content_img_full), content_name_no_ext,false);
+         sizeof(path_data->content_img_full), tmp_buf, false);
       gfx_thumbnail_fill_content_img(path_data->content_img,
          sizeof(path_data->content_img), path_data->content_label,false);
 

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -262,14 +262,12 @@ static void video_shader_replace_wildcards(char *s, size_t len, char *in_preset_
                            rarch_path_basename,
                            sizeof(content_dir_name));
                   if (string_is_not_equal_fast(content_dir_name, "", sizeof("")))
-                     strlcpy(content_dir_name,
-                           path_basename_nocompression(content_dir_name),
+                     fill_pathname(content_dir_name,
+                           path_basename_nocompression(content_dir_name), "",
                            sizeof(content_dir_name));
-                  if (string_is_not_equal_fast(content_dir_name, "", sizeof("")))
-                     path_remove_extension(content_dir_name);
 
                   if (string_is_not_equal_fast(content_dir_name, "", sizeof("")))
-                     replace_len = strlcpy(replace_text, content_dir_name, sizeof(replace_text));
+                     replace_len     = strlcpy(replace_text, content_dir_name, sizeof(replace_text));
                   else
                      replace_text[0] = '\0';
                }
@@ -379,11 +377,10 @@ static void video_shader_replace_wildcards(char *s, size_t len, char *in_preset_
                   char preset_dir_name[DIR_MAX_LENGTH];
                   fill_pathname_parent_dir_name(preset_dir_name, in_preset_path, sizeof(preset_dir_name));
                   if (string_is_not_equal_fast(preset_dir_name, "", sizeof("")))
-                     strlcpy(preset_dir_name, path_basename_nocompression(preset_dir_name), sizeof(preset_dir_name));
+                     fill_pathname(preset_dir_name, path_basename_nocompression(preset_dir_name),
+                           "", sizeof(preset_dir_name));
                   if (string_is_not_equal_fast(preset_dir_name, "", sizeof("")))
-                     path_remove_extension(preset_dir_name);
-                  if (string_is_not_equal_fast(preset_dir_name, "", sizeof("")))
-                     replace_len = strlcpy(replace_text, preset_dir_name, sizeof(replace_text));
+                     replace_len     = strlcpy(replace_text, preset_dir_name, sizeof(replace_text));
                   else
                      replace_text[0] = '\0';
                }
@@ -391,11 +388,11 @@ static void video_shader_replace_wildcards(char *s, size_t len, char *in_preset_
             case RARCH_WILDCARD_PRESET:
                {
                   char preset_name[NAME_MAX_LENGTH];
-                  strlcpy(preset_name, path_basename_nocompression(in_preset_path), sizeof(preset_name));
+                  fill_pathname(preset_name,
+                        path_basename_nocompression(in_preset_path), "",
+                        sizeof(preset_name));
                   if (string_is_not_equal_fast(preset_name, "", sizeof("")))
-                     path_remove_extension(preset_name);
-                  if (string_is_not_equal_fast(preset_name, "", sizeof("")))
-                     replace_len = strlcpy(replace_text, preset_name, sizeof(replace_text));
+                     replace_len     = strlcpy(replace_text, preset_name, sizeof(replace_text));
                   else
                      replace_text[0] = '\0';
                }

--- a/gfx/widgets/gfx_widget_load_content_animation.c
+++ b/gfx/widgets/gfx_widget_load_content_animation.c
@@ -378,9 +378,8 @@ bool gfx_widget_start_load_content_animation(void)
          /* Get entry db_name, */
          if (!string_is_empty(entry->db_name))
          {
-            strlcpy(state->system_name, entry->db_name,
+            fill_pathname(state->system_name, entry->db_name, "",
                   sizeof(state->system_name));
-            path_remove_extension(state->system_name);
 
             has_system  = true;
             has_db_name = true;
@@ -398,8 +397,7 @@ bool gfx_widget_start_load_content_animation(void)
          if (!string_is_empty(playlist_path))
          {
             char new_system_name[512];
-            strlcpy(new_system_name, playlist_path, sizeof(new_system_name));
-            path_remove_extension(new_system_name);
+            fill_pathname(new_system_name, playlist_path, "", sizeof(new_system_name));
             state->system_name_len = fill_pathname_base(
                   state->system_name, new_system_name,
                   sizeof(state->system_name));
@@ -423,11 +421,8 @@ bool gfx_widget_start_load_content_animation(void)
    /* If we haven't yet set the content name,
     * use content file name as a fallback */
    if (!has_content)
-   {
-      fill_pathname_base(state->content_name, content_path,
-            sizeof(state->content_name));
-      path_remove_extension(state->content_name);
-   }
+      fill_pathname(state->content_name, path_basename(content_path),
+            "", sizeof(state->content_name));
 
    /* Check whether system name has been set */
    if (!has_system)

--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -505,7 +505,6 @@ enum manual_content_scan_playlist_refresh_status
             const char *path_content_database, bool show_hidden_files)
 {
    const char *playlist_path    = NULL;
-   const char *playlist_file    = NULL;
    const char *content_dir      = NULL;
    const char *core_name        = NULL;
    const char *file_exts        = NULL;
@@ -555,11 +554,8 @@ enum manual_content_scan_playlist_refresh_status
       goto end;
    }
 
-   if ((playlist_file = path_basename(playlist_path)))
-   {
-      strlcpy(system_name, playlist_file, sizeof(system_name));
-      path_remove_extension(system_name);
-   }
+   fill_pathname(system_name, path_basename(playlist_path),
+         "", sizeof(system_name));
 
    if (string_is_empty(system_name))
    {
@@ -604,9 +600,8 @@ enum manual_content_scan_playlist_refresh_status
          if (string_is_empty(rdb_file))
             continue;
 
-         /* Remove file extension */
-         strlcpy(rdb_name, rdb_file, sizeof(rdb_name));
-         path_remove_extension(rdb_name);
+         fill_pathname(rdb_name, rdb_file, "",
+               sizeof(rdb_name));
 
          if (string_is_empty(rdb_name))
             continue;
@@ -865,9 +860,8 @@ struct string_list *manual_content_scan_get_menu_system_name_list(
             if (string_is_empty(rdb_file))
                continue;
 
-            /* Remove file extension */
-            strlcpy(rdb_name, rdb_file, sizeof(rdb_name));
-            path_remove_extension(rdb_name);
+            fill_pathname(rdb_name, rdb_file, "",
+                  sizeof(rdb_name));
 
             if (string_is_empty(rdb_name))
                continue;

--- a/menu/cbs/menu_cbs_label.c
+++ b/menu/cbs/menu_cbs_label.c
@@ -77,13 +77,7 @@ static int action_bind_label_playlist_collection_entry(
          strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB), len);
       /* Handle collection playlists */
       else
-      {
-         char playlist_name[NAME_MAX_LENGTH];
-         strlcpy(playlist_name, playlist_file, sizeof(playlist_name));
-         path_remove_extension(playlist_name);
-
-         strlcpy(s, playlist_name, len);
-      }
+         fill_pathname(s, playlist_file, "", len);
    }
    /* This should never happen, but if it does just set
     * the label to the file name (it's better than nothing...) */

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1581,8 +1581,8 @@ int generic_action_ok_displaylist_push(
                   settings->paths.path_content_database,
                   path, sizeof(tmp));
 
-            fill_pathname_base(lpl_basename, path, sizeof(lpl_basename));
-            path_remove_extension(lpl_basename);
+            fill_pathname(lpl_basename, path_basename(path), "",
+                  sizeof(lpl_basename));
             menu_driver_set_thumbnail_system(
                   menu_st->userdata, lpl_basename, sizeof(lpl_basename));
 
@@ -8597,12 +8597,9 @@ static int action_ok_playlist_refresh(const char *path,
          case MANUAL_CONTENT_SCAN_PLAYLIST_REFRESH_INVALID_SYSTEM_NAME:
             {
                const char *playlist_file = NULL;
-
                if ((playlist_file = path_basename(playlist_config->path)))
-               {
-                  strlcpy(system_name, playlist_file, sizeof(system_name));
-                  path_remove_extension(system_name);
-               }
+                  fill_pathname(system_name, playlist_file, "",
+                        sizeof(system_name));
                else
                   system_name[0] = '\0';
 

--- a/menu/cbs/menu_cbs_title.c
+++ b/menu/cbs/menu_cbs_title.c
@@ -412,13 +412,7 @@ static int action_get_title_deferred_playlist_list(const char *path, const char 
          strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB), len);
       /* Handle collection playlists */
       else
-      {
-         char playlist_name[NAME_MAX_LENGTH];
-         strlcpy(playlist_name, playlist_file, sizeof(playlist_name));
-         path_remove_extension(playlist_name);
-
-         strlcpy(s, playlist_name, len);
-      }
+         fill_pathname(s, playlist_file, "", len);
    }
    /* This should never happen, but if it does just set
     * the label to the file name (it's better than nothing...) */
@@ -832,13 +826,13 @@ static int action_get_title_generic(char *s, size_t len,
       {
          size_t _len;
          char elem0_path[NAME_MAX_LENGTH];
-         strlcpy(elem0_path, tok, sizeof(elem0_path));
+         fill_pathname(elem0_path, path_basename(tok), "",
+               sizeof(elem0_path));
          _len      = strlcpy(s, text, len);
-         path_remove_extension(elem0_path);
          s[  _len] = ':';
          s[++_len] = ' ';
          s[++_len] = '\0';
-         strlcpy(s + _len, path_basename(elem0_path), len - _len);
+         strlcpy(s + _len, elem0_path, len - _len);
          free(path_cpy);
          return 0;
       }

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -4872,10 +4872,9 @@ static void ozone_init_horizontal_list(
          continue;
       }
 
-      /* Remove extension */
-      fill_pathname_base(playlist_file_noext,
-            playlist_file, sizeof(playlist_file_noext));
-      path_remove_extension(playlist_file_noext);
+      fill_pathname(playlist_file_noext,
+            path_basename(playlist_file), "",
+            sizeof(playlist_file_noext));
 
       console_name = playlist_file_noext;
 
@@ -5911,8 +5910,7 @@ border_iterate:
                for (offset = 0; offset < ozone->horizontal_list.size; offset++)
                {
                   char playlist_file_noext[NAME_MAX_LENGTH];
-                  strlcpy(playlist_file_noext, ozone->horizontal_list.list[offset].path, sizeof(playlist_file_noext));
-                  path_remove_extension(playlist_file_noext);
+                  fill_pathname(playlist_file_noext, ozone->horizontal_list.list[offset].path, "", sizeof(playlist_file_noext));
                   if (string_is_equal(playlist_file_noext, entry.rich_label))
                      break;
                }

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -2130,8 +2130,7 @@ static void xmb_set_title(xmb_handle_t *xmb)
          return;
 
       /* Use real title for dynamic backgrounds */
-      fill_pathname_base(xmb->title_name, path, sizeof(xmb->title_name));
-      path_remove_extension(xmb->title_name);
+      fill_pathname(xmb->title_name, path_basename(path), "", sizeof(xmb->title_name));
 
       /* Set alternative title for visible header */
       if (node && node->console_name)
@@ -2491,8 +2490,8 @@ static void xmb_init_horizontal_list(xmb_handle_t *xmb)
          }
 
          /* Remove extension */
-         fill_pathname_base(playlist_file_noext, playlist_file, sizeof(playlist_file_noext));
-         path_remove_extension(playlist_file_noext);
+         fill_pathname(playlist_file_noext, path_basename(playlist_file), "",
+               sizeof(playlist_file_noext));
 
          console_name = playlist_file_noext;
 
@@ -4869,8 +4868,8 @@ static int xmb_draw_item(
             for (offset = 0; offset < xmb->horizontal_list.size; offset++)
             {
                char playlist_file_noext[NAME_MAX_LENGTH];
-               strlcpy(playlist_file_noext, xmb->horizontal_list.list[offset].path, sizeof(playlist_file_noext));
-               path_remove_extension(playlist_file_noext);
+               fill_pathname(playlist_file_noext, xmb->horizontal_list.list[offset].path, "",
+                     sizeof(playlist_file_noext));
                if (string_is_equal(playlist_file_noext, entry.rich_label))
                   break;
             }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2399,8 +2399,8 @@ static int menu_displaylist_parse_playlist(
       else if (!string_is_empty(info_path))
       {
          char lpl_basename[NAME_MAX_LENGTH];
-         fill_pathname_base(lpl_basename, info_path, sizeof(lpl_basename));
-         path_remove_extension(lpl_basename);
+         fill_pathname(lpl_basename, path_basename(info_path), "",
+               sizeof(lpl_basename));
          menu_driver_set_thumbnail_system(
                menu_st->userdata, lpl_basename, sizeof(lpl_basename));
       }
@@ -2661,7 +2661,6 @@ static int menu_displaylist_parse_database_entry(menu_handle_t *menu,
 
    fill_pathname(path_base, path_basename(info->path), "",
          sizeof(path_base));
-   path_remove_extension(path_base);
 
    menu_driver_set_thumbnail_system(
          menu_st->userdata, path_base, sizeof(path_base));
@@ -3525,8 +3524,8 @@ static int menu_displaylist_parse_horizontal_list(
 
          /* Thumbnail system must be set *after* playlist
           * is loaded/cached */
-         fill_pathname_base(lpl_basename, item->path, sizeof(lpl_basename));
-         path_remove_extension(lpl_basename);
+         fill_pathname(lpl_basename, path_basename(item->path), "",
+               sizeof(lpl_basename));
          menu_driver_set_thumbnail_system(
                menu_st->userdata, lpl_basename, sizeof(lpl_basename));
       }
@@ -4657,8 +4656,8 @@ static unsigned menu_displaylist_parse_add_to_playlist_list(
                || string_is_equal(playlist_file, FILE_PATH_CONTENT_FAVORITES))
             continue;
 
-         strlcpy(playlist_display_name, playlist_file, sizeof(playlist_display_name));
-         path_remove_extension(playlist_display_name);
+         fill_pathname(playlist_display_name, playlist_file, "",
+               sizeof(playlist_display_name));
 
          menu_entries_append(list, playlist_display_name, path,
                MENU_ENUM_LABEL_ADD_ENTRY_TO_PLAYLIST,
@@ -4920,8 +4919,7 @@ static unsigned menu_displaylist_parse_pl_thumbnail_download_list(
                   "lpl"))
             continue;
 
-         strlcpy(path_base, path, sizeof(path_base));
-         path_remove_extension(path_base);
+         fill_pathname(path_base, path, "", sizeof(path_base));
 
          menu_entries_append(list, path_base, path,
                MENU_ENUM_LABEL_PL_THUMBNAILS_UPDATER_ENTRY,
@@ -5013,12 +5011,9 @@ static unsigned menu_displaylist_parse_content_information(
 
          if (!string_is_empty(entry->label))
             strlcpy(content_label, entry->label, sizeof(content_label));
-         else if (!string_is_empty(content_path))
-         {
-            /* Create content label from the path */
-            strlcpy(content_label, path_basename(content_path), sizeof(content_label));
-            path_remove_extension(content_label);
-         }
+         else if (!string_is_empty(content_path)) /* Create content label from the path */
+            fill_pathname(content_label, path_basename(content_path), "",
+                  sizeof(content_label));
 
          /* Only display core name if both core name and
           * core path are valid */
@@ -5037,8 +5032,8 @@ static unsigned menu_displaylist_parse_content_information(
       core_path      = loaded_core_path;
 
       /* Create content label from the path */
-      strlcpy(content_label, path_basename(content_path), sizeof(content_label));
-      path_remove_extension(content_label);
+      fill_pathname(content_label, path_basename(content_path), "",
+            sizeof(content_label));
 
       if (core_info_find(core_path, &core_info))
       {
@@ -5076,15 +5071,11 @@ static unsigned menu_displaylist_parse_content_information(
    /* Database */
    if (!string_is_empty(db_name))
    {
-      char *db_name_no_ext = NULL;
       char db_name_no_ext_buff[NAME_MAX_LENGTH];
-      /* Remove .lpl extension
-      * > path_remove_extension() requires a char * (not const)
-      *   so have to use a temporary buffer... */
-      strlcpy(db_name_no_ext_buff, db_name, sizeof(db_name_no_ext_buff));
-      db_name_no_ext = path_remove_extension(db_name_no_ext_buff);
+      fill_pathname(db_name_no_ext_buff, db_name, "",
+            sizeof(db_name_no_ext_buff));
 
-      if (!string_is_empty(db_name_no_ext))
+      if (!string_is_empty(db_name_no_ext_buff))
       {
          size_t _len = strlcpy(tmp,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_DATABASE),
@@ -5092,7 +5083,7 @@ static unsigned menu_displaylist_parse_content_information(
          tmp[  _len] = ':';
          tmp[++_len] = ' ';
          tmp[++_len] = '\0';
-         strlcpy(tmp + _len, db_name_no_ext, sizeof(tmp) - _len);
+         strlcpy(tmp + _len, db_name_no_ext_buff, sizeof(tmp) - _len);
          if (menu_entries_append(info_list, tmp,
                msg_hash_to_str(MENU_ENUM_LABEL_CONTENT_INFO_DATABASE),
                MENU_ENUM_LABEL_CONTENT_INFO_DATABASE,

--- a/playlist.c
+++ b/playlist.c
@@ -1335,8 +1335,8 @@ bool playlist_push(playlist_t *playlist,
    if (string_is_empty(core_name))
    {
       static char base_path[NAME_MAX_LENGTH] = {0};
-      fill_pathname_base(base_path, real_core_path, sizeof(base_path));
-      path_remove_extension(base_path);
+      fill_pathname(base_path, path_basename(real_core_path), "",
+            sizeof(base_path));
 
       core_name = base_path;
 

--- a/runloop.c
+++ b/runloop.c
@@ -4169,10 +4169,9 @@ static bool runloop_path_init_subsystem(runloop_state_t *runloop_st)
             ext[  _len]  = '.';
             ext[++_len]  = '\0';
             strlcpy(ext + _len, mem->extension, sizeof(ext) - _len);
-            strlcpy(savename,
-                  runloop_st->subsystem_fullpaths->elems[i].data,
+            fill_pathname(savename,
+                  runloop_st->subsystem_fullpaths->elems[i].data, "",
                   sizeof(savename));
-            path_remove_extension(savename);
 
             if (path_is_directory(savefile_dir))
             {
@@ -8183,8 +8182,7 @@ void runloop_path_set_special(char **argv, unsigned num_content)
    for (i = 0; i < num_content; i++)
    {
       string_list_append(runloop_st->subsystem_fullpaths, argv[i], attr);
-      strlcpy(str, argv[i], sizeof(str));
-      path_remove_extension(str);
+      fill_pathname(str, argv[i], "", sizeof(str));
       string_list_append(&subsystem_paths, path_basename(str), attr);
    }
 

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -334,32 +334,17 @@ runtime_log_t *runtime_log_init(
          size_t path_length = last_slash + 1 - content_path;
          if (path_length < PATH_MAX_LENGTH)
          {
-            size_t _len;
             memset(tmp_buf, 0, sizeof(tmp_buf));
             strlcpy(tmp_buf,
                   content_path, path_length * sizeof(char));
-            _len = strlcpy(content_name,
-                  path_basename(tmp_buf), sizeof(content_name));
-            strlcpy(content_name + _len, ".lrtl", sizeof(content_name) - _len);
+            fill_pathname(content_name,
+                  path_basename(tmp_buf), ".lrtl", sizeof(content_name));
          }
       }
    }
    else
-   {
-      size_t _len;
-      /* path_remove_extension() requires a char * (not const)
-       * so have to use a temporary buffer... */
-      char *tmp_buf_no_ext = NULL;
-      tmp_buf[0]           = '\0';
-      strlcpy(tmp_buf, path_basename(content_path), sizeof(tmp_buf));
-      tmp_buf_no_ext       = path_remove_extension(tmp_buf);
-
-      if (string_is_empty(tmp_buf_no_ext))
-         return NULL;
-
-      _len = strlcpy(content_name, tmp_buf_no_ext, sizeof(content_name));
-      strlcpy(content_name + _len, ".lrtl", sizeof(content_name) - _len);
-   }
+      fill_pathname(content_name, path_basename(content_path), ".lrtl",
+            sizeof(content_name));
 
    if (string_is_empty(content_name))
       return NULL;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -581,8 +581,8 @@ static bool content_file_list_set_info(
           * searching related content. For archived content,
           * this is the basename of the archive file without
           * extension */
-         fill_pathname_base(name, archive_path, sizeof(name));
-         path_remove_extension(name);
+         fill_pathname(name, path_basename(archive_path), "",
+               sizeof(name));
 
          file_info->file_in_archive = true;
       }
@@ -595,8 +595,8 @@ static bool content_file_list_set_info(
          /* For uncompressed content, 'canonical' name/id
           * is the basename of the content file, without
           * extension */
-         fill_pathname_base(name, path, sizeof(name));
-         path_remove_extension(name);
+         fill_pathname(name, path_basename(path), "",
+               sizeof(name));
       }
 
       if (!string_is_empty(dir))

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -791,7 +791,6 @@ static int database_info_list_iterate_found_match(
 
    fill_pathname(db_playlist_base_str,
          path_basename_nocompression(db_path), "", str_len);
-   path_remove_extension(db_playlist_base_str);
 
    strlcat(db_playlist_base_str, ".lpl", sizeof(db_playlist_base_str));
 
@@ -827,7 +826,6 @@ static int database_info_list_iterate_found_match(
          *delim = '\0';
       fill_pathname(entry_lbl,
             path_basename_nocompression(entry_path), "", str_len);
-      path_remove_extension(entry_lbl);
 
       RARCH_LOG("[Scanner]: No match for: \"%s\", CRC: 0x%08X\n", entry_path_str, db_state->crc);
    }
@@ -1049,7 +1047,6 @@ static int task_database_iterate_playlist_lutro(
       char game_title[NAME_MAX_LENGTH];
       fill_pathname(game_title,
             path_basename(path), "", sizeof(game_title));
-      path_remove_extension(game_title);
 
       /* the push function reads our entry as const,
        * so these casts are safe */

--- a/tasks/task_netplay_find_content.c
+++ b/tasks/task_netplay_find_content.c
@@ -205,9 +205,11 @@ static bool find_content_by_name(playlist_config_t *playlist_config,
                   continue;
             }
 
-            strlcpy(buf, path_basename(entry->path), sizeof(buf));
             if (!with_extension)
-               path_remove_extension(buf);
+               fill_pathname(buf, path_basename(entry->path),
+                     "", sizeof(buf));
+            else
+               strlcpy(buf, path_basename(entry->path), sizeof(buf));
 
             if (string_is_equal_case_insensitive(buf, name))
             {

--- a/tasks/task_playlist_manager.c
+++ b/tasks/task_playlist_manager.c
@@ -207,12 +207,8 @@ static void task_pl_manager_reset_cores_handler(retro_task_t *task)
                if (!string_is_empty(entry->label))
                   strlcpy(task_title + _len, entry->label, sizeof(task_title) - _len);
                else if (!string_is_empty(entry->path))
-               {
-                  char entry_name[128];
-                  fill_pathname_base(entry_name, entry->path, sizeof(entry_name));
-                  path_remove_extension(entry_name);
-                  strlcpy(task_title + _len, entry_name, sizeof(task_title) - _len);
-               }
+                  fill_pathname(task_title + _len, path_basename(entry->path), "",
+                        sizeof(task_title) - _len);
 
                task_set_title(task, strdup(task_title));
                task_set_progress(task, (pl_manager->list_index * 100) / pl_manager->list_size);
@@ -294,9 +290,9 @@ bool task_push_pl_manager_reset_cores(const playlist_config_t *playlist_config)
    if (string_is_empty(playlist_config->path))
       goto error;
 
-   fill_pathname_base(playlist_name,
-         playlist_config->path, sizeof(playlist_name));
-   path_remove_extension(playlist_name);
+   fill_pathname(playlist_name,
+         path_basename(playlist_config->path), "",
+         sizeof(playlist_name));
 
    if (string_is_empty(playlist_name))
       goto error;
@@ -721,9 +717,9 @@ bool task_push_pl_manager_clean_playlist(
    if (string_is_empty(playlist_config->path))
       goto error;
 
-   fill_pathname_base(playlist_name,
-         playlist_config->path, sizeof(playlist_name));
-   path_remove_extension(playlist_name);
+   fill_pathname(playlist_name,
+         path_basename(playlist_config->path), "",
+         sizeof(playlist_name));
 
    if (string_is_empty(playlist_name))
       goto error;


### PR DESCRIPTION
This PR aims to remove a lot of unneccessary calls to path_remove_extension and temporary string copies by calling fill_pathname instead. Leaving the third parameter empty ("") will strip the extension, while adding in a new one (like ".lrtl") will replace the extension.

To test usage of it, I made this sample program:

```
#include <stdio.h>
#include <stdbool.h>

static size_t strlcpy(char *dest, const char *source, size_t size)
{
   size_t src_size = 0;
   size_t        n = size;

   if (n)
      while (--n && (*dest++ = *source++)) src_size++;

   if (!n)
   {
      if (size) *dest = '\0';
      while (*source++) src_size++;
   }

   return src_size;
}


static bool string_is_equal(const char *a, const char *b)
{
   return (a && b) ? !strcmp(a, b) : false;
}

char *string_to_lower(char *s)
{
   char *cs = (char *)s;
   for ( ; *cs != '\0'; cs++)
      *cs = tolower((unsigned char)*cs);
   return s;
}

const char *path_get_archive_delim(const char *path)
{
   char buf[5];
   /* Find delimiter position
    * > Since filenames may contain '#' characters,
    *   must loop until we find the first '#' that
    *   is directly *after* a compression extension */
   const char *delim      = strchr(path, '#');

   while (delim)
   {
      /* Check whether this is a known archive type
       * > Note: The code duplication here is
       *   deliberate, to maximise performance */
      if (delim - path > 4)
      {
         strlcpy(buf, delim - 4, sizeof(buf));
         buf[4] = '\0';

         string_to_lower(buf);

         /* Check if this is a '.zip', '.apk' or '.7z' file */
         if (   string_is_equal(buf,     ".zip")
             || string_is_equal(buf,     ".apk")
             || string_is_equal(buf + 1, ".7z"))
            return delim;
      }
      else if (delim - path > 3)
      {
         strlcpy(buf, delim - 3, sizeof(buf));
         buf[3] = '\0';

         string_to_lower(buf);

         /* Check if this is a '.7z' file */
         if (string_is_equal(buf, ".7z"))
            return delim;
      }

      delim++;
      delim = strchr(delim, '#');
   }

   return NULL;
}

const char *path_basename(const char *path)
{
   /* We cut either at the first compression-related hash,
    * or we cut at the last slash */
   const char *ptr       = NULL;
   const char *slash     = strrchr(path, '/');
   const char *backslash = strrchr(path, '\\');
   char *last_slash      = (!slash || (backslash > slash)) ? (char*)backslash : (char*)slash;
   if (     (ptr = path_get_archive_delim(path))
         || (ptr = last_slash))
      return ptr + 1;
   return path;
}

size_t fill_pathname(char *s, const char *in_path,
      const char *replace, size_t len)
{
   size_t _len;
   char tmp_path[8192];
   char *tok   = NULL;
   strlcpy(tmp_path, in_path, sizeof(tmp_path));
   if ((tok = (char*)strrchr(path_basename(tmp_path), '.')))
      *tok = '\0';

   _len  = strlcpy(s,        tmp_path, len);
   _len += strlcpy(s + _len, replace,  len - _len);
   return _len;
}

int main(int argc, char **argv)
{
	char s[8192];
	char str[] = "/f/git/libretro-super/somefile.zip";
	fill_pathname(s, str, ".lrtl", sizeof(s));
	printf("s: %s\n", s);
	return 0;
}
```
Save as test.c and compile with gcc -o test test.c

@warmenhoven 