### PR TITLE
ios9: re-enable web server/webdav server

### DIFF
--- a/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
+++ b/pkg/apple/RetroArch_iOS13.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		07019B932CD24FF200D6C3FD /* GCDWebDAVServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C5C63E2CD167470030FBEC /* GCDWebDAVServer.m */; };
+		070672FB2D1723A10099FC74 /* GCDWebUploader.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 92CC059F21FE3C1700FF79F0 /* GCDWebUploader.bundle */; };
 		070A88432A4E7AA9003161C0 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070A88422A4E7AA9003161C0 /* OpenAL.framework */; };
 		071212C82C6FD65B00F1B4B0 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 071212C72C6FD65B00F1B4B0 /* Settings.bundle */; };
 		0712A7722B807AE400C9765F /* TVServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0712A7712B807AE400C9765F /* TVServices.framework */; };
@@ -1434,6 +1435,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				070672FB2D1723A10099FC74 /* GCDWebUploader.bundle in Resources */,
 				07F7FB022A2DA8B800037C04 /* filters in Resources */,
 				0753AD192C86144200874A42 /* BaseConfig.xcconfig in Resources */,
 				9222F2092315DAD50097C0FD /* Launch Screen.storyboard in Resources */,

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -712,10 +712,8 @@ void cocoa_file_load_with_detect_core(const char *filename);
 -(void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-#if TARGET_OS_TV
     [[WebServer sharedInstance] startServers];
     [WebServer sharedInstance].webUploader.delegate = self;
-#endif
 }
 
 #if TARGET_OS_IOS && HAVE_IOS_TOUCHMOUSE


### PR DESCRIPTION
Also happens to re-enable it for all IOS builds, not just iOS9, which is why the iOS13 project.pbxproj change is necessary.

The Files.app was only introduced in iOS11 so iOS9/iOS10 are really helped by having the server available. And it doesn't hurt having it on the newer version app as well. It makes it slightly easier to manage from a computer.