### PR TITLE
Fix bluetooth option ifdef

### DIFF
--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -22935,6 +22935,7 @@ static bool setting_append_list(
                   SD_FLAG_NONE);
             (*list)[list_info->index - 1].change_handler = samba_enable_toggle_change_handler;
 
+#ifdef HAVE_BLUETOOTH
             CONFIG_BOOL(
                   list, list_info,
                   &settings->bools.bluetooth_enable,
@@ -22950,7 +22951,7 @@ static bool setting_append_list(
                   general_read_handler,
                   SD_FLAG_NONE);
             (*list)[list_info->index - 1].change_handler = bluetooth_enable_toggle_change_handler;
-
+#endif
 #ifdef HAVE_WIFI
             CONFIG_BOOL(
                   list, list_info,


### PR DESCRIPTION
## Description

bluetooth_enable_toggle_change_handler was already behind #ifdef in the same file, so it makes sense to align the respective option as well.
