### PR TITLE
* platform: Honor the LIBRETRO_CHEATS_DIRECTORY environment variable.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3571,6 +3571,7 @@ static bool config_load_file(global_t *global,
    char* libretro_directory                        = NULL;
    char* libretro_assets_directory                 = NULL;
    char* libretro_autoconfig_directory             = NULL;
+   char* libretro_cheats_directory                 = NULL;
    char* libretro_database_directory               = NULL;
    char* libretro_system_directory                 = NULL;
    char* libretro_video_filter_directory           = NULL;
@@ -3882,6 +3883,12 @@ static bool config_load_file(global_t *global,
        configuration_set_string(settings,
 				settings->paths.directory_autoconfig,
 				libretro_autoconfig_directory);
+
+   libretro_cheats_directory = getenv("LIBRETRO_CHEATS_DIRECTORY");
+   if (libretro_cheats_directory) /* override configuration value */
+       configuration_set_string(settings,
+				settings->paths.path_cheat_database,
+				libretro_cheats_directory);
 
    libretro_database_directory = getenv("LIBRETRO_DATABASE_DIRECTORY");
    if (libretro_database_directory) /* override configuration value */

--- a/docs/retroarch.6
+++ b/docs/retroarch.6
@@ -1,6 +1,6 @@
 .\" retroarch.6:
 
-.TH  "RETROARCH" "6" "January 18, 2025" "RETROARCH" "System Manager's Manual: retroarch"
+.TH  "RETROARCH" "6" "January 20, 2025" "RETROARCH" "System Manager's Manual: retroarch"
 
 .SH NAME
 
@@ -260,6 +260,12 @@ option.
 Specify the directory where RetroArch looks for controller
 auto-configuration files, overriding the value of the
 "joypad_autoconfig_dir" configuration file option.
+
+.TP
+\fBLIBRETRO_CHEATS_DIRECTORY\fR
+Specify the directory where RetroArch looks for cheat files,
+overriding the value of the "cheat_database_path" configuration file
+option.
 
 .TP
 \fBLIBRETRO_DATABASE_DIRECTORY\fR

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1325,6 +1325,7 @@ static void frontend_unix_get_env(int *argc,
    const char* libretro_directory = getenv("LIBRETRO_DIRECTORY");
    const char* libretro_assets_directory = getenv("LIBRETRO_ASSETS_DIRECTORY");
    const char* libretro_autoconfig_directory = getenv("LIBRETRO_AUTOCONFIG_DIRECTORY");
+   const char* libretro_cheats_directory = getenv("LIBRETRO_CHEATS_DIRECTORY");
    const char* libretro_database_directory = getenv("LIBRETRO_DATABASE_DIRECTORY");
    const char* libretro_system_directory = getenv("LIBRETRO_SYSTEM_DIRECTORY");
    const char* libretro_video_filter_directory = getenv("LIBRETRO_VIDEO_FILTER_DIRECTORY");
@@ -1904,8 +1905,13 @@ static void frontend_unix_get_env(int *argc,
    else
        fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SHADER], base_path,
              "shaders", sizeof(g_defaults.dirs[DEFAULT_DIR_SHADER]));
-   fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CHEATS], base_path,
-         "cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
+   if (!string_is_empty(libretro_cheats_directory))
+       strlcpy(g_defaults.dirs[DEFAULT_DIR_CHEATS],
+	       libretro_cheats_directory,
+	       sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
+   else
+       fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CHEATS], base_path,
+             "cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_OVERLAY], base_path,
          "overlays", sizeof(g_defaults.dirs[DEFAULT_DIR_OVERLAY]));
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_OSK_OVERLAY], base_path,

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -568,6 +568,7 @@ static void frontend_win32_env_get(int *argc, char *argv[],
    const char *libretro_directory = getenv("LIBRETRO_DIRECTORY");
    const char *libretro_assets_directory = getenv("LIBRETRO_ASSETS_DIRECTORY");
    const char* libretro_autoconfig_directory = getenv("LIBRETRO_AUTOCONFIG_DIRECTORY");
+   const char* libretro_cheats_directory = getenv("LIBRETRO_CHEATS_DIRECTORY");
    const char* libretro_database_directory = getenv("LIBRETRO_DATABASE_DIRECTORY");
    const char* libretro_system_directory = getenv("LIBRETRO_SYSTEM_DIRECTORY");
    const char* libretro_video_filter_directory = getenv("LIBRETRO_VIDEO_FILTER_DIRECTORY");
@@ -594,8 +595,13 @@ static void frontend_win32_env_get(int *argc, char *argv[],
    else
        fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER],
            ":\\filters\\video", sizeof(g_defaults.dirs[DEFAULT_DIR_VIDEO_FILTER]));
-   fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CHEATS],
-      ":\\cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
+   if (!string_is_empty(libretro_cheats_directory))
+       strlcpy(g_defaults.dirs[DEFAULT_DIR_CHEATS],
+	       libretro_cheats_directory,
+	       sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
+   else
+       fill_pathname_expand_special(g_defaults.dirs[DEFAULT_DIR_CHEATS],
+           ":\\cheats", sizeof(g_defaults.dirs[DEFAULT_DIR_CHEATS]));
    if (!string_is_empty(libretro_database_directory))
        strlcpy(g_defaults.dirs[DEFAULT_DIR_DATABASE],
 	       libretro_database_directory,

--- a/retroarch.c
+++ b/retroarch.c
@@ -6531,6 +6531,7 @@ static void retroarch_print_help(const char *arg0)
          "\nThe following environment variables are supported:\n\n"
          "  LIBRETRO_ASSETS_DIRECTORY\n"
          "  LIBRETRO_AUTOCONFIG_DIRECTORY\n"
+         "  LIBRETRO_CHEATS_DIRECTORY\n"
          "  LIBRETRO_DATABASE_DIRECTORY\n"
          "  LIBRETRO_DIRECTORY\n"
          "  LIBRETRO_SYSTEM_DIRECTORY\n"


### PR DESCRIPTION
Yet another environment variable useful to have.  I think this may be the last one in a while (these have been motivated by improving the user experience of the `retroarch` package in GNU Guix), as everything now seems functional/usefully configured out of the box.

* frontend/drivers/platform_unix.c (libretro_cheats_directory): New variable.
(frontend_unix_get_env): Set DEFAULT_DIR_CHEATS to the value of the LIBRETRO_CHEATS_DIRECTORY environment variable, if available.
* frontend/drivers/platform_win32.c: Likewise.
* configuration.c (config_load_file) <libretro_cheats_directory>: New variable. Use the values of the LIBRETRO_CHEATS_DIRECTORY environment variables instead of their corresponding configured values, when set.
* docs/retroarch.6: Document it.
* retroarch.c (retroarch_print_help): Extend help text.

## Reviewers

@JesseTG 
