### PR TITLE
Reapply "Define WIN32_LEAN_AND_MEAN to avoid collision with winsock2"

### DIFF
--- a/ui/drivers/ui_qt.cpp
+++ b/ui/drivers/ui_qt.cpp
@@ -14,6 +14,7 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
+#define WIN32_LEAN_AND_MEAN
 #include <QApplication>
 #include <QAbstractEventDispatcher>
 #include <QtWidgets>


### PR DESCRIPTION
It was reverted in 309c67a205895b5036897e7f0aefc5730750a9a1 because it was suspected of breaking Windows releases, but the reason was different.