### PR TITLE
wayland: Fix improperly sized commits

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -634,7 +634,12 @@ static bool wl_draw_splash_screen(gfx_ctx_wayland_data_t *wl)
       wl_surface_damage_buffer(wl->surface, 0, 0,
          wl->buffer_width,
          wl->buffer_height);
+
+   if (wl->viewport)
+      wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
+
    wl_surface_commit(wl->surface);
+
    return true;
 }
 
@@ -906,12 +911,12 @@ bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
    {
       /* Stretch old buffer to fill new size, commit/roundtrip to apply */
       wp_viewport_set_destination(wl->viewport, wl->width, wl->height);
-      wl_surface_commit(wl->surface);
    }
 
 #ifdef HAVE_LIBDECOR_H
    if (wl->libdecor)
    {
+     wl->libdecor_frame_set_visibility(wl->libdecor_frame, !fullscreen);
      struct libdecor_state *state = wl->libdecor_state_new(wl->width, wl->height);
      wl->libdecor_frame_commit(wl->libdecor_frame, state, NULL);
      wl->libdecor_state_free(state);

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -43,6 +43,10 @@
 #define DEFAULT_WINDOWED_WIDTH 640
 #define DEFAULT_WINDOWED_HEIGHT 480
 
+/* Icon is 16x15 scaled by 16 */
+#define SPLASH_WINDOW_WIDTH 240
+#define SPLASH_WINDOW_HEIGHT 256
+
 #ifndef MFD_CLOEXEC
 #define MFD_CLOEXEC		0x0001U
 #endif

--- a/gfx/common/wayland_common.h
+++ b/gfx/common/wayland_common.h
@@ -21,10 +21,6 @@
 
 #include "../../input/common/wayland_common.h"
 
-/* Icon is 16x15 scaled by 16 */
-#define SPLASH_WINDOW_WIDTH 240
-#define SPLASH_WINDOW_HEIGHT 256
-
 #define WAYLAND_APP_ID "com.libretro.RetroArch"
 
 typedef struct toplevel_listener

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -54,9 +54,7 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration &&
-       width == SPLASH_WINDOW_WIDTH &&
-       height == SPLASH_WINDOW_HEIGHT)
+   if (wl->ignore_configuration)
       return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
 #ifdef HAVE_EGL
@@ -117,17 +115,12 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 }
 
 #ifdef HAVE_LIBDECOR_H
-#include <libdecor.h>
 static void
 libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   int width, height;
-   if (wl->ignore_configuration &&
-       wl->libdecor_configuration_get_content_size(configuration, frame, &width, &height) &&
-       width == SPLASH_WINDOW_WIDTH &&
-       height == SPLASH_WINDOW_HEIGHT)
+   if (wl->ignore_configuration)
       return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -46,9 +46,7 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration &&
-       width == SPLASH_WINDOW_WIDTH &&
-       height == SPLASH_WINDOW_HEIGHT)
+   if (wl->ignore_configuration)
       return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
    wl->configured = false;
@@ -102,17 +100,12 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 }
 
 #ifdef HAVE_LIBDECOR_H
-#include <libdecor.h>
 static void
 libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl   = (gfx_ctx_wayland_data_t*)data;
-   int width, height;
-   if (wl->ignore_configuration &&
-       wl->libdecor_configuration_get_content_size(configuration, frame, &width, &height) &&
-       width == SPLASH_WINDOW_WIDTH &&
-       height == SPLASH_WINDOW_HEIGHT)
+   if (wl->ignore_configuration)
       return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 


### PR DESCRIPTION
## Description

This removes the need for hacks I added in #16412
* Set viewport on splash commit
* Don't commit "set video mode" viewport update
* Hide the libdecor frame before transitioning to fullscreen

## Related Issues

Fixes #16410, fixes #16198

## Related Pull Requests

#16412

## Reviewers

@Sunderland93 This should make it easier to develop #17298