### PR TITLE
Fix core descriptions not showing

### DIFF
--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -449,7 +449,7 @@ typedef struct
       char file_name[NAME_MAX_LENGTH];
    } last_start_content;
 
-   char menu_state_msg[PATH_MAX_LENGTH * 2];
+   char menu_state_msg[MENU_LABEL_MAX_LENGTH];
    /* Scratchpad variables. These are used for instance
     * by the filebrowser when having to store intermediary
     * paths (subdirs/previous dirs/current dir/path, etc).


### PR DESCRIPTION
## Description

In core downloader, description can be brought up by pressing Select. However, for those cores where the description is longer than what would be possible to display, nothing was displayed. Several such cores exist, one example is Dosbox-Core.

Since this array is used for the messagebox, it is needless to make it larger than what would be displayed anyway, and it makes other safeguards act reasonably, so now there is info, just truncated.

## Related Issues

Well, the .info files should be aligned to not have descriptions larger than 512 chars, but that's libretro-super anyway.