### PR TITLE
Add lightgun support to cocoa input driver

### DIFF
--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -413,6 +413,69 @@ static void cocoa_input_poll(void *data)
    }
 }
 
+static int16_t cocoa_lightgun_aiming_state(
+      cocoa_input_data_t *apple, unsigned idx, unsigned id)
+{
+   struct video_viewport vp    = {0};
+   int16_t res_x               = 0;
+   int16_t res_y               = 0;
+   int16_t res_screen_x        = 0;
+   int16_t res_screen_y        = 0;
+   
+   int16_t x = apple->window_pos_x;
+   int16_t y = apple->window_pos_y;
+
+#ifndef IOS
+   x *= cocoa_screen_get_backing_scale_factor();
+   y *= cocoa_screen_get_backing_scale_factor();
+#endif
+
+   if (video_driver_translate_coord_viewport_wrap(
+               &vp, x, y,
+               &res_x, &res_y, &res_screen_x, &res_screen_y))
+   {
+      switch (id)
+      {
+         case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X:
+            return res_x;
+         case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y:
+            return res_y;
+         case RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN:
+            return input_driver_pointer_is_offscreen(res_x, res_y);
+         default:
+            break;
+      }
+   }
+
+   return 0;
+}
+
+static bool cocoa_mouse_button_pressed(
+      cocoa_input_data_t *apple, unsigned port, unsigned key)
+{
+   switch (key)
+   {
+      case RETRO_DEVICE_ID_MOUSE_LEFT:
+         return apple->mouse_buttons & 1;
+      case RETRO_DEVICE_ID_MOUSE_RIGHT:
+         return apple->mouse_buttons & 2;
+      case RETRO_DEVICE_ID_MOUSE_MIDDLE:
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
+      case RETRO_DEVICE_ID_MOUSE_BUTTON_5:
+         return false;
+      case RETRO_DEVICE_ID_MOUSE_WHEELUP:
+         return apple->mouse_wu;
+      case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
+         return apple->mouse_wd;
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+         return apple->mouse_wl;
+      case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+         return apple->mouse_wr;
+   }
+
+   return false;
+}
+
 static int16_t cocoa_input_state(
       void *data,
       const input_device_driver_t *joypad,
@@ -598,6 +661,64 @@ static int16_t cocoa_input_state(
             }
          }
          break;
+      case RETRO_DEVICE_LIGHTGUN:
+         switch (id)
+         {
+            /*aiming*/
+            case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X:
+            case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y:
+            case RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN:
+               return cocoa_lightgun_aiming_state(apple, idx, id);
+            /*buttons*/
+            case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:
+            case RETRO_DEVICE_ID_LIGHTGUN_RELOAD:
+            case RETRO_DEVICE_ID_LIGHTGUN_AUX_A:
+            case RETRO_DEVICE_ID_LIGHTGUN_AUX_B:
+            case RETRO_DEVICE_ID_LIGHTGUN_AUX_C:
+            case RETRO_DEVICE_ID_LIGHTGUN_START:
+            case RETRO_DEVICE_ID_LIGHTGUN_SELECT:
+            case RETRO_DEVICE_ID_LIGHTGUN_DPAD_UP:
+            case RETRO_DEVICE_ID_LIGHTGUN_DPAD_DOWN:
+            case RETRO_DEVICE_ID_LIGHTGUN_DPAD_LEFT:
+            case RETRO_DEVICE_ID_LIGHTGUN_DPAD_RIGHT:
+            case RETRO_DEVICE_ID_LIGHTGUN_PAUSE:
+               {
+                  unsigned new_id                = input_driver_lightgun_id_convert(id);
+                  const uint64_t bind_joykey     = input_config_binds[port][new_id].joykey;
+                  const uint64_t bind_joyaxis    = input_config_binds[port][new_id].joyaxis;
+                  const uint64_t autobind_joykey = input_autoconf_binds[port][new_id].joykey;
+                  const uint64_t autobind_joyaxis= input_autoconf_binds[port][new_id].joyaxis;
+                  uint16_t joyport               = joypad_info->joy_idx;
+                  float axis_threshold           = joypad_info->axis_threshold;
+                  const uint64_t joykey          = (bind_joykey != NO_BTN) ? bind_joykey  : autobind_joykey;
+                  const uint32_t joyaxis         = (bind_joyaxis != AXIS_NONE) ? bind_joyaxis : autobind_joyaxis;
+                  
+                  if (binds[port][new_id].valid)
+                  {
+                     if ((uint16_t)joykey != NO_BTN && joypad->button(joyport, (uint16_t)joykey))
+                        return 1;
+                     if (joyaxis != AXIS_NONE &&
+                         ((float)abs(joypad->axis(joyport, joyaxis))
+                          / 0x8000) > axis_threshold)
+                        return 1;
+                     else if ((binds[port][new_id].key && binds[port][new_id].key < RETROK_LAST)
+                              && !keyboard_mapping_blocked
+                              && apple_key_state[rarch_keysym_lut[(enum retro_key)binds[port][new_id].key]])
+                        return 1;
+                     else
+                     {
+                        settings_t *settings = config_get_ptr();
+                        if (settings->uints.input_mouse_index[port] == 0)
+                        {
+                           if (cocoa_mouse_button_pressed(apple, port, binds[port][new_id].mbutton))
+                              return 1;
+                        }
+                     }
+                  }
+               }
+               break;
+         }
+         break;
    }
 
    return 0;
@@ -623,6 +744,7 @@ static uint64_t cocoa_input_get_capabilities(void *data)
         (1 << RETRO_DEVICE_JOYPAD)
       | (1 << RETRO_DEVICE_MOUSE)
       | (1 << RETRO_DEVICE_KEYBOARD)
+      | (1 << RETRO_DEVICE_LIGHTGUN)
       | (1 << RETRO_DEVICE_POINTER)
       | (1 << RETRO_DEVICE_ANALOG);
 }


### PR DESCRIPTION
## Description

The current cocoa input driver does not support `RETRO_DEVICE_LIGHTGUN`, thus MacOS and iOS can't control this device and cores must use an alternative like `RETRO_DEVICE_POINTER`.

This PR adds support for lightgun input to the cocoa input driver using an implementation similar to those found in `dinput` and `x11_input` drivers.

I was able to test it on macOS but not on iOS.

## Reviewers

@warmenhoven @zoltanvb 
