### PR TITLE
CTR: more compiler warnings cleanup

### DIFF
--- a/audio/drivers/ctr_csnd_audio.c
+++ b/audio/drivers/ctr_csnd_audio.c
@@ -164,7 +164,7 @@ static void ctr_csnd_audio_free(void *data)
 
 static ssize_t ctr_csnd_audio_write(void *data, const void *buf, size_t len)
 {
-   int i;
+   unsigned int i;
    uint32_t samples_played      = 0;
    uint64_t current_tick        = 0;
    const uint16_t          *src = buf;

--- a/ctr/ctr_debug.h
+++ b/ctr/ctr_debug.h
@@ -17,7 +17,7 @@ void dump_result_value(Result val);
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 #define DEBUG_LINE() do{printf("%s:%d.\n",__FUNCTION__, __LINE__);fflush(stdout);}while(0)
 #define DEBUG_STR(X) printf( "%s: %s\n", #X, (char*)(X))
-#define DEBUG_VAR(X) printf( "%-20s: 0x%08X\n", #X, (u32)(X))
+#define DEBUG_VAR(X) printf( "%-20s: 0x%08" PRIX32 "\n", #X, (uint32_t)(X))
 #define DEBUG_INT(X) printf( "%-20s: %10i\n", #X, (s32)(X))
 #define DEBUG_VAR64(X) printf( #X"\r\t\t\t\t : 0x%016llX\n", (u64)(X))
 #define DEBUG_ERROR(X) do{if(X)dump_result_value(X);}while(0)

--- a/ctr/ctr_system.c
+++ b/ctr/ctr_system.c
@@ -257,7 +257,7 @@ void __attribute__((noreturn)) __ctru_exit(int rc)
 {
    __libc_fini_array();
    __appExit();
-   asm ("mov sp, %[saved_stack] \n\t" : : [saved_stack] "r"  (__saved_stack) : "sp");
+   asm ("mov sp, %[saved_stack] \n\t" : : [saved_stack] "r" (__saved_stack));
    __libctru_exit(rc);
 }
 

--- a/gfx/common/ctr_defines.h
+++ b/gfx/common/ctr_defines.h
@@ -92,8 +92,8 @@ typedef struct ctr_video
    void *texture_linear;
    void *texture_swizzled;
    int display_list_size;
-   int texture_width;
-   int texture_height;
+   unsigned int texture_width;
+   unsigned int texture_height;
 
    ctr_scale_vector_t scale_vector;
    ctr_vertex_t* frame_coords;
@@ -119,7 +119,7 @@ typedef struct ctr_video
    {
       ctr_vertex_t* buffer;
       ctr_vertex_t* current;
-      int size;
+      size_t size;
    }vertex_cache;
 
    int state_slot;
@@ -158,10 +158,10 @@ typedef struct ctr_video
 
 typedef struct ctr_texture
 {
-   int width;
-   int height;
-   int active_width;
-   int active_height;
+   unsigned int width;
+   unsigned int height;
+   unsigned int active_width;
+   unsigned int active_height;
 
    enum texture_filter_type type;
    void* data;

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -232,7 +232,7 @@ gfx_display_ctx_driver_t gfx_display_ctx_ctr = {
 static void* ctr_font_init(void* data, const char* font_path,
       float font_size, bool is_threaded)
 {
-   int i, j;
+   unsigned int i, j;
    ctr_scale_vector_t *vec_top    = NULL;
    ctr_scale_vector_t *vec_bottom = NULL;
    const uint8_t*     src         = NULL;
@@ -321,7 +321,7 @@ static void ctr_font_free(void* data, bool is_threaded)
 static int ctr_font_get_message_width(void* data, const char* msg,
       size_t msg_len, float scale)
 {
-   int i;
+   size_t i;
    int delta_x = 0;
    const struct font_glyph* glyph_q = NULL;
    ctr_font_t* font                 = (ctr_font_t*)data;
@@ -361,7 +361,7 @@ static void ctr_font_render_line(
       float pos_y,
       unsigned width, unsigned height, unsigned text_align)
 {
-   unsigned i;
+   unsigned int i;
    const struct font_glyph* glyph_q = NULL;
    ctr_vertex_t* v  = NULL;
    int delta_x      = 0;
@@ -504,7 +504,7 @@ static void ctr_font_render_message(
    for (;;)
    {
       const char* delim = strchr(msg, '\n');
-      size_t msg_len    = delim ? (delim - msg) : strlen(msg);
+      size_t msg_len    = delim ? (size_t)(delim - msg) : strlen(msg);
 
       /* Draw the line */
       ctr_font_render_line(ctr, font, msg, msg_len,
@@ -729,7 +729,7 @@ static INLINE void ctr_set_screen_coords(ctr_video_t * ctr)
 #ifdef HAVE_OVERLAY
 static void ctr_free_overlay(ctr_video_t *ctr)
 {
-   int i;
+   unsigned int i;
 
    for (i = 0; i < ctr->overlays; i++)
    {
@@ -818,8 +818,10 @@ static void ctr_update_state_date(void *data)
    ctr_video_t *ctr = (ctr_video_t*)data;
    time_t now       = time(NULL);
    struct tm *t     = localtime(&now);
-   snprintf(ctr->state_date, sizeof(ctr->state_date), "%02d/%02d/%d",
-      t->tm_mon + 1, t->tm_mday, t->tm_year + 1900);
+   snprintf(ctr->state_date, sizeof(ctr->state_date), "%02u/%02u/%u",
+      ((unsigned)t->tm_mon + 1) % 100,
+      (unsigned)t->tm_mday % 100,
+      ((unsigned)t->tm_year + 1900) % 10000);
 }
 
 static bool ctr_update_state_date_from_file(void *data)
@@ -846,10 +848,11 @@ static bool ctr_update_state_date_from_file(void *data)
 
    ft    = mtime;
    t     = localtime(&ft);
-   snprintf(ctr->state_date, sizeof(ctr->state_date), "%02d/%02d/%d",
-      t->tm_mon + 1, t->tm_mday, t->tm_year + 1900);
-
-  return true;
+   snprintf(ctr->state_date, sizeof(ctr->state_date), "%02u/%02u/%u",
+      ((unsigned)t->tm_mon + 1) % 100,
+      (unsigned)t->tm_mday % 100,
+      ((unsigned)t->tm_year + 1900) % 10000);
+   return true;
 
 error:
   ctr->state_data_exist = false;
@@ -1052,6 +1055,8 @@ static void ctr_bottom_menu_control(void* data, bool lcd_bottom, uint32_t flags)
 
       switch (ctr->bottom_menu)
       {
+         case CTR_BOTTOM_MENU_NOT_AVAILABLE:
+            return;
          case CTR_BOTTOM_MENU_DEFAULT:
             BIT64_SET(lifecycle_state, RARCH_MENU_TOGGLE);
             break;
@@ -1142,8 +1147,7 @@ static void ctr_bottom_menu_control(void* data, bool lcd_bottom, uint32_t flags)
       ctr->refresh_bottom_menu = true;
    }
 
-   if (      ctr->bottom_menu == CTR_BOTTOM_MENU_NOT_AVAILABLE
-         || (!(flags & RUNLOOP_FLAG_CORE_RUNNING)))
+   if (!(flags & RUNLOOP_FLAG_CORE_RUNNING))
       return;
 
 
@@ -1580,6 +1584,9 @@ static void ctr_lcd_aptHook(APT_HookType hook, void* param)
       case APTHOOK_ONWAKEUP:
          command_event(CMD_EVENT_AUDIO_START, NULL);
          break;
+      case APTHOOK_ONEXIT:
+      case APTHOOK_COUNT:
+         break;
    }
 }
 
@@ -1792,7 +1799,7 @@ static void* ctr_init(const video_info_t* video,
          video->is_threaded,
          FONT_DRIVER_RENDER_CTR);
 
-   ctr->msg_rendering_enabled     = false;
+   ctr->msg_rendering_enabled     = true;
    ctr->menu_texture_frame_enable = false;
    ctr->menu_texture_enable       = false;
 
@@ -2058,7 +2065,7 @@ static bool ctr_frame(void* data, const void* frame,
       }
       else
       {
-         int i;
+         unsigned int i;
          uint8_t       *dst = (uint8_t*)ctr->texture_linear;
          const uint8_t *src = frame;
 
@@ -2195,11 +2202,9 @@ static bool ctr_frame(void* data, const void* frame,
          }
       }
 
-      ctr->msg_rendering_enabled = true;
 #ifdef HAVE_MENU
       menu_driver_frame(menu_is_alive, video_info);
 #endif
-      ctr->msg_rendering_enabled = false;
    }
    else if (statistics_show)
    {
@@ -2463,7 +2468,7 @@ static void ctr_free(void* data)
 static void ctr_set_texture_frame(void* data, const void* frame, bool rgb32,
                                   unsigned width, unsigned height, float alpha)
 {
-   int i;
+   unsigned int i;
    uint16_t *dst;
    const uint16_t *src;
    ctr_video_t *ctr = (ctr_video_t*)data;
@@ -2563,10 +2568,10 @@ static uintptr_t ctr_load_texture(void *video_data, void *data,
    ctr_texture_t *texture      = NULL;
    ctr_video_t            *ctr = (ctr_video_t*)video_data;
    struct texture_image *image = (struct texture_image*)data;
-   int size                    = image->width
+   u32 size                    = image->width
       * image->height * sizeof(uint32_t);
 
-   if ((size * 3) > linearSpaceFree())
+   if ((u64)size * 3 > linearSpaceFree())
       return 0;
 
    if (!ctr || !image || image->width > 2048 || image->height > 2048)
@@ -2591,7 +2596,7 @@ static uintptr_t ctr_load_texture(void *video_data, void *data,
 
    if ((image->width <= 32) || (image->height <= 32))
    {
-      int i, j;
+      unsigned int i, j;
       uint32_t* src = (uint32_t*)image->pixels;
 
       for (j = 0; j < image->height; j++)
@@ -2610,7 +2615,7 @@ static uintptr_t ctr_load_texture(void *video_data, void *data,
    }
    else
    {
-      int i;
+      unsigned int i;
       uint32_t *src = NULL;
       uint32_t *dst = NULL;
 
@@ -2716,7 +2721,7 @@ static void ctr_overlay_vertex_geom(void *data,
 static bool ctr_overlay_load(void *data,
             const void *image_data, unsigned num_images)
 {
-   int i, j;
+   unsigned int i, j;
    void *tmpdata;
    ctr_texture_t       *texture = NULL;
    ctr_video_t             *ctr = (ctr_video_t *)data;
@@ -2823,7 +2828,7 @@ static void ctr_overlay_set_alpha(void *data, unsigned image, float mod){ }
 
 static void ctr_render_overlay(ctr_video_t *ctr)
 {
-   int i;
+   unsigned int i;
 
    for (i = 0; i < ctr->overlays; i++)
    {
@@ -2905,7 +2910,7 @@ static const video_poke_interface_t ctr_poke_interface = {
    ctr_apply_state_changes,
    ctr_set_texture_frame,
    ctr_set_texture_enable,
-   font_driver_render_msg,
+   ctr_set_osd_msg,
    NULL, /* show_mouse */
    NULL, /* grab_mouse_toggle */
    NULL, /* get_current_shader */


### PR DESCRIPTION
* unsigned vs signed comparison
* copy DEBUG_VAR from wiiu - this one prints pointer values in a portable way
* prove GCC14 that a date formatted as "00/00/0000" can fit into 11 bytes
* explicitly mention previously unhandled enum constants
* Adding GFX widgets in b9849f78f7b and 1235a7435e0 orphaned ctr_set_osd_msg(). Reinstate it instead of removing, since it's effectively the same as calling font_driver_render_msg, but with checks.
* remove sp from clobber list in inline assembly