### PR TITLE
Pointer sanitization - sdl

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -256,7 +256,7 @@ static int16_t sdl_input_state(
       case RARCH_DEVICE_POINTER_SCREEN:
          if (idx == 0)
          {
-            struct video_viewport vp    = {0};
+            video_viewport_t vp         = {0};
             bool screen                 = device ==
                RARCH_DEVICE_POINTER_SCREEN;
             int16_t res_x               = 0;
@@ -290,26 +290,42 @@ static int16_t sdl_input_state(
          break;
       case RETRO_DEVICE_KEYBOARD:
          return (id && id < RETROK_LAST) && sdl_key_pressed(id);
-      /* TODO: update to match other input drivers (aiming state, button binds) */
+      /* TODO: update button binds to match other input drivers */
       case RETRO_DEVICE_LIGHTGUN:
+      {
+         video_viewport_t vp         = {0};
+         int16_t res_x               = 0;
+         int16_t res_y               = 0;
+         int16_t res_screen_x        = 0;
+         int16_t res_screen_y        = 0;
+
+         if (video_driver_translate_coord_viewport_wrap(
+                     &vp, sdl->mouse_abs_x, sdl->mouse_abs_y,
+                     &res_x, &res_y, &res_screen_x, &res_screen_y))
+
          switch (id)
          {
+            case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X:
+               return res_x;
+            case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y:
+               return res_y;
+            case RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN:
+               return input_driver_pointer_is_offscreen(res_x, res_y);
             case RETRO_DEVICE_ID_LIGHTGUN_X:
                return sdl->mouse_x;
             case RETRO_DEVICE_ID_LIGHTGUN_Y:
                return sdl->mouse_y;
             case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:
                return sdl->mouse_l;
-            case RETRO_DEVICE_ID_LIGHTGUN_CURSOR:
+            case RETRO_DEVICE_ID_LIGHTGUN_RELOAD:
                return sdl->mouse_m;
-            case RETRO_DEVICE_ID_LIGHTGUN_TURBO:
-               return sdl->mouse_r;
             case RETRO_DEVICE_ID_LIGHTGUN_START:
-               return sdl->mouse_m && sdl->mouse_r;
-            case RETRO_DEVICE_ID_LIGHTGUN_PAUSE:
-               return sdl->mouse_m && sdl->mouse_l;
+               return sdl->mouse_r;
+            case RETRO_DEVICE_ID_LIGHTGUN_SELECT:
+               return sdl->mouse_l && sdl->mouse_r;
          }
          break;
+      }
    }
 
    return 0;


### PR DESCRIPTION
## Description

Adapt the sanitized pointer handling, discussed at #17196  :

sdl driver specific changes:

- lightgun position handling fixed
- lightgun buttons mapped in a fixed way for now

Since #17283 , I found out that sdl input driver can in practice only be used when display driver is also sdl, so now the missing lightgun changes are done and tested. Button mapping is fixed for now, I have a draft plan for unifying it across the board, but that is better left to another stream of activity.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/17169#issuecomment-2480050754

