### PR TITLE
wayland: Dedupe wayland GL/VK configure code again

### DIFF
--- a/gfx/common/wayland_common.h
+++ b/gfx/common/wayland_common.h
@@ -15,45 +15,9 @@
 
 #pragma once
 
-#ifdef HAVE_LIBDECOR_H
-#include <libdecor.h>
-#endif
-
 #include "../../input/common/wayland_common.h"
 
 #define WAYLAND_APP_ID "com.libretro.RetroArch"
-
-typedef struct toplevel_listener
-{
-#ifdef HAVE_LIBDECOR_H
-   struct libdecor_frame_interface libdecor_frame_interface;
-#endif
-   struct xdg_toplevel_listener xdg_toplevel_listener;
-} toplevel_listener_t;
-
-typedef struct shm_buffer
-{
-   struct wl_buffer *wl_buffer;
-   void *data;
-   size_t data_size;
-} shm_buffer_t;
-
-void xdg_toplevel_handle_configure_common(gfx_ctx_wayland_data_t *wl, void *toplevel,
-      int32_t width, int32_t height, struct wl_array *states);
-
-void xdg_toplevel_handle_close(void *data,
-      struct xdg_toplevel *xdg_toplevel);
-
-#ifdef HAVE_LIBDECOR_H
-void libdecor_frame_handle_configure_common(struct libdecor_frame *frame,
-      struct libdecor_configuration *configuration, gfx_ctx_wayland_data_t *wl);
-
-void libdecor_frame_handle_close(struct libdecor_frame *frame,
-      void *data);
-
-void libdecor_frame_handle_commit(struct libdecor_frame *frame,
-      void *data);
-#endif
 
 void gfx_ctx_wl_get_video_size_common(void *data, unsigned *width,
       unsigned *height);
@@ -66,7 +30,7 @@ bool gfx_ctx_wl_get_metrics_common(void *data,
       enum display_metric_types type, float *value);
 
 bool gfx_ctx_wl_init_common(
-      const toplevel_listener_t *toplevel_listener,
+      const driver_configure_handler_t driver_configure_handler,
       gfx_ctx_wayland_data_t **wl);
 
 bool gfx_ctx_wl_set_video_mode_common_size(gfx_ctx_wayland_data_t *wl,
@@ -89,6 +53,3 @@ void gfx_ctx_wl_check_window_common(gfx_ctx_wayland_data_t *wl,
       void (*get_video_size)(void*, unsigned*, unsigned*), bool *quit,
       bool *resize, unsigned *width, unsigned *height);
 
-#ifdef HAVE_LIBDECOR_H
-extern const struct libdecor_interface libdecor_interface;
-#endif

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -661,13 +661,6 @@ static void xdg_shell_ping(
     xdg_wm_base_pong(shell, serial);
 }
 
-static void xdg_surface_handle_configure(
-      void *data, struct xdg_surface *surface,
-      uint32_t serial)
-{
-    xdg_surface_ack_configure(surface, serial);
-}
-
 static void wl_output_handle_geometry(void *data,
       struct wl_output *output,
       int x, int y,
@@ -1086,10 +1079,6 @@ const struct wl_output_listener output_listener = {
 
 const struct xdg_wm_base_listener xdg_shell_listener = {
     xdg_shell_ping,
-};
-
-const struct xdg_surface_listener xdg_surface_listener = {
-    xdg_surface_handle_configure,
 };
 
 const struct wp_fractional_scale_v1_listener wp_fractional_scale_v1_listener = {

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -104,7 +104,7 @@ typedef struct surface_output
    struct wl_list link;
 } surface_output_t;
 
-struct gfx_ctx_wayland_data;
+typedef struct gfx_ctx_wayland_data gfx_ctx_wayland_data_t;
 
 typedef struct input_ctx_wayland_data
 {
@@ -142,6 +142,10 @@ typedef struct data_offer_ctx
   bool dropped;
   enum wl_data_device_manager_dnd_action supported_actions;
 } data_offer_ctx;
+
+typedef struct wayland_configuration wayland_configuration_t;
+
+typedef void (*driver_configure_handler_t)(gfx_ctx_wayland_data_t *wl);
 
 typedef struct gfx_ctx_wayland_data
 {
@@ -209,6 +213,8 @@ typedef struct gfx_ctx_wayland_data
    int num_active_touches;
    int swap_interval;
    touch_pos_t active_touch_positions[MAX_TOUCHES]; /* int32_t alignment */
+   wayland_configuration_t *pending_configuration;
+   driver_configure_handler_t driver_configure_handler;
    unsigned width;
    unsigned height;
    unsigned buffer_width;
@@ -227,7 +233,6 @@ typedef struct gfx_ctx_wayland_data
    bool maximized;
    bool resize;
    bool configured;
-   bool ignore_configuration;
    bool activated;
    bool reported_display_size;
    bool swap_complete;
@@ -263,8 +268,6 @@ extern const struct wp_fractional_scale_v1_listener wp_fractional_scale_v1_liste
 extern const struct wl_surface_listener wl_surface_listener;
 
 extern const struct xdg_wm_base_listener xdg_shell_listener;
-
-extern const struct xdg_surface_listener xdg_surface_listener;
 
 extern const struct wl_output_listener output_listener;
 


### PR DESCRIPTION
Configurations of xdg_toplevels are pending until acked on xdg_surface configure.

The vulkan backend doesn't need  to take additional actions on configure.

Incorporates changes from https://github.com/libretro/RetroArch/pull/17317

I was intending on polishing it a bit more but if it's better than the current state it may be worth merging.

## Related Issues

https://github.com/libretro/RetroArch/issues/16198#issuecomment-2565093049

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/17309

## Reviewers

@Sunderland93 
