### PR TITLE
CTR: more compiler warnings cleanup

### DIFF
--- a/audio/drivers/ctr_csnd_audio.c
+++ b/audio/drivers/ctr_csnd_audio.c
@@ -164,7 +164,7 @@ static void ctr_csnd_audio_free(void *data)
 
 static ssize_t ctr_csnd_audio_write(void *data, const void *buf, size_t len)
 {
-   int i;
+   unsigned int i;
    uint32_t samples_played      = 0;
    uint64_t current_tick        = 0;
    const uint16_t          *src = buf;

--- a/ctr/ctr_debug.h
+++ b/ctr/ctr_debug.h
@@ -17,7 +17,7 @@ void dump_result_value(Result val);
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 #define DEBUG_LINE() do{printf("%s:%d.\n",__FUNCTION__, __LINE__);fflush(stdout);}while(0)
 #define DEBUG_STR(X) printf( "%s: %s\n", #X, (char*)(X))
-#define DEBUG_VAR(X) printf( "%-20s: 0x%08X\n", #X, (u32)(X))
+#define DEBUG_VAR(X) printf( "%-20s: 0x%08" PRIX32 "\n", #X, (uint32_t)(X))
 #define DEBUG_INT(X) printf( "%-20s: %10i\n", #X, (s32)(X))
 #define DEBUG_VAR64(X) printf( #X"\r\t\t\t\t : 0x%016llX\n", (u64)(X))
 #define DEBUG_ERROR(X) do{if(X)dump_result_value(X);}while(0)

--- a/gfx/common/ctr_defines.h
+++ b/gfx/common/ctr_defines.h
@@ -92,8 +92,8 @@ typedef struct ctr_video
    void *texture_linear;
    void *texture_swizzled;
    int display_list_size;
-   int texture_width;
-   int texture_height;
+   unsigned int texture_width;
+   unsigned int texture_height;
 
    ctr_scale_vector_t scale_vector;
    ctr_vertex_t* frame_coords;
@@ -119,7 +119,7 @@ typedef struct ctr_video
    {
       ctr_vertex_t* buffer;
       ctr_vertex_t* current;
-      int size;
+      size_t size;
    }vertex_cache;
 
    int state_slot;
@@ -158,10 +158,10 @@ typedef struct ctr_video
 
 typedef struct ctr_texture
 {
-   int width;
-   int height;
-   int active_width;
-   int active_height;
+   unsigned int width;
+   unsigned int height;
+   unsigned int active_width;
+   unsigned int active_height;
 
    enum texture_filter_type type;
    void* data;


### PR DESCRIPTION
* unsigned vs signed comparison
* copy DEBUG_VAR from wiiu - this one prints pointer values in a portable way
* prove GCC14 that a date formatted as "00/00/0000" can fit into 11 bytes
* explicitly mention previously unhandled enum constants
* Adding GFX widgets in b9849f78f7b and 1235a7435e0 orphaned ctr_set_osd_msg(). Reinstate it instead of removing, since it's effectively the same as calling font_driver_render_msg, but with checks.