### PR TITLE
GLUI: Fix null label icon

### DIFF
--- a/intl/msg_hash_lbl.h
+++ b/intl/msg_hash_lbl.h
@@ -1551,6 +1551,10 @@ MSG_HASH(
    "core_disk_options"
    )
 MSG_HASH(
+   MENU_ENUM_LABEL_DISK_INDEX,
+   "core_disk_index"
+   )
+MSG_HASH(
    MENU_ENUM_LABEL_DOWNLOADED_FILE_DETECT_CORE_LIST,
    "downloaded_file_detect_core_list"
    )

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -10692,6 +10692,8 @@ static void materialui_list_insert(void *userdata,
              * switch */
             break;
          default:
+            if (string_is_equal(label, "null"))
+               break;
 #ifdef HAVE_CHEEVOS
             if (type >= MENU_SETTINGS_CHEEVOS_START &&
                type < MENU_SETTINGS_NETPLAY_ROOMS_START)


### PR DESCRIPTION
## Description

Prevent showing the mysterious CD icon ever again on menu items that don't have labels added to `msg_hash_lbl.h`. One missing label caused all "null" labels to match with "null" `DISK_INDEX`.
