### PR TITLE
Replace upload-artifact v3 with v4

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -30,7 +30,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: retroarch-android-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/DOS-DJGPP.yml
+++ b/.github/workflows/DOS-DJGPP.yml
@@ -31,7 +31,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RA-DOS-dummy-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -26,7 +26,7 @@ jobs:
       id: slug
       run: echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RetroArch-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/Miyoo.yml
+++ b/.github/workflows/Miyoo.yml
@@ -31,7 +31,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: retroarch_miyoo_arm32${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/PS2.yml
+++ b/.github/workflows/PS2.yml
@@ -36,7 +36,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RA-PS2-dummy-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/PS4-ORBIS.yml
+++ b/.github/workflows/PS4-ORBIS.yml
@@ -37,7 +37,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: bin-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/PSP.yml
+++ b/.github/workflows/PSP.yml
@@ -42,7 +42,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RA-PSP-dummy-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/PSVita.yml
+++ b/.github/workflows/PSVita.yml
@@ -35,7 +35,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RA-PSVita-dummy-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/RS90.yml
+++ b/.github/workflows/RS90.yml
@@ -31,7 +31,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: retroarch_rs90_mips32${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/RetroFW.yml
+++ b/.github/workflows/RetroFW.yml
@@ -31,7 +31,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: retroarch_retrofw_mips32${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/Switch-libnx.yml
+++ b/.github/workflows/Switch-libnx.yml
@@ -30,7 +30,7 @@ jobs:
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RA-libnx-dummy-${{ steps.slug.outputs.sha8 }}
         path: |


### PR DESCRIPTION
## Description

Actions started failing:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Luckily, the upload-artifact was not as picky as the checkout, so a simple update ran successfully.

## Related Pull Requests

#17217 

