### PR TITLE
Fix argv for webOS

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -7007,8 +7007,11 @@ static bool retroarch_parse_input_and_config(
       BSV_MOVIE_ARG NETPLAY_ARG DYNAMIC_ARG FFMPEG_RECORD_ARG CONFIG_FILE_ARG;
 
 #if defined(WEBOS)
-   argv                            = &(argv[1]);
-   argc                            = argc - 1;
+   if (argv[1][0] == '{')
+   {
+      argv                            = &(argv[1]);
+      argc                            = argc - 1;
+   }
 #endif
 
 #ifndef HAVE_MENU


### PR DESCRIPTION
## Description

webOS passes a JSON as launchParams for `argv[1]`

## Related Issues

https://github.com/libretro/RetroArch/issues/17946

## Reviewers

@sonninnos
