### PR TITLE
Silence warnings

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -6178,7 +6178,11 @@ bool input_remapping_save_file(const char *path)
       if (skip_port)
          continue;
 
-      snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
+      _len = snprintf(formatted_number, sizeof(formatted_number), "%u", i + 1);
+      if (_len >= sizeof(formatted_number)) {
+         RARCH_ERR("[Config]: unexpectedly high number of users");
+         break;
+      }
       _len       = strlcpy(prefix, "input_player",   sizeof(prefix));
       strlcpy(prefix + _len, formatted_number, sizeof(prefix) - _len);
       _len       = strlcpy(s1, prefix, sizeof(s1));

--- a/deps/dr/dr_flac.h
+++ b/deps/dr/dr_flac.h
@@ -682,10 +682,17 @@ const char* drflac_next_vorbis_comment(drflac_vorbis_comment_iterator* pIter, dr
 #define DRFLAC_NO_CPUID
 #endif
 
-
 #ifdef __linux__
-#define _BSD_SOURCE
-#include <endian.h>
+    #ifndef _BSD_SOURCE
+        #define _BSD_SOURCE
+    #endif
+    #ifndef _DEFAULT_SOURCE
+        #define _DEFAULT_SOURCE
+    #endif
+    #ifndef __USE_BSD
+        #define __USE_BSD
+    #endif
+    #include <endian.h>
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1500 && (defined(DRFLAC_X86) || defined(DRFLAC_X64))

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -343,7 +343,7 @@ static void frontend_ps2_exec(const char *path, bool should_load_game)
    deinit_drivers(true, true);
    reset_IOP();
    common_init_drivers(false);
-   waitUntilDeviceIsReady(path);
+   waitUntilDeviceIsReady((char *)path);
 
 #ifndef IS_SALAMANDER
    char game_path[FILENAME_MAX];

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -436,16 +436,16 @@ static void frontend_ps3_exec(const char *path, bool should_load_game)
 {
 #ifndef IS_SALAMANDER
 #ifdef HAVE_NETWORKING
-   char *arg_data[NETPLAY_FORK_MAX_ARGS];
+   const char *arg_data[NETPLAY_FORK_MAX_ARGS];
 #else
-   char *arg_data[2];
+   const char *arg_data[2];
 #endif
    char game_path[PATH_MAX_LENGTH];
    bool verbosity = verbosity_is_enabled();
 
    verbosity_enable();
 #else
-   char *arg_data[1];
+   const char *arg_data[1];
 #endif
 
    arg_data[0] = NULL;

--- a/gfx/drivers/gl_shaders/pipeline_snow.glsl.vert.h
+++ b/gfx/drivers/gl_shaders/pipeline_snow.glsl.vert.h
@@ -1,5 +1,6 @@
 #include "shaders_common.h"
 
+#if defined(HAVE_OPENGLES)
 /* Need to duplicate these to work around broken stuff on Android.
  * Must enforce alpha = 1.0 or 32-bit games can potentially go black. */
 static const char *stock_vertex_xmb_snow = GLSL(
@@ -14,3 +15,4 @@ static const char *stock_vertex_xmb_snow = GLSL(
       tex_coord = TexCoord;
    }
 );
+#endif

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -44,6 +44,11 @@
 #include "../../deps/xxHash/xxhash.h"
 #endif
 
+#if defined(VITA)
+#include <psp2/kernel/threadmgr/thread.h>
+#include <psp2/power.h>
+#endif
+
 #define PREV_TEXTURES (GFX_MAX_TEXTURES - 1)
 
 /* Cache the VBO. */

--- a/input/drivers_joypad/switch_joypad.c
+++ b/input/drivers_joypad/switch_joypad.c
@@ -430,7 +430,7 @@ bool switch_joypad_set_rumble(unsigned pad,
    HidVibrationDeviceHandle* handle;
    float amp;
 
-   if (pad >= DEFAULT_MAX_PADS || !vibration_handles[pad])
+   if (pad >= DEFAULT_MAX_PADS)
       return false;
 
    amp  = (float)strength / 65535.0f;

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -62,6 +62,9 @@
 #include "../verbosity.h"
 
 #include "../ai/game_ai.h"
+#if defined(_WIN32)
+#include <winsock2.h>
+#endif
 
 #define HOLD_BTN_DELAY_SEC 2
 
@@ -6776,7 +6779,12 @@ void input_driver_poll(void)
             ssize_t ret;
             struct remote_message msg;
 
+
+#if defined(_WIN32)
+            if (input_st->remote->net_fd[user] == INVALID_SOCKET)
+#else
             if (input_st->remote->net_fd[user] < 0)
+#endif
                return;
 
             FD_ZERO(&fds);

--- a/libretro-common/features/features_cpu.c
+++ b/libretro-common/features/features_cpu.c
@@ -269,7 +269,8 @@ retro_time_t cpu_features_get_time_usec(void)
 #endif
 
 #if defined(CPU_X86) && !defined(__MACH__)
-void x86_cpuid(int func, int flags[4])
+#include <limits.h>
+void x86_cpuid(int func, int32_t flags[4])
 {
    /* On Android, we compile RetroArch with PIC, and we
     * are not allowed to clobber the ebx register. */
@@ -288,8 +289,8 @@ void x86_cpuid(int func, int flags[4])
          "xchg %%" REG_b ", %%" REG_S "\n"
          : "=a"(flags[0]), "=S"(flags[1]), "=c"(flags[2]), "=d"(flags[3])
          : "a"(func));
-#elif defined(_MSC_VER)
-   __cpuid(flags, func);
+#elif defined(_MSC_VER) && INT_MAX == 2147483647
+   __cpuid((int*)flags, func);
 #else
 #ifndef NDEBUG
    printf("Unknown compiler. Cannot check CPUID with inline assembly.\n");

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1826,7 +1826,7 @@ static int action_bind_sublabel_netplay_kick_client(file_list_t *list,
    if (status)
    {
       size_t _len = strlcpy(buf, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_STATUS),
-            sizeof(buf));
+            sizeof(buf) - 3);
       buf[  _len] = ':';
       buf[++_len] = ' ';
       buf[++_len] = '\0';

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -9167,7 +9167,7 @@ static void ozone_cache_footer_label(
    /* If font_driver_get_message_width() fails,
     * use predetermined glyph_width as a fallback */
    if (label->width < 0)
-      label->width = _len * ozone->fonts.footer.glyph_width;
+      label->width = (int)(_len * ozone->fonts.footer.glyph_width);
 }
 
 /* Assigns footer label strings (based on current

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8004,8 +8004,7 @@ static enum menu_action ozone_parse_menu_entry_action(
       enum menu_action action)
 {
    uintptr_t tag;
-   int new_selection;
-   size_t selection;
+   size_t new_selection, selection;
    size_t selection_total;
    bool is_current_entry_settings = false;
    struct menu_state *menu_st     = menu_state_get_ptr();

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -817,8 +817,8 @@ static size_t setting_get_string_representation_size_in_mb(
       rarch_setting_t *setting, char *s, size_t len)
 {
    if (setting)
-      return snprintf(s, len, "%" PRI_SIZET,
-            (*setting->value.target.sizet) / (1024 * 1024));
+      return snprintf(s, len, "%ju", (uintmax_t)
+            ((*setting->value.target.sizet) / (1024 * 1024)));
    return 0;
 }
 


### PR DESCRIPTION
Use platform-specific checks for invalid descriptors
PSVita: add missing include
Use int32_t for x86_cpuid flags and handle MSVC types
Silence a shorten-64-to-32 warning
Use size_t for new_selection as done everywhere else
Don't redefine _BSD_SOURCE
Silence an incompatible-pointer-types warning
Silence a discarded-qualifiers warning
Silence a -Wformat warning
Make space for three characters after a strlcpy call
Guard definition of an array just like its use is guarded
Silence a -Waddress warning
Check for string truncation to silence a warning