### PR TITLE
Use `-Wl,--pic-veneer` instead of `-fno-optimize-sibling-calls` in Makefile.vita

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -138,7 +138,7 @@ ifeq ($(HAVE_VITAGLES), 1)
    ARCHFLAGS += -DSCE_LIBC_SIZE=$(SCE_LIBC_SIZE)
 endif
 
-CFLAGS    += $(ARCHFLAGS) -mword-relocations -fno-optimize-sibling-calls
+CFLAGS    += $(ARCHFLAGS) -mword-relocations
 
 ifeq ($(DEBUG), 1)
    CFLAGS += -g -Og
@@ -147,7 +147,7 @@ else
 endif
 
 ASFLAGS := $(CFLAGS)
-LDFLAGS := -Wl,-q
+LDFLAGS := -Wl,-q,--pic-veneer
 
 CFLAGS += -Wall -ffast-math
 CFLAGS += -DRARCH_INTERNAL -DHAVE_SCREENSHOTS -DRARCH_CONSOLE


### PR DESCRIPTION
When building RetroArch for PlayStation Vita, Makefile.vita currently passes `-fno-optimize-sibling-calls` to the compiler to work around a bug where if sibling call optimization is enabled, the compiler may generate veneers to switch between ARM mode and Thumb mode. The veneers cause Vita SDK's tools to break -- the code will still compile, but the compiled binary crashes when executed when it tries to call a veneer.

However, according to https://github.com/vitasdk/buildscripts/pull/123, it's possible to stop the veneers from breaking things by passing `-Wl,--pic-veneer` when linking.

This seems like a better solution than `-fno-optimize-sibling-calls` in my opinion because there may be other things that generate veneers than just sibling calls. In fact, I'm working on a new libretro core, and the compiler still generates veneers even when `-fno-optimize-sibling-calls` is enabled in both RetroArch and every single file in my core's code, so using `-Wl,--pic-veneer` is the only solution for me.