### PR TITLE
default to FFmpeg libavfilter virtual input device

### DIFF
--- a/camera/drivers/ffmpeg.c
+++ b/camera/drivers/ffmpeg.c
@@ -40,6 +40,8 @@
 #define FFMPEG_CAMERA_DEFAULT_BACKEND "dshow"
 #elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined (__NetBSD__)
 #define FFMPEG_CAMERA_DEFAULT_BACKEND "bktr"
+#else
+#define FFMPEG_CAMERA_DEFAULT_BACKEND "lavfi"
 #endif
 
 typedef struct ffmpeg_camera


### PR DESCRIPTION
## Description

Default to ffmpeg's libavfilter virtual input device for camera when no specific backend exists. This will help with platforms where ffmpeg is available, but no specific backend is, like Haiku.

## Related Issues

#17846 

## Reviewers

@JesseTG 