### PR TITLE
Fix threaded asset download caching

### DIFF
--- a/pkg/emscripten/libretro-thread/libretro.worker.js
+++ b/pkg/emscripten/libretro-thread/libretro.worker.js
@@ -41,7 +41,7 @@ async function setupZipFS(zipBuf) {
 
 onmessage = async (msg) => {
   if(msg.data.command == "load_bundle") {
-    let old_timestamp = msg.data;
+    let old_timestamp = msg.data.time;
     try {
       const root = await navigator.storage.getDirectory();
       const _bundle = await root.getDirectoryHandle("bundle");


### PR DESCRIPTION
This is a small bugfix to my last PR, which didn't use the previous download timestamp correctly in the worker that fetched the initial asset bundle.