### PR TITLE
Revert "Define WIN32_LEAN_AND_MEAN to avoid collision with winsock2"

### DIFF
--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -14,7 +14,6 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define WIN32_LEAN_AND_MEAN
 #include <QApplication>
 #include <QAbstractEventDispatcher>
 #include <QtWidgets>


### PR DESCRIPTION
The Windows builds have been missing some libraries, notably avdevice-58.dll, avfilter-7.dll, and postproc-55.dll as reported by a user on Discord.  I suspect it's caused by cc842fd, although I don't fully understand why that would happen.

```
$ du -sh 2025-0[45]*
558M    2025-04-14_RetroArch
422M    2025-04-15_RetroArch
$ strings 2025-04-14_RetroArch/retroarch.exe | fgrep 7b99
7b99a7c
$ strings 2025-04-15_RetroArch/retroarch.exe | fgrep 203f
203fff1
$ git log --oneline 7b99a7c^..203fff1
203fff1a11 Bump version
d14bf2f40d Update CHANGES.md
fd54639965 Fetch translations from Crowdin
7b99a7ce85 Merge pull request #17807 from pstef/fixes
011469d7ef Fix broken logic in the clean target
6d2e7e4ec9 Remove unused variable
cc842fd4b2 Define WIN32_LEAN_AND_MEAN to avoid collision with winsock2
89218d5640 Revert "Silence a -Wformat warning"
```