### PR TITLE
Fix passing wrong length of message

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -243,6 +243,7 @@ void gfx_widgets_msg_queue_push(
 
          if (task)
          {
+            len                                 = strlen(task->title);
             title = msg_widget->msg             = strdup(task->title);
             msg_widget->msg_new                 = strdup(title);
             msg_widget->msg_len                 = len;


### PR DESCRIPTION
`len` is passed in based on the length of `msg`, which in this branch is not used in favor of `task->title`, which sometimes is of shorter length.