### PR TITLE
wayland: Remove hack ignoring configure events

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -880,9 +880,6 @@ bool gfx_ctx_wl_init_common(
       }
    }
 
-   // Ignore configure events until splash screen has been replaced
-   wl->ignore_configuration = true;
-
    wl->input.fd = wl_display_get_fd(wl->input.dpy);
 
    wl->input.keyboard_focus  = true;
@@ -945,6 +942,8 @@ bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
      wl->libdecor_state_free(state);
    }
 #endif
+
+   wl_surface_commit(wl->surface);
 
    return true;
 }

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -54,8 +54,6 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
-      return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
 #ifdef HAVE_EGL
    if (wl->win)
@@ -106,7 +104,6 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
    if (!wl->fractional_scale)
       wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
 
-   wl->ignore_configuration = false;
 #ifdef HAVE_EGL
    wl_egl_window_resize(wl->win, width, height, 0, 0);
 #endif
@@ -120,8 +117,6 @@ libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
-      return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 
 #ifdef HAVE_EGL

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -46,8 +46,6 @@ static void xdg_toplevel_handle_configure(void *data,
       int32_t width, int32_t height, struct wl_array *states)
 {
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
-      return;
    xdg_toplevel_handle_configure_common(wl, toplevel, width, height, states);
    wl->configured = false;
 }
@@ -85,7 +83,6 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
 
    if (vulkan_create_swapchain(&wl->vk, width, height, wl->swap_interval))
    {
-      wl->ignore_configuration = false;
       wl->vk.context.flags |= VK_CTX_FLAG_INVALID_SWAPCHAIN;
       if (wl->vk.flags & VK_DATA_FLAG_CREATED_NEW_SWAPCHAIN)
          vulkan_acquire_next_image(&wl->vk);
@@ -105,8 +102,6 @@ libdecor_frame_handle_configure(struct libdecor_frame *frame,
       struct libdecor_configuration *configuration, void *data)
 {
    gfx_ctx_wayland_data_t *wl   = (gfx_ctx_wayland_data_t*)data;
-   if (wl->ignore_configuration)
-      return;
    libdecor_frame_handle_configure_common(frame, configuration, wl);
 
    wl->configured = false;

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -227,7 +227,6 @@ typedef struct gfx_ctx_wayland_data
    bool maximized;
    bool resize;
    bool configured;
-   bool ignore_configuration;
    bool activated;
    bool reported_display_size;
    bool swap_complete;


### PR DESCRIPTION
See https://github.com/libretro/RetroArch/pull/17320

## Description

This fixes issues (re)introduced by "Fix improperly sized commits (#17309)"
It seems I didn't fully revert my past hacks.

My previous commit reintroduced an issue where the window stay at the size of the splash screen. It also created new issues around the surface being offset when set to fullscreen.

## Related Issues

https://github.com/libretro/RetroArch/issues/16198#issuecomment-2565093049

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/17309

## Reviewers

@Sunderland93 
