### PR TITLE
Silence warnings

### DIFF
--- a/deps/7zip/LzmaEnc.c
+++ b/deps/7zip/LzmaEnc.c
@@ -2828,12 +2828,13 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, BoolInt reInit,
 
   nowPos64 = p->nowPos64;
   RangeEnc_Init(&p->rc);
-  p->rc.outStream = &outStream.vt;
 
   if (desiredPackSize == 0)
     return SZ_ERROR_OUTPUT_EOF;
 
+  p->rc.outStream = &outStream.vt;
   res = LzmaEnc_CodeOneBlock(p, desiredPackSize, *unpackSize);
+  p->rc.outStream = NULL;
   
   *unpackSize = (uint32_t)(p->nowPos64 - nowPos64);
   *destLen -= outStream.rem;

--- a/libretro-common/formats/jpeg/rjpeg.c
+++ b/libretro-common/formats/jpeg/rjpeg.c
@@ -330,7 +330,7 @@ static void rjpeg_build_fast_ac(int16_t *fast_ac, rjpeg_huffman *h)
             int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
             int m = 1 << (magbits - 1);
             if (k < m)
-               k += (-1 << magbits) + 1;
+               k += (~0U << magbits) + 1;
 
             /* if the result is small enough, we can fit it in fast_ac table */
             if (k >= -128 && k <= 127)

--- a/libretro-common/formats/tga/rtga.c
+++ b/libretro-common/formats/tga/rtga.c
@@ -265,9 +265,7 @@ static uint8_t *rtga_tga_load(rtga_context *s,
       int RLE_repeating          = 0;
       int RLE_count              = 0;
       int read_next_pixel        = 1;
-      /* Needs to be at least 33 bytes to silence a GCC warning,
-       * only 4 are actually used */
-      unsigned char raw_data[33] = {0};
+      unsigned char raw_data[4] = {0};
       unsigned char *tga_palette = NULL;
 
       /*   Do I need to load a palette? */
@@ -337,8 +335,14 @@ static uint8_t *rtga_tga_load(rtga_context *s,
             else
             {
                /* read in the data raw */
-               for (j = 0; j*8 < tga_bits_per_pixel; ++j)
-                  raw_data[j] = rtga_get8(s);
+               /* manually unroll, probably GCC bug 92955 */
+               j = 0;
+               switch (tga_bits_per_pixel) {
+                  case 32: raw_data[j++] = rtga_get8(s); /* fallthrough */
+                  case 24: raw_data[j++] = rtga_get8(s); /* fallthrough */
+                  case 16: raw_data[j++] = rtga_get8(s); /* fallthrough */
+                  case  8: raw_data[j++] = rtga_get8(s);
+               }
             }
 
             /*   clear the reading flag for the next pixel */

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -269,7 +269,7 @@ static int intfstream_get_serial(intfstream_t *fd, char *s, size_t len, const ch
 }
 
 static bool intfstream_file_get_serial(const char *name,
-      uint64_t offset, size_t size, char *s, size_t len)
+      uint64_t offset, int64_t size, char *s, size_t len)
 {
    int rv;
    uint8_t *data     = NULL;
@@ -291,7 +291,7 @@ static bool intfstream_file_get_serial(const char *name,
    if (file_size < 0)
       goto error;
 
-   if (offset != 0 || size < (size_t) file_size)
+   if (offset != 0 || size < file_size)
    {
       if (intfstream_seek(fd, (int64_t)offset, SEEK_SET) == -1)
          goto error;
@@ -364,7 +364,7 @@ static int task_database_gdi_get_serial(const char *name, char *s, size_t len)
       return 0;
    }
 
-   return intfstream_file_get_serial(track_path, 0, SIZE_MAX, s, len);
+   return intfstream_file_get_serial(track_path, 0, INT64_MAX, s, len);
 }
 
 static int task_database_chd_get_serial(const char *name, char *serial, size_t len)
@@ -385,7 +385,7 @@ static int task_database_chd_get_serial(const char *name, char *serial, size_t l
 }
 
 static bool intfstream_file_get_crc(const char *name,
-      uint64_t offset, size_t len, uint32_t *crc)
+      uint64_t offset, int64_t len, uint32_t *crc)
 {
    bool rv;
    intfstream_t *fd  = intfstream_open_file(name,
@@ -407,7 +407,7 @@ static bool intfstream_file_get_crc(const char *name,
    if (file_size < 0)
       goto error;
 
-   if (offset != 0 || len < (uint64_t) file_size)
+   if (offset != 0 || len < file_size)
    {
       if (intfstream_seek(fd, (int64_t)offset, SEEK_SET) == -1)
          goto error;
@@ -480,7 +480,7 @@ static int task_database_gdi_get_crc(const char *name, uint32_t *crc)
       return 0;
    }
 
-   return intfstream_file_get_crc(track_path, 0, SIZE_MAX, crc);
+   return intfstream_file_get_crc(track_path, 0, INT64_MAX, crc);
 }
 
 static bool task_database_chd_get_crc(const char *name, uint32_t *crc)
@@ -624,7 +624,7 @@ static int task_database_iterate_playlist(
          db->type = DATABASE_TYPE_CRC_LOOKUP;
          /* first check crc of archive itself */
          return intfstream_file_get_crc(name,
-               0, SIZE_MAX, &db_state->archive_crc);
+               0, INT64_MAX, &db_state->archive_crc);
 #else
          break;
 #endif
@@ -656,7 +656,7 @@ static int task_database_iterate_playlist(
       case FILE_TYPE_WIA:
       case FILE_TYPE_ISO:
          db_state->serial[0] = '\0';
-         intfstream_file_get_serial(name, 0, SIZE_MAX, db_state->serial, sizeof(db_state->serial));
+         intfstream_file_get_serial(name, 0, INT64_MAX, db_state->serial, sizeof(db_state->serial));
          db->type            =  DATABASE_TYPE_SERIAL_LOOKUP;
          break;
       case FILE_TYPE_CHD:
@@ -675,7 +675,7 @@ static int task_database_iterate_playlist(
       default:
          db_state->serial[0] = '\0';
          db->type            = DATABASE_TYPE_CRC_LOOKUP;
-         return intfstream_file_get_crc(name, 0, SIZE_MAX, &db_state->crc);
+         return intfstream_file_get_crc(name, 0, INT64_MAX, &db_state->crc);
    }
 
    return 1;
@@ -1136,7 +1136,7 @@ static int task_database_iterate_serial_lookup(
             if (task_database_check_serial_and_crc(db_state))
             {
                if (db_state->crc == 0)
-                  intfstream_file_get_crc(name, 0, SIZE_MAX, &db_state->crc);
+                  intfstream_file_get_crc(name, 0, INT64_MAX, &db_state->crc);
                if (db_state->crc == db_info_entry->crc32)
                   return database_info_list_iterate_found_match(_db,
                         db_state, db, NULL);


### PR DESCRIPTION
Silence -Walloc-size-larger-than=byte-size
Silence GCC stringop-overflow
Silence warning: left shift of negative value
Silence a dangling-pointer warning in Lzma