### PR TITLE
Pointer sanitization, rwebinput driver

### DIFF
--- a/input/drivers/rwebinput_input.c
+++ b/input/drivers/rwebinput_input.c
@@ -507,26 +507,17 @@ static int16_t rwebinput_input_state(
       case RARCH_DEVICE_POINTER_SCREEN:
          if (idx == 0)
          {
-            struct video_viewport vp;
+            struct video_viewport vp    = {0};
             rwebinput_mouse_state_t
                *mouse                   = &rwebinput->mouse;
-            const int edge_detect       = 32700;
             bool screen                 = device ==
                RARCH_DEVICE_POINTER_SCREEN;
-            bool inside                 = false;
             int16_t res_x               = 0;
             int16_t res_y               = 0;
             int16_t res_screen_x        = 0;
             int16_t res_screen_y        = 0;
 
-            vp.x                        = 0;
-            vp.y                        = 0;
-            vp.width                    = 0;
-            vp.height                   = 0;
-            vp.full_width               = 0;
-            vp.full_height              = 0;
-
-            if (!(video_driver_translate_coord_viewport_wrap(
+            if (!(video_driver_translate_coord_viewport_confined_wrap(
                         &vp, mouse->x, mouse->y,
                         &res_x, &res_y, &res_screen_x, &res_screen_y)))
                return 0;
@@ -537,25 +528,16 @@ static int16_t rwebinput_input_state(
                res_y = res_screen_y;
             }
 
-            inside =    (res_x >= -edge_detect)
-               && (res_y >= -edge_detect)
-               && (res_x <= edge_detect)
-               && (res_y <= edge_detect);
-
             switch (id)
             {
                case RETRO_DEVICE_ID_POINTER_X:
-                  if (inside)
-                     return res_x;
-                  break;
+                  return res_x;
                case RETRO_DEVICE_ID_POINTER_Y:
-                  if (inside)
-                     return res_y;
-                  break;
+                  return res_y;
                case RETRO_DEVICE_ID_POINTER_PRESSED:
                   return !!(mouse->buttons & (1 << RWEBINPUT_MOUSE_BTNL));
-               case RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN:
-                  return !inside;
+               case RETRO_DEVICE_ID_POINTER_IS_OFFSCREEN:
+                  return input_driver_pointer_is_offscreen(res_x, res_y);
                default:
                   break;
             }


### PR DESCRIPTION
## Description
Adapt the sanitized pointer handling, discussed at #17196 :

Rwebinput driver specific changes:

- make sure pointer position is always within `[-0x7fff,0x7fff]` by using the confined wrapper
- align pointer offscreen query with other drivers

Tested with self hosted build. For anyone looking to do that, https://github.com/Inglebard/dockerfiles/tree/retroarch-web-nightly is a very simple approach if you have docker, compiled updates can be just thrown in to the running container's `/var/www/html`.

I think this concludes the more important findings from the investigation: https://github.com/libretro/RetroArch/pull/17169#issuecomment-2480050754 . Maybe uwp can be changed still.

## Related Issues
This PR does not any way address the issue, but the web player is currently not working: #17245 