### PR TITLE
Add CoreLocation location driver for macOS and iOS

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -746,6 +746,8 @@ static const enum wifi_driver_enum WIFI_DEFAULT_DRIVER = WIFI_NULL;
 
 #if defined(ANDROID)
 static const enum location_driver_enum LOCATION_DEFAULT_DRIVER = LOCATION_ANDROID;
+#elif defined(HAVE_CORELOCATION)
+static const enum location_driver_enum LOCATION_DEFAULT_DRIVER = LOCATION_CORELOCATION;
 #else
 static const enum location_driver_enum LOCATION_DEFAULT_DRIVER = LOCATION_NULL;
 #endif

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -839,6 +839,8 @@ LOCATION
 ============================================================ */
 #if defined(ANDROID)
 #include "../location/drivers/android.c"
+#elif defined(HAVE_CORELOCATION)
+#include "../location/drivers/corelocation.m"
 #endif
 
 /*============================================================

--- a/location/drivers/corelocation.m
+++ b/location/drivers/corelocation.m
@@ -1,0 +1,146 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2025      - Joseph Mattiello
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <CoreLocation/CoreLocation.h>
+#include "../../location_driver.h"
+#include "../../retroarch.h"
+#include "../../verbosity.h"
+@interface CoreLocationManager : NSObject <CLLocationManagerDelegate>
+@property (strong, nonatomic) CLLocationManager *locationManager;
+@property (assign) double latitude;
+@property (assign) double longitude;
+@property (assign) bool authorized;
+@end
+
+@implementation CoreLocationManager
+
++ (instancetype)sharedInstance {
+    static CoreLocationManager *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[CoreLocationManager alloc] init];
+    });
+    return sharedInstance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _locationManager = [[CLLocationManager alloc] init];
+        _locationManager.delegate = self;
+        _locationManager.desiredAccuracy = kCLLocationAccuracyBest;
+        _authorized = false;
+    }
+    return self;
+}
+
+- (void)requestAuthorization {
+    if (_locationManager.authorizationStatus == kCLAuthorizationStatusNotDetermined) {
+        [_locationManager requestWhenInUseAuthorization];
+    }
+}
+
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
+    CLLocation *location = [locations lastObject];
+    self.latitude = location.coordinate.latitude;
+    self.longitude = location.coordinate.longitude;
+}
+
+- (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {
+    RARCH_WARN("[LOCATION]: Location manager failed with error: %s\n", error.description.UTF8String);
+    NSLog(@"Location manager failed with error: %@", error);
+}
+
+- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    self.authorized = (status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+                      status == kCLAuthorizationStatusAuthorizedAlways);
+}
+
+@end
+
+typedef struct corelocation {
+    CoreLocationManager *manager;
+} corelocation_t;
+
+static void *corelocation_init(void) {
+    corelocation_t *corelocation = (corelocation_t*)calloc(1, sizeof(*corelocation));
+    if (!corelocation)
+        return NULL;
+
+    corelocation->manager = [CoreLocationManager sharedInstance];
+    [corelocation->manager requestAuthorization];
+
+    return corelocation;
+}
+
+static void corelocation_free(void *data) {
+    corelocation_t *corelocation = (corelocation_t*)data;
+    if (!corelocation)
+        return;
+
+    free(corelocation);
+}
+
+static bool corelocation_start(void *data) {
+    corelocation_t *corelocation = (corelocation_t*)data;
+    if (!corelocation || !corelocation->manager.authorized)
+        return false;
+
+#if !TARGET_OS_TV
+    [corelocation->manager.locationManager startUpdatingLocation];
+#endif
+    return true;
+}
+
+static void corelocation_stop(void *data) {
+    corelocation_t *corelocation = (corelocation_t*)data;
+    if (!corelocation)
+        return;
+
+    [corelocation->manager.locationManager stopUpdatingLocation];
+}
+
+static bool corelocation_get_position(void *data, double *lat, double *lon,
+                                     double *horiz_accuracy, double *vert_accuracy) {
+    corelocation_t *corelocation = (corelocation_t*)data;
+    if (!corelocation || !corelocation->manager.authorized)
+        return false;
+
+    *lat = corelocation->manager.latitude;
+    *lon = corelocation->manager.longitude;
+    *horiz_accuracy = 0.0; // CoreLocation doesn't provide this directly
+    *vert_accuracy = 0.0;  // CoreLocation doesn't provide this directly
+    return true;
+}
+
+static void corelocation_set_interval(void *data, unsigned interval_ms,
+                                    unsigned interval_distance) {
+    corelocation_t *corelocation = (corelocation_t*)data;
+    if (!corelocation)
+        return;
+
+    corelocation->manager.locationManager.distanceFilter = interval_distance;
+    corelocation->manager.locationManager.desiredAccuracy = kCLLocationAccuracyBest;
+}
+
+location_driver_t location_corelocation = {
+    corelocation_init,
+    corelocation_free,
+    corelocation_start,
+    corelocation_stop,
+    corelocation_get_position,
+    corelocation_set_interval,
+    "corelocation",
+};

--- a/retroarch.c
+++ b/retroarch.c
@@ -361,6 +361,9 @@ static const location_driver_t *location_drivers[] = {
 #ifdef ANDROID
    &location_android,
 #endif
+#ifdef HAVE_CORELOCATION
+   &location_corelocation,
+#endif
    &location_null,
    NULL,
 };


### PR DESCRIPTION
## Description

This one is just for fun, because Android had it, but there's no core for iOS at the moment to test this with.

Hopefull this encourages more core support!

I haven't been able to test on macOS either but it should theoretically be the same code and APIs.

I got the driver to initialize and it initiated the request for location permissions.

Don't forget to add entitlements and `Info.plist` entries for CoreLocation and to link CoreLocation.framework!

To incorporate into build add `HAVE_CORELOCATION` to the `.xcconfig`.
## Related Issues

None found.

## Related Pull Requests

None found.

## Reviewers

[If possible @mention all the people that should review your pull request]
