### PR TITLE
Various Gamecube fixes

### DIFF
--- a/Makefile.ngc
+++ b/Makefile.ngc
@@ -233,6 +233,10 @@ else
    CFLAGS += -O3
 endif
 
+ifneq ($(V),1)
+	Q := @
+endif
+
 OBJOUT   = -o
 LINKOUT  = -o
 LINK = $(CXX)
@@ -246,7 +250,8 @@ $(EXT_INTER_TARGET): $(OBJ)
 	$(LINK) $(LINKOUT)$@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(PLATEXTRA) $(LIBS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.cpp
 	$(CXX) $(CFLAGS) -c $(OBJOUT)$@ $<

--- a/audio/drivers/gx_audio.c
+++ b/audio/drivers/gx_audio.c
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 
 #ifdef GEKKO
 #include <gccore.h>

--- a/gfx/drivers/gx_gfx.c
+++ b/gfx/drivers/gx_gfx.c
@@ -742,8 +742,8 @@ static void init_vtx(gx_video_t *gx, const video_info_t *video,
       }
    }
 
-   DCFlushRange(g_tex.data, ((g_tex.width *
-         g_tex.height) * video->rgb32) ? 4 : 2);
+   DCFlushRange(g_tex.data, g_tex.width * g_tex.height *
+            (video->rgb32 ? 4 : 2));
 
    gx->rgb32 = video->rgb32;
    gx->scale = video->input_scale;

--- a/input/drivers_joypad/gx_joypad.c
+++ b/input/drivers_joypad/gx_joypad.c
@@ -142,8 +142,10 @@ static void power_callback(void)
 }
 #endif
 
-static void reset_cb(void)
+static void reset_cb(unsigned int a, void *b)
 {
+   (void)a;
+   (void)b;
    g_menu = true;
 }
 

--- a/libretro-common/include/defines/gx_defines.h
+++ b/libretro-common/include/defines/gx_defines.h
@@ -27,8 +27,10 @@
 
 #define SYSMEM1_SIZE 0x01800000
 
+#ifndef _SHIFTL
 #define _SHIFTL(v, s, w)	((uint32_t) (((uint32_t)(v) & ((0x01 << (w)) - 1)) << (s)))
 #define _SHIFTR(v, s, w)	((uint32_t)(((uint32_t)(v) >> (s)) & ((0x01 << (w)) - 1)))
+#endif
 
 #define OSThread lwp_t
 #define OSCond lwpq_t

--- a/wii/libogc/include/ogcsys.h
+++ b/wii/libogc/include/ogcsys.h
@@ -32,7 +32,9 @@
 	extern "C" {
 #endif
 
+#ifndef _POSIX_TIMERS
 int nanosleep(struct timespec *tb);
+#endif
 
 #ifdef __cplusplus
 	}


### PR DESCRIPTION
Fix DCFlushRange size calculation
Don't redefine _SHIFTL and _SHIFTR macros
Guard nanosleep prototype behind _POSIX_TIMERS
Fix a callback function's type to enable compilation with GCC14
Add a missing malloc.h include for memalign()
Copy quiet compilation mode from other Makefiles