### PR TITLE
XInput: Fix rumble performance drops on Bluetooth and reduce unnecessary polling

### DIFF
--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -74,7 +74,11 @@ static XINPUT_FEEDBACK     g_xinput_rumble_states[4];
 static XINPUT_VIBRATION    g_xinput_rumble_states[4];
 #endif
 static xinput_joypad_state g_xinput_states[4];
+static bool xinput_active_port[4] = {0};
 static clock_t last_rumble_time[4] = {0};
+
+static unsigned xinput_hotplug_index = 0;
+static unsigned xinput_poll_counter = 0;
 
 /* Buttons are provided by XInput as bits of a uint16.
  * Map from rarch button index (0..10) to a mask to
@@ -208,6 +212,9 @@ static void *xinput_joypad_init(void *data)
       goto error;
 #endif
 
+   for (i = 0; i < 4; ++i)
+      xinput_active_port[i] = false;
+
    for (j = 0; j < MAX_USERS; j++)
    {
       const char *name = xinput_joypad_name(j);
@@ -225,6 +232,13 @@ static void *xinput_joypad_init(void *data)
                vid,
                pid);
       }
+   }
+
+   for (i = 0; i < MAX_USERS; ++i)
+   {
+      int xuser = pad_index_to_xuser_index(i);
+      if (xuser >= 0 && xuser < 4)
+         xinput_active_port[xuser] = true;
    }
 
 #ifdef __WINRT__
@@ -336,10 +350,41 @@ static int16_t xinput_joypad_state_func(
 
 static void xinput_joypad_poll(void)
 {
-   unsigned i;
+   /* Hotplugging detection: scanning one port at a time every few frames,
+    * to avoid polling overload and framerate drops. */
+   xinput_poll_counter++;
+   if (xinput_poll_counter >= 15)
+   {
+      xinput_poll_counter = 0;
+      if (!xinput_active_port[xinput_hotplug_index])
+      {
+         XINPUT_STATE tmp_state;
+         DWORD result = g_XInputGetStateEx(xinput_hotplug_index, &tmp_state);
+         if (result == ERROR_SUCCESS)
+         {
+            const char *name = xinput_joypad_name(xinput_hotplug_index);
+            int32_t vid = 0;
+            int32_t pid = 0;
+            input_autoconfigure_connect(
+                  name,
+                  NULL,
+                  xinput_joypad.ident,
+                  xinput_hotplug_index,
+                  vid,
+                  pid);
 
+            xinput_active_port[xinput_hotplug_index] = true;
+         }
+      }
+      xinput_hotplug_index = (xinput_hotplug_index + 1) % 4;
+   }
+
+   unsigned i;
    for (i = 0; i < 4; ++i)
    {
+      if (!xinput_active_port[i])
+         continue;
+
       xinput_joypad_state
          *state          = &g_xinput_states[i];
       DWORD status       = g_XInputGetStateEx(i, &state->xstate);

--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#include <time.h>
 
 #include <boolean.h>
 #include <retro_inline.h>
@@ -51,6 +52,8 @@ typedef struct
    bool         connected;
 } xinput_joypad_state;
 
+#define RUMBLE_INTERVAL 0.005
+
 /* Function pointer, to be assigned with dylib_proc */
 typedef uint32_t (__stdcall *XInputGetStateEx_t)(uint32_t, XINPUT_STATE*);
 typedef uint32_t (__stdcall *XInputSetState_t)(uint32_t, XINPUT_VIBRATION*);
@@ -71,6 +74,7 @@ static XINPUT_FEEDBACK     g_xinput_rumble_states[4];
 static XINPUT_VIBRATION    g_xinput_rumble_states[4];
 #endif
 static xinput_joypad_state g_xinput_states[4];
+static clock_t last_rumble_time[4] = {0};
 
 /* Buttons are provided by XInput as bits of a uint16.
  * Map from rarch button index (0..10) to a mask to
@@ -371,17 +375,31 @@ static bool xinput_joypad_rumble(unsigned pad,
    if (xuser == -1)
       return false;
 
+   XINPUT_VIBRATION *state    = &g_xinput_rumble_states[xuser];
+   XINPUT_VIBRATION new_state = *state;
+
    /* Consider the low frequency (left) motor the "strong" one. */
    if (effect == RETRO_RUMBLE_STRONG)
-      g_xinput_rumble_states[xuser].wLeftMotorSpeed = strength;
+      new_state.wLeftMotorSpeed = strength;
    else if (effect == RETRO_RUMBLE_WEAK)
-      g_xinput_rumble_states[xuser].wRightMotorSpeed = strength;
+      new_state.wRightMotorSpeed = strength;
+
+   bool rumble_state_unchanged = ((new_state.wLeftMotorSpeed  == state->wLeftMotorSpeed) &&
+                                  (new_state.wRightMotorSpeed == state->wRightMotorSpeed));
+
+   clock_t now = clock();
+   double time_since_last_rumble = (double)(now - last_rumble_time[xuser]) / CLOCKS_PER_SEC;
+   bool rumble_interval_unelapsed = (time_since_last_rumble < RUMBLE_INTERVAL);
+
+   if (rumble_state_unchanged || rumble_interval_unelapsed)
+      return true;
 
    if (!g_XInputSetState)
       return false;
 
-   return (g_XInputSetState(xuser, &g_xinput_rumble_states[xuser])
-      == 0);
+   *state = new_state;
+   last_rumble_time[xuser] = now;
+   return (g_XInputSetState(xuser, state) == ERROR_SUCCESS);
 }
 
 input_device_driver_t xinput_joypad = {


### PR DESCRIPTION
While testing a new Gulikit controller that I have bought recently, a pretty old issue came again to the surface, related to Xinput and Bluetooth on Windows.

I decided to investigate and I think I have now identified a couple of severe bottlenecks that were affecting the "xinput" controller driver in RetroArch, which were exacerbated by a few combinations of controller + connection type (wired/Bluetooth) + driver.

Long text incoming...

### Heavy slowdown when using Bluetooth XInput controllers with most cores that support rumble

This was first documented in the following issues:
- https://github.com/libretro/beetle-psx-libretro/issues/640
- https://github.com/libretro/mgba/issues/163
- https://github.com/mgba-emu/mgba/issues/1638
- https://github.com/libretro/vbam-libretro/issues/81

When using certain Xinput controllers (such as several 8bitdo ones) connected over Bluetooth, with the controller driver set to "xinput" in RA, severe framerate drops could be observed with most cores that support vibration.

This did **not** happen with any of the following scenarios:
- using the "xinput" controller driver and connecting the same controllers wired;
- using the "xinput" controller driver and connecting the same controllers over Bluetooth, while also having a separate application/wrapper running that intercepts the polling calls (such as an Xinput-to-DS4 wrapper, like VDX (https://github.com/nefarius/VDX);
- using any other controller driver than "xinput".

The reason for this issue is that the "xinput" controller driver is repeatedly calling `XInputSetState()` for setting the rumble state. This function is very taxing and was causing some severe overload, especially when using Bluetooth.

This PR implements the following:

1. anytime the xinput_joypad_rumble() function is called, we track whether there was a change in the rumble state;

2. we also limit the rumble calls to an interval of 5ms. This value was chosen to try and mimic the current behavior of the "sdl2" controller driver, although with a slightly different mechanism. Based on my understanding, in the "sdl2" controller driver all rumble effects are forced to have a set duration of 5ms. Here, instead, we are setting an interval of 5ms for deciding when to set a new rumble state.

If there's no change in the rumble state OR if the 5ms interval has not elapsed yet, we stop there. Otherwise, we use `XInputSetState()` to send the new rumble information, like we did before.

In the following screenshots, check the framerate while using fastforward with the mgba core. 
The difference is *very* noticeable...

Before:
![image](https://github.com/user-attachments/assets/031241d8-abc5-45c8-a0d2-528f3855ec97)

After:
![image](https://github.com/user-attachments/assets/d5bc0469-97cd-48b8-b143-c336f5d2a41f)

### Performance decrease due to excessive polling of all 4 ports at every frame

It turns out that - aside from the rumble problem - the "xinput" controller driver was performing significantly worse than both dinput and sdl2.
This is because the driver was using the similarly taxing `XInputGetStateEx()` function to constantly poll all 4 XInput ports at once for every single frame, regardless of whether any of the 4 ports were actually active at any given time. This was causing significant slowdown, over either wired connections or Bluetooth.

This PR implements the following changes:

1. we now only poll active XInput ports, reducing the number of `XInputGetStateEx()` calls significantly;

2. sdl2 has a significant advantage, because to my understanding it can check OS events to detect if a controller is plugged in or not, without necessarily having to poll its input. This seems impossible with xinput, so we have to use `XInputGetStateEx()` to understand if a controller is connected or not. To preserve hotplugging capabilities and still keep our performance improvements, we now check every 15 frames (arbitrarily defined number, based on 60 frames / 4, which is the maximum number of Xinput ports allowed) one XInput port after another.
If a new controller is detected to be plugged in, within 15ms that port gets marked as active and is polled as normal, just like before. But we now avoid all the redundant calls to inactive ports, which is what was causing the slowdown.

Again, check these screenshots for an indication of the performance difference.

Before:
![image](https://github.com/user-attachments/assets/594cfb3a-b4a7-47da-a5e2-5b04144b3bcf)

After:
![image](https://github.com/user-attachments/assets/0330292b-85b8-4a23-bac0-852d65c20a01)

------------------
Tested with the following controllers:
- Gulikit Elves 2 Pro
- 8bitdo SN30 Pro
- 8bitdo SN30 Pro+
- Xbox Series X/S

Fixes https://github.com/libretro/beetle-psx-libretro/issues/640.
Fixes https://github.com/libretro/mgba/issues/163
Fixes https://github.com/libretro/vbam-libretro/issues/81



