### PR TITLE
Add declaration for `libnx_apply_overclock()` in menu/menu_driver.c

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -92,6 +92,8 @@ typedef struct menu_input_ctx_bind
 
 /* TODO/FIXME - public global variable */
 extern u32 __nx_applet_type;
+
+void libnx_apply_overclock(void);
 #endif
 
 /* Accelerated navigation buttons */


### PR DESCRIPTION
## Description

Adds an explicit declaration of the `libnx_apply_overclock()` to menu/menu_driver.c, similar to the explicit declarations of this function that are already in configuration.c and frontend/drivers/platform_switch.c. Without this, RetroArch fails to build for Nintendo Switch using the devkitpro/devkita64 Docker image.

```
$ git checkout b5fd91972c87caa4c1fbba58bfa12112412316af
Note: switching to 'b5fd91972c87caa4c1fbba58bfa12112412316af'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at b5fd919 Fetch translations from Crowdin

$ make -f Makefile.libnx HAVE_STATIC_DUMMY=1
version_git.c
frontend_driver.c
retroarch.c
In file included from retroarch.c:93:
switch_performance_profiles.h:45:17: warning: 'SWITCH_CPU_SPEEDS_VALUES' defined but not used [-Wunused-variable]
   45 | static unsigned SWITCH_CPU_SPEEDS_VALUES[] = {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
switch_performance_profiles.h:35:14: warning: 'SWITCH_CPU_SPEEDS' defined but not used [-Wunused-variable]
   35 | static char *SWITCH_CPU_SPEEDS[] = {
      |              ^~~~~~~~~~~~~~~~~
switch_performance_profiles.h:22:14: warning: 'SWITCH_CPU_PROFILES' defined but not used [-Wunused-variable]
   22 | static char *SWITCH_CPU_PROFILES[] = {
      |              ^~~~~~~~~~~~~~~~~~~
runloop.c
In file included from runloop.c:100:
switch_performance_profiles.h:45:17: warning: 'SWITCH_CPU_SPEEDS_VALUES' defined but not used [-Wunused-variable]
   45 | static unsigned SWITCH_CPU_SPEEDS_VALUES[] = {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
switch_performance_profiles.h:35:14: warning: 'SWITCH_CPU_SPEEDS' defined but not used [-Wunused-variable]
   35 | static char *SWITCH_CPU_SPEEDS[] = {
      |              ^~~~~~~~~~~~~~~~~
switch_performance_profiles.h:22:14: warning: 'SWITCH_CPU_PROFILES' defined but not used [-Wunused-variable]
   22 | static char *SWITCH_CPU_PROFILES[] = {
      |              ^~~~~~~~~~~~~~~~~~~
ui_companion_driver.c
camera_driver.c
record_driver.c
record_wav.c
command.c
msg_hash.c
msg_hash_us.c
task_queue.c
task_content.c
task_patch.c
save.c
task_save.c
task_movie.c
task_file_transfer.c
task_image.c
task_playlist_manager.c
task_manual_content_scan.c
task_core_backup.c
encoding_utf.c
encoding_crc32.c
encoding_base64.c
task_translation.c
fopen_utf8.c
compat_strldup.c
file_list.c
dir_list.c
retro_dirent.c
stdin_stream.c
file_stream.c
file_stream_transforms.c
interface_stream.c
memory_stream.c
network_stream.c
vfs_implementation.c
string_list.c
stdstring.c
memalign.c
nbio_stdio.c
linked_list.c
nested_list.c
generic_queue.c
nbio_intf.c
file_path.c
file_path_io.c
file_path_special.c
lrc_hash.c
audio_driver.c
input_driver.c
input_hid_common.c
led_driver.c
video_driver.c
gfx_display.c
gfx_animation.c
configuration.c
In file included from configuration.c:70:
switch_performance_profiles.h:45:17: warning: 'SWITCH_CPU_SPEEDS_VALUES' defined but not used [-Wunused-variable]
   45 | static unsigned SWITCH_CPU_SPEEDS_VALUES[] = {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
switch_performance_profiles.h:35:14: warning: 'SWITCH_CPU_SPEEDS' defined but not used [-Wunused-variable]
   35 | static char *SWITCH_CPU_SPEEDS[] = {
      |              ^~~~~~~~~~~~~~~~~
switch_performance_profiles.h:22:14: warning: 'SWITCH_CPU_PROFILES' defined but not used [-Wunused-variable]
   22 | static char *SWITCH_CPU_PROFILES[] = {
      |              ^~~~~~~~~~~~~~~~~~~
configuration.c: In function 'input_remapping_save_file':
configuration.c:6143:61: warning: '%u' directive output may be truncated writing between 1 and 10 bytes into a region of size 4 [-Wformat-truncation=]
 6143 |       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
      |                                                             ^~
configuration.c:6143:60: note: directive argument in the range [1, 4294967295]
 6143 |       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
      |                                                            ^~~~
configuration.c:6143:7: note: 'snprintf' output between 2 and 11 bytes into a destination of size 4
 6143 |       snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
dylib.c
dynamic_dummy.c
message_queue.c
gfx_thumbnail_path.c
gfx_thumbnail.c
state_manager.c
bitmapfont.c
bitmapfont_10x10.c
bitmapfont_6x10.c
task_autodetect.c
input_autodetect_builtin.c
input_keymaps.c
fifo_queue.c
compat_fnmatch.c
compat_posix_string.c
cheat_manager.c
core_info.c
core_backup.c
core_option_manager.c
config_file.c
config_file_userdata.c
runtime_file.c
disk_index_file.c
task_screenshot.c
task_powerstate.c
scaler.c
pixconv.c
scaler_int.c
scaler_filter.c
font_driver.c
video_filter.c
audio_resampler.c
dsp_filter.c
sinc_resampler.c
md5.c
playlist.c
features_cpu.c
verbosity.c
label_sanitization.c
rtime.c
manual_content_scan.c
disk_control_interface.c
task_audio_mixer.c
audio_mix.c
audio_mixer.c
runahead.c
cc_resampler.c
compat_getopt.c
compat_strcasestr.c
compat_strl.c
image_texture.c
bintree.c
libretrodb.c
query.c
rmsgpack.c
rmsgpack_dom.c
database_info.c
task_database.c
task_database_cue.c
menu_explore.c
task_menu_explore.c
s16_to_float.c
float_to_s16.c
mono_to_stereo_float.c
stereo_to_mono_float.c
rwav.c
rgui.c
materialui.c
menu/drivers/materialui.c: In function 'materialui_update_fullscreen_thumbnail_label':
menu/drivers/materialui.c:2408:16: warning: unused variable 'thumbnail_label' [-Wunused-variable]
 2408 |    const char *thumbnail_label = NULL;
      |                ^~~~~~~~~~~~~~~
menu/drivers/materialui.c: In function 'materialui_show_fullscreen_thumbnails':
menu/drivers/materialui.c:7161:17: warning: unused variable 'selected_entry' [-Wunused-variable]
 7161 |    menu_entry_t selected_entry;
      |                 ^~~~~~~~~~~~~~
xmb.c
menu/drivers/xmb.c: In function 'xmb_context_reset_internal':
menu/drivers/xmb.c:6480:19: warning: unused variable 'settings' [-Wunused-variable]
 6480 |       settings_t *settings = config_get_ptr();
      |                   ^~~~~~~~
ozone.c
menu_screensaver.c
menu_setting.c
menu_driver.c
menu/menu_driver.c: In function 'menu_input_dialog_get_display_kb':
menu/menu_driver.c:5143:7: error: implicit declaration of function 'libnx_apply_overclock' [-Wimplicit-function-declaration]
 5143 |       libnx_apply_overclock();
      |       ^~~~~~~~~~~~~~~~~~~~~
In file included from menu/menu_driver.c:77:
menu/../switch_performance_profiles.h: At top level:
menu/../switch_performance_profiles.h:45:17: warning: 'SWITCH_CPU_SPEEDS_VALUES' defined but not used [-Wunused-variable]
   45 | static unsigned SWITCH_CPU_SPEEDS_VALUES[] = {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
menu/../switch_performance_profiles.h:35:14: warning: 'SWITCH_CPU_SPEEDS' defined but not used [-Wunused-variable]
   35 | static char *SWITCH_CPU_SPEEDS[] = {
      |              ^~~~~~~~~~~~~~~~~
menu/../switch_performance_profiles.h:22:14: warning: 'SWITCH_CPU_PROFILES' defined but not used [-Wunused-variable]
   22 | static char *SWITCH_CPU_PROFILES[] = {
      |              ^~~~~~~~~~~~~~~~~~~
make: *** [/opt/devkitpro/devkitA64/base_rules:22: menu/menu_driver.o] Error 1
```