### PR TITLE
Revert "Use size_t for new_selection as done everywhere else"

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8004,7 +8004,8 @@ static enum menu_action ozone_parse_menu_entry_action(
       enum menu_action action)
 {
    uintptr_t tag;
-   size_t new_selection, selection;
+   int new_selection;
+   size_t selection;
    size_t selection_total;
    bool is_current_entry_settings = false;
    struct menu_state *menu_st     = menu_state_get_ptr();


### PR DESCRIPTION
At least `case MENU_ACTION_UP` compares new_selection against 0, the type needs to be signed. Revert 5710a7f6 now and revisit after a deeper look.

Reported in https://github.com/libretro/RetroArch/issues/17810