### PR TITLE
Fixes asset paths/double bundle path for web player

### DIFF
--- a/pkg/emscripten/README.md
+++ b/pkg/emscripten/README.md
@@ -159,7 +159,7 @@ cp fceumm_libretro.{js,wasm} pkg/emscripten/libretro-thread
 
 ## Dependencies
 
-The emscripten build in the retroarch tree does not contain the necessary web assets for a complete RetroArch installation.  While it supports the regular desktop asset and content downloaders, we also provide a small bundle of UI assets for first launch.  You can obtain these files from the nightly Emscripten build on the buildbot, or make them yourself by `zip -r bundle-minimal.zip bundle-minimal` (essentially, just the `assets/ozone`, `assets/pkg`, and `assets/sounds` folders from the regular asset package).
+The emscripten build in the retroarch tree does not contain the necessary web assets for a complete RetroArch installation.  While it supports the regular desktop asset and content downloaders, we also provide a small bundle of UI assets for first launch.  You can obtain these files from the nightly Emscripten build on the buildbot, or make them yourself by `zip -r9 bundle-minimal.zip bundle` (essentially, just the `assets/ozone`, `assets/pkg`, and `assets/sounds` folders from the regular asset package).
 
 ## Usage
 

--- a/pkg/emscripten/libretro/libretro.js
+++ b/pkg/emscripten/libretro/libretro.js
@@ -198,14 +198,14 @@ function setupFileSystem(backend) {
    var mfs = new BrowserFS.FileSystem.MountableFileSystem();
 
    // create an XmlHttpRequest filesystem for the bundled data
-   var xfs1 = new BrowserFS.FileSystem.ZipFS(zipTOC);
+   var zipfs = new BrowserFS.FileSystem.ZipFS(zipTOC);
    // create an XmlHttpRequest filesystem for core assets
-   var xfs2 = new BrowserFS.FileSystem.XmlHttpRequest(".index-xhr", "assets/cores/");
+   var xfs = new BrowserFS.FileSystem.XmlHttpRequest(".index-xhr", "assets/cores/");
 
    console.log("WEBPLAYER: initializing filesystem: " + backend);
-   mfs.mount('/home/web_user/retroarch/bundle', xfs1);
+   mfs.mount('/home/web_user/retroarch/', zipfs);
    mfs.mount('/home/web_user/retroarch/userdata', afs);
-   mfs.mount('/home/web_user/retroarch/userdata/content/downloads', xfs2);
+   mfs.mount('/home/web_user/retroarch/userdata/content/downloads', xfs);
    BrowserFS.initialize(mfs);
    var BFS = new BrowserFS.EmscriptenFS(Module.FS, Module.PATH, Module.ERRNO_CODES);
    Module.FS.mount(BFS, {


### PR DESCRIPTION
This avoids a double bundle/ prefix by mounting the zipfs back at /home/web_user/retroarch instead of assuming the zip file directly contains the bundle contents.