### PR TITLE
Allow CLI --entryslot fallback to normal states

### DIFF
--- a/command.c
+++ b/command.c
@@ -1259,7 +1259,7 @@ size_t command_event_save_auto_state(void)
    size_t _len;
    runloop_state_t *runloop_st = runloop_state_get_ptr();
    char savestate_name_auto[PATH_MAX_LENGTH];
-   if (runloop_st->entry_state_slot)
+   if (runloop_st->entry_state_slot > -1)
       return 0;
    if (!core_info_current_supports_savestate())
       return 0;
@@ -1330,9 +1330,17 @@ bool command_event_load_entry_state(settings_t *settings)
    entry_state_path[0] = '\0';
 
    if (!runloop_get_entry_state_path(
+         entry_state_path, sizeof(entry_state_path),
+         runloop_st->entry_state_slot))
+      return false;
+
+   if (!path_is_valid(entry_state_path))
+   {
+      if (!runloop_get_savestate_path(
             entry_state_path, sizeof(entry_state_path),
             runloop_st->entry_state_slot))
-      return false;
+         return false;
+   }
 
    entry_path_stats = path_stat(entry_state_path);
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -7381,12 +7381,13 @@ static bool retroarch_parse_input_and_config(
                break;
             case 'e':
                {
-                  unsigned entry_state_slot = (unsigned)strtoul(optarg, NULL, 0);
+                  char *endptr;
+                  int16_t entry_state_slot = (unsigned)strtoul(optarg, &endptr, 0);
 
-                  if (entry_state_slot)
+                  if (entry_state_slot > -1 && string_is_empty(endptr))
                      runloop_st->entry_state_slot = entry_state_slot;
                   else
-                     RARCH_WARN("--entryslot argument \"%s\" is not a valid "
+                     RARCH_WARN("[State]: --entryslot argument \"%s\" is not a valid "
                         "entry state slot index. Ignoring.\n", optarg);
                }
                break;
@@ -7477,18 +7478,18 @@ static bool retroarch_parse_input_and_config(
        * command line interface */
       cli_content_set = true;
    }
-   else if (runloop_st->entry_state_slot)
+   else if (runloop_st->entry_state_slot > -1)
    {
-      runloop_st->entry_state_slot = 0;
+      runloop_st->entry_state_slot = -1;
       RARCH_WARN("Trying to load entry state without content. Ignoring.\n");
    }
    #ifdef HAVE_BSV_MOVIE
-   if (runloop_st->entry_state_slot)
+   if (runloop_st->entry_state_slot > -1)
    {
      input_driver_state_t *input_st = input_state_get_ptr();
      if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_START_PLAYBACK)
      {
-        runloop_st->entry_state_slot = 0;
+        runloop_st->entry_state_slot = -1;
         RARCH_WARN("Trying to load entry state while replay playback is active. Ignoring entry state.\n");
      }
    }
@@ -7585,6 +7586,7 @@ bool retroarch_main_init(int argc, char *argv[])
    input_st->osk_idx             = OSK_LOWERCASE_LATIN;
    video_st->flags              |= VIDEO_FLAG_ACTIVE;
    audio_state_get_ptr()->flags |= AUDIO_FLAG_ACTIVE;
+   runloop_st->entry_state_slot  = -1;
 
    if (setjmp(global->error_sjlj_context) > 0)
    {

--- a/runloop.c
+++ b/runloop.c
@@ -4281,11 +4281,11 @@ static bool event_init_content(
      if (!(input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_START_PLAYBACK))
 #endif
       {
-         if (      runloop_st->entry_state_slot
+         if (      runloop_st->entry_state_slot > -1
                && !command_event_load_entry_state(settings))
          {
            /* loading the state failed, reset entry slot */
-            runloop_st->entry_state_slot = 0;
+            runloop_st->entry_state_slot = -1;
          }
       }
 #ifdef HAVE_BSV_MOVIE
@@ -4293,7 +4293,7 @@ static bool event_init_content(
      if (!(input_st->bsv_movie_state.flags & (BSV_FLAG_MOVIE_START_RECORDING | BSV_FLAG_MOVIE_START_PLAYBACK)))
 #endif
       {
-        if (!runloop_st->entry_state_slot && settings->bools.savestate_auto_load)
+        if (runloop_st->entry_state_slot < 0 && settings->bools.savestate_auto_load)
           command_event_load_auto_state();
       }
    }
@@ -7323,13 +7323,13 @@ bool runloop_get_replay_path(char *s, size_t len, unsigned slot)
 }
 
 
-bool runloop_get_entry_state_path(char *s, size_t len, unsigned slot)
+bool runloop_get_entry_state_path(char *s, size_t len, int slot)
 {
    size_t _len;
    runloop_state_t *runloop_st = &runloop_state;
    const char *name_savestate  = NULL;
 
-   if (!s || !slot)
+   if (!s)
       return false;
 
    name_savestate              = runloop_st->name.savestate;

--- a/runloop.h
+++ b/runloop.h
@@ -252,8 +252,8 @@ struct runloop
    unsigned fastforward_after_frames;
    unsigned perf_ptr_libretro;
    unsigned subsystem_current_count;
-   unsigned entry_state_slot;
    unsigned video_swap_interval_auto;
+   int16_t entry_state_slot;
 
    fastmotion_overrides_t fastmotion_override; /* float alignment */
 
@@ -425,7 +425,7 @@ void runloop_path_set_names(void);
 
 uint32_t runloop_get_flags(void);
 
-bool runloop_get_entry_state_path(char *path, size_t len, unsigned slot);
+bool runloop_get_entry_state_path(char *path, size_t len, int slot);
 
 bool runloop_get_current_savestate_path(char *path, size_t len);
 


### PR DESCRIPTION
## Description

Currently the "--entryslot" CLI option requires its own manually created special states having `.entry` filename suffix, which is not convenient. With this tiny change the regular states are read instead if the special ones are not found. Also had to fix the "none" value to -1 so that 0 index can be used.

## Related Issues

Closes #7398

