### PR TITLE
Support for newer glslang versions without SPIRV and HLSL libraries

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -666,7 +666,6 @@ if [ "$HAVE_GLSLANG" != no ]; then
       glslang/Public/ShaderLang.h \
       glslang/SPIRV/GlslangToSpv.h
 
-   check_lib cxx GLSLANG -lglslang '' '-lSPIRV'
    check_lib cxx GLSLANG_OSDEPENDENT -lOSDependent
    check_lib cxx GLSLANG_OGLCOMPILER -lOGLCompiler
    check_lib cxx GLSLANG_MACHINEINDEPENDENT -lMachineIndependent
@@ -675,10 +674,9 @@ if [ "$HAVE_GLSLANG" != no ]; then
    check_lib cxx GLSLANG_SPIRV -lSPIRV
    check_lib cxx GLSLANG_SPIRV_TOOLS_OPT -lSPIRV-Tools-opt
    check_lib cxx GLSLANG_SPIRV_TOOLS -lSPIRV-Tools
+   check_lib cxx GLSLANG -lglslang '' "$GLSLANG_SPIRV_LIBS"
 
    if [ "$HAVE_GLSLANG" = no ] ||
-      [ "$HAVE_GLSLANG_HLSL" = no ] ||
-      [ "$HAVE_GLSLANG_SPIRV" = no ] ||
       [ "$HAVE_GLSLANG_SPIRV_TOOLS_OPT" = no ] ||
       [ "$HAVE_GLSLANG_SPIRV_TOOLS" = no ]; then
       if [ "$HAVE_BUILTINGLSLANG" != yes ]; then


### PR DESCRIPTION
## Description

This makes it so that RetroArch can be compiled with glslang 14+, which have removed the separate HLSL library. Currently, the SPIRV library is an empty stub in glslang 14/15 but the indicated plan is to eventually remove that too, so I've followed suit.

## Related Issues

Fixes #16571 