### PR TITLE
Implement `get_proc_address` for emscriptenwebgl_ctx

### DIFF
--- a/gfx/drivers_context/emscriptenwebgl_ctx.c
+++ b/gfx/drivers_context/emscriptenwebgl_ctx.c
@@ -239,6 +239,11 @@ static uint32_t gfx_ctx_emscripten_webgl_get_flags(void *data)
 
 static void gfx_ctx_emscripten_webgl_set_flags(void *data, uint32_t flags) { }
 
+static gfx_ctx_proc_t gfx_ctx_emscripten_webgl_get_proc_address(const char *symbol)
+{
+   return emscripten_webgl_get_proc_address(symbol);
+}
+
 const gfx_ctx_driver_t gfx_ctx_emscripten_webgl = {
    gfx_ctx_emscripten_webgl_init,
    gfx_ctx_emscripten_webgl_destroy,
@@ -261,7 +266,7 @@ const gfx_ctx_driver_t gfx_ctx_emscripten_webgl = {
    false,
    gfx_ctx_emscripten_webgl_swap_buffers,
    gfx_ctx_emscripten_webgl_input_driver,
-   NULL,
+   gfx_ctx_emscripten_webgl_get_proc_address,
    NULL,
    NULL,
    NULL,


### PR DESCRIPTION
In #17664, the default graphics driver for Emscripten builds was changed from emscriptenegl_ctx to the newer emscriptenwebgl_ctx.

However, emscriptenwebgl_ctx doesn't currently implement the `get_proc_address` function in `struct retro_hw_render_callback` in the libretro API, which hardware-accelerated cores using OpenGL need.

I've added an implementation of `get_proc_address` using Emscripten's `emscripten_webgl_get_proc_address` so that the Emscripten builds of OpenGL hardware-accelerated cores will work again.