### PR TITLE
Silence even more warnings

### DIFF
--- a/ctr/ctr_linear.cpp
+++ b/ctr/ctr_linear.cpp
@@ -191,10 +191,13 @@ void* linearMemAlign(size_t len, size_t alignment)
 		sLinearPool.Deallocate(chunk);
 		return nullptr;
 	}
-	if (rbtree_insert(&sAddrMap, &node->node));
+	if (!rbtree_insert(&sAddrMap, &node->node)) {
+		sLinearPool.Deallocate(chunk);
+		return nullptr;
+	}
 
-   if (sLinearPool_maxaddr < (u32)sLinearPool.last->base)
-      sLinearPool_maxaddr = (u32)sLinearPool.last->base;
+	if (sLinearPool_maxaddr < (u32)sLinearPool.last->base)
+		sLinearPool_maxaddr = (u32)sLinearPool.last->base;
 
 	return chunk.addr;
 }

--- a/ctr/exec-3dsx/exec_cia.c
+++ b/ctr/exec-3dsx/exec_cia.c
@@ -63,7 +63,7 @@ static int isCiaInstalled(u64 titleId, u16 version)
    return 0;
 }
 
-static int deleteCia(u64 TitleId)
+static void deleteCia(u64 TitleId)
 {
    u64 currTitleId = 0;
 

--- a/dynamic.h
+++ b/dynamic.h
@@ -66,7 +66,7 @@ struct retro_core_t
    void *(*retro_get_memory_data)(unsigned);
    size_t (*retro_get_memory_size)(unsigned);
 
-   unsigned poll_type;
+   enum poll_type poll_type;
    uint8_t flags;
 };
 

--- a/libretro-common/audio/dsp_filters/tremolo.c
+++ b/libretro-common/audio/dsp_filters/tremolo.c
@@ -35,8 +35,8 @@ struct tremolo_core
    float *wavetable;
    float freq;
    float depth;
-   int index;
-   int maxindex;
+   unsigned index;
+   unsigned maxindex;
 };
 
 struct tremolo

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -707,10 +707,7 @@ int generic_action_ok_displaylist_push(
    recording_state_t *recording_st         = recording_state_get_ptr();
 
    if (!menu || string_is_equal(menu_ident, "null"))
-   {
-      menu_displaylist_info_free(&info);
       return -1;
-   }
 
 #ifdef HAVE_AUDIOMIXER
    if (audio_enable_menu && audio_enable_menu_ok)

--- a/retroarch_types.h
+++ b/retroarch_types.h
@@ -20,7 +20,7 @@
 
 RETRO_BEGIN_DECLS
 
-enum
+enum poll_type
 {
    /* Polling is performed before
     * call to retro_run. */

--- a/runloop.c
+++ b/runloop.c
@@ -4518,7 +4518,7 @@ static void core_input_state_poll_maybe(void)
    runloop_state_t *runloop_st = &runloop_state;
    const enum poll_type_override_t
       core_poll_type_override  = runloop_st->core_poll_type_override;
-   unsigned new_poll_type      = (core_poll_type_override > POLL_TYPE_OVERRIDE_DONTCARE)
+   enum poll_type new_poll_type      = (core_poll_type_override > POLL_TYPE_OVERRIDE_DONTCARE)
       ? (core_poll_type_override - 1)
       : runloop_st->current_core.poll_type;
    if (new_poll_type == POLL_TYPE_NORMAL)
@@ -4531,7 +4531,7 @@ static retro_input_state_t core_input_state_poll_return_cb(void)
    runloop_state_t *runloop_st = &runloop_state;
    const enum poll_type_override_t
       core_poll_type_override  = runloop_st->core_poll_type_override;
-   unsigned new_poll_type      = (core_poll_type_override > POLL_TYPE_OVERRIDE_DONTCARE)
+   enum poll_type new_poll_type      = (core_poll_type_override > POLL_TYPE_OVERRIDE_DONTCARE)
       ? (core_poll_type_override - 1)
       : runloop_st->current_core.poll_type;
    if (new_poll_type == POLL_TYPE_LATE)
@@ -7715,7 +7715,7 @@ void core_run(void)
       current_core             = &runloop_st->current_core;
    const enum poll_type_override_t
       core_poll_type_override  = runloop_st->core_poll_type_override;
-   unsigned new_poll_type      = (core_poll_type_override != POLL_TYPE_OVERRIDE_DONTCARE)
+   enum poll_type new_poll_type      = (core_poll_type_override != POLL_TYPE_OVERRIDE_DONTCARE)
       ? (core_poll_type_override - 1)
       : current_core->poll_type;
    bool early_polling          = new_poll_type == POLL_TYPE_EARLY;

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -722,8 +722,7 @@ int detect_sat_game(intfstream_t *fd, char *s, size_t len, const char *filename)
                && raw_game_id[1] == 'K'
                && raw_game_id[2] == '-')
          {
-            strncpy(s, &raw_game_id[3], __len - 3);
-            s[__len - 3] = '\0';
+            strlcpy(s, &raw_game_id[3], len);
          }
          else
             strlcpy(s, raw_game_id, len);


### PR DESCRIPTION
Silence warning about type sign mismatch
Silence warning about possible truncation
Adjust types of index and maxindex to unsigned
Don't free members of struct before init
Silence a warning about no return value from non-void function
Use the return value of rbtree_insert to silence a warning
