### PR TITLE
Fix launch app when pipewire service is stopped

### DIFF
--- a/audio/common/pipewire.c
+++ b/audio/common/pipewire.c
@@ -162,13 +162,17 @@ bool pipewire_core_init(pipewire_core_t *pw, const char *loop_name)
    pw_thread_loop_lock(pw->thread_loop);
 
    pw->core = pw_context_connect(pw->ctx, NULL, 0);
-   if(!pw->core)
-      return false;
+   if (!pw->core)
+      goto unlock;
 
    if (pw_core_add_listener(pw->core,
                             &pw->core_listener,
                             &core_events, pw) < 0)
-      return false;
+      goto unlock;
 
    return true;
+
+unlock:
+   pw_thread_loop_unlock(pw->thread_loop);
+   return false;
 }


### PR DESCRIPTION
RA hangs on startup when the pipewire audio driver is selected in the configuration, but the pipewire service is exist and stopped. This PR fixes this issue.