### PR TITLE
Allow Start button to quick manage media playlists

### DIFF
--- a/menu/cbs/menu_cbs_label.c
+++ b/menu/cbs/menu_cbs_label.c
@@ -112,6 +112,11 @@ int menu_cbs_init_bind_label(menu_file_list_cbs_t *cbs,
    {
       switch (cbs->enum_idx)
       {
+         case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
+         case MENU_ENUM_LABEL_GOTO_FAVORITES:
+         case MENU_ENUM_LABEL_GOTO_IMAGES:
+         case MENU_ENUM_LABEL_GOTO_MUSIC:
+         case MENU_ENUM_LABEL_GOTO_VIDEO:
          case MENU_ENUM_LABEL_PLAYLIST_COLLECTION_ENTRY:
             BIND_ACTION_LABEL(cbs, action_bind_label_playlist_collection_entry);
             break;

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -8634,6 +8634,7 @@ static int action_ok_delete_playlist(const char *path,
 {
    playlist_t       *playlist = playlist_get_cached();
    struct menu_state *menu_st = menu_state_get_ptr();
+   menu_entry_t entry;
 
    if (!playlist)
       return -1;
@@ -8646,7 +8647,12 @@ static int action_ok_delete_playlist(const char *path,
       menu_st->driver_ctx->environ_cb(MENU_ENVIRON_RESET_HORIZONTAL_LIST,
                NULL, menu_st->userdata);
 
-   return action_cancel_pop_default(NULL, NULL, 0, 0);
+   MENU_ENTRY_INITIALIZE(entry);
+   menu_entry_get(&entry, 0, 0, NULL, false);
+
+   /* Ozone sidebar quick manager needs 'MENU_ACTION_CANCEL' instead
+    * of 'action_cancel_pop_default' to return back to sidebar cleanly */
+   return menu_entry_action(&entry, 0, MENU_ACTION_CANCEL);
 }
 
 #ifdef HAVE_NETWORKING

--- a/menu/cbs/menu_cbs_start.c
+++ b/menu/cbs/menu_cbs_start.c
@@ -897,6 +897,13 @@ static int menu_cbs_init_bind_start_compare_label(menu_file_list_cbs_t *cbs)
          case MENU_ENUM_LABEL_MENU_WALLPAPER:
             BIND_ACTION_START(cbs, action_start_menu_wallpaper);
             break;
+         case MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY:
+         case MENU_ENUM_LABEL_GOTO_FAVORITES:
+         case MENU_ENUM_LABEL_GOTO_IMAGES:
+         case MENU_ENUM_LABEL_GOTO_MUSIC:
+         case MENU_ENUM_LABEL_GOTO_VIDEO:
+            BIND_ACTION_START(cbs, action_ok_push_playlist_manager_settings);
+            break;
          default:
             return -1;
       }

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -4321,7 +4321,7 @@ static unsigned menu_displaylist_parse_playlists(
          {
             if (settings->bools.menu_content_show_favorites)
                if (menu_entries_append(info_list,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES),
+                        FILE_PATH_CONTENT_FAVORITES,
                         msg_hash_to_str(MENU_ENUM_LABEL_GOTO_FAVORITES),
                         MENU_ENUM_LABEL_GOTO_FAVORITES,
                         MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4329,7 +4329,7 @@ static unsigned menu_displaylist_parse_playlists(
 
             if (settings->bools.menu_content_show_history)
                if (menu_entries_append(info_list,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY),
+                        FILE_PATH_CONTENT_HISTORY,
                         msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY),
                         MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
                         MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4339,7 +4339,7 @@ static unsigned menu_displaylist_parse_playlists(
          {
             if (settings->bools.menu_content_show_history)
                if (menu_entries_append(info_list,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_LOAD_CONTENT_HISTORY),
+                        FILE_PATH_CONTENT_HISTORY,
                         msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY),
                         MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
                         MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4347,7 +4347,7 @@ static unsigned menu_displaylist_parse_playlists(
 
             if (settings->bools.menu_content_show_favorites)
                if (menu_entries_append(info_list,
-                        msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES),
+                        FILE_PATH_CONTENT_FAVORITES,
                         msg_hash_to_str(MENU_ENUM_LABEL_GOTO_FAVORITES),
                         MENU_ENUM_LABEL_GOTO_FAVORITES,
                         MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4357,7 +4357,7 @@ static unsigned menu_displaylist_parse_playlists(
 
       if (settings->bools.menu_content_show_images)
          if (menu_entries_append(info_list,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_IMAGES),
+                  FILE_PATH_CONTENT_IMAGE_HISTORY,
                   msg_hash_to_str(MENU_ENUM_LABEL_GOTO_IMAGES),
                   MENU_ENUM_LABEL_GOTO_IMAGES,
                   MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4365,7 +4365,7 @@ static unsigned menu_displaylist_parse_playlists(
 
       if (settings->bools.menu_content_show_music)
          if (menu_entries_append(info_list,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_MUSIC),
+                  FILE_PATH_CONTENT_MUSIC_HISTORY,
                   msg_hash_to_str(MENU_ENUM_LABEL_GOTO_MUSIC),
                   MENU_ENUM_LABEL_GOTO_MUSIC,
                   MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4374,7 +4374,7 @@ static unsigned menu_displaylist_parse_playlists(
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
       if (settings->bools.menu_content_show_video)
          if (menu_entries_append(info_list,
-                  msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_VIDEO),
+                  FILE_PATH_CONTENT_VIDEO_HISTORY,
                   msg_hash_to_str(MENU_ENUM_LABEL_GOTO_VIDEO),
                   MENU_ENUM_LABEL_GOTO_VIDEO,
                   MENU_SETTING_ACTION, 0, 0, NULL))
@@ -4971,18 +4971,20 @@ static bool menu_displaylist_parse_playlist_manager_settings(
     *   (i.e. it is not relevant for history/favourites) */
    if (   !is_content_history
        && !string_is_equal(playlist_file, FILE_PATH_CONTENT_FAVORITES))
+   {
       menu_entries_append(list,
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_DEFAULT_CORE),
             msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_DEFAULT_CORE),
             MENU_ENUM_LABEL_PLAYLIST_MANAGER_DEFAULT_CORE,
             MENU_SETTING_PLAYLIST_MANAGER_DEFAULT_CORE, 0, 0, NULL);
 
-   /* Reset core associations */
-   menu_entries_append(list,
-         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_RESET_CORES),
-         msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES),
-         MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES,
-         MENU_SETTING_ACTION_PLAYLIST_MANAGER_RESET_CORES, 0, 0, NULL);
+      /* Reset core associations */
+      menu_entries_append(list,
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_PLAYLIST_MANAGER_RESET_CORES),
+            msg_hash_to_str(MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES),
+            MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES,
+            MENU_SETTING_ACTION_PLAYLIST_MANAGER_RESET_CORES, 0, 0, NULL);
+   }
 
    /* Refresh playlist */
    if (playlist_scan_refresh_enabled(playlist))
@@ -13704,15 +13706,18 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         &ret);
 
                if (count == 0)
+               {
                   if (menu_entries_append(info->list,
                            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_HISTORY_AVAILABLE),
                            msg_hash_to_str(MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE),
                            MENU_ENUM_LABEL_NO_HISTORY_AVAILABLE,
                            MENU_INFO_MESSAGE, 0, 0, NULL))
                      count++;
+                  info->flags    &= ~MD_FLAG_NEED_PUSH_NO_PLAYLIST_ENTRIES;
+               }
             }
 
-            ret                         = 0;
+            ret                   = 0;
             /* Playlists themselves are sorted
              * > Display lists generated from playlists
              *   must never be sorted */
@@ -13744,7 +13749,6 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                         MENU_INFO_MESSAGE, 0, 0, NULL))
                      count++;
                   info->flags       &= ~MD_FLAG_NEED_PUSH_NO_PLAYLIST_ENTRIES;
-                  ret                = 0;
                }
 
                ret                   = 0;
@@ -15208,29 +15212,33 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   {
                      if (settings->bools.menu_content_show_favorites)
                         if (menu_entries_append(info->list,
-                                 msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES),
+                                 FILE_PATH_CONTENT_FAVORITES,
                                  msg_hash_to_str(MENU_ENUM_LABEL_GOTO_FAVORITES),
                                  MENU_ENUM_LABEL_GOTO_FAVORITES,
                                  MENU_SETTING_ACTION, 0, 0, NULL))
                            count++;
 
                      if (settings->bools.menu_content_show_history)
-                        if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(info->list,
+                        if (menu_entries_append(info->list,
+                                 FILE_PATH_CONTENT_HISTORY,
+                                 msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY),
                                  MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
-                                 PARSE_ACTION, false) == 0)
+                                 MENU_SETTING_ACTION, 0, 0, NULL))
                            count++;
                   }
                   else
                   {
                      if (settings->bools.menu_content_show_history)
-                        if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(info->list,
+                        if (menu_entries_append(info->list,
+                                 FILE_PATH_CONTENT_HISTORY,
+                                 msg_hash_to_str(MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY),
                                  MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY,
-                                 PARSE_ACTION, false) == 0)
+                                 MENU_SETTING_ACTION, 0, 0, NULL))
                            count++;
 
                      if (settings->bools.menu_content_show_favorites)
                         if (menu_entries_append(info->list,
-                                 msg_hash_to_str(MENU_ENUM_LABEL_VALUE_GOTO_FAVORITES),
+                                 FILE_PATH_CONTENT_FAVORITES,
                                  msg_hash_to_str(MENU_ENUM_LABEL_GOTO_FAVORITES),
                                  MENU_ENUM_LABEL_GOTO_FAVORITES,
                                  MENU_SETTING_ACTION, 0, 0, NULL))

--- a/tasks/task_playlist_manager.c
+++ b/tasks/task_playlist_manager.c
@@ -661,11 +661,29 @@ static void task_pl_manager_clean_playlist_handler(retro_task_t *task)
             playlist_write_file(pl_manager->playlist);
             /* Update progress display */
             task_free_title(task);
+
             _len = strlcpy(task_title,
                   msg_hash_to_str(MSG_PLAYLIST_MANAGER_PLAYLIST_CLEANED),
                   sizeof(task_title));
-            strlcpy(task_title + _len, pl_manager->playlist_name,
-                  sizeof(task_title) - _len);
+
+            if (string_starts_with(FILE_PATH_CONTENT_FAVORITES, pl_manager->playlist_name))
+               strlcpy(task_title + _len, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB),
+                     sizeof(task_title) - _len);
+            else if (string_starts_with(FILE_PATH_CONTENT_HISTORY, pl_manager->playlist_name))
+               strlcpy(task_title + _len, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_HISTORY_TAB),
+                     sizeof(task_title) - _len);
+            else if (string_starts_with(FILE_PATH_CONTENT_IMAGE_HISTORY, pl_manager->playlist_name))
+               strlcpy(task_title + _len, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_IMAGES_TAB),
+                     sizeof(task_title) - _len);
+            else if (string_starts_with(FILE_PATH_CONTENT_MUSIC_HISTORY, pl_manager->playlist_name))
+               strlcpy(task_title + _len, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MUSIC_TAB),
+                     sizeof(task_title) - _len);
+            else if (string_starts_with(FILE_PATH_CONTENT_VIDEO_HISTORY, pl_manager->playlist_name))
+               strlcpy(task_title + _len, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_VIDEO_TAB),
+                     sizeof(task_title) - _len);
+            else
+               strlcpy(task_title + _len, pl_manager->playlist_name,
+                     sizeof(task_title) - _len);
 
             task_set_title(task, strdup(task_title));
          }


### PR DESCRIPTION
## Description

Additions to previous PR:
- Start button opens playlist manager with media playlists just like regular playlists
- Ozone can also do it from the sidebar and shows bottom legend when suitable
- Ozone stops showing empty thumbnails in music+video playlists under Main Menu Playlists
- Playlist manager reset core association option is hidden when core selection is hidden
- Widget notification on playlist clean shows visible name instead of raw filename
- Empty history no longer shows redundant "No Playlist Entries Available" when it already shows "No History Available"

## Related Pull Requests

#17945
