### PR TITLE
Relocate Switch CPU profile definitions

### DIFF
--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -76,6 +76,37 @@ static enum frontend_fork switch_fork_mode = FRONTEND_FORK_NONE;
 bool platform_switch_has_focus = true;
 
 #ifdef HAVE_LIBNX
+char *SWITCH_CPU_PROFILES[] = {
+    "Maximum Performance",
+    "High Performance",
+    "Boost Performance",
+    "Stock Performance",
+    "Powersaving Mode 1",
+    "Powersaving Mode 2",
+    "Powersaving Mode 3",
+    NULL
+};
+char *SWITCH_CPU_SPEEDS[] = {
+    "1785 MHz",
+    "1581 MHz",
+    "1224 MHz",
+    "1020 MHz",
+    "918 MHz",
+    "816 MHz",
+    "714 MHz",
+    NULL
+};
+unsigned SWITCH_CPU_SPEEDS_VALUES[] = {
+    1785000000,
+    1581000000,
+    1224000000,
+    1020000000,
+    918000000,
+    816000000,
+    714000000,
+    0
+};
+
 static bool psmInitialized  = false;
 
 static AppletHookCookie applet_hook_cookie;
@@ -87,7 +118,7 @@ extern bool nxlink_connected;
 void libnx_apply_overclock(void)
 {
    const size_t profiles_count = sizeof(SWITCH_CPU_PROFILES)
-      / sizeof(SWITCH_CPU_PROFILES[1]);
+      / sizeof(SWITCH_CPU_PROFILES[1]) - 1;
    settings_t *settings        = config_get_ptr();
    unsigned libnx_overclock    = settings->uints.libnx_overclock;
 

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -12840,7 +12840,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                size_t _len;
                unsigned i;
                char text[128];
-               const size_t profiles_count = sizeof(SWITCH_CPU_PROFILES)/sizeof(SWITCH_CPU_PROFILES[1]);
                /* TODO/FIXME - localize */
                runloop_msg_queue_push(
                      "Warning : extended overclocking can damage the Switch",
@@ -12867,7 +12866,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         0, 0, NULL))
                   count++;
 
-               for (i = 0; i < profiles_count; i++)
+               for (i = 0; SWITCH_CPU_PROFILES[i]; i++)
                {
                   char title[NAME_MAX_LENGTH];
                   size_t _len = strlcpy(title, SWITCH_CPU_PROFILES[i],

--- a/switch_performance_profiles.h
+++ b/switch_performance_profiles.h
@@ -19,38 +19,10 @@
 
 #if defined(HAVE_LIBNX)
 
-static char *SWITCH_CPU_PROFILES[] = {
-    "Maximum Performance",
-    "High Performance",
-    "Boost Performance",
-    "Stock Performance",
-    "Powersaving Mode 1",
-    "Powersaving Mode 2",
-    "Powersaving Mode 3",
-};
-
+extern char *SWITCH_CPU_PROFILES[];
+extern char *SWITCH_CPU_SPEEDS[];
+extern unsigned SWITCH_CPU_SPEEDS_VALUES[];
 #define SWITCH_DEFAULT_CPU_PROFILE 3 /* Stock Performance */
-#define LIBNX_MAX_CPU_PROFILE 0 /* Max Performance */
-
-static char *SWITCH_CPU_SPEEDS[] = {
-    "1785 MHz",
-    "1581 MHz",
-    "1224 MHz",
-    "1020 MHz",
-    "918 MHz",
-    "816 MHz",
-    "714 MHz"
-};
-
-static unsigned SWITCH_CPU_SPEEDS_VALUES[] = {
-    1785000000,
-    1581000000,
-    1224000000,
-    1020000000,
-    918000000,
-    816000000,
-    714000000
-};
 
 #endif
 


### PR DESCRIPTION
Move SWITCH_CPU_* array definitions from header to platform_switch.c. Use extern declarations in the header. Add NULL/0 terminators to the arrays and update size calculation and loops to use the terminators where the number of elements can't be calculated.

The motivation for this change is to remove code duplication and silence warnings about unused arrays in translation units that only used a subset of them.

## Reviewers

@m4xw