### PR TITLE
Push the compiler to reserve space for negative commands

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -990,7 +990,7 @@ void rcheevos_test(void)
 #ifdef HAVE_THREADS
    if (rcheevos_locals.queued_command != CMD_EVENT_NONE)
    {
-      if ((int)rcheevos_locals.queued_command == CMD_CHEEVOS_FINALIZE_LOAD)
+      if (rcheevos_locals.queued_command == CMD_CHEEVOS_FINALIZE_LOAD)
          rcheevos_finalize_game_load_on_ui_thread();
       else
          command_event(rcheevos_locals.queued_command, NULL);

--- a/command.h
+++ b/command.h
@@ -41,6 +41,7 @@ RETRO_BEGIN_DECLS
 
 enum event_command
 {
+   CMD_SPECIAL = -1,
    CMD_EVENT_NONE = 0,
    /* Resets RetroArch. */
    CMD_EVENT_RESET,

--- a/retroarch.c
+++ b/retroarch.c
@@ -5486,6 +5486,10 @@ bool command_event(enum event_command cmd, void *data)
       /* Deprecated */
       case CMD_EVENT_SEND_DEBUG_INFO:
          break;
+
+      /* Do nothing about the special negative value */
+      case CMD_SPECIAL:
+         break;
    }
 
    return true;


### PR DESCRIPTION
Cheevos define a special macro defined to -1 and uses it as one of the values for enum event_command. Make this value a part of the enum definition so that this type is not optimized to be unsigned.