### PR TITLE
UWP: Bump version to 1.20.0 (don't merge yet)

### DIFF
--- a/pkg/msvc-uwp/RetroArch-msvcUWP/Package.appxmanifest
+++ b/pkg/msvc-uwp/RetroArch-msvcUWP/Package.appxmanifest
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp rescap">
-  <Identity Name="1e4cf179-f3c2-404f-b9f3-cb2070a5aad8" Publisher="CN=libretro" Version="1.19.0.0" />
+  <Identity Name="1e4cf179-f3c2-404f-b9f3-cb2070a5aad8" Publisher="CN=libretro" Version="1.20.0.0" />
   <mp:PhoneIdentity PhoneProductId="1e4cf179-f3c2-404f-b9f3-cb2070a5aad8" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>RetroArch</DisplayName>


### PR DESCRIPTION
## Description

This was forgotten when this [commit](https://github.com/libretro/RetroArch/commit/7d1d8322e69e05b61f4918739cb58fb4c8f83926) was made. So this just bumps it for UWP.

Edit: Don't merge yet I'm going to look into cloud saves on UWP.

## Issues

Fixes #17640