### PR TITLE
Restore cheevos_badges_enable for HAVE_GFX_WIDGETS builds

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1382,12 +1382,10 @@ static void rcheevos_client_login_callback(int result,
 
 static void rcheevos_finalize_game_load(rc_client_t* client)
 {
-#if defined(HAVE_GFX_WIDGETS) /* We always want badges if widgets are enabled */
-   bool want_badges     = true;
-#else
    settings_t* settings = config_get_ptr();
    bool want_badges     = settings->bools.cheevos_badges_enable;
-   /* Badges are only needed for xmb and ozone menus */
+#if !defined(HAVE_GFX_WIDGETS)
+   /* Then badges are only needed for xmb and ozone menus */
    want_badges          = want_badges &&
       (        string_is_equal(settings->arrays.menu_driver, "xmb")
             || string_is_equal(settings->arrays.menu_driver, "ozone"));

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9306,9 +9306,7 @@ unsigned menu_displaylist_build_list(
                {MENU_ENUM_LABEL_CHEEVOS_HARDCORE_MODE_ENABLE,                          PARSE_ONLY_BOOL,   false  },
                {MENU_ENUM_LABEL_CHEEVOS_LEADERBOARDS_ENABLE,                           PARSE_ONLY_STRING_OPTIONS,   false  },
                {MENU_ENUM_LABEL_CHEEVOS_RICHPRESENCE_ENABLE,                           PARSE_ONLY_BOOL,   false  },
-#ifndef HAVE_GFX_WIDGETS
                {MENU_ENUM_LABEL_CHEEVOS_BADGES_ENABLE,                                 PARSE_ONLY_BOOL,   false  },
-#endif
                {MENU_ENUM_LABEL_CHEEVOS_TEST_UNOFFICIAL,                               PARSE_ONLY_BOOL,   false  },
 #ifdef HAVE_AUDIOMIXER
                {MENU_ENUM_LABEL_CHEEVOS_UNLOCK_SOUND_ENABLE,                           PARSE_ONLY_BOOL,   false  },

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -21982,25 +21982,21 @@ static bool setting_append_list(
                SD_FLAG_ADVANCED
                );
 
-#ifndef HAVE_GFX_WIDGETS
-         if (     string_is_equal(settings->arrays.menu_driver, "xmb")
-               || string_is_equal(settings->arrays.menu_driver, "ozone"))
-            CONFIG_BOOL(
-                  list, list_info,
-                  &settings->bools.cheevos_badges_enable,
-                  MENU_ENUM_LABEL_CHEEVOS_BADGES_ENABLE,
-                  MENU_ENUM_LABEL_VALUE_CHEEVOS_BADGES_ENABLE,
-                  false,
-                  MENU_ENUM_LABEL_VALUE_OFF,
-                  MENU_ENUM_LABEL_VALUE_ON,
-                  &group_info,
-                  &subgroup_info,
-                  parent_group,
-                  general_write_handler,
-                  general_read_handler,
-                  SD_FLAG_ADVANCED
-                  );
-#endif
+         CONFIG_BOOL(
+               list, list_info,
+               &settings->bools.cheevos_badges_enable,
+               MENU_ENUM_LABEL_CHEEVOS_BADGES_ENABLE,
+               MENU_ENUM_LABEL_VALUE_CHEEVOS_BADGES_ENABLE,
+               false,
+               MENU_ENUM_LABEL_VALUE_OFF,
+               MENU_ENUM_LABEL_VALUE_ON,
+               &group_info,
+               &subgroup_info,
+               parent_group,
+               general_write_handler,
+               general_read_handler,
+               SD_FLAG_ADVANCED
+               );
 
 #ifdef HAVE_AUDIOMIXER
          CONFIG_BOOL(


### PR DESCRIPTION
This change reduces stuttering when starting a game with retroachievements enabled. I assume the stuttering is just postponed until the badges are downloaded on demand, but it lets users pick their poison.

This change helps but doesn't fix
https://github.com/libretro/RetroArch/issues/16470 https://github.com/libretro/RetroArch/issues/17027 https://github.com/libretro/RetroArch/issues/17758

My ideas for improvement of the actual performance issue:
* prioritize the more important threads using sthread_create_with_priority in place of sthread_create
* move mbedtls_ctr_drbg_init() to once per thread
* bulk save file contents
* more ideas in the comment to 17027
