### PR TITLE
Win32: Fix pick core dialog

### DIFF
--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -333,10 +333,11 @@ static INT_PTR_COMPAT CALLBACK pick_core_proc(
    {
       case WM_INITDIALOG:
          {
+            const core_info_t *info = NULL;
             HWND hwndList;
             unsigned i;
-            /* Add items to list.  */
 
+            /* Add items to list.  */
             core_info_get_list(&core_info_list);
             core_info_list_get_supported_cores(core_info_list,
                   path_get(RARCH_PATH_CONTENT), &core_info, &list_size);
@@ -349,8 +350,12 @@ static INT_PTR_COMPAT CALLBACK pick_core_proc(
                SendMessage(hwndList, LB_ADDSTRING, 0,
                      (LPARAM)info->display_name);
             }
+
             /* Select the first item in the list */
             SendMessage(hwndList, LB_SETCURSEL, 0, 0);
+            info = (const core_info_t*)&core_info[0];
+            path_set(RARCH_PATH_CORE, info->path);
+
             SetFocus(hwndList);
             return TRUE;
          }


### PR DESCRIPTION
## Description

Apparently `LB_SETCURSEL` alone was only cosmetics, so even if it looked like the first item was selected it still behaved as if nothing was selected - which is crash due to no core loaded - requiring a selection click regardless, therefore copypaste from the selection code to actually get and set the core path from the cursor.

## Related Issues

Closes #17707

## Related Pull Requests

#17557

