### PR TITLE
Pop fast-math at the end of the file

### DIFF
--- a/libretro-common/audio/resampler/drivers/sinc_resampler.c
+++ b/libretro-common/audio/resampler/drivers/sinc_resampler.c
@@ -22,7 +22,8 @@
 
 /* Bog-standard windowed SINC implementation. */
 
-#if defined(__GNUC__) && defined(__OPTIMIZE__)
+#if defined(__GNUC__) && defined(__OPTIMIZE__) && !defined(__clang__)
+#pragma GCC push_options
 #pragma GCC optimize ("fast-math")
 #endif
 
@@ -1027,3 +1028,7 @@ retro_resampler_t sinc_resampler = {
    "sinc",
    "sinc"
 };
+
+#if defined(__GNUC__) && defined(__OPTIMIZE__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif


### PR DESCRIPTION
so that it doesn't affect the rest of the code in Griffin builds.

This is unfortunately GCC-only, but Clang will miss only 1 vectorization.