### PR TITLE
Enable non-png thumbnails also for Qt interface.

### DIFF
--- a/ui/drivers/qt/qt_playlist.cpp
+++ b/ui/drivers/qt/qt_playlist.cpp
@@ -168,9 +168,23 @@ bool PlaylistModel::isSupportedImage(const QString path) const
    return false;
 }
 
-QString PlaylistModel::getSanitizedThumbnailName(QString label) const
+QString PlaylistModel::getSanitizedThumbnailName(QString dir, QString label) const
 {
-   return label.replace(m_fileSanitizerRegex, "_") + ".png";
+   QDir tnDir(dir);
+
+   QString tnName = label.replace(m_fileSanitizerRegex, "_");
+   if (tnDir.exists(tnName + ".png"))
+      return dir + tnName + ".png";
+   if (tnDir.exists(tnName + ".jpg"))
+      return dir + tnName + ".jpg";
+   if (tnDir.exists(tnName + ".jpeg"))
+      return dir + tnName + ".jpeg";
+   if (tnDir.exists(tnName + ".bmp"))
+      return dir + tnName + ".bmp";
+   if (tnDir.exists(tnName + ".tga"))
+      return dir + tnName + ".tga";
+   return dir + tnName + ".png";
+
 }
 
 QString PlaylistModel::getThumbnailPath(const QHash<QString, QString> &hash, QString type) const
@@ -179,11 +193,12 @@ QString PlaylistModel::getThumbnailPath(const QHash<QString, QString> &hash, QSt
    if (isSupportedImage(hash["path"]))
       return hash["path"];
 
-   return getPlaylistThumbnailsDir(hash.value("db_name"))
+   return getSanitizedThumbnailName(
+      getPlaylistThumbnailsDir(hash.value("db_name"))
       + QStringLiteral("/")
       + type
-      + QStringLiteral("/")
-      + getSanitizedThumbnailName(hash["label_noext"]);
+      + QStringLiteral("/"),
+      hash["label_noext"]);
 }
 
 QString PlaylistModel::getCurrentTypeThumbnailPath(const QModelIndex &index) const

--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -2250,8 +2250,8 @@ QString MainWindow::changeThumbnail(const QImage &image, QString type)
    QString dirString            = m_playlistModel->getPlaylistThumbnailsDir(
                                       hash["db_name"])
                                 + QStringLiteral("/") + type;
-   QString thumbPath            = dirString + QStringLiteral("/")
-                                + m_playlistModel->getSanitizedThumbnailName(
+   QString thumbPath            = m_playlistModel->getSanitizedThumbnailName(
+                                      dirString + QStringLiteral("/"),
                                       hash["label_noext"]);
    QByteArray   dirArray        = QDir::toNativeSeparators(dirString).toUtf8();
    const char   *dirData        = dirArray.constData();
@@ -3618,13 +3618,23 @@ void MainWindow::onCurrentItemChanged(const QHash<QString, QString> &hash)
    {
       QString thumbnailsDir = m_playlistModel->getPlaylistThumbnailsDir(
             hash["db_name"]);
-      QString thumbnailName = m_playlistModel->getSanitizedThumbnailName(
+      QString thumbnailName1 = m_playlistModel->getSanitizedThumbnailName(
+            thumbnailsDir + QStringLiteral("/") + THUMBNAIL_BOXART     + QStringLiteral("/"),
+            hash["label_noext"]);
+      QString thumbnailName2 = m_playlistModel->getSanitizedThumbnailName(
+            thumbnailsDir + QStringLiteral("/") + THUMBNAIL_TITLE      + QStringLiteral("/"),
+            hash["label_noext"]);
+      QString thumbnailName3 = m_playlistModel->getSanitizedThumbnailName(
+            thumbnailsDir + QStringLiteral("/") + THUMBNAIL_SCREENSHOT + QStringLiteral("/"),
+            hash["label_noext"]);
+      QString thumbnailName4 = m_playlistModel->getSanitizedThumbnailName(
+            thumbnailsDir + QStringLiteral("/") + THUMBNAIL_LOGO       + QStringLiteral("/"),
             hash["label_noext"]);
 
-      m_thumbnailPixmap     = new QPixmap(thumbnailsDir + QStringLiteral("/") + THUMBNAIL_BOXART + QStringLiteral("/") + thumbnailName);
-      m_thumbnailPixmap2    = new QPixmap(thumbnailsDir + QStringLiteral("/") + THUMBNAIL_TITLE  + QStringLiteral("/") + thumbnailName);
-      m_thumbnailPixmap3    = new QPixmap(thumbnailsDir + QStringLiteral("/") + THUMBNAIL_SCREENSHOT + QStringLiteral("/") + thumbnailName);
-      m_thumbnailPixmap4    = new QPixmap(thumbnailsDir + QStringLiteral("/") + THUMBNAIL_LOGO + QStringLiteral("/") + thumbnailName);
+      m_thumbnailPixmap     = new QPixmap(thumbnailName1);
+      m_thumbnailPixmap2    = new QPixmap(thumbnailName2);
+      m_thumbnailPixmap3    = new QPixmap(thumbnailName3);
+      m_thumbnailPixmap4    = new QPixmap(thumbnailName4);
 
       if (      m_currentBrowser == BROWSER_TYPE_PLAYLISTS
             && !currentPlaylistIsSpecial())

--- a/ui/drivers/ui_qt.h
+++ b/ui/drivers/ui_qt.h
@@ -155,7 +155,7 @@ public:
    void setThumbnailCacheLimit(int limit);
    bool isSupportedImage(const QString path) const;
    QString getPlaylistThumbnailsDir(const QString playlistName) const;
-   QString getSanitizedThumbnailName(QString label) const;
+   QString getSanitizedThumbnailName(QString dir, QString label) const;
 
 signals:
    void imageLoaded(const QImage image, const QModelIndex &index, const QString &path);


### PR DESCRIPTION
## Description

Enable fallback to non-png file names on desktop interface as well. Note: flexible names will still not be supported on the Qt interface.

## Related Issues

Fixes #17676 

## Related Pull Requests

#16806 
