### PR TITLE
webOS: Disable core dumps

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -49,6 +49,10 @@
 #include <process.h>
 #endif
 
+#if defined(WEBOS)
+#include <sys/resource.h>
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -5891,6 +5895,11 @@ int rarch_main(int argc, char *argv[], void *data)
       RARCH_ERR("FATAL: Failed to initialize the COM interface\n");
       return 1;
    }
+#endif
+
+#if defined(WEBOS)
+   struct rlimit limit = {0, 0};
+   setrlimit(RLIMIT_CORE, &limit);
 #endif
 
    rtime_init();


### PR DESCRIPTION
## Description

TVs have limited storage and by default crashes dump core files that can be very large, as seen in this screenshot:

![image](https://github.com/user-attachments/assets/5270c1e1-935c-478e-a483-14473cc675b1)

This code disables the core dumps on webOS.