### PR TITLE
ios: jump back to selected item after closing content

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1048,7 +1048,7 @@ int generic_action_ok_displaylist_push(
          p_dialog->pending_push = true;
          break;
       case ACTION_OK_DL_RPL_ENTRY:
-         strlcpy(menu->deferred_path, label, sizeof(menu->deferred_path));
+         fill_pathname_expand_special(menu->deferred_path, label, sizeof(menu->deferred_path));
          info_label = msg_hash_to_str(MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS);
          info.enum_idx                 = MENU_ENUM_LABEL_DEFERRED_RPL_ENTRY_ACTIONS;
          info.directory_ptr            = idx;

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -2129,12 +2129,6 @@ bool task_push_load_content_from_playlist_from_menu(
          fullpath, &content_ctx, false)))
       goto end;
 
-#ifdef HAVE_COCOATOUCH
-   /* This seems to be needed for iOS for some reason
-    * to show the quick menu after the menu is shown */
-   menu_driver_ctl(RARCH_MENU_CTL_SET_PENDING_QUICK_MENU, NULL);
-#endif
-
 #ifndef HAVE_DYNAMIC
    /* No dynamic core loading support: if we reach
     * this point then a new instance has been


### PR DESCRIPTION
Fixes #17427 .

Seems to have been introduced trying to fix #9118 , which I now can't reproduce even with this workaround removed.