### PR TITLE
Fix a crash when initializing an illuminance sensor on Linux

### DIFF
--- a/input/common/linux_common.c
+++ b/input/common/linux_common.c
@@ -201,6 +201,10 @@ linux_illuminance_sensor_t *linux_open_illuminance_sensor(unsigned rate)
    if (!sensor)
       goto error;
 
+   device = retro_opendir(IIO_DEVICES_DIR);
+   if (!device)
+      goto error;
+
    sensor->millilux  = 0;
    sensor->poll_rate = rate ? rate : DEFAULT_POLL_RATE;
    sensor->thread    = NULL; /* We'll spawn a thread later, once we find a sensor */
@@ -243,7 +247,7 @@ linux_illuminance_sensor_t *linux_open_illuminance_sensor(unsigned rate)
    }
 
 error:
-   RARCH_ERR("Failed to find an illuminance sensor\n");
+   RARCH_ERR("Failed to find an illuminance sensor in " IIO_DEVICES_DIR "\n");
    retro_closedir(device);
 
    free(sensor);


### PR DESCRIPTION
## Description

This PR fixes a crash that I inadvertently introduced when adding support for light sensors on Linux.

## Related Issues

None that have a ticket.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/17208 is the PR that introduced this crash.
