### PR TITLE
udev_input.c: restore linux terminal in udev_input_free

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -3933,6 +3933,10 @@ static void udev_input_free(void *data)
    if (!data || !udev)
       return;
 
+#ifdef __linux__
+   linux_terminal_restore_input();
+#endif
+
    if (udev->fd >= 0)
       close(udev->fd);
 


### PR DESCRIPTION
Linux terminal settings were lost after restarting via menu. This was caused by udev_input_init calling linux_terminal_disable_input multiple times.

New code follows the restore pattern of linuxraw_input.c

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
