### PR TITLE
Align GDI feature reporting with actual status

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -2232,7 +2232,9 @@ static unsigned menu_displaylist_parse_system_info(file_list_t *list)
          {SUPPORTS_SDL2        ,    MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_SDL2_SUPPORT},
 #endif
 #ifdef HAVE_GDI
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
          {SUPPORTS_GDI         ,    MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_GDI_SUPPORT},
+#endif
 #endif
 #ifdef HAVE_D3D8
          {SUPPORTS_D3D8        ,    MENU_ENUM_LABEL_VALUE_SYSTEM_INFO_D3D8_SUPPORT},

--- a/retroarch.c
+++ b/retroarch.c
@@ -6122,7 +6122,9 @@ static void retroarch_print_features(void)
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_THREAD,          "Threads",         "Threading support");
 #endif
 #ifdef HAVE_GDI
+#if defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_GDI,            "GDI",               "Video driver");
+#endif
 #endif
 #ifdef HAVE_D3D8
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_D3D8,            "Direct3D 8",       "Video driver");


### PR DESCRIPTION
## Description

Value of HAVE_GDI is always 1 unless explicitly disabled, however it only takes effect on Windows platforms. Actual functionality is behind multiple #ifdef's, but the feature indication was showing up even on platforms like Linux.

## Related Issues
No explicit report, but it was slightly misleading during troubleshooting.
