### PR TITLE
Fix non-griffin build for 3DS and make it the default

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2014,6 +2014,7 @@ ifeq ($(HAVE_BUILTINZLIB), 1)
           $(DEPS_DIR)/libz/inflate.o \
           $(DEPS_DIR)/libz/inftrees.o \
           $(DEPS_DIR)/libz/trees.o \
+          $(DEPS_DIR)/libz/uncompr.o \
           $(DEPS_DIR)/libz/zutil.o
    INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include/compat/zlib
 else ifeq ($(HAVE_ZLIB),1)

--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -3,8 +3,8 @@ LIBRETRO =
 
 DEBUG                   = 0
 CONSOLE_LOG             = 0
-GRIFFIN_BUILD           = 1
-HAVE_STATIC_DUMMY ?= 0
+GRIFFIN_BUILD           = 0
+HAVE_STATIC_DUMMY      ?= 0
 WHOLE_ARCHIVE_LINK      = 0
 BUILD_3DSX              = 1
 BUILD_3DS               = 0
@@ -87,11 +87,16 @@ else
 	HAVE_PATCH = 1
 	HAVE_SCREENSHOTS = 1
 	HAVE_REWIND = 1
-	HAVE_AUDIOMIXER = 1
 	HAVE_RWAV = 1
-	#HAVE_NETWORKING = 1
-	#HAVE_IFINFO = 1
-	#HAVE_CHEEVOS = 1
+	HAVE_CHEATS = 1
+	HAVE_VIDEO_FILTER = 1
+	HAVE_DSP_FILTER = 1
+	HAVE_CONFIGFILE = 1
+	HAVE_OVERLAY = 1
+	HAVE_GFX_WIDGETS = 1
+	HAVE_NETWORKING = 1
+	HAVE_IFINFO = 1
+	HAVE_CHEEVOS = 1
 	#HAVE_SOCKET_LEGACY = 1
 	HAVE_THREADS = 1
 	#HAVE_SSL = 1
@@ -100,10 +105,6 @@ else
 
 	include Makefile.common
 	CFLAGS += $(DEF_FLAGS)
-	BLACKLIST :=
-	BLACKLIST += input/input_overlay.o
-	BLACKLIST += tasks/task_overlay.o
-	OBJ := $(filter-out $(BLACKLIST),$(OBJ))
 endif
 
 ifeq ($(strip $(DEVKITPRO)),)
@@ -155,7 +156,6 @@ ARCH     := -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp -mtp=so
 
 CFLAGS	+= -mword-relocations \
 	   -ffast-math \
-	   -Werror=implicit-function-declaration \
 	   $(ARCH)
 
 #CFLAGS	+= -Wall
@@ -188,17 +188,17 @@ CFLAGS += -I. \
 	  -Ideps \
 	  -Ideps/7zip \
 	  -Ideps/stb \
+	  -Ideps/mbedtls \
 	  -Ideps/rcheevos/include \
 	  -Ilibretro-common/include \
 	  -Ilibretro-common/include/compat/zlib
 
 CFLAGS += -DRARCH_INTERNAL -DRARCH_CONSOLE
-CFLAGS += -DHAVE_DSP_FILTER
-CFLAGS += -DHAVE_VIDEO_FILTER
 CFLAGS += -DHAVE_FILTERS_BUILTIN $(DEFINES)
-CFLAGS += -DHAVE_CHEATS
+CFLAGS += -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_CORES -DHAVE_UPDATE_CORE_INFO
 
 CXXFLAGS := $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
+CFLAGS += -Werror=implicit-function-declaration
 
 ASFLAGS	 := -g $(ARCH) -O3
 LDFLAGS  += -specs=ctr/3dsx_custom.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
@@ -220,6 +220,10 @@ ifeq ($(DEBUG), 1)
 	LIBS	+= -lctrud
 else
 	LIBS	+= -lctru
+endif
+
+ifneq ($(V),1)
+	Q := @
 endif
 
 ifeq ($(BUILD_3DSX), 1)
@@ -291,7 +295,8 @@ endif
 	$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS)
 
 %.o: %.c
-	$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS)
 
 %.o: %.s
 	$(CC) -c -o $@ $< $(ASFLAGS)

--- a/Makefile.ctr.salamander
+++ b/Makefile.ctr.salamander
@@ -85,7 +85,6 @@ ARCH     := -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp -mtp=so
 
 CFLAGS	+=	-mword-relocations \
 			-fomit-frame-pointer -ffast-math \
-         -Werror=implicit-function-declaration \
 			$(ARCH)
 
 #CFLAGS	+= -Wall
@@ -111,6 +110,7 @@ CFLAGS += -I. -Ideps/7zip -Ideps/stb -Ilibretro-common/include -Ilibretro-common
 CFLAGS += -DRARCH_CONSOLE -DIS_SALAMANDER
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
+CFLAGS += -Werror=implicit-function-declaration
 
 ASFLAGS	:=	-g $(ARCH) -O3
 LDFLAGS  +=	-specs=ctr/3dsx_custom.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/audio/drivers/ctr_dsp_audio.c
+++ b/audio/drivers/ctr_dsp_audio.c
@@ -19,6 +19,8 @@
 
 #include "../audio_driver.h"
 #include "../../ctr/ctr_debug.h"
+#include "../../retroarch.h"
+#include "../../verbosity.h"
 
 typedef struct
 {
@@ -113,7 +115,7 @@ static ssize_t ctr_dsp_audio_write(void *data, const void *buf, size_t len)
              * changed, this prevents a hang on sleep. */
             if (!aptMainLoop())
             {
-               command_event(CMD_EVENT_QUIT, NULL);
+               retroarch_main_quit();
                return true;
             }
 

--- a/audio/drivers/ctr_dsp_thread_audio.c
+++ b/audio/drivers/ctr_dsp_thread_audio.c
@@ -16,11 +16,13 @@
 #include <3ds.h>
 #include <string.h>
 #include <malloc.h>
+#include <math.h>
 #include <queues/fifo_queue.h>
 #include <rthreads/rthreads.h>
 
 #include "../audio_driver.h"
 #include "../../ctr/ctr_debug.h"
+#include "../../verbosity.h"
 
 typedef struct
 {

--- a/ctr/gpu_old.c
+++ b/ctr/gpu_old.c
@@ -11,7 +11,9 @@
 #include <3ds/gpu/gx.h>
 #include <3ds/gpu/shbin.h>
 
+#define DEPRECATED
 #include "gpu_old.h"
+#undef DEPRECATED
 
 void GPU_Init(Handle *gsphandle)
 {

--- a/deps/rcheevos/src/rc_compat.c
+++ b/deps/rcheevos/src/rc_compat.c
@@ -138,6 +138,29 @@ void rc_mutex_unlock(rc_mutex_t* mutex)
   LWP_MutexUnlock(mutex);
 }
 
+#elif defined(_3DS)
+
+void rc_mutex_init(rc_mutex_t* mutex)
+{
+  RecursiveLock_Init(mutex);
+}
+
+void rc_mutex_destroy(rc_mutex_t* mutex)
+{
+  /* Nothing to do here */
+  (void)mutex;
+}
+
+void rc_mutex_lock(rc_mutex_t* mutex)
+{
+  RecursiveLock_Lock(mutex);
+}
+
+void rc_mutex_unlock(rc_mutex_t* mutex)
+{
+  RecursiveLock_Unlock(mutex);
+}
+
 #else
 
 void rc_mutex_init(rc_mutex_t* mutex)

--- a/deps/rcheevos/src/rc_compat.h
+++ b/deps/rcheevos/src/rc_compat.h
@@ -81,6 +81,9 @@ RC_BEGIN_C_DECLS
   typedef struct rc_mutex_t {
     void* handle; /* HANDLE is defined as "void*" */
   } rc_mutex_t;
+ #elif defined(_3DS)
+  #include <3ds/synchronization.h>
+  typedef RecursiveLock rc_mutex_t;
  #else
   #include <pthread.h>
   typedef pthread_mutex_t rc_mutex_t;

--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -61,6 +61,9 @@
 #endif
 #endif
 
+#include "../../audio/audio_driver.h"
+#include "../../menu/menu_entries.h"
+
 static enum frontend_fork ctr_fork_mode = FRONTEND_FORK_NONE;
 static const char* elf_path_cst         = "sdmc:/retroarch/retroarch.3dsx";
 
@@ -138,6 +141,12 @@ static void frontend_ctr_get_env(int* argc, char* argv[],
    dir_check_defaults("custom.ini");
 #endif
 }
+
+#ifdef USE_CTRULIB_2
+u8* gfxTopLeftFramebuffers[2];
+u8* gfxTopRightFramebuffers[2];
+u8* gfxBottomFramebuffers[2];
+#endif
 
 static void frontend_ctr_deinit(void* data)
 {
@@ -371,10 +380,6 @@ __attribute__((weak)) u32 __ctr_patch_services;
 void gfxSetFramebufferInfo(gfxScreen_t screen, u8 id);
 
 #ifdef USE_CTRULIB_2
-u8* gfxTopLeftFramebuffers[2];
-u8* gfxTopRightFramebuffers[2];
-u8* gfxBottomFramebuffers[2];
-
 void gfxSetFramebufferInfo(gfxScreen_t screen, u8 id)
 {
    if (screen==GFX_TOP)

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -39,7 +39,9 @@
 #endif
 
 #include "../font_driver.h"
+#define DEPRECATED
 #include "../../ctr/gpu_old.h"
+#undef DEPRECATED
 #include "ctr_gu.h"
 
 #include "../../configuration.h"
@@ -49,6 +51,7 @@
 #include "../../retroarch.h"
 #include "../../runloop.h"
 #include "../../verbosity.h"
+#include "../../paths.h"
 
 #include "../common/ctr_defines.h"
 #ifndef HAVE_THREADS

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -23,6 +23,11 @@
 #include <features/features_cpu.h>
 #include <string/stdstring.h>
 
+#ifdef _3DS
+#include <3ds/types.h>
+#include <3ds/allocator/linear.h> /* linearMemAlign() */
+#endif
+
 #include "video_driver.h"
 #include "video_thread_wrapper.h"
 #include "font_driver.h"

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -35,7 +35,7 @@
 #ifdef HAVE_THREADS
 #include <rthreads/rthreads.h>
 #endif
-#ifdef EMSCRIPTEN
+#if defined(EMSCRIPTEN) || defined(_3DS)
 #include <retro_timers.h>
 #endif
 #ifdef HAVE_GCD

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -140,6 +140,10 @@
 #include "../steam/steam.h"
 #endif
 
+#ifdef _3DS
+#include <3ds/services/cfgu.h> /* CFGU_GetSystemModel */
+#endif
+
 /* Spacers used for '<content> - <core name>' labels
  * in playlists */
 #define PL_LABEL_SPACER_DEFAULT "   |   "


### PR DESCRIPTION
While here:
* remove input_overlay and task_overlay from linking blacklist
* move -Werror to CC invocation since C++ refuses to use it
* copy the quiet build mode from the main Makefile and make it the default
* temporarily define DEPRECATED for gpu_old.h to allow succesful build