### PR TITLE
Fix UI freeze when threaded rendering is enabled on 3DS

### DIFF
--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -525,7 +525,7 @@ static void threaded_worker(void *userdata)
 
       slock_unlock(running_lock);
       task->handler(task);
-#ifdef EMSCRIPTEN
+#if defined(EMSCRIPTEN) || defined(_3DS)
       /* Workaround emscripten pthread bug where not parking the
          thread will prevent other important stuff from
          happening. Maybe due to lack of signals implementation in


### PR DESCRIPTION
Before this change, there was at least one scenario in which the UI would seemingly freeze and a restart was needed. That's when an update of cores was attempted with threaded rendering enabled.

Fixes https://github.com/libretro/RetroArch/issues/17727