### PR TITLE
Fix overlay lightgun, mouse & pointer

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -81,7 +81,7 @@ enum {
 #endif
 
 /* Use this to enable/disable using the touch screen as mouse */
-#define ENABLE_TOUCH_SCREEN_MOUSE 1
+#define ENABLE_TOUCH_SCREEN_MOUSE 0
 
 #define AKEYCODE_ASSIST 219
 

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1776,7 +1776,7 @@ static int16_t input_state_device(
                   input_st->overlay_ptr, port, device, idx, id);
 #endif
 
-         if (res && input_st->flags & INP_FLAG_BLOCK_POINTER_INPUT)
+         if (res || input_st->flags & INP_FLAG_BLOCK_POINTER_INPUT)
             break;
 
          if (id < RARCH_FIRST_META_KEY)
@@ -3256,14 +3256,9 @@ static void input_overlay_poll_mouse(settings_t *settings,
       mouse_st->click = 0;
       pending_click   = false;
 
-      if (ptr_count)
-      {
-         /* Assume main pointer changed. Reset deltas */
-         mouse_st->prev_screen_x = x_start = ptr_st->screen_x;
-         mouse_st->prev_screen_y = y_start = ptr_st->screen_y;
-      }
-      else
-         old_peak_ptr_count = peak_ptr_count;
+      /* Assume main pointer changed. Reset deltas */
+      mouse_st->prev_screen_x = x_start = ptr_st->screen_x;
+      mouse_st->prev_screen_y = y_start = ptr_st->screen_y;
 
       if (ptr_count > old_ptr_count)
       {
@@ -3272,8 +3267,12 @@ static void input_overlay_poll_mouse(settings_t *settings,
          start_usec     = now_usec;
       }
       else
+      {
          /* Pointer removed */
          mouse_st->hold = 0;
+         if (!ptr_count)
+            old_peak_ptr_count = peak_ptr_count;
+      }
    }
 
    /* Action type */
@@ -3623,8 +3622,6 @@ static void input_poll_overlay(
       if (ptr_state->device_mask & (1 << RETRO_DEVICE_MOUSE))
          input_overlay_poll_mouse(settings, &ptr_state->mouse, ol,
                ptr_state->count, old_ptr_count);
-
-      ptr_state->device_mask = 0;
    }
 
    if (     OVERLAY_GET_KEY(ol_state, RETROK_LSHIFT)
@@ -3714,10 +3711,19 @@ static void input_poll_overlay(
          (input_overlay_show_inputs == OVERLAY_SHOW_INPUT_TOUCHED),
          input_overlay_show_inputs_port);
 
-   if (button_pressed || ol_ptr_enable)
+   /* Block other touchscreen input as needed. */
+   if (     button_pressed
+#ifdef IOS
+         || (ptr_state->device_mask & (1 << RETRO_DEVICE_LIGHTGUN))
+         || (ol->flags & INPUT_OVERLAY_BLOCKED))
+#else
+         || ol_ptr_enable)
+#endif
       input_st->flags |=  INP_FLAG_BLOCK_POINTER_INPUT;
    else
       input_st->flags &= ~INP_FLAG_BLOCK_POINTER_INPUT;
+
+   ptr_state->device_mask = 0;
 
    if (input_overlay_show_inputs == OVERLAY_SHOW_INPUT_NONE)
       button_pressed = false;


### PR DESCRIPTION
Fixes #17699

- Ensure non-overlay touch input is blocked when overlay buttons are pressed
- Limit physical+overlay mouse input to iOS for now
- Reset overlay mouse deltas when there is no touch input
- Disable touch mouse in android_input.c for now. Too buggy

Eventually the code behind `#ifdef IOS` could be the norm if other touchscreen mice are tested to not interfere with the overlay mouse.  For that, some input drivers might need to be updated to not create touchscreen mouse input at all when the overlay mouse is on.

@warmenhoven Test on iOS when you can.