### PR TITLE
Moved declarations to fix MSVC2010 builds (C89 compliance)

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -283,7 +283,6 @@ static size_t frontend_win32_get_os(char *s, size_t len, int *major, int *minor)
    /* Windows 2000 and later */
    SYSTEM_INFO si         = {{0}};
    OSVERSIONINFOEX vi     = {0};
-   vi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 #if _WIN32_WINNT >= 0x0600
    /* Vista and later*/
    const char win_ver_reg_key[]    = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
@@ -300,7 +299,9 @@ static size_t frontend_win32_get_os(char *s, size_t len, int *major, int *minor)
    /* end Vista and later; still within Windows 2000 and later block */
 #endif
 
-GetSystemInfo(&si);
+   vi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+
+   GetSystemInfo(&si);
    switch (si.wProcessorArchitecture)
    {
       case PROCESSOR_ARCHITECTURE_AMD64:


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Relocate a variable assignment after all declarations to resolve a C89 violation (and resultant msvc2010 build failure) in https://github.com/libretro/RetroArch/pull/17749. 

## Related Issues

N/A

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/17749

## Reviewers

@sonninnos @pstef 
