### PR TITLE
Win32 socket improvements

### DIFF
--- a/gfx/common/d3d10_common.c
+++ b/gfx/common/d3d10_common.c
@@ -14,6 +14,7 @@
  */
 
 #define CINTERFACE
+#define WIN32_LEAN_AND_MEAN
 
 #include "d3d10_defines.h"
 #include "d3dcompiler_common.h"

--- a/gfx/common/d3d11_common.c
+++ b/gfx/common/d3d11_common.c
@@ -14,6 +14,7 @@
  */
 
 #define CINTERFACE
+#define WIN32_LEAN_AND_MEAN
 
 #include <string.h>
 

--- a/gfx/common/win32_common.c
+++ b/gfx/common/win32_common.c
@@ -15,6 +15,8 @@
 
 #if !defined(_XBOX)
 
+#define WIN32_LEAN_AND_MEAN
+
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0601 /* Windows 7 */
 #endif

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -15,6 +15,8 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define WIN32_LEAN_AND_MEAN
+
 /* VC6 needs objbase included before initguid, but nothing else does */
 #include <objbase.h>
 #include <initguid.h>

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -22,6 +22,7 @@
  */
 
 #define CINTERFACE
+#define WIN32_LEAN_AND_MEAN
 #define COBJMACROS
 
 #include <string.h>

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -22,6 +22,7 @@
  */
 
 #define CINTERFACE
+#define WIN32_LEAN_AND_MEAN
 
 #include <string.h>
 #include <malloc.h>

--- a/gfx/drivers_context/w_vk_ctx.c
+++ b/gfx/drivers_context/w_vk_ctx.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <math.h>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <commdlg.h>
 

--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <math.h>
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <commdlg.h>
 

--- a/gfx/drivers_font/d3d9x_w32_font.c
+++ b/gfx/drivers_font/d3d9x_w32_font.c
@@ -15,6 +15,7 @@
  */
 
 #define CINTERFACE
+#define WIN32_LEAN_AND_MEAN
 
 #include <tchar.h>
 

--- a/input/drivers/dinput.c
+++ b/input/drivers/dinput.c
@@ -18,6 +18,8 @@
 #pragma comment(lib, "dinput8")
 #endif
 
+#define WIN32_LEAN_AND_MEAN
+
 #undef DIRECTINPUT_VERSION
 #define DIRECTINPUT_VERSION 0x0800
 

--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -13,6 +13,7 @@
  *  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #ifdef CXX_BUILD

--- a/input/drivers_joypad/dinput_joypad.c
+++ b/input/drivers_joypad/dinput_joypad.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windowsx.h>
 
 #include <dinput.h>

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -62,9 +62,6 @@
 #include "../verbosity.h"
 
 #include "../ai/game_ai.h"
-#if defined(_WIN32)
-#include <winsock2.h>
-#endif
 
 #define HOLD_BTN_DELAY_SEC 2
 

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -32,6 +32,10 @@
 #include "../config.h"
 #endif /* HAVE_CONFIG_H */
 
+#if defined(_WIN32) && !defined(SOCKET)
+#include <winsock2.h>
+#endif
+
 #include "input_defines.h"
 #include "input_types.h"
 #ifdef HAVE_OVERLAY
@@ -284,7 +288,11 @@ struct remote_message
 struct input_remote
 {
 #if defined(HAVE_NETWORKING) && defined(HAVE_NETWORKGAMEPAD)
+#ifdef _WIN32
+   SOCKET net_fd[MAX_USERS];
+#else
    int net_fd[MAX_USERS];
+#endif
 #endif
    bool state[RARCH_BIND_LIST_END];
 };

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -32,6 +32,7 @@
 #else
 #include <io.h>
 #include <fcntl.h>
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 #endif


### PR DESCRIPTION
Windows headers have the unfortunate feature that including windows.h implicitly includes winsock.h, which is incompatible with winsock2.h that I want to include in input/input_driver.h to have access to the SOCKET "type". To stop windows.h from doing that, one has to define WIN32_LEAN_AND_MEAN before the inclusion.