### PR TITLE
Save fallback to linuxraw driver in case of first boot.

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -4126,7 +4126,28 @@ static void *udev_input_init(const char *joypad_driver)
    /* If using KMS and we forgot this,
     * we could lock ourselves out completely. */
    if (!udev->num_devices)
+   {
+      settings_t *settings = config_get_ptr();
       RARCH_WARN("[udev]: Couldn't open any keyboard, mouse or touchpad. Are permissions set correctly for /dev/input/event* and /run/udev/?\n");
+      /* Start screen is not used nowadays, but it still gets true value only
+       * on first startup without config file, so it should be good to catch
+       * initial boots without udev devices available. */
+#if defined(__linux__) && !defined(ANDROID)
+      if (settings->bools.menu_show_start_screen)
+      {
+         /* Force fallback to linuxraw. Driver reselection would happen even
+          * without overwriting input_driver setting, but that would not be saved
+          * as input driver auto-changes are not stored (due to interlock with
+          * video context driver), and on next boot user would be stuck with a
+          * possibly nonworking configuration.
+          */
+         strlcpy(settings->arrays.input_driver, "linuxraw",
+                 sizeof(settings->arrays.input_driver));
+         RARCH_WARN("[udev]: First boot and without input devices, forcing fallback to linuxraw.\n");
+         goto error;
+      }
+#endif
+   }
 
    input_keymaps_init_keyboard_lut(rarch_key_map_linux);
 


### PR DESCRIPTION
## Description

When no devices can be detected in the udev driver and it is the initial boot, make sure the driver is set to linuxraw.

When starting a new install (without retroarch.cfg) and input driver driver default is either udev, or it is something else but fallback happens to udev, and udev cannot find any device (most probably due to access right problems), fallback will be initiated and the new driver name `linuxraw` will be forcibly saved.

It does not prevent users incidentally locking themselves out later by setting input driver to udev manually, but I can imagine cases when those devices are not present always but udev driver is still wanted, so that is intentional.

## Related Issues

Closes #17746 .
