### PR TITLE
Make the condition for using `camera_ffmpeg` consistent with the `Makefile`

### DIFF
--- a/camera/camera_driver.c
+++ b/camera/camera_driver.c
@@ -27,6 +27,12 @@
 
 #include "camera_driver.h"
 
+#if defined(HAVE_FFMPEG) && defined(HAVE_AVFORMAT) && defined(HAVE_AVCODEC) && \
+   defined(HAVE_AVDEVICE) && defined(HAVE_AVUTIL) && defined(HAVE_SWSCALE)
+/* FFMPEG consists of several libraries, and the camera driver needs most of them */
+#define HAVE_FFMPEG_CAMERA
+#endif
+
 static void *nullcamera_init(const char *device, uint64_t caps,
       unsigned width, unsigned height) { return (void*)-1; }
 static void nullcamera_free(void *data) { }
@@ -61,7 +67,7 @@ const camera_driver_t *camera_drivers[] = {
 #ifdef HAVE_AVF
    &camera_avfoundation,
 #endif
-#ifdef HAVE_FFMPEG
+#ifdef HAVE_FFMPEG_CAMERA
    &camera_ffmpeg,
 #endif
    &camera_null,


### PR DESCRIPTION
Should fix a link error.