### PR TITLE
Pointer sanitization: cocoa

### DIFF
--- a/input/drivers/cocoa_input.h
+++ b/input/drivers/cocoa_input.h
@@ -34,6 +34,7 @@ typedef struct
    int16_t screen_x, screen_y;
    int16_t fixed_x, fixed_y;
    int16_t full_x, full_y;
+   int16_t confined_x, confined_y;
 } cocoa_touch_data_t;
 
 typedef struct

--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -402,6 +402,15 @@ static void cocoa_input_poll(void *data)
 
       memset(&vp, 0, sizeof(vp));
 
+      video_driver_translate_coord_viewport_confined_wrap(
+            &vp,
+            apple->touches[i].screen_x * backing_scale_factor,
+            apple->touches[i].screen_y * backing_scale_factor,
+            &apple->touches[i].confined_x,
+            &apple->touches[i].confined_y,
+            &apple->touches[i].full_x,
+            &apple->touches[i].full_y);
+
       video_driver_translate_coord_viewport_wrap(
             &vp,
             apple->touches[i].screen_x * backing_scale_factor,
@@ -588,11 +597,13 @@ static int16_t cocoa_input_state(
                            return (touch->full_x  != -0x8000) && (touch->full_y  != -0x8000); /* Inside? */
                         return    (touch->fixed_x != -0x8000) && (touch->fixed_y != -0x8000); /* Inside? */
                      case RETRO_DEVICE_ID_POINTER_X:
-                        return (device == RARCH_DEVICE_POINTER_SCREEN) ? touch->full_x : touch->fixed_x;
+                        return (device == RARCH_DEVICE_POINTER_SCREEN) ? touch->full_x : touch->confined_x;
                      case RETRO_DEVICE_ID_POINTER_Y:
-                        return (device == RARCH_DEVICE_POINTER_SCREEN) ? touch->full_y : touch->fixed_y;
+                        return (device == RARCH_DEVICE_POINTER_SCREEN) ? touch->full_y : touch->confined_y;
                      case RETRO_DEVICE_ID_POINTER_COUNT:
                         return apple->touch_count;
+                     case RETRO_DEVICE_ID_POINTER_IS_OFFSCREEN:
+                        return input_driver_pointer_is_offscreen(touch->fixed_x, touch->fixed_y);
                   }
                }
             }


### PR DESCRIPTION
Adapt the sanitized pointer handling, discussed at #17196 :

Cocoa driver specific changes:

- make sure pointer position is always within [-0x7fff,0x7fff] by using the confined wrapper
- enable pointer offscreen query

Changes are minimal, since I have no means to actually test it, so this is now a minimal change set, to bring it in line with the other input drivers. After the PR, pointer input should never return -0x8000, but should indicate "offscreen" state near the edges, can be tested with Remote Retropad.

Leaving this in draft until confirmation is received.

## Related Pull Requests
https://github.com/libretro/RetroArch/pull/17169#issuecomment-2480050754

## Reviewers
@warmenhoven (testing is welcome from anyone)