### PR TITLE
Update web player core list based on what is compiled for 1.20.0 stable version.

### DIFF
--- a/pkg/emscripten/libretro/index.html
+++ b/pkg/emscripten/libretro/index.html
@@ -28,96 +28,94 @@
                         <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Core Selection</button>
                         <div class="dropdown-menu dropdown-primary" aria-labelledby="dropdownMenu1" data-dropdown-in="fadeIn" data-dropdown-out="fadeOut" id="core-selector">
                            <a class="dropdown-item" href="." data-core="2048">2048</a>
-                           <a class="dropdown-item" href="." data-core="arduous">Arduous</a>
-                           <a class="dropdown-item" href="." data-core="bk">BK</a>
-                           <a class="dropdown-item" href="." data-core="bluemsx">BlueMSX</a>
+                           <a class="dropdown-item" href="." data-core="anarch">Anarch</a>
+                           <a class="dropdown-item" href="." data-core="ardens">Arduboy (Ardens)</a>
+                           <a class="dropdown-item" href="." data-core="arduous">Arduboy (Arduous)</a>
+                           <a class="dropdown-item" href="." data-core="bk">Elektronika - BK-0010/BK-0011 (BK)</a>
                            <a class="dropdown-item" href="." data-core="chailove">ChaiLove</a>
-                           <a class="dropdown-item" href="." data-core="craft">Craft</a>
-                           <a class="dropdown-item" href="." data-core="desmume">DeSmuME</a>
-                           <a class="dropdown-item" href="." data-core="dosbox">DOSBox</a>
-                           <a class="dropdown-item" href="." data-core="easyrpg">EasyRPG</a>
-                           <a class="dropdown-item" href="." data-core="ecwolf">ECWolf</a>
-                           <a class="dropdown-item" href="." data-core="fbalpha2012">FB Alpha 2012</a>
-                           <a class="dropdown-item" href="." data-core="fbalpha2012_cps1">FB Alpha 2012 CPS1</a>
-                           <a class="dropdown-item" href="." data-core="fbalpha2012_cps2">FB Alpha 2012 CPS2</a>
-                           <a class="dropdown-item" href="." data-core="fbalpha2012_neo">FB Alpha 2012 NeoGeo</a>
-                           <a class="dropdown-item" href="." data-core="fceumm">FCEUmm</a>
-                           <a class="dropdown-item" href="." data-core="ffmpeg">FFmpeg</a>
-                           <a class="dropdown-item" href="." data-core="freechaf">FreeChaF</a>
-                           <a class="dropdown-item" href="." data-core="gambatte">Gambatte</a>
+                           <a class="dropdown-item" href="." data-core="craft">Minecraft (Craft)</a>
+                           <a class="dropdown-item" href="." data-core="DoubleCherryGB">Nintendo - Game Boy / Color (DoubleCherryGB)</a>
+                           <a class="dropdown-item" href="." data-core="ecwolf">Wolfenstein 3D (ECWolf)</a>
+                           <a class="dropdown-item" href="." data-core="fbalpha2012">Arcade (FB Alpha 2012)</a>
+                           <a class="dropdown-item" href="." data-core="fbalpha2012_cps1">Arcade (FB Alpha 2012 CPS1)</a>
+                           <a class="dropdown-item" href="." data-core="fbalpha2012_cps2">Arcade (FB Alpha 2012 CPS2)</a>
+                           <a class="dropdown-item" href="." data-core="fbalpha2012_neogeo">Arcade (FB Alpha 2012 NeoGeo)</a>
+                           <a class="dropdown-item" href="." data-core="fceumm">Nintendo - NES / Famicom (FCEUmm)</a>
+                           <a class="dropdown-item" href="." data-core="freechaf">Fairchild ChannelF (FreeChaF)</a>
+                           <a class="dropdown-item" href="." data-core="galaksija">Galaksija</a>
+                           <a class="dropdown-item" href="." data-core="gambatte">Nintendo - Game Boy / Color (Gambatte)</a>
                            <a class="dropdown-item" href="." data-core="gme">Game Music Emu</a>
-                           <a class="dropdown-item" href="." data-core="gearboy">GearBoy</a>
-                           <a class="dropdown-item" href="." data-core="gearcoleco">GearColeco</a>
-                           <a class="dropdown-item" href="." data-core="gearsystem">GearSystem</a>
-                           <a class="dropdown-item" href="." data-core="genesis_plus_gx">Genesis Plus GX</a>
-                           <a class="dropdown-item" href="." data-core="genesis_plus_gx_wide">Genesis Plus GX Wide</a>
-                           <a class="dropdown-item" href="." data-core="glupen64">GLupeN64</a>
-                           <!--<a class="dropdown-item" href="." data-core="gpsp">gPSP</a>-->
-                           <a class="dropdown-item" href="." data-core="handy">Handy</a>
-                           <a class="dropdown-item" href="." data-core="jaxe">JAXE</a>
+                           <a class="dropdown-item" href="." data-core="gearboy">Nintendo - Game Boy / Color (GearBoy)</a>
+                           <a class="dropdown-item" href="." data-core="gearcoleco">Coleco - ColecoVision (GearColeco)</a>
+                           <a class="dropdown-item" href="." data-core="gearsystem">Sega - MS/GG/SG-1000 (GearSystem)</a>
+                           <a class="dropdown-item" href="." data-core="genesis_plus_gx">Sega - MS/GG/MD/CD (Genesis Plus GX)</a>
+                           <a class="dropdown-item" href="." data-core="genesis_plus_gx_wide">Sega - MS/GG/MD/CD (Genesis Plus GX Wide)</a>
+                           <a class="dropdown-item" href="." data-core="gong">Gong</a>
+                           <a class="dropdown-item" href="." data-core="gw">Handheld Electronic (GW)</a>
+                           <a class="dropdown-item" href="." data-core="handy">Atari - Lynx (Handy)</a>
+                           <a class="dropdown-item" href="." data-core="jaxe">CHIP-8/S-CHIP/XO-CHIP (JAXE)</a>
                            <a class="dropdown-item" href="." data-core="jumpnbump">Jump 'n Bump</a>
                            <a class="dropdown-item" href="." data-core="lowresnx">LowResNX</a>
-                           <a class="dropdown-item" href="." data-core="lutro">Lutro</a>
-                           <a class="dropdown-item" href="." data-core="m2000">M2000</a>
-                           <a class="dropdown-item" href="." data-core="mame2000">MAME 2000</a>
-                           <a class="dropdown-item" href="." data-core="mame2003">MAME 2003</a>
-                           <a class="dropdown-item" href="." data-core="mame2003_plus">MAME 2003-Plus</a>
-                           <a class="dropdown-item" href="." data-core="mednafen_lynx">Mednafen Lynx</a>
-                           <a class="dropdown-item" href="." data-core="mednafen_ngp">Mednafen Neo Geo Pocket</a>
-                           <a class="dropdown-item" href="." data-core="mednafen_pce_fast">Mednafen PC Engine Fast</a>
-                           <!--<a class="dropdown-item" href="." data-core="mednafen_pcfx">Mednafen/Beetle PCFX</a>-->
-                           <a class="dropdown-item" href="." data-core="mednafen_psx">Mednafen/Beetle PSX</a>
-                           <!--<a class="dropdown-item" href="." data-core="mednafen_saturn">Mednafen/Beetle Saturn</a>-->
-                           <a class="dropdown-item" href="." data-core="mednafen_snes">Mednafen/Beetle SNES</a>
-                           <a class="dropdown-item" href="." data-core="mednafen_vb">Mednafen/Beetle Virtual Boy</a>
-                           <a class="dropdown-item" href="." data-core="mednafen_wswan">Mednafen/Beetle WonderSwan</a>
-                           <a class="dropdown-item" href="." data-core="mgba">Mgba</a>
-                           <a class="dropdown-item" href="." data-core="minivmac">MiniVmac</a>
-                           <a class="dropdown-item" href="." data-core="mu">Mu</a>
-                           <a class="dropdown-item" href="." data-core="mupen64plus">Mupen64 Plus</a>
-                           <a class="dropdown-item" href="." data-core="mrboom">MrBoom</a>
-                           <a class="dropdown-item" href="." data-core="nestopia">Nestopia</a>
-                           <a class="dropdown-item" href="." data-core="nxengine">NX Engine</a>
-                           <a class="dropdown-item" href="." data-core="o2em">O2em</a>
-                           <a class="dropdown-item" href="." data-core="opera">Opera</a>
-                           <a class="dropdown-item" href="." data-core="picodrive">PicoDrive</a>
-                           <a class="dropdown-item" href="." data-core="prboom">PrBoom</a>
-                           <a class="dropdown-item" href="." data-core="quasi88">Quasi88</a>
-                           <a class="dropdown-item" href="." data-core="quicknes">QuickNES</a>
-                           <a class="dropdown-item" href="." data-core="retro8">Retro8</a>
-                           <a class="dropdown-item" href="." data-core="flycast">Flycast</a>
-                           <a class="dropdown-item" href="." data-core="snes9x2002">Snes9x 2002</a>
-                           <a class="dropdown-item" href="." data-core="snes9x2005">Snes9x 2005</a>
-                           <a class="dropdown-item" href="." data-core="snes9x2010">Snes9x 2010</a>
-                           <a class="dropdown-item" href="." data-core="snes9x">Snes9x</a>
-                           <a class="dropdown-item" href="." data-core="squirreljme">SquirrelJME</a>
-                           <a class="dropdown-item" href="." data-core="stella">Stella</a>
-                           <a class="dropdown-item" href="." data-core="tgbdual">TGB Dual</a>
+                           <a class="dropdown-item" href="." data-core="lutro">Lua Engine (Lutro)</a>
+                           <a class="dropdown-item" href="." data-core="m2000">Philips - P2000T (M2000)</a>
+                           <a class="dropdown-item" href="." data-core="mame2000">Arcade - MAME 2000</a>
+                           <a class="dropdown-item" href="." data-core="mame2003">Arcade - MAME 2003</a>
+                           <a class="dropdown-item" href="." data-core="mame2003_plus">Arcade - MAME 2003-Plus</a>
+                           <a class="dropdown-item" href="." data-core="mednafen_lynx">Atari - Lynx (Beetle Lynx)</a>
+                           <a class="dropdown-item" href="." data-core="mednafen_ngp">SNK - Neo Geo Pocket / Color (Beetle Neo Geo Pop)</a>
+                           <a class="dropdown-item" href="." data-core="mednafen_pce_fast">NEC - PC Engine / CD (Beetle PC Engine Fast)</a>
+                           <a class="dropdown-item" href="." data-core="mednafen_vb">Nintendo - Virtual Boy (Beetle VB)</a>
+                           <a class="dropdown-item" href="." data-core="mednafen_wswan">Bandai - WonderSwan/Color (Beetle WonderSwan)</a>
+                           <a class="dropdown-item" href="." data-core="mgba">Nintendo - Game Boy Advance (mGBA)</a>
+                           <a class="dropdown-item" href="." data-core="minivmac">Mac II (MiniVmac)</a>
+                           <a class="dropdown-item" href="." data-core="mu">Palm OS(Mu)</a>
+                           <a class="dropdown-item" href="." data-core="mrboom">Bomberman (Mr.Boom)</a>
+                           <a class="dropdown-item" href="." data-core="neocd">SNK - Neo Geo CD (NeoCD)</a>
+                           <a class="dropdown-item" href="." data-core="nestopia">Nintendo - NES / Famicom (Nestopia)</a>
+                           <a class="dropdown-item" href="." data-core="numero">Texas Instruments TI-83 (Numero)</a>
+                           <a class="dropdown-item" href="." data-core="nxengine">Cave Story (NX Engine)</a>
+                           <a class="dropdown-item" href="." data-core="o2em">Magnavox - Odyssey2 / Philips Videopac+ (O2EM)</a>
+                           <a class="dropdown-item" href="." data-core="opera">The 3DO Company - 3DO (Opera)</a>
+                           <a class="dropdown-item" href="." data-core="pcsx_rearmed">Sony - PlayStation (PCSX ReARMed)</a>
+                           <a class="dropdown-item" href="." data-core="picodrive">Sega - MS/GG/MD/CD/32X (PicoDrive)</a>
+                           <a class="dropdown-item" href="." data-core="pocketcdg">PocketCDG</a>
+                           <a class="dropdown-item" href="." data-core="prboom">Doom (PrBoom)</a>
+                           <a class="dropdown-item" href="." data-core="quasi88">NEC - PC-8000 / PC-8800 series (QUASI88)</a>
+                           <a class="dropdown-item" href="." data-core="quicknes">Nintendo - NES / Famicom (QuickNES)</a>
+                           <a class="dropdown-item" href="." data-core="retro8">PICO-8 (Retro8)</a>
+                           <a class="dropdown-item" href="." data-core="scummvm">ScummVM</a>
+                           <a class="dropdown-item" href="." data-core="snes9x2002">Nintendo - SNES / SFC (Snes9x 2002)</a>
+                           <a class="dropdown-item" href="." data-core="snes9x2005">Nintendo - SNES / SFC (Snes9x 2005)</a>
+                           <a class="dropdown-item" href="." data-core="snes9x2010">Nintendo - SNES / SFC (Snes9x 2010)</a>
+                           <a class="dropdown-item" href="." data-core="snes9x">Nintendo - SNES / SFC (Snes9x)</a>
+                           <a class="dropdown-item" href="." data-core="squirreljme">Java ME (SquirrelJME)</a>
+                           <a class="dropdown-item" href="." data-core="tamalibretro">Bandai - Tamagothci P1 (TamaLIBretro)</a>
+                           <a class="dropdown-item" href="." data-core="tgbdual">Nintendo - Game Boy / Color (TGB Dual)</a>
                            <a class="dropdown-item" href="." data-core="theodore">Theodore (Thomson TO8/TO9)</a>
                            <a class="dropdown-item" href="." data-core="tic80">TIC-80</a>
-                           <a class="dropdown-item" href="." data-core="tyrquake">TyrQuake</a>
-                           <a class="dropdown-item" href="." data-core="uzem">UZEM</a>
+                           <a class="dropdown-item" href="." data-core="tyrquake">Quake (TyrQuake)</a>
+                           <a class="dropdown-item" href="." data-core="uw8">MicroW8 (UW8)</a>
+                           <a class="dropdown-item" href="." data-core="uzem">Uzebox (Uzem)</a>
                            <a class="dropdown-item" href="." data-core="vaporspec">Vaporspec</a>
-                           <a class="dropdown-item" href="." data-core="vba_next">VBA Next</a>
-                           <a class="dropdown-item" href="." data-core="vecx">Vecx</a>
-                           <a class="dropdown-item" href="." data-core="vice_x64">VICE x64</a>
-                           <a class="dropdown-item" href="." data-core="vice_x64sc">VICE x64sc</a>
-                           <a class="dropdown-item" href="." data-core="vice_x128">VICE x128</a>
-                           <a class="dropdown-item" href="." data-core="vice_xcbm2">VICE xcbm2</a>
-                           <a class="dropdown-item" href="." data-core="vice_xcbm5x0">VICE xcbm5x0</a>
-                           <a class="dropdown-item" href="." data-core="vice_xpet">VICE xPET</a>
-                           <a class="dropdown-item" href="." data-core="vice_xplus4">VICE xPlus4</a>
-                           <a class="dropdown-item" href="." data-core="vice_xscpu64">VICE xscpu4</a>
-                           <a class="dropdown-item" href="." data-core="vice_xvic">VICE xVIC</a>
-                           <a class="dropdown-item" href="." data-core="vitaquake2">Vita Quake2</a>
-                           <a class="dropdown-item" href="." data-core="vitaquake2-rogue">Vita Quake2 (rogue)</a>
-                           <a class="dropdown-item" href="." data-core="vitaquake2-xatrix">Vita Quake2 (xatrix)</a>
-                           <a class="dropdown-item" href="." data-core="vitaquake2-zaero">Vita Quake2 (zaero)</a>
-                           <a class="dropdown-item" href="." data-core="virtualjaguar">Virtual Jaguar</a>
+                           <a class="dropdown-item" href="." data-core="vba_next">Nintendo - Game Boy Advance (VBA Next)</a>
+                           <a class="dropdown-item" href="." data-core="vecx">GCE - Vectrex (Vecx)</a>
+                           <a class="dropdown-item" href="." data-core="vice_x64">Commodore - C64 (VICE x64, fast)</a>
+                           <a class="dropdown-item" href="." data-core="vice_x64sc">Commodore - C64 (VICE x64sc, accurate)</a>
+                           <a class="dropdown-item" href="." data-core="vice_x128">Commodore - C128 (VICE x128)</a>
+                           <a class="dropdown-item" href="." data-core="vice_xcbm2">Commodore - CBM-II 6x0/7x0 (VICE xcbm2)</a>
+                           <a class="dropdown-item" href="." data-core="vice_xcbm5x0">Commodore - CBM-II 5x0 (xcbm5x0)</a>
+                           <a class="dropdown-item" href="." data-core="vice_xpet">Commodore - PET (VICE xpet)</a>
+                           <a class="dropdown-item" href="." data-core="vice_xplus4">Commodore - PLUS/4 (VICE xplus4)</a>
+                           <a class="dropdown-item" href="." data-core="vice_xscpu64">Commodore - C64 SuperCPU (VICE xscpu4)</a>
+                           <a class="dropdown-item" href="." data-core="vice_xvic">Commodore - VIC-20 (VICE xvic)</a>
+                           <a class="dropdown-item" href="." data-core="virtualxt">VirtualXT</a>
+                           <a class="dropdown-item" href="." data-core="vitaquake2">Quake II (vitaQuake 2)</a>
+                           <a class="dropdown-item" href="." data-core="vitaquake2-rogue">Quake II - Ground Zero (vitaQuake2 (rogue))</a>
+                           <a class="dropdown-item" href="." data-core="vitaquake2-xatrix">Quake II - The Reckoning (vitaQuake2 (xatrix))</a>
+                           <a class="dropdown-item" href="." data-core="vitaquake2-zaero">Quake II - Zaero (vitaQuake2 (zaero))</a>
                            <a class="dropdown-item" href="." data-core="wasm4">WASM4</a>
-                           <a class="dropdown-item" href="." data-core="x1">XMillenium</a>
-                           <a class="dropdown-item" href="." data-core="xrick">XRick</a>
-                           <a class="dropdown-item" href="." data-core="yabause">Yabause</a>
+                           <a class="dropdown-item" href="." data-core="x1">Sharp X1 (X Millenium)</a>
+                           <a class="dropdown-item" href="." data-core="xrick">Rick Dangerous (XRick)</a>
                         </div>
                         <button class="btn btn-primary disabled" id="btnRun" onclick="startRetroArch()" disabled>
                            <span class="fa fa-spinner fa-spin" id="icnRun"></span> Run


### PR DESCRIPTION
## Description

Static list of cores in index.html is updated, based on buildbot contents for 1.20.0. Names updated in a way that they appear in the core downloader list - could probably be sorted, but I wanted the diff to be more or less clear now.

This means also removal of a few cores from the list, that were probably never compiled for emscripten platform (checked against 1.10.0 version), so they were not working anyway. These are: BlueMSX, Desmume, Dosbox, EasyRPG, GLupeN64, Beetle PSX, Beetle SNES, Mupen 64 Plus, Stella, Virtual Jaguar.

On the other hand, several cores were added, that are there on the server.

## Related Issues

Fixes #11924 

