### PR TITLE
Pointer sanitization: Android, overlay, and other enhancements

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -3685,7 +3685,7 @@ static bool udev_mouse_button_pressed(
 }
 
 static int16_t udev_pointer_state(udev_input_t *udev,
-      unsigned port, unsigned id, bool screen)
+      unsigned port, unsigned idx, unsigned id, bool screen)
 {
    udev_input_mouse_t *mouse = udev_get_mouse(udev, port);
    int16_t res_x;
@@ -3701,8 +3701,19 @@ static int16_t udev_pointer_state(udev_input_t *udev,
             return res_y;
          case RETRO_DEVICE_ID_POINTER_PRESSED:
             if (mouse->abs == 1)
-               return mouse->pp;
-            return mouse->l;
+            {
+               if (idx == 0)
+                  return mouse->pp;
+               else
+                  return 0;
+            }
+            /* Simulate max. 3 touches with mouse buttons*/
+            else if (idx == 0)
+               return (mouse->l | mouse->r | mouse->m);
+            else if (idx == 1)
+               return (mouse->r | mouse->m);
+            else if (idx == 2)
+               return mouse->m;
          case RETRO_DEVICE_ID_POINTER_IS_OFFSCREEN:
             return input_driver_pointer_is_offscreen(res_x, res_y);
       }
@@ -3828,8 +3839,8 @@ static int16_t udev_input_state(
              return udev_input_touch_state(udev, pointer_dev, binds,
                      keyboard_mapping_blocked, port, device, idx, id);
 #endif
-         if (idx == 0) /* multi-touch unsupported (for now) */
-            return udev_pointer_state(udev, port, id,
+         if (idx < 3)
+            return udev_pointer_state(udev, port, idx, id,
                   device == RARCH_DEVICE_POINTER_SCREEN);
          break;
 

--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -241,7 +241,8 @@ static int16_t x_input_state(
             break;
          case RETRO_DEVICE_POINTER:
          case RARCH_DEVICE_POINTER_SCREEN:
-            if (idx == 0)
+            /* Map up to 3 touches to mouse buttons. */
+            if (idx < 3)
             {
                struct video_viewport vp    = {0};
                bool screen                 =
@@ -268,7 +269,12 @@ static int16_t x_input_state(
                      case RETRO_DEVICE_ID_POINTER_Y:
                         return res_y;
                      case RETRO_DEVICE_ID_POINTER_PRESSED:
-                        return x11->mouse_l;
+                        if (idx == 0)
+                           return (x11->mouse_l | x11->mouse_r | x11->mouse_m);
+                        else if (idx == 1)
+                           return (x11->mouse_r | x11->mouse_m);
+                        else if (idx == 2)
+                           return x11->mouse_m;
                      case RETRO_DEVICE_ID_POINTER_IS_OFFSCREEN:
                         return input_driver_pointer_is_offscreen(res_x, res_y);
                   }

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1207,64 +1207,36 @@ static int16_t input_overlay_lightgun_state(settings_t *settings,
 
    switch(id)
    {
+      /* Pointer positions have been clamped earlier in input drivers,   *
+       * so if we want to pass true offscreen value, it must be detected */
       case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X:
          ptr_st->device_mask |= (1 << RETRO_DEVICE_LIGHTGUN);
-
-         if (     ptr_st->ptr[0].x != -0x8000
-               || settings->bools.input_overlay_lightgun_allow_offscreen)
+         if (   ( ptr_st->ptr[0].x > -0x7fff && ptr_st->ptr[0].x != 0x7fff)
+               || !settings->bools.input_overlay_lightgun_allow_offscreen)
             return ptr_st->ptr[0].x;
-         else if (video_driver_get_viewport_info(&vp))
-         {
-            edge = ((2 * vp.x * 0x7fff) / (int)vp.full_width) - 0x7fff;
-            return ((ptr_st->screen_x > edge) ? 0x7fff : -0x7fff);
-         }
-         return -0x8000;
+         else
+            return -0x8000;
       case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y:
-         if (     ptr_st->ptr[0].y != -0x8000
-               || settings->bools.input_overlay_lightgun_allow_offscreen)
+         if (   ( ptr_st->ptr[0].y > -0x7fff && ptr_st->ptr[0].y != 0x7fff)
+               || !settings->bools.input_overlay_lightgun_allow_offscreen)
             return ptr_st->ptr[0].y;
-         else if (video_driver_get_viewport_info(&vp))
-         {
-            edge = ((2 * vp.y * 0x7fff) / (int)vp.full_height) - 0x7fff;
-            return ((ptr_st->screen_y > edge) ? 0x7fff : -0x7fff);
-         }
-         return -0x8000;
+         else
+            return -0x8000;
       case RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN:
-         return ( settings->bools.input_overlay_lightgun_allow_offscreen
-               && (ptr_st->ptr[0].x == -0x8000 || ptr_st->ptr[0].y == -0x8000));
+         return input_driver_pointer_is_offscreen(ptr_st->ptr[0].x, ptr_st->ptr[0].y);
       case RETRO_DEVICE_ID_LIGHTGUN_AUX_A:
-         rarch_id = RARCH_LIGHTGUN_AUX_A;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_AUX_B:
-         rarch_id = RARCH_LIGHTGUN_AUX_B;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_AUX_C:
-         rarch_id = RARCH_LIGHTGUN_AUX_C;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:
-         rarch_id = RARCH_LIGHTGUN_TRIGGER;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_START:
       case RETRO_DEVICE_ID_LIGHTGUN_PAUSE:
-         rarch_id = RARCH_LIGHTGUN_START;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_SELECT:
-         rarch_id = RARCH_LIGHTGUN_SELECT;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_RELOAD:
-         rarch_id = RARCH_LIGHTGUN_RELOAD;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP:
-         rarch_id = RARCH_LIGHTGUN_DPAD_UP;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN:
-         rarch_id = RARCH_LIGHTGUN_DPAD_DOWN;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT:
-         rarch_id = RARCH_LIGHTGUN_DPAD_LEFT;
-         break;
       case RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT:
-         rarch_id = RARCH_LIGHTGUN_DPAD_RIGHT;
+         rarch_id = input_driver_lightgun_id_convert(id);
          break;
       default:
          rarch_id = RARCH_BIND_LIST_END;
@@ -1294,6 +1266,8 @@ static int16_t input_overlay_pointer_state(input_overlay_t *ol,
                && ptr_st->ptr[idx].y != -0x8000;
       case RETRO_DEVICE_ID_POINTER_COUNT:
          return ptr_st->count;
+      case RETRO_DEVICE_ID_POINTER_IS_OFFSCREEN:
+         return input_driver_pointer_is_offscreen(ptr_st->ptr[idx].x, ptr_st->ptr[idx].y);
    }
 
    return 0;


### PR DESCRIPTION
## Description

Adapt the sanitized pointer handling, discussed at #17196  :

Overlay "driver" specific changes:

- make sure pointer position is always within [-0x7fff,0x7fff] by using the confined wrapper
- enable pointer offscreen query
- report -0x8000 for lightgun if pointer is at the edge
- align lightgun offscreen reporting and button ID conversion with other drivers

Android driver specific changes:

- make sure pointer position is always within [-0x7fff,0x7fff] by using the confined wrapper
- remove extra "inside" checks, general simplification
- enable pointer offscreen query
- report same value for all ports when querying mouse and lightgun
- fill missing lightgun support, with fixed button map

Udev and X11 driver specific changes:

- simulate max. 3 touches instead of 1 using different mouse buttons

Wayland driver specific changes:

- integrate touch input better to the overall handling (enabling overlay usage with mouse)
- simulate max. 3 touches instead of 1 using different mouse buttons

Tested on Android and the changed Linux desktop environments. The mouse-simulates-multitouch gimmick is probably not very useful for cores, but it does enable easier testing of related functions.

There is one significant difference between mobile platforms (Android and iOS) and other platforms: touches outside the core viewport are:
- reported on desktop platforms
- not reported on Android/iOS
- but are again reported if there is an overlay (which is probably almost always there).
I did not align this now, as it may be an intentional function.

Also, in libretro.h there is `RETRO_DEVICE_ID_POINTER_COUNT` [since 2019](https://github.com/zoltanvb/RetroArch/commit/2dde223d23871773bf399f3a0afcf847e0b4499d) but support for that is not present everywhere, and it is also not documented (though it should be quite clear). It may be aligned later.

## Related Pull Requests

#16343 - in my opinion, the "enable offscreen reporting" lightgun config setting can go away now, since other input drivers will do report -0x8000 anyway. I will send a different PR for that eventually. Even if it needs to stay, menu text should probably be re-worded, since the option does not control whether "offscreen" touches are reported or not, but instead the value that is reported.
