### PR TITLE
Fix non-integer cast to pthread_t

### DIFF
--- a/input/common/linux_common.c
+++ b/input/common/linux_common.c
@@ -266,7 +266,7 @@ void linux_close_illuminance_sensor(linux_illuminance_sensor_t *sensor)
 
    if (sensor->thread)
    {
-      pthread_t thread = sthread_get_thread_id(sensor->thread);
+      pthread_t thread = (pthread_t)sthread_get_thread_id(sensor->thread);
       sensor->done = true;
 
       if (pthread_cancel(thread) != 0)


### PR DESCRIPTION
## Guidelines
## Description

This fixes the cast of pthread_t assuming it's an integer. However, a better solution should be implemented later on. Maybe adding a specific `sthread_get_native_handle` or something alike + a native `typedef`.

## Related Issues

#17511
