### PR TITLE
GLUI: Minor entry height adjustment

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2996,7 +2996,7 @@ static void materialui_compute_entries_box_default(
       node->entry_height = node->text_height +
             mui->dip_base_unit_size / 10;
 
-      node->entry_height      += mui->dip_base_unit_size / 10;
+      node->entry_height      += mui->dip_base_unit_size / 15;
       node->y                  = sum;
 
       node->entry_width        = node_entry_width;


### PR DESCRIPTION
## Description

Just a tiny adjustment to entry padding so that at default 1.00x scale and 1080p with all Main Menu items visible the items fit properly.

Current:
![retroarch_2025_05_27_18_15_07_376](https://github.com/user-attachments/assets/d0501319-8e33-4c8d-b5bb-11143783a219)

After:
![retroarch_2025_05_27_18_15_25_578](https://github.com/user-attachments/assets/93636ebb-f633-4a1d-b838-4120f2932455)

