### PR TITLE
Fix minor build warning

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -319,7 +319,7 @@ static size_t frontend_win32_get_os(char *s, size_t len, int *major, int *minor)
 
 #ifndef _MSC_VER
    /* Vista and later, MSYS2/MINGW64 build
-   /* Check for Win11 by looking for a specific Registry value.
+    * Check for Win11 by looking for a specific Registry value.
     * The behavior of GetVersionEx is changed under Win11 and no longer provides
     * relevant data. If the specific Registry value is present, read version data
     * directly from registry and skip remainder of function.


### PR DESCRIPTION
Quick edit to fix a minor warning when compiling RA through MSYS2/Mingw64. `/*` was being repeated within an existing comment in `frontend/drivers/platform_win32.c`.