### PR TITLE
Fix qt6 dispatcher

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -313,6 +313,7 @@ if [ "$HAVE_QT" != 'no' ]; then
       then
          HAVE_QT6='yes'
          add_define MAKEFILE HAVE_QT6 1
+         add_define CONFIG HAVE_QT6 1
       fi
    fi
    if [ "$HAVE_QT6" != 'yes' ]; then

--- a/ui/ui_companion_driver.c
+++ b/ui/ui_companion_driver.c
@@ -140,7 +140,11 @@ void ui_companion_driver_init_first(
 {
    uico_driver_state_t *uico_st        = &uico_driver_st;
 #ifdef HAVE_QT
+#ifdef HAVE_QT6  /* FIXME: deferred initialization after loading/unloading content */
+   if (desktop_menu_enable)
+#else
    if (desktop_menu_enable && ui_companion_toggle)
+#endif
    {
       uico_st->qt_data                 = ui_companion_qt.init();
       uico_st->flags                  |= UICO_ST_FLAG_QT_IS_INITED;


### PR DESCRIPTION
## Description

Force qtcore initialization on startup for Qt6. As far as I could figure out, qt is designed in such a way that the main eventloop must be started at the very beginning of the application.
Maybe later we will find a way to deferred initialization, but for now in any case it's better than crashes in the upcoming release.

## Related Issues

#17452

## Reviewers

[If possible @mention all the people that should review your pull request]
