### PR TITLE
Fix savestate auto-index detection

### DIFF
--- a/command.c
+++ b/command.c
@@ -1460,7 +1460,8 @@ static void scan_states(settings_t *settings,
       if (string_is_empty(dir_elem))
          continue;
 
-      _len = fill_pathname_base(elem_base, dir_elem, sizeof(elem_base));
+      _len = strlen(dir_elem);
+      fill_pathname_base(elem_base, dir_elem, sizeof(elem_base));
 
       /* Only consider files with a '.state' extension
        * > i.e. Ignore '.state.auto', '.state.bak', etc. */


### PR DESCRIPTION
## Description

Due to length confusion, state 0 would always be detected.

[DEBUG] [State]: savestate scanning finished, used slots (in range): 6 (6), max:0, load index 0, gap index 1, delete index 0


## Related Issues

Introduced in 2cfdccc08555d