### PR TITLE
Prevent crash when Main Menu is empty

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -3300,7 +3300,7 @@ static float materialui_get_scroll(materialui_handle_t *mui,
    float view_centre          = 0.0f;
    float selection_centre     = 0.0f;
 
-   if (!mui || !list)
+   if (!mui || !list || !list->size)
       return 0;
 
    /* Get current window size */
@@ -6208,7 +6208,7 @@ static void materialui_render_selection_highlight(
       struct menu_state *menu_st = menu_state_get_ptr();
       menu_list_t *menu_list     = menu_st->entries.list;
       file_list_t *list          = menu_list ? MENU_LIST_GET_SELECTION(menu_list, 0) : NULL;
-      if (!list)
+      if (!list || !list->size)
          return;
 
       if (!(node = (materialui_node_t*)list->list[selection].userdata))
@@ -7750,6 +7750,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    video_driver_state_t *video_st = video_state_get_ptr();
    struct menu_state *menu_st     = menu_state_get_ptr();
    menu_list_t *menu_list         = menu_st->entries.list;
+   file_list_t *list              = menu_list ? MENU_LIST_GET_SELECTION(menu_list, (unsigned)0) : NULL;
    menu_input_t *menu_input       = &menu_st->input_state;
    size_t selection               = menu_st->selection_ptr;
    unsigned header_height         = p_disp->header_height;
@@ -7880,9 +7881,11 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    if (mui->flags & MUI_FLAG_SCROLLBAR_ACTIVE)
       materialui_update_scrollbar(mui, video_width, video_height,
             header_height, list_x_offset);
-   materialui_render_menu_list(mui, p_disp,
-         userdata, selection,
-         video_width, video_height, list_x_offset);
+
+   if (list && list->size)
+      materialui_render_menu_list(mui, p_disp,
+            userdata, selection,
+            video_width, video_height, list_x_offset);
 
    /* Flush first layer of text
     * > Menu list only uses list and hint fonts */

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -4540,6 +4540,9 @@ static void ozone_list_cache(void *data,
    selection_buf              = MENU_LIST_GET_SELECTION(menu_list, 0);
    bottom_boundary            = video_info_height - ozone->dimensions.header_height - ozone->dimensions.footer_height;
 
+   if (!selection_buf->size)
+      return;
+
    for (i = 0; i < entries_end; i++)
    {
       ozone_node_t *node = (ozone_node_t*)selection_buf->list[i].userdata;
@@ -5462,6 +5465,9 @@ static void ozone_compute_entries_position(ozone_handle_t *ozone,
       ozone_update_content_metadata(ozone);
 
    selection_buf                 = MENU_LIST_GET_SELECTION(menu_list, 0);
+
+   if (!selection_buf->size)
+      return;
 
    video_driver_get_size(&video_info_width, &video_info_height);
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -382,7 +382,7 @@ void menu_entry_get(menu_entry_t *entry, size_t stack_idx,
 
    newpath[0]                  = '\0';
 
-   if (!list)
+   if (!list || !list->size)
       return;
 
    path_enabled               = (entry_flags & MENU_ENTRY_FLAG_PATH_ENABLED) ? true : false;
@@ -5670,7 +5670,7 @@ static int menu_input_post_iterate(
    menu_list_t *menu_list                          = menu_st->entries.list;
    file_list_t *selection_buf                      = menu_list ? MENU_LIST_GET_SELECTION(menu_list, (unsigned)0) : NULL;
    size_t selection                                = menu_st->selection_ptr;
-   menu_file_list_cbs_t *cbs                       = selection_buf
+   menu_file_list_cbs_t *cbs                       = selection_buf && selection_buf->size
       ? (menu_file_list_cbs_t*)selection_buf->list[selection].actiondata
       : NULL;
 
@@ -7384,7 +7384,7 @@ int generic_menu_entry_action(
    file_list_t *menu_stack        = menu_list ? MENU_LIST_GET(menu_list, (unsigned)0) : NULL;
    size_t entries_size            = menu_list ? MENU_LIST_GET_SELECTION(menu_list, 0)->size : 0;
    size_t selection_buf_size      = selection_buf ? selection_buf->size : 0;
-   menu_file_list_cbs_t *cbs      = selection_buf ?
+   menu_file_list_cbs_t *cbs      = selection_buf && selection_buf->size ?
       (menu_file_list_cbs_t*)selection_buf->list[i].actiondata : NULL;
 #ifdef HAVE_ACCESSIBILITY
    bool accessibility_enable      = settings->bools.accessibility_enable;
@@ -7664,7 +7664,7 @@ int generic_menu_entry_action(
          break;
    }
 
-   if (MENU_ENTRIES_NEEDS_REFRESH(menu_st))
+   if (MENU_ENTRIES_NEEDS_REFRESH(menu_st) && selection_buf_size)
    {
       menu_driver_displaylist_push(
             menu_st,


### PR DESCRIPTION
## Description

Simply added some guard rails for being able to hide all items in Main Menu. Won't be much usable, but at least it won't crash.

## Related Issues

Closes #17583

