### PR TITLE
GLUI: Add save state thumbnails

### DIFF
--- a/gfx/gfx_thumbnail.c
+++ b/gfx/gfx_thumbnail.c
@@ -35,7 +35,7 @@
 
 #include "../tasks/tasks_internal.h"
 
-#define DEFAULT_GFX_THUMBNAIL_STREAM_DELAY  83.333333f
+#define DEFAULT_GFX_THUMBNAIL_STREAM_DELAY  16.66667f * 3
 #define DEFAULT_GFX_THUMBNAIL_FADE_DURATION 166.66667f
 
 /* Utility structure, sent as userdata when pushing
@@ -884,6 +884,16 @@ void gfx_thumbnail_get_draw_dimensions(
 
       if (thumbnail->flags & GFX_THUMB_FLAG_CORE_ASPECT)
          *draw_width  = *draw_width / (thumbnail_aspect / core_aspect);
+   }
+
+   /* Final overwidth check */
+   if (*draw_width > width)
+   {
+      *draw_width  = (float)width;
+      *draw_height = (float)thumbnail->height * (*draw_width / (float)thumbnail->width);
+
+      if (thumbnail->flags & GFX_THUMB_FLAG_CORE_ASPECT)
+         *draw_height = *draw_height * (thumbnail_aspect / core_aspect);
    }
 
    /* Account for scale factor

--- a/menu/cbs/menu_cbs_cancel.c
+++ b/menu/cbs/menu_cbs_cancel.c
@@ -83,16 +83,6 @@ int action_cancel_pop_default(const char *path,
    new_selection_ptr      = menu_st->selection_ptr;
    menu_entries_pop_stack(&new_selection_ptr, 0, 1);
    menu_st->selection_ptr = new_selection_ptr;
-
-   if (menu_st->driver_ctx)
-   {
-      if (menu_st->driver_ctx->update_savestate_thumbnail_path)
-         menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
-      if (menu_st->driver_ctx->update_savestate_thumbnail_image)
-         menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
-   }
-
    return 0;
 }
 

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -951,8 +951,8 @@ static int action_left_video_gpu_index(unsigned type, const char *label,
 static int action_left_state_slot(unsigned type, const char *label,
       bool wraparound)
 {
-   struct menu_state *menu_st     = menu_state_get_ptr();
-   settings_t           *settings = config_get_ptr();
+   struct menu_state *menu_st = menu_state_get_ptr();
+   settings_t       *settings = config_get_ptr();
 
    settings->ints.state_slot--;
    if (settings->ints.state_slot < -1)
@@ -960,16 +960,16 @@ static int action_left_state_slot(unsigned type, const char *label,
 
    if (menu_st->driver_ctx)
    {
-      size_t selection            = menu_st->selection_ptr;
       if (menu_st->driver_ctx->update_savestate_thumbnail_path)
          menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
+               menu_st->userdata, (unsigned)menu_st->selection_ptr);
       if (menu_st->driver_ctx->update_savestate_thumbnail_image)
          menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
    }
 
    return 0;
 }
+
 static int action_left_replay_slot(unsigned type, const char *label,
       bool wraparound)
 {
@@ -979,16 +979,6 @@ static int action_left_replay_slot(unsigned type, const char *label,
    settings->ints.replay_slot--;
    if (settings->ints.replay_slot < -1)
       settings->ints.replay_slot = 999;
-
-   if (menu_st->driver_ctx)
-   {
-      size_t selection            = menu_st->selection_ptr;
-      if (menu_st->driver_ctx->update_savestate_thumbnail_path)
-         menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
-      if (menu_st->driver_ctx->update_savestate_thumbnail_image)
-         menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
-   }
 
    return 0;
 }
@@ -1102,6 +1092,9 @@ static int menu_cbs_init_bind_left_compare_label(menu_file_list_cbs_t *cbs,
                break;
             case MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_CORE_NAME:
                BIND_ACTION_LEFT(cbs, manual_content_scan_core_name_left);
+               break;
+            case MENU_ENUM_LABEL_STATE_SLOT:
+               BIND_ACTION_LEFT(cbs, action_left_state_slot);
                break;
             #ifdef HAVE_LAKKA
             case MENU_ENUM_LABEL_CPU_PERF_MODE:

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4687,15 +4687,6 @@ static int action_ok_cheat_delete(const char *path,
    menu_entries_pop_stack(&new_selection_ptr, 0, 1);
    menu_st->selection_ptr = new_selection_ptr;
 
-   if (menu_st->driver_ctx)
-   {
-      if (menu_st->driver_ctx->update_savestate_thumbnail_path)
-         menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
-      if (menu_st->driver_ctx->update_savestate_thumbnail_image)
-         menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
-   }
-
    return 0;
 }
 #endif

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -951,8 +951,8 @@ static int disk_options_disk_idx_right(unsigned type, const char *label,
 static int action_right_state_slot(unsigned type, const char *label,
       bool wraparound)
 {
-   settings_t       *settings = config_get_ptr();
    struct menu_state *menu_st = menu_state_get_ptr();
+   settings_t       *settings = config_get_ptr();
 
    settings->ints.state_slot++;
    if (settings->ints.state_slot > 999)
@@ -960,10 +960,9 @@ static int action_right_state_slot(unsigned type, const char *label,
 
    if (menu_st->driver_ctx)
    {
-      size_t selection = menu_st->selection_ptr;
       if (menu_st->driver_ctx->update_savestate_thumbnail_path)
          menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
+               menu_st->userdata, (unsigned)menu_st->selection_ptr);
       if (menu_st->driver_ctx->update_savestate_thumbnail_image)
          menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
    }
@@ -975,21 +974,11 @@ static int action_right_replay_slot(unsigned type, const char *label,
       bool wraparound)
 {
    struct menu_state *menu_st     = menu_state_get_ptr();
-   size_t selection               = menu_st->selection_ptr;
    settings_t           *settings = config_get_ptr();
 
    settings->ints.replay_slot++;
    if (settings->ints.replay_slot > 999)
       settings->ints.replay_slot = -1;
-
-   if (menu_st->driver_ctx)
-   {
-      if (menu_st->driver_ctx->update_savestate_thumbnail_path)
-         menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
-      if (menu_st->driver_ctx->update_savestate_thumbnail_image)
-         menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
-   }
 
    return 0;
 }
@@ -1241,6 +1230,9 @@ static int menu_cbs_init_bind_right_compare_label(menu_file_list_cbs_t *cbs,
                break;
             case MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_CORE_NAME:
                BIND_ACTION_RIGHT(cbs, manual_content_scan_core_name_right);
+               break;
+            case MENU_ENUM_LABEL_STATE_SLOT:
+               BIND_ACTION_RIGHT(cbs, action_right_state_slot);
                break;
             #ifdef HAVE_LAKKA
             case MENU_ENUM_LABEL_CPU_PERF_MODE:

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -485,7 +485,6 @@ static int action_start_state_slot(
       unsigned type, size_t idx, size_t entry_idx)
 {
    struct menu_state *menu_st = menu_state_get_ptr();
-   size_t selection           = menu_st->selection_ptr;
    settings_t *settings       = config_get_ptr();
 
    settings->ints.state_slot  = 0;
@@ -494,7 +493,7 @@ static int action_start_state_slot(
    {
       if (menu_st->driver_ctx->update_savestate_thumbnail_path)
          menu_st->driver_ctx->update_savestate_thumbnail_path(
-               menu_st->userdata, (unsigned)selection);
+               menu_st->userdata, (unsigned)menu_st->selection_ptr);
       if (menu_st->driver_ctx->update_savestate_thumbnail_image)
          menu_st->driver_ctx->update_savestate_thumbnail_image(menu_st->userdata);
    }

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -7977,39 +7977,26 @@ size_t menu_update_fullscreen_thumbnail_label(
    /* > State slot label */
    else if (   is_quick_menu
             && (
-               string_is_equal(selected_entry.label, "state_slot")
-            || string_is_equal(selected_entry.label, "loadstate")
-            || string_is_equal(selected_entry.label, "savestate")
+               string_is_equal(selected_entry.label, msg_hash_to_str(MENU_ENUM_LABEL_STATE_SLOT))
+            || string_is_equal(selected_entry.label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_STATE))
+            || string_is_equal(selected_entry.label, msg_hash_to_str(MENU_ENUM_LABEL_SAVE_STATE))
                )
            )
    {
-      size_t _len = strlcpy(s,
-            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
+      int slot    = config_get_ptr()->ints.state_slot;
+      size_t _len = strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
             len);
-      _len += snprintf(s + _len, len - _len, " %d",
-            config_get_ptr()->ints.state_slot);
-      return _len;
-   }
-   else if (   is_quick_menu
-            && (
-               string_is_equal(selected_entry.label, "replay_slot")
-            || string_is_equal(selected_entry.label, "record_replay")
-            || string_is_equal(selected_entry.label, "play_replay")
-            || string_is_equal(selected_entry.label, "halt_replay")
-         ))
-   {
-      size_t _len = strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_REPLAY_SLOT),
-            len);
-      _len += snprintf(s + _len, len - _len, " %d",
-               config_get_ptr()->ints.replay_slot);
+      if (slot < 0)
+         _len += snprintf(s + _len, len - _len, " %s", "Auto");
+      else
+         _len += snprintf(s + _len, len - _len, " %d", slot);
       return _len;
    }
    else if (string_to_unsigned(selected_entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
    {
       size_t _len = strlcpy(s, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATE_SLOT),
             len);
-      _len += snprintf(s + _len, len - _len, " %d",
-            string_to_unsigned(selected_entry.path));
+      _len += snprintf(s + _len, len - _len, " %s", selected_entry.path);
       return _len;
    }
    /* > Quick Menu playlist label */

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7231,33 +7231,11 @@ int menu_action_handle_setting(rarch_setting_t *setting,
                   break;
                case MENU_ACTION_LEFT:
                   if (setting->action_left)
-                  {
                      ret = setting->action_left(setting, selection, false);
-                     if (menu_st->driver_ctx)
-                     {
-                        if (menu_st->driver_ctx->update_savestate_thumbnail_path)
-                           menu_st->driver_ctx->update_savestate_thumbnail_path(
-                                 menu_st->userdata, (unsigned)selection);
-                        if (menu_st->driver_ctx->update_savestate_thumbnail_image)
-                           menu_st->driver_ctx->update_savestate_thumbnail_image(
-                                 menu_st->userdata);
-                     }
-                  }
                   break;
                case MENU_ACTION_RIGHT:
                   if (setting->action_right)
-                  {
                      ret = setting->action_right(setting, selection, false);
-                     if (menu_st->driver_ctx)
-                     {
-                        if (menu_st->driver_ctx->update_savestate_thumbnail_path)
-                           menu_st->driver_ctx->update_savestate_thumbnail_path(
-                                 menu_st->userdata, (unsigned)selection);
-                        if (menu_st->driver_ctx->update_savestate_thumbnail_image)
-                           menu_st->driver_ctx->update_savestate_thumbnail_image(
-                                 menu_st->userdata);
-                     }
-                  }
                   break;
                case MENU_ACTION_SELECT:
                   if (setting->action_select)


### PR DESCRIPTION
## Description

Here is the missing thing preventing save state thumbnails from being enabled by default at least for some platforms.

The goal was to make everything thumbnail related as similar and seamless as possible between all menu drivers, and minimize flashing issues as much as possible, therefore this touches a lot more than just glui driver.

Major points:
- Fullscreen thumbnail mode can be toggled regardless if images exist or not
- Show clear "missing" thumbnail placeholder when suitable
- Call thumbnail updates only when necessary

Bonus:
- Fixed save state thumbnail size issues with double height image resolutions
- GLUI random selector scrolling animation is instant
- RGUI messagebox tidying
- Common fullscreen thumbnail label for all drivers

## Related Issues

Closes #16620