### PR TITLE
Color the notification icon by message category

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -212,6 +212,11 @@ void gfx_widgets_msg_queue_push(
             msg_widget->unfold                  = 1.0f;
          }
 
+         if (category == MESSAGE_QUEUE_CATEGORY_WARNING)
+            msg_widget->flags                  |=  DISPWIDG_FLAG_CATEGORY_WARNING;
+         else if (category == MESSAGE_QUEUE_CATEGORY_ERROR)
+            msg_widget->flags                  |=  DISPWIDG_FLAG_CATEGORY_ERROR;
+
          if (task)
          {
             len                                 = strlen(task->title);
@@ -1361,24 +1366,30 @@ static void gfx_widgets_draw_regular_msg(
       unsigned video_width,
       unsigned video_height)
 {
-   static float msg_queue_info[16] = COLOR_HEX_TO_FLOAT(0x0C99D6, 1.0f);
-   static float msg_queue_bar[16]  = COLOR_HEX_TO_FLOAT(0xCCCCCC, 1.0f);
+   static float msg_queue_info_blue[16]   = COLOR_HEX_TO_FLOAT(0x0C99D6, 1.0f);
+   static float msg_queue_info_yellow[16] = COLOR_HEX_TO_FLOAT(0xD6C10C, 1.0f);
+   static float msg_queue_info_red[16]    = COLOR_HEX_TO_FLOAT(0xD6160C, 1.0f);
+   static float msg_queue_bar[16]         = COLOR_HEX_TO_FLOAT(0xCCCCCC, 1.0f);
+   float* msg_queue_info;
    unsigned rect_width;
    unsigned rect_margin;
    unsigned text_color;
-   static float last_alpha = 0.0f;
 
    msg->flags             &= ~DISPWIDG_FLAG_UNFOLDING;
    msg->flags             |=  DISPWIDG_FLAG_UNFOLDED;
 
-   if (last_alpha != msg->alpha)
-   {
-      /* Icon */
-      gfx_display_set_alpha(msg_queue_info, msg->alpha);
-      gfx_display_set_alpha(p_dispwidget->pure_white, msg->alpha);
-      gfx_display_set_alpha(p_dispwidget->msg_queue_bg, msg->alpha);
-      last_alpha = msg->alpha;
-   }
+   /* Tint icon yellow for warnings and red for errors, otherwise use blue */
+   if (msg->flags & DISPWIDG_FLAG_CATEGORY_WARNING)
+      msg_queue_info = msg_queue_info_yellow;
+   else if (msg->flags & DISPWIDG_FLAG_CATEGORY_ERROR)
+      msg_queue_info = msg_queue_info_red;
+   else
+      msg_queue_info = msg_queue_info_blue;
+
+   /* Icon */
+   gfx_display_set_alpha(msg_queue_info, msg->alpha);
+   gfx_display_set_alpha(p_dispwidget->pure_white, msg->alpha);
+   gfx_display_set_alpha(p_dispwidget->msg_queue_bg, msg->alpha);
 
    if (    !(msg->flags & DISPWIDG_FLAG_UNFOLDED)
          || (msg->flags & DISPWIDG_FLAG_UNFOLDING))
@@ -1461,6 +1472,10 @@ static void gfx_widgets_draw_regular_msg(
 
    if (p_dispwidget->flags & DISPGFX_WIDGET_FLAG_MSG_QUEUE_HAS_ICONS)
    {
+      /* For warnings and errors, flip the 'i' upside down so it becomes '!' */
+      bool invert_y = (msg->flags & (  DISPWIDG_FLAG_CATEGORY_WARNING
+                                     | DISPWIDG_FLAG_CATEGORY_ERROR)) != 0;
+
       if (dispctx && dispctx->blend_begin)
          dispctx->blend_begin(userdata);
 
@@ -1476,7 +1491,7 @@ static void gfx_widgets_draw_regular_msg(
                   + (p_dispwidget->simple_widget_padding / 4.0f),
             video_height - msg->offset_y - p_dispwidget->msg_queue_icon_offset_y,
             0.0f, /* rad                         */
-            1.0f, /* cos(rad)   = cos(0)  = 1.0f */
+            (invert_y ? -1.0f : 1.0f), /* cosine */
             0.0f, /* sine(rad)  = sine(0) = 0.0f */
             msg_queue_info);
 

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -116,7 +116,9 @@ enum disp_widget_flags_enum
    DISPWIDG_FLAG_UNFOLDING                 = (1 << 7),
    /* Color style */
    DISPWIDG_FLAG_POSITIVE                  = (1 << 8),
-   DISPWIDG_FLAG_NEGATIVE                  = (1 << 9)
+   DISPWIDG_FLAG_NEGATIVE                  = (1 << 9),
+   DISPWIDG_FLAG_CATEGORY_WARNING          = (1 << 10),
+   DISPWIDG_FLAG_CATEGORY_ERROR            = (1 << 11)
 };
 
 /* There can only be one message animation at a time to


### PR DESCRIPTION
## Description

In RetroArch showing of notification messages is done via a call to `runloop_msg_queue_push` which gets passed a category (info, warning, error or success). Currently the message popup will look exactly the same regardless of that category. Also when a libretro core uses `RETRO_ENVIRONMENT_SET_MESSAGE_EXT` with `RETRO_MESSAGE_TYPE_NOTIFICATION` it can specify a level (info, warn, error) which is then translated by RetroArch to that same internal message category.

This commit adds a simple color selection of the icon based on the category so that errors and warnings stand out better.

It uses yellow for warnings and red for errors, and keeps the current blue for everything else (info and success messages). Additionally, it flips the 'i' info icon upside down for warnings and errors so it becomes a '!' exclamation mark icon.

![image](https://github.com/user-attachments/assets/96d37313-b416-45b1-a869-002131651b88)

Many RetroArch systems like shaders, netplay or cheevos use these types of notifications. Some correctly specify an appropriate message category but I've noticed a lot of calls to `runloop_msg_queue_push` use the generic `MESSAGE_QUEUE_CATEGORY_INFO` instead of `MESSAGE_QUEUE_CATEGORY_ERROR` (or `MESSAGE_QUEUE_CATEGORY_WARNING`) for things that clearly are errors. Might be a good idea to search through the code base for `MESSAGE_QUEUE_CATEGORY_INFO` and assign a more appropriate category for things that clearly should be warning or error.

## Related Issues

## Related Pull Requests

## Reviewers