### PR TITLE
Revisit selection and size_t to silence warnings

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2424,7 +2424,7 @@ static void materialui_update_fullscreen_thumbnail_label(
          NULL);
 }
 
-static void materialui_update_savestate_thumbnail_path(void *data, size_t i)
+static void materialui_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    settings_t *settings     = config_get_ptr();
    materialui_handle_t *mui = (materialui_handle_t*)data;
@@ -9232,7 +9232,7 @@ static void materialui_navigation_set(void *data, bool scroll)
    /* Update savestate thumbnail */
    if (mui->flags & MUI_FLAG_IS_SAVESTATE_LIST)
    {
-      materialui_update_savestate_thumbnail_path(mui, selection);
+      materialui_update_savestate_thumbnail_path(mui, (unsigned)selection);
       materialui_update_savestate_thumbnail_image(mui);
    }
 
@@ -9635,7 +9635,8 @@ static void materialui_populate_entries(void *data, const char *path,
             || string_to_unsigned(path) == MENU_ENUM_LABEL_STATE_SLOT))
    {
       mui->flags |= MUI_FLAG_IS_SAVESTATE_LIST;
-      materialui_update_savestate_thumbnail_path(mui, menu_state_get_ptr()->selection_ptr);
+      materialui_update_savestate_thumbnail_path(mui,
+         (unsigned)menu_state_get_ptr()->selection_ptr);
       materialui_update_savestate_thumbnail_image(mui);
    }
    else
@@ -12090,7 +12091,7 @@ static void materialui_list_clear(file_list_t *list)
    }
 }
 
-static void materialui_refresh_thumbnail_image(void *userdata, unsigned i)
+static void materialui_refresh_thumbnail_image(void *userdata, size_t i)
 {
    materialui_handle_t *mui           = (materialui_handle_t*)userdata;
    struct menu_state *menu_st         = menu_state_get_ptr();

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3705,7 +3705,7 @@ static bool ozone_is_main_menu_playlist(void *userdata)
    return entry.type == FILE_TYPE_RPL_ENTRY;
 }
 
-static void ozone_update_savestate_thumbnail_path(void *data, size_t i)
+static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    settings_t *settings     = config_get_ptr();
    ozone_handle_t *ozone    = (ozone_handle_t*)data;
@@ -9083,7 +9083,7 @@ static void ozone_update_thumbnail_image(void *data)
             ozone->title);
 }
 
-static void ozone_refresh_thumbnail_image(void *data, unsigned i)
+static void ozone_refresh_thumbnail_image(void *data, size_t i)
 {
    ozone_handle_t *ozone        = (ozone_handle_t*)data;
    struct menu_state   *menu_st = menu_state_get_ptr();
@@ -10290,7 +10290,7 @@ static void ozone_render(void *data,
                            && ozone->depth >= 2)
                            || (ozone->flags & OZONE_FLAG_IS_STATE_SLOT))
                      {
-                        ozone_update_savestate_thumbnail_path(ozone, i);
+                        ozone_update_savestate_thumbnail_path(ozone, (unsigned)i);
                         ozone_update_savestate_thumbnail_image(ozone);
                      }
                   }
@@ -11563,7 +11563,7 @@ static void ozone_selection_changed(ozone_handle_t *ozone, bool allow_animation)
             ozone_update_thumbnail_image(ozone);
       }
 
-      ozone_update_savestate_thumbnail_path(ozone, ozone->selection);
+      ozone_update_savestate_thumbnail_path(ozone, (unsigned)ozone->selection);
       ozone_update_savestate_thumbnail_image(ozone);
    }
 }
@@ -12287,7 +12287,7 @@ static void ozone_populate_entries(
          ozone_list_open(ozone, ozone_collapse_sidebar, (!(ozone->flags & OZONE_FLAG_FIRST_FRAME)));
 
    /* Reset savestate thumbnails always */
-   ozone_update_savestate_thumbnail_path(ozone, menu_st->selection_ptr);
+   ozone_update_savestate_thumbnail_path(ozone, (unsigned)menu_st->selection_ptr);
    ozone_update_savestate_thumbnail_image(ozone);
 
    /* Thumbnails
@@ -12316,7 +12316,7 @@ static void ozone_populate_entries(
       {
          ozone->flags &= ~(OZONE_FLAG_WANT_THUMBNAIL_BAR
                          | OZONE_FLAG_SKIP_THUMBNAIL_RESET);
-         ozone_update_savestate_thumbnail_path(ozone, menu_st->selection_ptr);
+         ozone_update_savestate_thumbnail_path(ozone, (unsigned)menu_st->selection_ptr);
          ozone_update_savestate_thumbnail_image(ozone);
       }
       else if (   gfx_thumbnail_is_enabled(menu_st->thumbnail_path_data, GFX_THUMBNAIL_RIGHT)
@@ -12426,7 +12426,7 @@ static void ozone_toggle(void *userdata, bool menu_on)
       ozone->flags              &= ~(OZONE_FLAG_WANT_THUMBNAIL_BAR
                                    | OZONE_FLAG_SKIP_THUMBNAIL_RESET);
       gfx_thumbnail_reset(&ozone->thumbnails.savestate);
-      ozone_update_savestate_thumbnail_path(ozone, menu_st->selection_ptr);
+      ozone_update_savestate_thumbnail_path(ozone, (unsigned)menu_st->selection_ptr);
       ozone_update_savestate_thumbnail_image(ozone);
    }
 

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -6872,7 +6872,7 @@ static void rgui_load_current_thumbnails(rgui_t *rgui, struct menu_state *menu_s
 #endif
 }
 
-static void rgui_update_savestate_thumbnail_path(void *data, size_t i)
+static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    settings_t *settings = config_get_ptr();
    rgui_t *rgui         = (rgui_t*)data;
@@ -7072,7 +7072,7 @@ static void rgui_scan_selected_entry_thumbnail(rgui_t *rgui, bool force_load)
    /* Reset savestate thumbnails always */
    if (selection < list_size)
    {
-      rgui_update_savestate_thumbnail_path(rgui, selection);
+      rgui_update_savestate_thumbnail_path(rgui, (unsigned)selection);
       rgui_update_savestate_thumbnail_image(rgui);
    }
 
@@ -7141,7 +7141,7 @@ static void rgui_toggle_fs_thumbnail(rgui_t *rgui,
    rgui_scan_selected_entry_thumbnail(rgui, true);
 }
 
-static void rgui_refresh_thumbnail_image(void *userdata, unsigned i)
+static void rgui_refresh_thumbnail_image(void *userdata, size_t i)
 {
    rgui_t                *rgui = (rgui_t*)userdata;
    struct menu_state *menu_st  = menu_state_get_ptr();

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1233,7 +1233,7 @@ static void xmb_update_dynamic_wallpaper(xmb_handle_t *xmb, bool reset)
    }
 }
 
-static void xmb_update_savestate_thumbnail_path(void *data, size_t i)
+static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    xmb_handle_t *xmb        = (xmb_handle_t*)data;
    settings_t *settings     = config_get_ptr();
@@ -1385,7 +1385,7 @@ static unsigned xmb_get_horizontal_selection_type(xmb_handle_t *xmb)
    return 0;
 }
 
-static void xmb_refresh_thumbnail_image(void *data, unsigned i)
+static void xmb_refresh_thumbnail_image(void *data, size_t i)
 {
    xmb_handle_t *xmb          = (xmb_handle_t*)data;
    struct menu_state *menu_st = menu_state_get_ptr();
@@ -2127,7 +2127,7 @@ static void xmb_list_open_new(xmb_handle_t *xmb,
       /* This shows savestate thumbnail after
        * opening savestate submenu */
       xmb->skip_thumbnail_reset = false;
-      xmb_update_savestate_thumbnail_path(xmb, current);
+      xmb_update_savestate_thumbnail_path(xmb, (unsigned)current);
       xmb_update_savestate_thumbnail_image(xmb);
    }
 

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -388,10 +388,10 @@ typedef struct menu_ctx_driver
    int (*environ_cb)(enum menu_environ_cb type, void *data, void *userdata);
    void (*update_thumbnail_path)(void *data, unsigned i, char pos);
    void (*update_thumbnail_image)(void *data);
-   void (*refresh_thumbnail_image)(void *data, unsigned i);
+   void (*refresh_thumbnail_image)(void *data, size_t i);
    void (*set_thumbnail_content)(void *data, const char *s);
    int  (*osk_ptr_at_pos)(void *data, int x, int y, unsigned width, unsigned height);
-   void (*update_savestate_thumbnail_path)(void *data, size_t i);
+   void (*update_savestate_thumbnail_path)(void *data, unsigned i);
    void (*update_savestate_thumbnail_image)(void *data);
    int (*pointer_down)(void *data, unsigned x, unsigned y, unsigned ptr,
          menu_file_list_cbs_t *cbs,


### PR DESCRIPTION
There is a type mismatch between selection (size_t) and how it's passed to some functions. In 4f3ae82 I got it backwards and changed the type in savestate thumbnail function definitions to size_t, but in that case we can assume that there won't be more than 999. So in this case it's OK to keep the unsigned int and cast selection to that type.

Thumbnails on playlists are the other case and the limit is not so clear to me, so I assume it's reasonable to promote the type of the function parameter i from unsigned to size_t.

This is a continuation of discussion with @sonninnos and @LibretroAdmin from under https://github.com/libretro/RetroArch/pull/17795