### PR TITLE
RGUI: Entry value cleanup

### DIFF
--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -2301,6 +2301,8 @@ int menu_cbs_init_bind_get_string_representation(menu_file_list_cbs_t *cbs,
          case MENU_ENUM_LABEL_SWITCH_GPU_PROFILE:
          case MENU_ENUM_LABEL_REBOOT:
          case MENU_ENUM_LABEL_SHUTDOWN:
+         case MENU_ENUM_LABEL_SAVE_CURRENT_CONFIG:
+         case MENU_ENUM_LABEL_SAVE_NEW_CONFIG:
          case MENU_ENUM_LABEL_RESET_TO_DEFAULT_CONFIG:
          case MENU_ENUM_LABEL_START_NET_RETROPAD:
          case MENU_ENUM_LABEL_START_VIDEO_PROCESSOR:

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4931,6 +4931,8 @@ static enum rgui_entry_value_type rgui_get_entry_value_type(
                   string_is_equal(entry_value, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_ON)))
             return RGUI_ENTRY_VALUE_SWITCH_ON;
       }
+      else if (string_is_equal(entry_value, "(RDB)"))
+         return RGUI_ENTRY_VALUE_NONE;
       return RGUI_ENTRY_VALUE_TEXT;
    }
    else if (entry_checked)


### PR DESCRIPTION
## Description

Stop showing:
- `...` in "Save Current Configuration" and "Save New Configuration", since they are not submenus
- `(RDB)` as entry value in Database Manager, since the files already have `.rdb` extension
