### PR TITLE
wayland: add support for single-pixel-buffer-v1 protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,8 @@ gfx/common/wayland/tablet-unstable-v2.h
 gfx/common/wayland/tablet-unstable-v2.c
 gfx/common/wayland/content-type-v1.h
 gfx/common/wayland/content-type-v1.c
+gfx/common/wayland/single-pixel-buffer-v1.h
+gfx/common/wayland/single-pixel-buffer-v1.c
 
 # libretro-common samples
 libretro-common/samples/streams/rzip/rzip

--- a/Makefile.common
+++ b/Makefile.common
@@ -1278,7 +1278,8 @@ ifeq ($(HAVE_WAYLAND), 1)
         gfx/common/wayland/relative-pointer-unstable-v1.o \
         gfx/common/wayland/cursor-shape-v1.o \
         gfx/common/wayland/tablet-unstable-v2.o \
-        gfx/common/wayland/content-type-v1.o
+        gfx/common/wayland/content-type-v1.o \
+        gfx/common/wayland/single-pixel-buffer-v1.o
 
    ifeq ($(HAVE_VULKAN), 1)
       OBJ += gfx/drivers_context/wayland_vk_ctx.o

--- a/deps/wayland-protocols/staging/single-pixel-buffer/README
+++ b/deps/wayland-protocols/staging/single-pixel-buffer/README
@@ -1,0 +1,4 @@
+Single-pixel buffer protocol
+
+Maintainers:
+Simon Ser <contact@emersion.fr> (@emersion)

--- a/deps/wayland-protocols/staging/single-pixel-buffer/single-pixel-buffer-v1.xml
+++ b/deps/wayland-protocols/staging/single-pixel-buffer/single-pixel-buffer-v1.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="single_pixel_buffer_v1">
+  <copyright>
+    Copyright © 2022 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="single pixel buffer factory">
+    This protocol extension allows clients to create single-pixel buffers.
+
+    Compositors supporting this protocol extension should also support the
+    viewporter protocol extension. Clients may use viewporter to scale a
+    single-pixel buffer to a desired size.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="wp_single_pixel_buffer_manager_v1" version="1">
+    <description summary="global factory for single-pixel buffers">
+      The wp_single_pixel_buffer_manager_v1 interface is a factory for
+      single-pixel buffers.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the wp_single_pixel_buffer_manager_v1 object.
+
+        The child objects created via this interface are unaffected.
+      </description>
+    </request>
+
+    <request name="create_u32_rgba_buffer">
+      <description summary="create a 1×1 buffer from 32-bit RGBA values">
+        Create a single-pixel buffer from four 32-bit RGBA values.
+
+        Unless specified in another protocol extension, the RGBA values use
+        pre-multiplied alpha.
+
+        The width and height of the buffer are 1.
+      </description>
+      <arg name="id" type="new_id" interface="wl_buffer"/>
+      <arg name="r" type="uint" summary="value of the buffer's red channel"/>
+      <arg name="g" type="uint" summary="value of the buffer's green channel"/>
+      <arg name="b" type="uint" summary="value of the buffer's blue channel"/>
+      <arg name="a" type="uint" summary="value of the buffer's alpha channel"/>
+    </request>
+  </interface>
+</protocol>

--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -69,6 +69,7 @@ generate_source 'unstable/pointer-constraints' 'pointer-constraints-unstable-v1'
 generate_source 'unstable/relative-pointer' 'relative-pointer-unstable-v1'
 generate_source 'staging/fractional-scale' 'fractional-scale-v1'
 generate_source 'staging/cursor-shape' 'cursor-shape-v1'
-# Required by cursor-shape-v1
+# tablet-unstable-v1 is required by cursor-shape-v1
 generate_source 'unstable/tablet' 'tablet-unstable-v2'
 generate_source 'staging/content-type' 'content-type-v1'
+generate_source 'staging/single-pixel-buffer' 'single-pixel-buffer-v1'

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -627,9 +627,9 @@ static bool wl_draw_splash_screen(gfx_ctx_wayland_data_t *wl)
    else
    {
       shm_buffer_t *buffer = create_shm_buffer(wl,
-      wl->buffer_width,
-      wl->buffer_height,
-      WL_SHM_FORMAT_XRGB8888);
+         wl->buffer_width,
+         wl->buffer_height,
+         WL_SHM_FORMAT_XRGB8888);
 
       if (!buffer)
          return false;

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -802,6 +802,10 @@ static void wl_registry_handle_global(void *data, struct wl_registry *reg,
       wl->content_type_manager = (struct wp_content_type_manager_v1*)
          wl_registry_bind(
             reg, id, &wp_content_type_manager_v1_interface, MIN(version, 1));
+   else if (string_is_equal(interface, wp_single_pixel_buffer_manager_v1_interface.name) && found++)
+      wl->single_pixel_manager = (struct wp_single_pixel_buffer_manager_v1*)
+         wl_registry_bind(
+            reg, id, &wp_single_pixel_buffer_manager_v1_interface, MIN(version, 1));
 
    if (found > 1)
    RARCH_LOG("[Wayland]: Registered interface %s at version %u\n",

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -37,12 +37,13 @@
 #include "../../gfx/common/wayland/content-type-v1.h"
 #include "../../gfx/common/wayland/cursor-shape-v1.h"
 #include "../../gfx/common/wayland/fractional-scale-v1.h"
-#include "../../gfx/common/wayland/viewporter.h"
 #include "../../gfx/common/wayland/idle-inhibit-unstable-v1.h"
-#include "../../gfx/common/wayland/xdg-shell.h"
-#include "../../gfx/common/wayland/xdg-decoration-unstable-v1.h"
 #include "../../gfx/common/wayland/pointer-constraints-unstable-v1.h"
 #include "../../gfx/common/wayland/relative-pointer-unstable-v1.h"
+#include "../../gfx/common/wayland/single-pixel-buffer-v1.h"
+#include "../../gfx/common/wayland/viewporter.h"
+#include "../../gfx/common/wayland/xdg-decoration-unstable-v1.h"
+#include "../../gfx/common/wayland/xdg-shell.h"
 
 #define FRACTIONAL_SCALE_V1_DEN 120
 #define FRACTIONAL_SCALE_MULT(v, scale_num) \
@@ -187,6 +188,7 @@ typedef struct gfx_ctx_wayland_data
    struct wp_cursor_shape_device_v1 *cursor_shape_device;
    struct wp_content_type_manager_v1 *content_type_manager;
    struct wp_content_type_v1 *content_type;
+   struct wp_single_pixel_buffer_manager_v1 *single_pixel_manager;
    output_info_t *current_output;
 #ifdef HAVE_VULKAN
    gfx_ctx_vulkan_data_t vk;


### PR DESCRIPTION
## Description

Add support for `single-pixel-buffer-v1` protocol for optimizing the use of the `wl_shm` 1x1 pixel case. I'm not sure I implemented the creation of a single-pixel buffer correctly in its current form, so a review is required. Also note that support for this protocol is currently available in GNOME and wlroots.

See https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/single-pixel-buffer/single-pixel-buffer-v1.xml

## Related Issues

No

## Related Pull Requests

No

## Reviewers

@ColinKinloch
