### PR TITLE
Enable savestate thumbnails by default for x64

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1401,7 +1401,12 @@
 #define DEFAULT_SAVESTATE_AUTO_SAVE false
 #define DEFAULT_SAVESTATE_AUTO_LOAD false
 
+/* Take screenshots for save states */
+#if defined(__x86_64__)
+#define DEFAULT_SAVESTATE_THUMBNAIL_ENABLE true
+#else
 #define DEFAULT_SAVESTATE_THUMBNAIL_ENABLE false
+#endif
 
 /* When creating save (srm) files, compress
  * written data */

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11345,7 +11345,7 @@ static bool setting_append_list(
             bool_entries[listing].target         = &settings->bools.savestate_thumbnail_enable;
             bool_entries[listing].name_enum_idx  = MENU_ENUM_LABEL_SAVESTATE_THUMBNAIL_ENABLE;
             bool_entries[listing].SHORT_enum_idx = MENU_ENUM_LABEL_VALUE_SAVESTATE_THUMBNAIL_ENABLE;
-            bool_entries[listing].flags          = SD_FLAG_ADVANCED;
+            bool_entries[listing].flags          = SD_FLAG_NONE;
             if (DEFAULT_SAVESTATE_THUMBNAIL_ENABLE)
                bool_entries[listing].flags      |= SD_FLAG_DEFAULT_VALUE;
             listing++;


### PR DESCRIPTION
## Description

Since save state thumbnails are currently available for all menu drivers, let's enable them by default at least for the modern hardware, and remove the advanced menu visibility flag.
