### PR TITLE
Silence warnings

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -309,7 +309,7 @@ static void rcheevos_award_achievement(const rc_client_achievement_t* cheevo)
             strlcpy(title,
                msg_hash_to_str(MSG_ACHIEVEMENT_UNLOCKED), sizeof(title));
 
-         snprintf(subtitle, sizeof(subtitle), "%s (%d)", cheevo->title, cheevo->points);
+         snprintf(subtitle, sizeof(subtitle), "%s (%lu)", cheevo->title, (unsigned long)cheevo->points);
 
          gfx_widgets_push_achievement(title, subtitle, cheevo->badge_name);
       }

--- a/command.c
+++ b/command.c
@@ -992,7 +992,7 @@ bool command_get_status(command_t *cmd, const char* arg)
       _len    += strlcpy(reply + _len,
             path_basename(path_get(RARCH_PATH_BASENAME)), sizeof(reply) - _len);
       _len    += snprintf(reply + _len, sizeof(reply) - _len,
-            ",crc32=%x\n", content_get_crc());
+            ",crc32=%lx\n", (unsigned long)content_get_crc());
    }
    else
        _len = strlcpy(reply, "GET_STATUS CONTENTLESS", sizeof(reply));

--- a/configuration.c
+++ b/configuration.c
@@ -4916,6 +4916,7 @@ static void save_keybind_axis(config_file_t *conf,
       const struct retro_keybind *bind, bool save_empty)
 {
    char key[64];
+   char config[16];
    size_t _len = fill_pathname_join_delim(key, prefix, base, '_', sizeof(key));
    strlcpy(key + _len, "_axis", sizeof(key) - _len);
 
@@ -4923,25 +4924,20 @@ static void save_keybind_axis(config_file_t *conf,
    {
       if (save_empty)
          config_set_string(conf, key, "nul");
+      return;
    }
-   else if (AXIS_NEG_GET(bind->joyaxis) != AXIS_DIR_NONE)
+
+   if (AXIS_NEG_GET(bind->joyaxis) != AXIS_DIR_NONE)
    {
-      char config[16];
-      config[0] = '-';
-      config[1] = '\0';
-      snprintf(config + 1, sizeof(config) - 1, "%u",
-            AXIS_NEG_GET(bind->joyaxis));
-      config_set_string(conf, key, config);
+      snprintf(config, sizeof(config), "-%lu",
+            (unsigned long)AXIS_NEG_GET(bind->joyaxis));
    }
    else if (AXIS_POS_GET(bind->joyaxis) != AXIS_DIR_NONE)
    {
-      char config[16];
-      config[0] = '+';
-      config[1] = '\0';
-      snprintf(config + 1, sizeof(config) - 1, "%u",
-            AXIS_POS_GET(bind->joyaxis));
-      config_set_string(conf, key, config);
+      snprintf(config, sizeof(config), "+%lu",
+            (unsigned long)AXIS_POS_GET(bind->joyaxis));
    }
+   config_set_string(conf, key, config);
 }
 
 static void save_keybind_mbutton(config_file_t *conf,

--- a/configuration.c
+++ b/configuration.c
@@ -4475,7 +4475,7 @@ bool config_load_override(void *data)
          char tmp_path[PATH_MAX_LENGTH];
          size_t _len      = strlcpy(tmp_path,
                path_get(RARCH_PATH_CONFIG_OVERRIDE),
-               sizeof(tmp_path));
+               sizeof(tmp_path) - 2);
          tmp_path[  _len] = '|';
          tmp_path[++_len] = '\0';
          strlcpy(tmp_path + _len, core_path, sizeof(tmp_path) - _len);
@@ -4503,7 +4503,7 @@ bool config_load_override(void *data)
             char tmp_path[PATH_MAX_LENGTH];
             size_t _len      = strlcpy(tmp_path,
                   path_get(RARCH_PATH_CONFIG_OVERRIDE),
-                  sizeof(tmp_path));
+                  sizeof(tmp_path) - 2);
             tmp_path[  _len] = '|';
             tmp_path[++_len] = '\0';
             strlcpy(tmp_path + _len, content_path, sizeof(tmp_path) - _len);
@@ -4529,7 +4529,7 @@ bool config_load_override(void *data)
             char tmp_path[PATH_MAX_LENGTH];
             size_t _len      = strlcpy(tmp_path,
                   path_get(RARCH_PATH_CONFIG_OVERRIDE),
-                  sizeof(tmp_path));
+                  sizeof(tmp_path) - 2);
             tmp_path[  _len] = '|';
             tmp_path[++_len] = '\0';
             strlcpy(tmp_path + _len, game_path, sizeof(tmp_path) - _len);

--- a/core_option_manager.c
+++ b/core_option_manager.c
@@ -1204,7 +1204,7 @@ core_option_manager_t *core_option_manager_new(
          }
          else
          {
-            size_t __len      = strlcpy(address, category_key, sizeof(address));
+            size_t __len      = strlcpy(address, category_key, sizeof(address) - 3);
             address[  __len]  = ':';
             address[++__len]  = '#';
             address[++__len]  = '\0';

--- a/disk_control_interface.c
+++ b/disk_control_interface.c
@@ -623,7 +623,7 @@ bool disk_control_append_image(
       goto error;
 
    /* Display log */
-   _len        = strlcpy(msg, msg_hash_to_str(MSG_APPENDED_DISK), sizeof(msg));
+   _len        = strlcpy(msg, msg_hash_to_str(MSG_APPENDED_DISK), sizeof(msg) - 3);
    msg[  _len] = ':';
    msg[++_len] = ' ';
    msg[++_len] = '\0';
@@ -653,7 +653,7 @@ error:
       disk_control_set_eject_state(disk_control, false, false);
 
    _len        = strlcpy(msg,
-         msg_hash_to_str(MSG_FAILED_TO_APPEND_DISK), sizeof(msg));
+         msg_hash_to_str(MSG_FAILED_TO_APPEND_DISK), sizeof(msg) - 3);
    msg[  _len] = ':';
    msg[++_len] = ' ';
    msg[++_len] = '\0';

--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -3787,7 +3787,7 @@ static int16_t udev_input_state(
          }
          break;
       case RETRO_DEVICE_ANALOG:
-         if (binds[port])
+         if (binds)
          {
             int id_minus_key      = 0;
             int id_plus_key       = 0;

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1517,7 +1517,6 @@ static int16_t input_state_device(
                uint8_t turbo_period     = settings->uints.input_turbo_period;
                uint8_t turbo_duty_cycle = settings->uints.input_turbo_duty_cycle;
                uint8_t turbo_mode       = settings->uints.input_turbo_mode;
-               int8_t turbo_bind        = settings->ints.input_turbo_bind;
 
                if (turbo_duty_cycle == 0)
                   turbo_duty_cycle = turbo_period / 2;

--- a/menu/cbs/menu_cbs_cancel.c
+++ b/menu/cbs/menu_cbs_cancel.c
@@ -35,7 +35,6 @@ int action_cancel_pop_default(const char *path,
 {
    size_t new_selection_ptr;
    struct menu_state *menu_st             = menu_state_get_ptr();
-   size_t selection                       = menu_st->selection_ptr;
    const char *menu_label                 = NULL;
    unsigned menu_type                     = MENU_SETTINGS_NONE;
    menu_search_terms_t *menu_search_terms = menu_entries_search_get_terms();

--- a/menu/cbs/menu_cbs_left.c
+++ b/menu/cbs/menu_cbs_left.c
@@ -969,7 +969,6 @@ static int action_left_state_slot(unsigned type, const char *label,
 static int action_left_replay_slot(unsigned type, const char *label,
       bool wraparound)
 {
-   struct menu_state *menu_st     = menu_state_get_ptr();
    settings_t           *settings = config_get_ptr();
 
    settings->ints.replay_slot--;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -7503,9 +7503,6 @@ static int action_ok_push_dropdown_item_input_retropad_bind(const char *path,
 {
    rarch_setting_t *setting;
    enum msg_hash_enums enum_idx;
-   retro_ctx_controller_info_t pad;
-   unsigned port                = 0;
-   unsigned device              = 0;
 
    const char *menu_path        = NULL;
    menu_entries_get_last_stack(&menu_path, NULL, NULL, NULL, NULL);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -4670,7 +4670,6 @@ static int action_ok_cheat_delete(const char *path,
    char msg[128];
    size_t new_selection_ptr   = 0;
    struct menu_state *menu_st = menu_state_get_ptr();
-   size_t selection           = menu_st->selection_ptr;
    unsigned int new_size      = cheat_manager_get_size() - 1;
 
    if (new_size >0)

--- a/menu/cbs/menu_cbs_right.c
+++ b/menu/cbs/menu_cbs_right.c
@@ -960,7 +960,6 @@ static int action_right_state_slot(unsigned type, const char *label,
 static int action_right_replay_slot(unsigned type, const char *label,
       bool wraparound)
 {
-   struct menu_state *menu_st     = menu_state_get_ptr();
    settings_t           *settings = config_get_ptr();
 
    settings->ints.replay_slot++;

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -7157,7 +7157,6 @@ static void materialui_show_fullscreen_thumbnails(
       materialui_handle_t *mui, struct menu_state *menu_st,
       size_t selection)
 {
-   menu_entry_t selected_entry;
    gfx_animation_ctx_entry_t animation_entry;
    gfx_thumbnail_t *primary_thumbnail   = NULL;
    gfx_thumbnail_t *secondary_thumbnail = NULL;

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2405,7 +2405,6 @@ static void materialui_update_fullscreen_thumbnail_label(
 {
    struct menu_state *menu_st  = menu_state_get_ptr();
    size_t selection            = menu_st->selection_ptr;
-   const char *thumbnail_label = NULL;
    menu_entry_t selected_entry;
 
    /* Cache selected entry label

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -4692,7 +4692,7 @@ static void rgui_render_osk(
        * If OSK cannot physically fit on the screen,
        * fallback to old style 'message box' implementation */
       char msg[NAME_MAX_LENGTH];
-      size_t _len = strlcpy(msg, input_label, sizeof(msg));
+      size_t _len = strlcpy(msg, input_label, sizeof(msg) - 2);
       msg[  _len] = '\n';
       msg[++_len] = '\0';
       strlcpy(msg       + _len,

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -6537,7 +6537,6 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
 
    if (reinit_textures)
    {
-      settings_t *settings = config_get_ptr();
       gfx_display_deinit_white_texture();
       gfx_display_init_white_texture();
       xmb->assets_missing     = false;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -8418,7 +8418,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    {
       const char *str             = menu_input_dialog_get_buffer();
       const char *label           = menu_st->input_dialog_kb_label;
-      size_t _len                 = strlcpy(msg, label, sizeof(msg));
+      size_t _len                 = strlcpy(msg, label, sizeof(msg) - 2);
       msg[  _len]                 = '\n';
       msg[++_len]                 = '\0';
       strlcpy(msg       + _len,

--- a/menu/menu_contentless_cores.c
+++ b/menu/menu_contentless_cores.c
@@ -124,7 +124,7 @@ static void contentless_cores_init_info_entries(
                (contentless_core_info_entry_t*)malloc(sizeof(*entry));
          size_t _len          = strlcpy(licenses_str,
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_INFO_LICENSES),
-               sizeof(licenses_str));
+               sizeof(licenses_str) - 3);
          licenses_str[  _len] = ':';
          licenses_str[++_len] = ' ';
          licenses_str[++_len] = '\0';

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5238,7 +5238,7 @@ static unsigned menu_displaylist_parse_content_information(
    {
       const char *cheevos_hash_str =
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CONTENT_INFO_CHEEVOS_HASH);
-      size_t _len                  = strlcpy(tmp, cheevos_hash_str, sizeof(tmp));
+      size_t _len                  = strlcpy(tmp, cheevos_hash_str, sizeof(tmp) - 4);
       tmp[  _len]                  = ':';
       tmp[++_len]                  = ' ';
       tmp[++_len]                  = '\n';

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5167,7 +5167,7 @@ unsigned menu_event(
    static unsigned ok_old                          = 0;
    unsigned ret                                    = MENU_ACTION_NOOP;
    bool set_scroll                                 = false;
-   size_t new_scroll_accel                         = 0;
+   unsigned new_scroll_accel                       = 0;
    struct menu_state *menu_st                      = &menu_driver_state;
    menu_input_t *menu_input                        = &menu_st->input_state;
    input_driver_state_t *input_st                  = input_state_get_ptr();
@@ -5380,7 +5380,7 @@ unsigned menu_event(
          p_trigger_input->data[0]  |= p_input->data[0] & input_repeat;
          set_scroll                 = true;
          hold_reset                 = true;
-         new_scroll_accel           = MIN(menu_st->scroll.acceleration + 1, (menu_scroll_fast) ? 25 : 5);
+         new_scroll_accel           = MIN(menu_st->scroll.acceleration + 1, menu_scroll_fast ? 25U : 5U);
       }
    }
    else
@@ -5392,7 +5392,7 @@ unsigned menu_event(
    }
 
    if (set_scroll)
-      menu_st->scroll.acceleration  = (unsigned)(new_scroll_accel);
+      menu_st->scroll.acceleration  = new_scroll_accel;
 
    if (display_kb)
    {

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6175,6 +6175,7 @@ static int setting_string_action_right_driver(
    return 0;
 }
 
+#if !defined(RARCH_CONSOLE)
 static int setting_string_action_left_midi_input(
       rarch_setting_t *setting, size_t idx, bool wraparound)
 {
@@ -6266,6 +6267,7 @@ static int setting_string_action_right_midi_output(
    command_event(CMD_EVENT_AUDIO_REINIT, NULL);
    return -1;
 }
+#endif
 
 #ifdef HAVE_CHEATS
 static size_t setting_get_string_representation_uint_cheat_exact(

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6889,7 +6889,6 @@ static size_t setting_get_string_representation_retropad_bind(
 {
    if (setting)
    {
-      settings_t *settings = config_get_ptr();
       int retro_id         = *setting->value.target.integer;
 
       if (retro_id < 0)

--- a/tasks/task_cloudsync.c
+++ b/tasks/task_cloudsync.c
@@ -1199,7 +1199,7 @@ static void task_cloud_sync_task_handler(retro_task_t *task)
 
    slock_lock(tcs_running_lock);
    /* we can transfer more than one file at a time */
-   if (sync_state->waiting > ((sync_state->phase == CLOUD_SYNC_PHASE_DIFF) ? 4 : 0))
+   if (sync_state->waiting > ((sync_state->phase == CLOUD_SYNC_PHASE_DIFF) ? 4U : 0U))
    {
       task->when = cpu_features_get_time_usec() + 17 * 1000; /* 17ms */
       slock_unlock(tcs_running_lock);

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -867,7 +867,7 @@ static void content_file_get_path(
             char info_path[PATH_MAX_LENGTH];
             /* Build 'complete' archive file path */
             size_t _len       = strlcpy(info_path,
-                  content_path, sizeof(info_path));
+                  content_path, sizeof(info_path) - 2);
             info_path[_len  ] = '#';
             info_path[_len+1] = '\0';
             _len             += 1;

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -855,7 +855,7 @@ int detect_dc_game(intfstream_t *fd, char *s, size_t len, const char *filename)
       lgame_id[1]          = '\0';
       strncpy(rgame_id, &raw_game_id[1], __len - 1);
       rgame_id[__len - 1]  = '\0';
-      _len                 = strlcpy(pre_game_id, lgame_id, sizeof(pre_game_id));
+      _len                 = strlcpy(pre_game_id, lgame_id, sizeof(pre_game_id) - 2);
       pre_game_id[  _len]  = '-';
       pre_game_id[++_len]  = '\0';
       strlcpy(pre_game_id + _len, rgame_id, sizeof(pre_game_id) - _len);

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -558,7 +558,7 @@ static void task_save_handler(retro_task_t *task)
       {
          size_t _len = strlcpy(msg,
                msg_hash_to_str(MSG_FAILED_TO_SAVE_STATE_TO),
-               sizeof(msg));
+               sizeof(msg) - 2);
          msg[  _len] = ' ';
          msg[++_len] = '\0';
          strlcpy(msg + _len, state->path, sizeof(msg) - _len);


### PR DESCRIPTION
Guarantee space for string characters after strlcpy
Remove unused variable
Silence warnings about sign mismatch
Silence an unreferenced local variable warning
Silence a -Waddress warning
Remove unused variables
Make printf format match the type
Silence an unused variable warning
Silence a defined-but-not-used-function warning
Simplify save_keybind_axis()
Remove unused variable