### PR TITLE
macos: reset keyboard state when focus is lost

### DIFF
--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -78,6 +78,11 @@ static UISelectionFeedbackGenerator *feedbackGenerator;
 
 static bool apple_key_state[MAX_KEYS];
 
+void apple_input_keyboard_reset(void)
+{
+   memset(apple_key_state, 0, sizeof(apple_key_state));
+}
+
 /* Send keyboard inputs directly using RETROK_* codes
  * Used by the iOS custom keyboard implementation */
 void apple_direct_input_keyboard_event(bool down,
@@ -743,8 +748,7 @@ static void cocoa_input_free(void *data)
    if (!apple || !data)
       return;
 
-   for (i = 0; i < MAX_KEYS; i++)
-      apple_key_state[i] = 0;
+   memset(apple_key_state, 0, sizeof(apple_key_state));
 
    free(apple);
 }

--- a/input/drivers_keyboard/keyboard_event_apple.h
+++ b/input/drivers_keyboard/keyboard_event_apple.h
@@ -166,6 +166,8 @@ enum
 
 RETRO_BEGIN_DECLS
 
+void apple_input_keyboard_reset(void);
+
 void apple_input_keyboard_event(bool down,
       unsigned code, uint32_t character, uint32_t mod, unsigned device);
 

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -824,7 +824,10 @@ static ui_application_t ui_application_cocoa = {
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification  { }
-- (void)applicationWillResignActive:(NSNotification *)notification { }
+- (void)applicationWillResignActive:(NSNotification *)notification
+{
+   apple_input_keyboard_reset();
+}
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theApplication { return YES; }
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender
 {


### PR DESCRIPTION
Should serve as a reasonable (?) workaround for #13880 (not a root cause fix).