### PR TITLE
Enable core options reset without starting a core.

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -9464,11 +9464,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_RESET,
-   "Reset Options"
+   "Reset Core Options"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CORE_OPTIONS_RESET,
-   "Set all core options to default values."
+   "Set all options of the current core to default values."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_FLUSH,

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -5655,7 +5655,7 @@ static int action_ok_folder_specific_core_options_remove(const char *path,
 static int action_ok_core_options_reset(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
-   core_options_reset();
+   core_options_reset(label);
    return 0;
 }
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -1021,6 +1021,14 @@ end:
                      MENU_SETTING_ACTION_CORE_DELETE, 0, 0, NULL))
                count++;
 #endif
+
+         /* Reset core options */
+         if (menu_entries_append(list,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_RESET),
+               core_info->core_name,
+               MENU_ENUM_LABEL_CORE_OPTIONS_RESET,
+               MENU_SETTING_ACTION_CORE_OPTIONS_RESET, 0, 0, NULL))
+            count++;
       }
 #endif
    }
@@ -1471,7 +1479,7 @@ end:
       /* Reset core options */
       if (menu_entries_append(list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_RESET),
-            msg_hash_to_str(MENU_ENUM_LABEL_CORE_OPTIONS_RESET),
+            "",
             MENU_ENUM_LABEL_CORE_OPTIONS_RESET,
             MENU_SETTING_ACTION_CORE_OPTIONS_RESET, 0, 0, NULL))
          count++;
@@ -11317,6 +11325,13 @@ unsigned menu_displaylist_build_list(
                         false) == 0)
                   count++;
             }
+            /* Reset core options */
+            if (!settings->bools.global_core_options && menu_entries_append(list,
+                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_RESET),
+                  "",
+                  MENU_ENUM_LABEL_CORE_OPTIONS_RESET,
+                  MENU_SETTING_ACTION_CORE_OPTIONS_RESET, 0, 0, NULL))
+               count++;
          }
          break;
       case DISPLAYLIST_DIRECTORY_SETTINGS_LIST:

--- a/retroarch.h
+++ b/retroarch.h
@@ -195,7 +195,7 @@ void retroarch_init_task_queue(void);
 /* Creates folder and core options stub file for subsequent runs */
 bool core_options_create_override(bool game_specific);
 bool core_options_remove_override(bool game_specific);
-void core_options_reset(void);
+void core_options_reset(const char *label);
 void core_options_flush(void);
 
 /**


### PR DESCRIPTION
## Description

This PR adds "Reset Core Options" to two places:
- Manage Cores, to delete the options for the core being managed
- Configuration, to delete the options for the loaded core

Current reset function is extended to delete the core options file if reset is wanted for a specific core, or core is loaded but not yet started. Menu text updated as it is not any more obvious from context that it refers to core options.

The aim is to make it possible to recover from core option changes potentially causing core crash on startup. This was one of the UI improvement suggestions from Nic Watt, my own notes here: https://gist.github.com/zoltanvb/e10a28a959b725f5869b89fe05c275e3

(edit: menu options moved as suggested by @sonninnos )
(edit2: covering more corner cases with the 3 possible menu entries)