### PR TITLE
(Win32) Unrevert TTS fallback

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -1124,9 +1124,12 @@ static bool accessibility_speak_windows(int speed,
       if (!wc || res != 0)
       {
          RARCH_ERR("Error communicating with NVDA\n");
+         /* Fallback on powershell immediately and retry */
+         g_plat_win32_flags &= ~PLAT_WIN32_FLAG_USE_NVDA;
+         g_plat_win32_flags |= PLAT_WIN32_FLAG_USE_POWERSHELL;
          if (wc)
             free(wc);
-         return false;
+         return accessibility_speak_windows(speed, speak_text, priority);
       }
 
       nvdaController_cancelSpeech_func();


### PR DESCRIPTION
## Description

This was implemented in https://github.com/libretro/RetroArch/commit/274d47f957c917b2139d7248cd0589c25725f656#diff-5b749d3bf38c4e45f736f21f20aded50ddd3b468ff3d31c599d88d2f5235f9e0 and got into the version 1.17.0.  Later this was fully reverted due to the unrelated side-effects. 

I haven't tested it yet, but the code is obvious that it does not affect the implementation of the AI-service and will not cause any graphic issues.

## Related Issues

Should fix #17628

## Related Pull Requests

26a824caff4c1c31ab24deaa2a76a6ae71bc2071