### PR TITLE
Only read first frame of inputs on load under new movie formats

### DIFF
--- a/tasks/task_movie.c
+++ b/tasks/task_movie.c
@@ -138,7 +138,9 @@ static bool bsv_movie_init_playback(
    }
 
    handle->min_file_pos = sizeof(header) + state_size;
-   bsv_movie_read_next_events(handle);
+   if(vsn > 0)
+      bsv_movie_read_next_events(handle);
+
 
    return true;
 }


### PR DESCRIPTION
This fixes a back compatibility issue when playing old-format (version 0) input recordings in more recent retroarch versions.  Old-format versions would get off by two bytes early on, and never recover.