### PR TITLE
Refine menu info+search disable buttons

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -3762,7 +3762,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_INPUT_DISABLE_INFO_BUTTON,
-   "If enabled Info button presses will be ignored."
+   "If enabled Info function will be disabled."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_DISABLE_SEARCH_BUTTON,
@@ -3770,7 +3770,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_INPUT_DISABLE_SEARCH_BUTTON,
-   "If enabled Search button presses will be ignored."
+   "If enabled Search function will be disabled."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_INPUT_DISABLE_LEFT_ANALOG_IN_MENU,

--- a/menu/cbs/menu_cbs_info.c
+++ b/menu/cbs/menu_cbs_info.c
@@ -42,6 +42,9 @@ static int action_info_default(unsigned type, const char *label)
    bool audio_enable_menu_notice = settings->bools.audio_enable_menu_notice;
 #endif
 
+   if (settings->bools.menu_disable_info_button)
+      goto error;
+
    menu_displaylist_info_init(&info);
 
    info.list                    = menu_stack;

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5629,19 +5629,13 @@ unsigned menu_event(
       else if (BIT256_GET_PTR(p_trigger_input, menu_cancel_btn))
          ret = MENU_ACTION_CANCEL;
       else if (BIT256_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_X))
-      {
-         if (!settings->bools.menu_disable_search_button)
-            ret = MENU_ACTION_SEARCH;
-      }
+         ret = MENU_ACTION_SEARCH;
       else if (BIT256_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_Y))
          ret = MENU_ACTION_SCAN;
       else if (BIT256_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_START))
          ret = MENU_ACTION_START;
       else if (BIT256_GET_PTR(p_trigger_input, RETRO_DEVICE_ID_JOYPAD_SELECT))
-      {
-         if (!settings->bools.menu_disable_info_button)
-            ret = MENU_ACTION_INFO;
-      }
+         ret = MENU_ACTION_INFO;
       else if (BIT256_GET_PTR(p_trigger_input, RARCH_MENU_TOGGLE))
          ret = MENU_ACTION_TOGGLE;
 
@@ -7911,8 +7905,8 @@ bool menu_driver_iterate(
 bool menu_input_dialog_start_search(void)
 {
    input_driver_state_t *input_st          = input_state_get_ptr();
-#ifdef HAVE_ACCESSIBILITY
    settings_t *settings                    = config_get_ptr();
+#ifdef HAVE_ACCESSIBILITY
    bool accessibility_enable               = settings->bools.accessibility_enable;
    unsigned accessibility_narrator_speech_speed = settings->uints.accessibility_narrator_speech_speed;
    access_state_t *access_st               = access_state_get_ptr();
@@ -7920,7 +7914,7 @@ bool menu_input_dialog_start_search(void)
    struct menu_state *menu_st              = &menu_driver_state;
    menu_handle_t         *menu             = menu_st->driver_data;
 
-   if (!menu)
+   if (!menu || settings->bools.menu_disable_search_button)
       return false;
 
 #ifdef HAVE_MIST


### PR DESCRIPTION
## Description

Instead of blocking menu actions completely when Info or Search buttons are disabled, allow menu drivers to intercept the button for other uses, and rather block the actual function itself. Otherwise thumbnails and view modes can't be cycled when only the default function is supposed to be disabled.
