### PR TITLE
change increment on max Fast-Forward speed

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16541,7 +16541,7 @@ static bool setting_append_list(
                general_read_handler);
          (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
          MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_SET_FRAME_LIMIT);
-         menu_settings_list_current_add_range(list, list_info, 0, MAXIMUM_FASTFORWARD_RATIO, 1.0, true, true);
+         menu_settings_list_current_add_range(list, list_info, 0, MAXIMUM_FASTFORWARD_RATIO, 0.1, true, true);
 
          CONFIG_BOOL(
                list, list_info,


### PR DESCRIPTION
closes https://github.com/libretro/RetroArch/issues/15540

we can still tick through to higher values quite fast, but there's not much reason for someone to exceed, say, 3x without just setting it to 0 anyway, so I don't think there's any real usability loss.

## Description

Change the increment tick on max fast-forward speed to 0.1 from the current value of 1.0 (i.e., integer only).

## Related Issues

https://github.com/libretro/RetroArch/issues/15540

## Related Pull Requests

none

## Reviewers

anyone who cares, I guess
