### PR TITLE
Remove special handling of pause key on Android

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1607,8 +1607,7 @@ static void android_input_poll_user(android_input_t *android)
    }
 }
 
-/* Handle all events. If our activity is in pause state,
- * block until we're unpaused.
+/* Handle all events.
  */
 static void android_input_poll(void *data)
 {
@@ -1618,11 +1617,7 @@ static void android_input_poll(void *data)
    settings_t            *settings = config_get_ptr();
 
    while ((ident =
-            ALooper_pollAll((input_config_binds[0][RARCH_PAUSE_TOGGLE].valid 
-               && input_key_pressed(RARCH_PAUSE_TOGGLE,
-                  ANDROID_KEYBOARD_PORT_INPUT_PRESSED(input_config_binds[0],
-                     RARCH_PAUSE_TOGGLE)))
-               ? -1 : settings->uints.input_block_timeout,
+            ALooper_pollAll(settings->uints.input_block_timeout,
                NULL, NULL, NULL)) >= 0)
    {
       switch (ident)


### PR DESCRIPTION
## Description

Followup of #17662 . "P" key (or whatever was assigned to pause) was not registering in case of Android + keyboard + game focus, and pause was not triggered either.

It seems this is a legacy behavior since at least 2013: https://github.com/libretro/RetroArch/commit/ec114db3569cf0c4d01a3f2736ec347ff035299f (functionality has been moved around since then). But I could not find any specific reason why it should behave like that nowadays, probably in those days pause was meant to behave like current pause (hold), as this is what the code was doing: if pause key was pressed, it waited until a new event arrived.

Tested after the modification, pause works as expected and in case of game focus, keyboard input is passed through.

## Related Issues
https://github.com/zoltanvb/b2-libretro/issues/19

Edit: found old issues that are addressed by the same fix.
Closes #14200 
Closes #9998 