### PR TITLE
video4linux2.c: do not close before open.

### DIFF
--- a/camera/drivers/video4linux2.c
+++ b/camera/drivers/video4linux2.c
@@ -310,7 +310,8 @@ static void *v4l_init(const char *device, uint64_t caps,
    if (!path_is_character_special(v4l->dev_name))
    {
       RARCH_ERR("[V4L2]: %s is no device.\n", v4l->dev_name);
-      goto error;
+      free(v4l);
+      return NULL;
    }
 
    v4l->fd = open(v4l->dev_name, O_RDWR | O_NONBLOCK, 0);


### PR DESCRIPTION
With no camera connected this would call close(0), causing problems later.

## Description

Problems only occur on linux when a core is loaded that uses camera input. For example libretro_mgba.