### PR TITLE
Move core options reset to a better fitting menu

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -10755,6 +10755,12 @@ unsigned menu_displaylist_build_list(
                   MENU_ENUM_LABEL_RESET_TO_DEFAULT_CONFIG,
                   MENU_SETTING_ACTION, 0, 0, NULL))
             count++;
+         if (!settings->bools.global_core_options && menu_entries_append(list,
+               msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_RESET),
+               "",
+               MENU_ENUM_LABEL_CORE_OPTIONS_RESET,
+               MENU_SETTING_ACTION_CORE_OPTIONS_RESET, 0, 0, NULL))
+            count++;
          break;
       case DISPLAYLIST_PRIVACY_SETTINGS_LIST:
          {
@@ -11329,13 +11335,6 @@ unsigned menu_displaylist_build_list(
                         false) == 0)
                   count++;
             }
-            /* Reset core options */
-            if (!settings->bools.global_core_options && menu_entries_append(list,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CORE_OPTIONS_RESET),
-                  "",
-                  MENU_ENUM_LABEL_CORE_OPTIONS_RESET,
-                  MENU_SETTING_ACTION_CORE_OPTIONS_RESET, 0, 0, NULL))
-               count++;
          }
          break;
       case DISPLAYLIST_DIRECTORY_SETTINGS_LIST:


### PR DESCRIPTION
## Description
Move core options reset from Settings/Configuration to Main Menu / Configuration Files

## Related Issues
https://github.com/libretro/RetroArch/pull/17776#issuecomment-2856042881

## Related Pull Requests
#17776 

## Reviewers
@sonninnos 