### PR TITLE
Add more help text for custom options of ./configure in general.

### DIFF
--- a/qb/qb.params.sh
+++ b/qb/qb.params.sh
@@ -50,6 +50,10 @@ EOF
 	print_help_option "--host=HOST"              "Cross-compile with HOST-gcc instead of gcc"
 	print_help_option "--help"                   "Show this help"
 
+	printf %s\\n '' 'Default for custom toggle options can be yes, no, or auto.'
+	print_help_option 'Disable option is shown:' 'Default is yes'
+	print_help_option 'Enable option is shown:'  'Default is no'
+	print_help_option 'Both options are shown:'  'Default is auto (included if the necessary library is present)'
 	printf %s\\n '' 'Custom options:'
 
 	while read -r VAR _ COMMENT; do


### PR DESCRIPTION
## Description

Add some clarification on how custom options behave.
Output of `./configure --help` after this PR:

```
====================
 Quickbuild script
====================
Package: retroarch

General environment variables:
  CC:         C compiler
  CFLAGS:     C compiler flags
  CXX:        C++ compiler
  CXXFLAGS:   C++ compiler flags
  LDFLAGS:    Linker flags

General options:
  --prefix=PATH               Install path prefix
  --sysconfdir=PATH           System wide config file prefix
  --bindir=PATH               Binary install directory
  --datarootdir=PATH          Read-only data install directory
  --docdir=PATH               Documentation install directory
  --mandir=PATH               Manpage install directory
  --build=BUILD               The build system (no-op)
  --host=HOST                 Cross-compile with HOST-gcc instead of gcc
  --help                      Show this help

Default for custom toggle options can be yes, no, or auto.
  Disable option is shown:    Default is yes
  Enable option is shown:     Default is no
  Both options are shown:     Default is auto (included if the necessary library is present)

Custom options:
  --with-libretro             Config   Libretro library used
  --with-assets_dir           Config   Assets install directory
  --with-filters_dir          Config   Audio/video filters directory
  --with-core_info_dir        Config   Core info directory
  --disable-core_info_cache   Disable  Core info cache support
  --enable-bluetooth          Enable   Bluetooth support
  --disable-nvda              Disable  NVDA support
  --disable-patch             Disable  Softpatching support (BPS/IPS/UPS)
  --enable-xdelta             Enable   Xdelta softpatching support (requires softpatching)
  --disable-xdelta            Disable  Xdelta softpatching support (requires softpatching)
[...]

```

## Related Issues

Closes #9634 
