### PR TITLE
Enable compilation with plain_drm without other video drivers.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1504,6 +1504,7 @@ ifeq ($(HAVE_PLAIN_DRM), 1)
       INCLUDE_DIRS += -I/usr/include/libdrm
    endif
    LIBS += -ldrm
+   HAVE_AND_WILL_USE_DRM = 1
 endif
 
 ifeq ($(HAVE_VITAGL), 1)


### PR DESCRIPTION
## Description

drm_common was not getting included if the available video drivers are very limited.

```
./configure --disable-x11 --disable-wayland --disable-kms --enable-plain_drm
[...]
make
[...]
LD retroarch
/usr/bin/ld: obj-unix/release/gfx/drivers/drm_gfx.o: warning: relocation against `g_drm_mode' in read-only section `.text'
/usr/bin/ld: obj-unix/release/gfx/drivers/drm_gfx.o: in function `drm_init':
drm_gfx.c:(.text+0x404): undefined reference to `g_drm_mode'
/usr/bin/ld: obj-unix/release/gfx/drivers/drm_gfx.o: in function `drm_gfx_free':
drm_gfx.c:(.text+0x13a8): undefined reference to `g_drm_mode'
/usr/bin/ld: obj-unix/release/gfx/drivers/drm_gfx.o:(.data.rel.ro+0x20): undefined reference to `drm_get_refresh_rate'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
make: *** [Makefile:204: retroarch] Error 1

```

## Related Issues

#17564 (does not solve it, but this PR is useful anyway)
