### PR TITLE
Fix feature test for `GL_CAPS_ARGB8` in Emscripten builds

### DIFF
--- a/libretro-common/gfx/gl_capabilities.c
+++ b/libretro-common/gfx/gl_capabilities.c
@@ -190,10 +190,14 @@ bool gl_check_capability(enum gl_capability_enum enum_idx)
          break;
 #endif
       case GL_CAPS_ARGB8:
-#ifdef HAVE_OPENGLES
+#if defined(HAVE_OPENGLES) && !defined(EMSCRIPTEN)
          if (gl_query_extension("OES_rgb8_rgba8")
                || gl_query_extension("ARM_rgba8")
                   || major >= 3)
+            return true;
+#elif defined(HAVE_OPENGLES) && defined(EMSCRIPTEN)
+         if (gl_query_extension("EXT_sRGB")
+               || major >= 3)
             return true;
 #else
          /* TODO/FIXME - implement this for non-GLES? */


### PR DESCRIPTION
RetroArch uses `GL_CAPS_ARGB8` to determine whether or not it can use 32-bit FBOs when using OpenGL ES for graphics. If the check returns true, RetroArch will use 32-bit FBOs, otherwise it'll use 16-bit FBOs.

The `GL_CAPS_ARGB8` check always returns false in Emscripten builds of RetroArch with WebGL 1 (which is currently the default graphics backend in Emscripten builds) because `OES_rgb8_rgba8` and `ARM_rgba8` aren't valid WebGL extensions and so they'll never be reported as being supported. That means when using WebGL 1, RetroArch will always use 16-bit FBOs even if 32-bit FBOs are supported, leading to a severe loss in colour depth.

I've fixed the check for 32-bit FBO support in Emscripten builds by checking for the presence of the `EXT_sRGB` extension instead in Emscripten builds, which implies support for 32-bit FBOs.