### PR TITLE
Standardize silent mode across Makefiles used in CI

### DIFF
--- a/.github/workflows/WiiU.yml
+++ b/.github/workflows/WiiU.yml
@@ -25,12 +25,12 @@ jobs:
     - name: Compile Salamander
       run: |
         make -f Makefile.wiiu -j$(getconf _NPROCESSORS_ONLN) SALAMANDER_BUILD=1 clean
-        make -f Makefile.wiiu -j$(getconf _NPROCESSORS_ONLN) SALAMANDER_BUILD=1 V=1
+        make -f Makefile.wiiu -j$(getconf _NPROCESSORS_ONLN) SALAMANDER_BUILD=1
 
     - name: Compile RA
       run: |
         make -f Makefile.wiiu -j$(getconf _NPROCESSORS_ONLN) clean
-        make -f Makefile.wiiu -j$(getconf _NPROCESSORS_ONLN) HAVE_STATIC_DUMMY=1 V=1
+        make -f Makefile.wiiu -j$(getconf _NPROCESSORS_ONLN) HAVE_STATIC_DUMMY=1
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"

--- a/Makefile
+++ b/Makefile
@@ -312,9 +312,13 @@ uninstall:
 	rm -rf $(DESTDIR)$(ASSETS_DIR)
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -rf $(OBJDIR_BASE)
 	rm -f $(TARGET)
 	rm -f *.d
+endif
 
 .PHONY: all install uninstall clean
 

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,34 @@ ifneq ($(MOC_HEADERS),)
     RARCH_OBJ += $(MOC_OBJ)
 endif
 
-all: $(TARGET) config.mk
+all: info $(TARGET) config.mk
+
+define INFO
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CPPFLAGS: $(CPPFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEFINES: $(DEFINES)
+LDFLAGS: $(LDFLAGS)
+LIBRARY_DIRS: $(LIBRARY_DIRS)
+LIBS: $(LIBS)
+LINK: $(LINK)
+MD: $(MD)
+MOC: $(MOC)
+MOC_TMP: $(MOC_TMP)
+OBJCFLAGS: $(OBJCFLAGS)
+QT_VERSION: $(QT_VERSION)
+RARCH_OBJ: $(RARCH_OBJ)
+WINDRES: $(WINDRES)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 $(MOC_SRC):
 	@$(if $(Q), $(shell echo echo MOC $<),)

--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -238,16 +238,7 @@ ifeq ($(BUILD_CIA), 1)
 	TARGET_CIA := $(TARGET).cia
 endif
 
-.PHONY: $(BUILD) clean all
-
-all: $(TARGET)
-
-$(TARGET): $(TARGET_3DSX) $(TARGET_3DS) $(TARGET_CIA)
-$(TARGET).3dsx: $(TARGET).elf
-$(TARGET).elf: $(OBJ) $(LIB_CORE_FULL)
-
 PREFIX		:=	$(DEVKITARM)/bin/arm-none-eabi-
-
 CC      := $(PREFIX)gcc
 CXX     := $(PREFIX)g++
 AS      := $(PREFIX)as
@@ -280,6 +271,36 @@ ifeq ($(strip $(CTRMAKEROM)),)
 else
 	MAKEROM = $(CTRMAKEROM)
 endif
+
+.PHONY: $(BUILD) clean all
+
+all: info $(TARGET)
+
+define INFO
+AR: $(AR)
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+INCDIRS: $(INCDIRS)
+LD: $(LD)
+LDFLAGS: $(LDFLAGS)
+LIBDIRS: $(LIBDIRS)
+LIBS: $(LIBS)
+OBJ: $(OBJ)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
+
+
+$(TARGET): $(TARGET_3DSX) $(TARGET_3DS) $(TARGET_CIA)
+$(TARGET).3dsx: $(TARGET).elf
+$(TARGET).elf: $(OBJ) $(LIB_CORE_FULL)
 
 %.o: %.vsh %.gsh
 	$(DEVKITTOOLS)/bin/picasso $^ -o $*.shbin

--- a/Makefile.ctr
+++ b/Makefile.ctr
@@ -313,20 +313,24 @@ $(TARGET).elf: $(OBJ) $(LIB_CORE_FULL)
 	rm $*.shbin
 
 %.o: %.cpp
-	$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS)
 
 %.o: %.c
 	@$(if $(Q), $(shell echo echo CC $<),)
 	$(Q)$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS)
 
 %.o: %.s
-	$(CC) -c -o $@ $< $(ASFLAGS)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $< $(ASFLAGS)
 
 %.o: %.S
-	$(CC) -c -o $@ $< $(ASFLAGS)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $< $(ASFLAGS)
 
 %.a:
-	$(AR) -rc $@ $^
+	@$(if $(Q), $(shell echo echo AR $<),)
+	$(Q)$(AR) -rc $@ $^
 
 %.vsh:
 
@@ -342,7 +346,8 @@ endif
 	$(DEVKITTOOLS)/bin/3dsxtool $< $@ $(_3DSXFLAGS)
 
 $(TARGET).elf: ctr/3dsx_custom_crt0.o
-	$(LD) $(LDFLAGS) $(OBJ) $(LIBDIRS) $(LIBS) -o $@
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LD) $(LDFLAGS) $(OBJ) $(LIBDIRS) $(LIBS) -o $@
 	$(NM) -CSn $@ > $(notdir $*.lst)
 
 $(TARGET).bnr: $(TARGET).elf $(APP_BANNER) $(APP_AUDIO)
@@ -358,6 +363,9 @@ $(TARGET).cia: $(TARGET).elf $(TARGET).bnr $(TARGET).icn $(APP_RSF)
 	$(MAKEROM) -f cia -o $@ $(MAKEROM_ARGS_COMMON) -DAPP_ENCRYPTED=false
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -f $(OBJ)
 	rm -f $(TARGET).3dsx
 	rm -f $(TARGET).elf
@@ -368,5 +376,6 @@ clean:
 	rm -f $(TARGET).icn
 	rm -f ctr/ctr_config_*.o
 	rm -f ctr/3dsx_custom_crt0.o
+endif
 
 .PHONY: clean

--- a/Makefile.dos
+++ b/Makefile.dos
@@ -195,6 +195,10 @@ else
   LIB_CORE += -lretro_dos
 endif
 
+ifneq ($(V),1)
+        Q := @
+endif
+
 DEPENDS_TMP  := $(OFILES:.o=.d)
 DEPENDS      := $(filter-out libretro_libnx.a,$(DEPENDS_TMP))
 
@@ -203,19 +207,43 @@ DEPENDS      := $(filter-out libretro_libnx.a,$(DEPENDS_TMP))
 #---------------------------------------------------------------------------------
 # main targets
 #---------------------------------------------------------------------------------
-all	:	$(OUTPUT)
+all: info $(OUTPUT)
+
+define INFO
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CXX: $(CXX)
+DEPENDS: $(DEPENDS)
+LDFLAGS: $(LDFLAGS)
+LIBDIRS: $(LIBDIRS)
+LIBS: $(LIBS)
+LIB_CORE: $(LIB_CORE)
+OBJ: $(OBJ)
+OUTPUT: $(OUTPUT)
+PLATEXTRA: $(PLATEXTRA)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 $(OUTPUT): $(OBJ)
-	$(CXX) -o $@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(PLATEXTRA) -L. $(LIB_CORE) $(LIBS)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) -o $@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(PLATEXTRA) -L. $(LIB_CORE) $(LIBS)
 
 %.o: %.c
-	$(CC) -c -o $@ $(CFLAGS) $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 
 %.o: %.cpp
-	$(CXX) -c -o $@ $(CFLAGS) $<
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) -c -o $@ $(CFLAGS) $<
 
 clean:
-	rm -f $(DEPENDS) $(OBJ) $(OUTPUT)
+	@$(if $(Q), $(shell echo echo RM),)
+	$(Q)rm -f $(DEPENDS) $(OBJ) $(OUTPUT)
 
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data

--- a/Makefile.miyoo
+++ b/Makefile.miyoo
@@ -160,7 +160,9 @@ CXXFLAGS += $(DEF_FLAGS)
 
 HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
 
-Q := @
+ifneq ($(V),1)
+        Q := @
+endif
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 

--- a/Makefile.miyoo
+++ b/Makefile.miyoo
@@ -166,7 +166,29 @@ endif
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
-all: $(TARGET)
+all: info $(TARGET)
+
+define INFO
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CPPFLAGS: $(CPPFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEFINES: $(DEFINES)
+LDFLAGS: $(LDFLAGS)
+LIBRARY_DIRS: $(LIBRARY_DIRS)
+LIBS: $(LIBS)
+LINK: $(LINK)
+OBJCFLAGS: $(OBJCFLAGS)
+RARCH_OBJ: $(RARCH_OBJ)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 -include $(RARCH_OBJ:.o=.d)
 

--- a/Makefile.miyoo
+++ b/Makefile.miyoo
@@ -201,9 +201,13 @@ $(OBJDIR)/%.o: %.S $(HEADERS)
 	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -rf $(OBJDIR_BASE)
 	rm -f $(TARGET)
 	rm -f *.d
+endif
 
 .PHONY: all clean
 

--- a/Makefile.ngc
+++ b/Makefile.ngc
@@ -241,7 +241,28 @@ OBJOUT   = -o
 LINKOUT  = -o
 LINK = $(CXX)
 
-all: $(EXT_TARGET)
+all: info $(EXT_TARGET)
+
+define INFO
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CXX: $(CXX)
+LD: $(LD)
+LDFLAGS: $(LDFLAGS)
+LIBDIRS: $(LIBDIRS)
+LIBS: $(LIBS)
+LINK: $(LINK)
+LINKOUT: $(LINKOUT)
+OBJ: $(OBJ)
+OBJOUT: $(OBJOUT)
+PLATEXTRA: $(PLATEXTRA)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 %.dol: %.elf
 	$(ELF2DOL) $< $@

--- a/Makefile.ngc
+++ b/Makefile.ngc
@@ -268,20 +268,24 @@ endif
 	$(ELF2DOL) $< $@
 
 $(EXT_INTER_TARGET): $(OBJ)
-	$(LINK) $(LINKOUT)$@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(PLATEXTRA) $(LIBS)
+	@$(if $(Q), $(shell echo echo LINK $@),)
+	$(Q)$(LINK) $(LINKOUT)$@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(PLATEXTRA) $(LIBS)
 
 %.o: %.c
 	@$(if $(Q), $(shell echo echo CC $<),)
 	$(Q)$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.cpp
-	$(CXX) $(CFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.binobj: %.bin
-	$(LD) -r -b binary $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LD) -r -b binary $(OBJOUT)$@ $<
 
 clean:
 ifneq ($(V),1)

--- a/Makefile.ngc
+++ b/Makefile.ngc
@@ -263,9 +263,13 @@ $(EXT_INTER_TARGET): $(OBJ)
 	$(LD) -r -b binary $(OBJOUT)$@ $<
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -f $(EXT_TARGET)
 	rm -f $(EXT_INTER_TARGET)
 	rm -f $(OBJ)
+endif
 
 .PHONY: clean
 

--- a/Makefile.orbis
+++ b/Makefile.orbis
@@ -176,38 +176,67 @@ else
    CXXFLAGS += -O3
 endif
 
+ifneq ($(V),1)
+        Q := @
+endif
+
 TARGETS := $(TARGET).self
 
-all: $(TARGETS)
+all: info $(TARGETS)
+
+define INFO
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+LD: $(LD)
+LDFLAGS: $(LDFLAGS)
+LIBS: $(LIBS)
+OBJ: $(OBJ)
+OBJOUT: $(OBJOUT)
+ORBISDEV: $(ORBISDEV)
+TARGET: $(TARGET)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 OBJOUT   = -o
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) $(CXXFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.s
-	$(CC) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c $(OBJOUT)$@ $<
 
 $(TARGET).elf: $(OBJ)
-	$(LD) $(ORBISDEV)/usr/lib/crt0.o $(OBJ) $(LDFLAGS) $(LIBS) -o $(TARGET).elf
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LD) $(ORBISDEV)/usr/lib/crt0.o $(OBJ) $(LDFLAGS) $(LIBS) -o $(TARGET).elf
 
 $(TARGET).oelf: $(TARGET).elf
-	@orbis-elf-create $(TARGET).elf $(TARGET).oelf
+	orbis-elf-create $(TARGET).elf $(TARGET).oelf
 
 $(TARGET).self: $(TARGET).oelf
 	python $(ORBISDEV)/bin/make_fself.py --auth-info $(AUTH_INFO) $(TARGET).oelf $(TARGET).self
 
 install:
-	@cp $(TARGET).self $(SELF_PATH_INSTALL)/homebrew.self
+	cp $(TARGET).self $(SELF_PATH_INSTALL)/homebrew.self
 	@echo "Installed!"
 
 clean:
-	rm -f $(OBJ) $(TARGET).elf $(TARGET).oelf $(TARGET).self
+	$(Q)rm -f $(OBJ) $(TARGET).elf $(TARGET).oelf $(TARGET).self
 
 .PHONY: clean all

--- a/Makefile.ps2
+++ b/Makefile.ps2
@@ -83,6 +83,10 @@ ifeq ($(strip $(PS2SDK)),)
 $(error "Please set PS2SDK in your environment. export PS2SDK=<path to>ps2sdk")
 endif
 
+ifneq ($(V),1)
+        Q := @
+endif
+
 INCDIR = -I$(PS2DEV)/gsKit/include -I$(PS2SDK)/ports/include
 INCDIR += -Ilibretro-common/include -Ideps -Ideps/stb -Ideps/7zip
 
@@ -104,10 +108,27 @@ EE_INCS = $(INCDIR)
 EE_BIN = $(TARGET).elf
 EE_GPVAL = $(GPVAL)
 
-all: $(EE_BIN)
+all: info $(EE_BIN)
+
+define INFO
+EE_BIN: $(EE_BIN)
+EE_CC: $(EE_CC)
+EE_CFLAGS: $(EE_CFLAGS)
+EE_CXX: $(EE_CXX)
+EE_CXXFLAGS: $(EE_CXXFLAGS)
+EE_INCS: $(EE_INCS)
+EE_OBJS: $(EE_OBJS)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 clean:
-	rm -f $(EE_BIN) $(EE_OBJS)
+	@$(if $(Q), $(shell echo echo RM $<),)
+	$(Q)rm -f $(EE_BIN) $(EE_OBJS)
 
 prepare:
 	ps2client -h $(PS2_IP) reset
@@ -131,3 +152,15 @@ release: all
 #Include preferences
 include $(PS2SDK)/samples/Makefile.pref
 include $(PS2SDK)/samples/Makefile.eeglobal_cpp
+
+%.o: %.c
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.cc
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
+
+%.o: %.cpp
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@

--- a/Makefile.psl1ght
+++ b/Makefile.psl1ght
@@ -126,10 +126,29 @@ else
    CXXFLAGS += -03 -g
 endif
 
-all: $(SELF_TARGET)
+ifneq ($(V),1)
+	Q := @
+endif
+
+all: info $(SELF_TARGET)
+
+define INFO
+CXX: $(CXX)
+LDFLAGS: $(LDFLAGS)
+LIBDIRS: $(LIBDIRS)
+LIBS: $(LIBS)
+OBJ: $(OBJ)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 $(ELF_TARGET): $(OBJ)
-	$(CXX) -o $@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(LIBS)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) -o $@ $(LDFLAGS) $(LIBDIRS) $(OBJ) $(LIBS)
 
 create-core: $(SELF_TARGET)
 	cp $(SELF_TARGET) $(CORE_PATH)
@@ -140,7 +159,11 @@ pkg: create-core
 #	$(PACKAGE_FINALIZE) $(PACKAGE_BASENAME).gnpdrm.pkg
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -f $(ELF_TARGET)
 	rm -f $(OBJ)
+endif
 
 .PHONY: clean

--- a/Makefile.retrofw
+++ b/Makefile.retrofw
@@ -216,10 +216,14 @@ $(OBJDIR)/%.o: %.S $(HEADERS)
 	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -rf $(OBJDIR_BASE)
 	rm -f $(TARGET)
 	rm -f *.d
 	rm -rf $(OPK_NAME)
+endif
 
 opk: $(TARGET)
 	echo "$$DESKTOP_ENTRY" > default.retrofw.desktop

--- a/Makefile.retrofw
+++ b/Makefile.retrofw
@@ -184,8 +184,29 @@ X-OD-NeedsDownscaling=true
 endef
 export DESKTOP_ENTRY
 
+all: info $(TARGET) opk
 
-all: $(TARGET) opk
+define INFO
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CPPFLAGS: $(CPPFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEFINES: $(DEFINES)
+LDFLAGS: $(LDFLAGS)
+LIBRARY_DIRS: $(LIBRARY_DIRS)
+LIBS: $(LIBS)
+LINK: $(LINK)
+OBJCFLAGS: $(OBJCFLAGS)
+RARCH_OBJ: $(RARCH_OBJ)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 -include $(RARCH_OBJ:.o=.d)
 

--- a/Makefile.retrofw
+++ b/Makefile.retrofw
@@ -164,7 +164,9 @@ CXXFLAGS += $(DEF_FLAGS)
 
 HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
 
-Q := @
+ifneq ($(V),1)
+        Q := @
+endif
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 

--- a/Makefile.rs90
+++ b/Makefile.rs90
@@ -186,7 +186,29 @@ X-OD-NeedsDownscaling=true
 endef
 export DESKTOP_ENTRY
 
-all: $(TARGET) opk
+all: info $(TARGET) opk
+
+define INFO
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CPPFLAGS: $(CPPFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEFINES: $(DEFINES)
+LDFLAGS: $(LDFLAGS)
+LIBRARY_DIRS: $(LIBRARY_DIRS)
+LIBS: $(LIBS)
+LINK: $(LINK)
+OBJCFLAGS: $(OBJCFLAGS)
+RARCH_OBJ: $(RARCH_OBJ)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 -include $(RARCH_OBJ:.o=.d)
 

--- a/Makefile.rs90
+++ b/Makefile.rs90
@@ -166,7 +166,9 @@ CXXFLAGS += $(DEF_FLAGS)
 
 HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
 
-Q := @
+ifneq ($(V),1)
+        Q := @
+endif
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 

--- a/Makefile.rs90
+++ b/Makefile.rs90
@@ -217,10 +217,12 @@ $(OBJDIR)/%.o: %.S $(HEADERS)
 	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
 
 clean:
+ifneq ($(V),1)
 	rm -rf $(OBJDIR_BASE)
 	rm -f $(TARGET)
 	rm -f *.d
 	rm -rf $(OPK_NAME)
+endif
 
 opk: $(TARGET)
 	echo "$$DESKTOP_ENTRY" > default.rs90.desktop

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -190,6 +190,10 @@ else
   LIBS += -lretro_vita
 endif
 
+ifneq ($(V),1)
+   Q := @
+endif
+
 LIBS    += $(WHOLE_END) $(VITA_LIBS) -lm -lc
 
 TARGETS := $(TARGET).vpk
@@ -197,27 +201,53 @@ TARGETS := $(TARGET).vpk
 DEPFLAGS    = -MT $@ -MMD -MP -MF $*.Tdepend
 POSTCOMPILE = mv -f $*.Tdepend $*.depend
 
-all: $(TARGETS)
+all: info $(TARGETS)
+
+define INFO
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEPFLAGS: $(DEPFLAGS)
+INCDIRS: $(INCDIRS)
+LD: $(LD)
+LDFLAGS: $(LDFLAGS)
+LIBDIRS: $(LIBDIRS)
+LIBS: $(LIBS)
+OBJ: $(OBJ)
+POSTCOMPILE: $(POSTCOMPILE)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 %.o: %.cpp
 %.o: %.cpp %.depend
-	$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), $(shell echo echo CXX $<),)
+	$(Q)$(CXX) -c -o $@ $< $(CXXFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 %.o: %.c
 %.o: %.c %.depend
-	$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $< $(CFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 %.o: %.S
 %.o: %.S %.depend
-	$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 %.o: %.s
 %.o: %.s %.depend
-	$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
-	$(POSTCOMPILE)
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) -c -o $@ $< $(ASFLAGS) $(INCDIRS) $(DEPFLAGS)
+	$(Q)$(POSTCOMPILE)
 
 %.depend: ;
 
@@ -228,7 +258,8 @@ liblibScePiglet_stub.a:
 	cp deps/Pigs-In-A-Blanket/piglet_stub/libScePiglet/liblibScePiglet_stub.a .
 
 $(TARGET).elf: $(OBJ) liblibScePiglet_stub.a
-	$(LD) $(OBJ) $(LDFLAGS) $(LIBDIRS) $(LIBS) -o $@
+	@$(if $(Q), $(shell echo echo LD $@),)
+	$(Q)$(LD) $(OBJ) $(LDFLAGS) $(LIBDIRS) $(LIBS) -o $@
 
 %.velf: %.elf
 	cp $< $<.unstripped.elf
@@ -243,9 +274,11 @@ $(TARGET).elf: $(OBJ) liblibScePiglet_stub.a
 	vita-pack-vpk -s param.sfo -b $< $@
 
 clean:
+ifneq ($(V),1)
 	rm -f $(OBJ) $(TARGET).elf $(TARGET).elf.unstripped.elf $(TARGET).velf $(TARGET).self param.sfo $(TARGET).vpk 
 	rm -rf  deps/Pigs-In-A-Blanket/piglet_stub/libScePiglet
 	rm -f $(OBJ:.o=.depend)
+endif
 
 # Useful for developers
 vpksend: $(TARGET).vpk

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -183,7 +183,9 @@ CXXFLAGS += $(DEF_FLAGS)
 
 HEADERS = $(wildcard */*/*.h) $(wildcard */*.h) $(wildcard *.h)
 
-Q := @
+ifneq ($(V),1)
+        Q := @
+endif
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -235,12 +235,16 @@ $(OBJDIR)/%.o: %.S $(HEADERS)
 	$(Q)$(CC) $(CFLAGS) $(ASFLAGS) $(DEFINES) -c -o $@ $<
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -rf $(OBJDIR_BASE)
 	rm -f $(TARGET)
 	rm -f *.d
 	rm -rf SDL
 	rm -rf webos/*.ipk
 	rm -rf webos/dist
+endif
 
 sdl2: $(TARGET)
 ifeq ($(ADD_SDL2_LIB), 1)

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -204,7 +204,29 @@ define APPINFO
 endef
 export APPINFO
 
-all: $(TARGET) ipk
+all: info $(TARGET) ipk
+
+define INFO
+ASFLAGS: $(ASFLAGS)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CPPFLAGS: $(CPPFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEFINES: $(DEFINES)
+LDFLAGS: $(LDFLAGS)
+LIBRARY_DIRS: $(LIBRARY_DIRS)
+LIBS: $(LIBS)
+LINK: $(LINK)
+OBJCFLAGS: $(OBJCFLAGS)
+RARCH_OBJ: $(RARCH_OBJ)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 -include $(RARCH_OBJ:.o=.d)
 

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -273,7 +273,19 @@ OBJOUT   = -o
 LINKOUT  = -o
 LINK = $(CXX)
 
-all: $(EXT_TARGET)
+all: info $(EXT_TARGET)
+
+define INFO
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+OBJOUT: $(OBJOUT)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 %.dol: %.elf
 	$(ELF2DOL) $< $@

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -301,7 +301,8 @@ $(EXT_INTER_TARGET): $(OBJ)
 	$(CXX) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
+	@$(if $(Q), $(shell echo echo CC $<),)
+	$(Q)$(CC) $(CFLAGS) -c $(OBJOUT)$@ $<
 
 %.binobj: %.bin
 	$(LD) -r -b binary $(OBJOUT)$@ $<

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -299,10 +299,14 @@ $(APP_BOOTER_DIR)/app_booter.bin:
 	$(MAKE) -C $(APP_BOOTER_DIR)
 
 clean:
+ifneq ($(V),1)
+	@echo RM
+else
 	rm -f $(EXT_TARGET)
 	rm -f $(EXT_INTER_TARGET)
 	rm -f $(OBJ)
 	$(MAKE) -C $(APP_BOOTER_DIR) clean
+endif
 
 .PHONY: clean
 

--- a/Makefile.wiiu
+++ b/Makefile.wiiu
@@ -302,7 +302,38 @@ endif
 
 DEPFLAGS    = -MT $@ -MMD -MP -MF $(BUILD_DIR)/$*.depend
 
-all: $(TARGETS)
+all: info $(TARGETS)
+
+define INFO
+AR: $(AR)
+ASFLAGS: $(ASFLAGS)
+BUILD_DIR: $(BUILD_DIR)
+CC: $(CC)
+CFLAGS: $(CFLAGS)
+CXX: $(CXX)
+CXXFLAGS: $(CXXFLAGS)
+DEFINES: $(DEFINES)
+DEPFLAGS: $(DEPFLAGS)
+ELF2RPL: $(ELF2RPL)
+HBL_ELF_LDFLAGS: $(HBL_ELF_LDFLAGS)
+HBL_ELF_OBJ: $(HBL_ELF_OBJ)
+INCDIRS: $(INCDIRS)
+LD: $(LD)
+LDFLAGS: $(LDFLAGS)
+LIBDIRS: $(LIBDIRS)
+LIBS: $(LIBS)
+MAKE: $(MAKE)
+OBJ: $(OBJ)
+RPX_LDFLAGS: $(RPX_LDFLAGS)
+RPX_OBJ: $(RPX_OBJ)
+TARGET: $(TARGET)
+endef
+export INFO
+
+info:
+ifneq ($(V),1)
+	@echo "$$INFO"
+endif
 
 %: $(BUILD_DIR)/%
 	cp $< $@


### PR DESCRIPTION
* Implement silent mode in Makefiles that didn't have it at all.
* Some had Q hardcoded as @, make it toggable.
* Others had silent mode implemented, but for a subset of targets; expand this subset.
* What's new everywhere is that now in silent mode these Makefiles will print all hidden variables once.
* I also re-enable silent mode for Wii U.