### PR TITLE
Partially revert 0033224c25a

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -336,7 +336,7 @@ typedef struct
 {
    const char *str;
    float x;
-   size_t width;
+   int width; /* -1 on error */
    bool show;
 } ozone_footer_label_t;
 


### PR DESCRIPTION
font_driver_get_message_width() can return -1 if it fails, ozone_cache_footer_label() has a fallback for this case
