### PR TITLE
Turbo mode corrections

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -1505,18 +1505,19 @@ static int16_t input_state_device(
 #endif
             }
 
-            /* Don't allow turbo for D-pad unless explicitly allowed. */
-            if (          (id  < RETRO_DEVICE_ID_JOYPAD_UP)
-                  || (    ((settings->bools.input_turbo_allow_dpad || settings->ints.input_turbo_bind != -1)
-                       || (id  > RETRO_DEVICE_ID_JOYPAD_RIGHT))
-                       && (id <= RETRO_DEVICE_ID_JOYPAD_R3)))
+            if (id <= RETRO_DEVICE_ID_JOYPAD_R3)
             {
-               /*
-                * Apply turbo button if activated.
-                */
+               /* Apply turbo button if activated. */
                uint8_t turbo_period     = settings->uints.input_turbo_period;
                uint8_t turbo_duty_cycle = settings->uints.input_turbo_duty_cycle;
                uint8_t turbo_mode       = settings->uints.input_turbo_mode;
+
+               /* Don't allow classic mode turbo for D-pad unless explicitly allowed. */
+               if (     turbo_mode <= INPUT_TURBO_MODE_CLASSIC_TOGGLE
+                     && !settings->bools.input_turbo_allow_dpad
+                     && id >= RETRO_DEVICE_ID_JOYPAD_UP
+                     && id <= RETRO_DEVICE_ID_JOYPAD_RIGHT)
+                  break;
 
                if (turbo_duty_cycle == 0)
                   turbo_duty_cycle = turbo_period / 2;
@@ -1528,9 +1529,16 @@ static int16_t input_state_device(
 
                if (turbo_mode > INPUT_TURBO_MODE_CLASSIC_TOGGLE)
                {
-                  /* Pressing turbo button toggles turbo mode on or off.
-                   * Holding the button will
-                   * pass through, else the pressed state will be modulated by a
+                  unsigned turbo_button = settings->uints.input_turbo_button;
+                  unsigned remap_button = settings->uints.input_remap_ids[port][turbo_button];
+
+                  /* Single button modes only care about the defined button. */
+                  if (id != remap_button)
+                     break;
+
+                  /* Pressing turbo bind toggles turbo button on or off.
+                   * Holding the button will pass through, else
+                   * the pressed state will be modulated by a
                    * periodic pulse defined by the configured duty cycle.
                    */
 
@@ -1539,13 +1547,10 @@ static int16_t input_state_device(
                      input_st->turbo_btns.turbo_pressed[port] &= ~(1 << 31);
                   else if (input_st->turbo_btns.turbo_pressed[port] >= 0)
                   {
-                     unsigned turbo_button = settings->uints.input_turbo_button;
-                     unsigned remap_button = settings->uints.input_remap_ids[port][turbo_button];
-
                      input_st->turbo_btns.turbo_pressed[port] |= (1 << 31);
-                     /* Toggle turbo for selected buttons. */
-                     if (input_st->turbo_btns.enable[port] != (1 << remap_button))
-                        input_st->turbo_btns.enable[port] = (1 << remap_button);
+                     /* Toggle turbo for selected button. */
+                     if (input_st->turbo_btns.enable[port] != (1 << id))
+                        input_st->turbo_btns.enable[port] = (1 << id);
                      input_st->turbo_btns.mode1_enable[port] ^= 1;
                   }
 
@@ -1559,8 +1564,6 @@ static int16_t input_state_device(
                      {
                         uint16_t enable_new;
                         input_st->turbo_btns.turbo_pressed[port] |= 1 << id;
-                        /* Toggle turbo for pressed button but make
-                         * sure at least one button has turbo */
                         enable_new = input_st->turbo_btns.enable[port] ^ (1 << id);
                         if (enable_new)
                            input_st->turbo_btns.enable[port] = enable_new;
@@ -1579,8 +1582,8 @@ static int16_t input_state_device(
                }
                else if (turbo_mode == INPUT_TURBO_MODE_CLASSIC)
                {
-                  /* If turbo button is held, all buttons pressed except
-                   * for D-pad will go into a turbo mode. Until the button is
+                  /* If turbo button is held, all buttons pressed
+                   * will go into a turbo mode. Until the button is
                    * released again, the input state will be modulated by a
                    * periodic pulse defined by the configured duty cycle.
                    */

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -15912,7 +15912,7 @@ static bool setting_append_list(
                general_read_handler);
          (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
          (*list)[list_info->index - 1].offset_by = 1;
-         menu_settings_list_current_add_range(list, list_info, 1, 100, 1, true, true);
+         menu_settings_list_current_add_range(list, list_info, 2, 100, 1, true, true);
 
          CONFIG_UINT(
                list, list_info,


### PR DESCRIPTION
## Description

Sorted a few goofs in turbo mode behavior:
- Fixed d-pad allow option from being ignored if the overriding bind option was empty, as in when legacy port turbo was used instead, resulting in classic modes allowing d-pad always
- Prevented single button toggle from toggling multiple buttons in classic style when it is supposed to limit itself only to the defined single button
- Limited minimum turbo period value to 2, since 1 is utterly useless
- Cleaned up some outdated comments

