### PR TITLE
Fix for warnings when compiling menu_cbs_sublabel.c after CRT Geometry PR 

### DIFF
--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -2530,6 +2530,9 @@ int menu_cbs_init_bind_sublabel(menu_file_list_cbs_t *cbs,
          case MENU_ENUM_LABEL_CRT_SWITCH_PORCH_ADJUST:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_crt_switchres_porch_adjust);
             break;
+         case MENU_ENUM_LABEL_CRT_SWITCH_VERTICAL_ADJUST:
+            BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_crt_switchres_vertical_adjust);
+            break;
          case MENU_ENUM_LABEL_CRT_SWITCH_RESOLUTION_USE_CUSTOM_REFRESH_RATE:
             BIND_ACTION_SUBLABEL(cbs, action_bind_sublabel_crt_switchres_use_custom_refresh_rate);
             break;


### PR DESCRIPTION
## Description

Fixed issues with warnings when compiling menu_cbs_sublabel.c after CRT geometry adjust PR

## Related Issues

Warning message when compiling menu_cbs_sublabel.c

warning: ‘action_bind_sublabel_crt_switchres_vertical_adjust’ defined but not used [-Wunused-function]
  255 | DEFAULT_SUBLABEL_MACRO(action_bind_sublabel_crt_switchres_vertical_adjust,       MENU_ENUM_SUBLABEL_CRT_SWITCH_VERTICAL_ADJUST)

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/17987

## Reviewers

@hunterk 
