### PR TITLE
common: Move audio_mixer_sound user_data to above the types union

### DIFF
--- a/libretro-common/audio/audio_mixer.c
+++ b/libretro-common/audio/audio_mixer.c
@@ -76,6 +76,7 @@
 struct audio_mixer_sound
 {
    enum audio_mixer_type type;
+   void* user_data;
 
    union
    {
@@ -122,7 +123,6 @@ struct audio_mixer_sound
       } mod;
 #endif
    } types;
-   void* user_data;
 };
 
 struct audio_mixer_voice


### PR DESCRIPTION
This moves the `void* user_data` to the top of the `audio_mixer_sound` as the size of `types` union can change depending on compilation options.
