### PR TITLE
common: Add a `user_data` pointer to `audio_mixer_sound`

### DIFF
--- a/libretro-common/audio/audio_mixer.c
+++ b/libretro-common/audio/audio_mixer.c
@@ -122,6 +122,7 @@ struct audio_mixer_sound
       } mod;
 #endif
    } types;
+   void* user_data;
 };
 
 struct audio_mixer_voice


### PR DESCRIPTION
This change adds a `void* userdata` to the `audio_mixer_sound_t` struct. This allows you to keep some context of the sound that's being stopped when using the `audio_mixer_stop_cb_t stop_cb` callback in `audio_mixer_play()`.

Without this, you need to reference globals within the thread to retrieve any kind of context, which can be problematic, and not thread-safe.

### Example

In the below example, you can see we pass an `AppContext` pointer which is thread-safe and doesn't mess with globals.

```c
void sound_finished(audio_mixer_sound_t* sound, unsigned reason) {
  AppContext* app = sound->user_data;
}

// ...

mySound->user_data = app;
audio_mixer_play(mySound, false, 1.0f, NULL, 0, sound_finished);
```