### PR TITLE
bluetoothctl: use two calls to disconnect/remove device

### DIFF
--- a/bluetooth/drivers/bluetoothctl.c
+++ b/bluetooth/drivers/bluetoothctl.c
@@ -225,8 +225,14 @@ static bool bluetoothctl_remove_device(void *data, unsigned idx)
    string_list_free(list);
 
    snprintf(btctl->command, sizeof(btctl->command), "\
-         echo -e \"disconnect %s\\nremove %s\\n\" | bluetoothctl",
-         device, device);
+         bluetoothctl -- disconnect %s",
+         device);
+
+   pclose(popen(btctl->command, "r"));
+
+   snprintf(btctl->command, sizeof(btctl->command), "\
+         bluetoothctl -- remove %s",
+         device);
 
    pclose(popen(btctl->command, "r"));
 


### PR DESCRIPTION
the previous method does not remove the pairing of the selected device, user must remove the pairing manually by modifying filesystem.

change tested on real system (Lakka-RPi4.aarch64).
