### PR TITLE
apple, mouse overlay: fix relative mouse deltas

### DIFF
--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -401,6 +401,32 @@ static void cocoa_input_poll(void *data)
    if (!apple)
       return;
 
+#ifdef IOS
+#ifdef HAVE_IOS_TOUCHMOUSE
+   if (apple->window_pos_x > 0 || apple->mouse_grabbed)
+   {
+      apple->mouse_rel_x = apple->window_pos_x - apple->mouse_x_last;
+      apple->mouse_x_last = apple->window_pos_x;
+   }
+#endif
+#else
+   apple->mouse_rel_x = apple->window_pos_x - apple->mouse_x_last;
+   apple->mouse_x_last = apple->window_pos_x;
+#endif
+
+#ifdef IOS
+#ifdef HAVE_IOS_TOUCHMOUSE
+   if (apple->window_pos_y > 0 || apple->mouse_grabbed)
+   {
+      apple->mouse_rel_y = apple->window_pos_y - apple->mouse_y_last;
+      apple->mouse_y_last = apple->window_pos_y;
+   }
+#endif
+#else
+   apple->mouse_rel_y = apple->window_pos_y - apple->mouse_y_last;
+   apple->mouse_y_last = apple->window_pos_y;
+#endif
+
    for (i = 0; i < apple->touch_count || i == 0; i++)
    {
       struct video_viewport vp;
@@ -573,75 +599,40 @@ static int16_t cocoa_input_state(
          return (id && id < RETROK_LAST) && apple_key_state[rarch_keysym_lut[(enum retro_key)id]];
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
+         switch (id)
          {
-            int16_t val = 0;
-            switch (id)
+         case RETRO_DEVICE_ID_MOUSE_X:
+            if (device == RARCH_DEVICE_MOUSE_SCREEN)
             {
-               case RETRO_DEVICE_ID_MOUSE_X:
-                  if (device == RARCH_DEVICE_MOUSE_SCREEN)
-                  {
 #ifdef IOS
-                     return apple->window_pos_x;
+               return apple->window_pos_x;
 #else
-                     return apple->window_pos_x * cocoa_screen_get_backing_scale_factor();
+               return apple->window_pos_x * cocoa_screen_get_backing_scale_factor();
 #endif
-                  }
-#ifdef IOS
-#ifdef HAVE_IOS_TOUCHMOUSE
-                  if (apple->window_pos_x > 0 || apple->mouse_grabbed)
-                  {
-                     val = apple->window_pos_x - apple->mouse_x_last;
-                     apple->mouse_x_last = apple->window_pos_x;
-                  }
-                  else
-                     val = apple->mouse_rel_x;
-#else
-                  val = apple->mouse_rel_x;
-#endif
-#else
-                  val = apple->window_pos_x - apple->mouse_x_last;
-                  apple->mouse_x_last = apple->window_pos_x;
-#endif
-                  return val;
-               case RETRO_DEVICE_ID_MOUSE_Y:
-                  if (device == RARCH_DEVICE_MOUSE_SCREEN)
-                  {
-#ifdef IOS
-                     return apple->window_pos_y;
-#else
-                     return apple->window_pos_y * cocoa_screen_get_backing_scale_factor();
-#endif
-                  }
-#ifdef IOS
-#ifdef HAVE_IOS_TOUCHMOUSE
-                  if (apple->window_pos_y > 0 || apple->mouse_grabbed)
-                  {
-                     val = apple->window_pos_y - apple->mouse_y_last;
-                     apple->mouse_y_last = apple->window_pos_y;
-                  }
-                  else
-                     val = apple->mouse_rel_y;
-#else
-                  val    = apple->mouse_rel_y;
-#endif
-#else
-                  val = apple->window_pos_y - apple->mouse_y_last;
-                  apple->mouse_y_last = apple->window_pos_y;
-#endif
-                  return val;
-               case RETRO_DEVICE_ID_MOUSE_LEFT:
-                  return apple->mouse_buttons & 1;
-               case RETRO_DEVICE_ID_MOUSE_RIGHT:
-                  return apple->mouse_buttons & 2;
-               case RETRO_DEVICE_ID_MOUSE_WHEELUP:
-                  return apple->mouse_wu;
-               case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
-                  return apple->mouse_wd;
-               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
-                  return apple->mouse_wl;
-               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
-                  return apple->mouse_wr;
             }
+            return apple->mouse_rel_x;
+         case RETRO_DEVICE_ID_MOUSE_Y:
+            if (device == RARCH_DEVICE_MOUSE_SCREEN)
+            {
+#ifdef IOS
+               return apple->window_pos_y;
+#else
+               return apple->window_pos_y * cocoa_screen_get_backing_scale_factor();
+#endif
+            }
+            return apple->mouse_rel_y;
+         case RETRO_DEVICE_ID_MOUSE_LEFT:
+            return apple->mouse_buttons & 1;
+         case RETRO_DEVICE_ID_MOUSE_RIGHT:
+            return apple->mouse_buttons & 2;
+         case RETRO_DEVICE_ID_MOUSE_WHEELUP:
+            return apple->mouse_wu;
+         case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
+            return apple->mouse_wd;
+         case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+            return apple->mouse_wl;
+         case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+            return apple->mouse_wr;
          }
          break;
       case RETRO_DEVICE_POINTER:

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1199,12 +1199,10 @@ static int16_t input_overlay_device_mouse_state(
          ptr_st->device_mask |= (1 << RETRO_DEVICE_MOUSE);
          res =   (ptr_st->mouse.scale_x)
                * (ptr_st->screen_x - ptr_st->mouse.prev_screen_x);
-         ptr_st->mouse.prev_screen_x = ptr_st->screen_x;
          return res;
       case RETRO_DEVICE_ID_MOUSE_Y:
          res =   (ptr_st->mouse.scale_y)
                * (ptr_st->screen_y - ptr_st->mouse.prev_screen_y);
-         ptr_st->mouse.prev_screen_y = ptr_st->screen_y;
          return res;
       case RETRO_DEVICE_ID_MOUSE_LEFT:
          return    (ptr_st->mouse.click & 0x1)
@@ -3468,11 +3466,13 @@ static void input_overlay_update_pointer_coords(
    if (     !ptr_st->count
          && (ptr_st->device_mask & (1 << RETRO_DEVICE_MOUSE)))
    {
+      ptr_st->mouse.prev_screen_x = ptr_st->screen_x;
       ptr_st->screen_x = current_input->input_state(
             input_data, NULL, NULL, NULL, NULL, true, 0,
             RARCH_DEVICE_POINTER_SCREEN,
             touch_idx,
             RETRO_DEVICE_ID_POINTER_X);
+      ptr_st->mouse.prev_screen_y = ptr_st->screen_y;
       ptr_st->screen_y = current_input->input_state(
             input_data, NULL, NULL, NULL, NULL, true, 0,
             RARCH_DEVICE_POINTER_SCREEN,


### PR DESCRIPTION
makes sure that relative mouse movement deltas are based on last poll, not last state check; checking state should not reset state

fixes #13805