### PR TITLE
Fix menu usage when OK/Cancel has mouse binds

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5300,7 +5300,11 @@ unsigned menu_event(
          memcpy(pointer_hw_state, &touchscreen_hw_state, sizeof(menu_input_pointer_hw_state_t));
 
       if (pointer_hw_state->flags & MENU_INP_PTR_FLG_ACTIVE)
+      {
          menu_st->input_last_time_us = menu_st->current_time_us;
+         /* Prevent double trigger when OK/Cancel has mouse binds */
+         menu_st->input_driver_flushing_input = 1;
+      }
    }
 
    /* Populate menu_input_state


### PR DESCRIPTION
## Description

This way manually created binds won't affect normal mouse menu usage by doing double triggers, and also with manual binds menu is usable with mouse if mouse support is disabled in menu.

## Related Issues

Closes #11861

