### PR TITLE
Static core loading

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -15073,6 +15073,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   {
                      if (settings->bools.menu_show_load_core)
                      {
+#ifdef HAVE_DYNAMIC
                         if (!string_is_empty(sys_info->info.library_name))
                         {
                            if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(info->list,
@@ -15080,6 +15081,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                               count++;
                         }
                         else
+#endif
                         {
                            if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(info->list,
                                     MENU_ENUM_LABEL_CORE_LIST, PARSE_ACTION, false) == 0)


### PR DESCRIPTION
Statically linked cores on certain platforms, like 3DS, without dummy cores always rely on a core being loaded.
In case of the 3DS, unloading a core is not possible.

The recent changes included in https://github.com/libretro/RetroArch/pull/17695, removed the option to load a core.
Since unloading a core is not possible on statically linked platforms, the 'Load Core' option will always be overridden.

@sonninnos 
While this is a quick fix for the 3DS platform, this may apply to other statically linked platforms as well.
Maybe this should be excluded with ```HAVE_DYNAMIC```.