### PR TITLE
D3D: Add alternative max frame latency hack mode

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2505,7 +2505,6 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("video_hard_sync_frames",        &settings->uints.video_hard_sync_frames, true, DEFAULT_HARD_SYNC_FRAMES, false);
    SETTING_UINT("video_frame_delay",             &settings->uints.video_frame_delay,      true, DEFAULT_FRAME_DELAY, false);
    SETTING_UINT("video_max_swapchain_images",    &settings->uints.video_max_swapchain_images, true, DEFAULT_MAX_SWAPCHAIN_IMAGES, false);
-   SETTING_UINT("video_max_frame_latency",       &settings->uints.video_max_frame_latency, true, DEFAULT_MAX_FRAME_LATENCY, false);
    SETTING_UINT("video_black_frame_insertion",   &settings->uints.video_black_frame_insertion, true, DEFAULT_BLACK_FRAME_INSERTION, false);
    SETTING_UINT("video_bfi_dark_frames",         &settings->uints.video_bfi_dark_frames, true, DEFAULT_BFI_DARK_FRAMES, false);
    SETTING_UINT("video_shader_subframes",        &settings->uints.video_shader_subframes, true, DEFAULT_SHADER_SUBFRAMES, false);
@@ -2692,6 +2691,7 @@ static struct config_int_setting *populate_settings_int(
    SETTING_INT("video_window_offset_x",          &settings->ints.video_window_offset_x, true, DEFAULT_WINDOW_OFFSET_X, false);
    SETTING_INT("video_window_offset_y",          &settings->ints.video_window_offset_y, true, DEFAULT_WINDOW_OFFSET_Y, false);
 #endif
+   SETTING_INT("video_max_frame_latency",        &settings->ints.video_max_frame_latency, true, DEFAULT_MAX_FRAME_LATENCY, false);
 
 #ifdef HAVE_D3D10
    SETTING_INT("d3d10_gpu_index",                &settings->ints.d3d10_gpu_index, true, DEFAULT_D3D10_GPU_INDEX, false);

--- a/configuration.h
+++ b/configuration.h
@@ -115,6 +115,7 @@ typedef struct settings
       int crt_switch_center_adjust;
       int crt_switch_porch_adjust;
       int crt_switch_vertical_adjust;
+      int video_max_frame_latency;
 #ifdef HAVE_VULKAN
       int vulkan_gpu_index;
 #endif
@@ -247,7 +248,6 @@ typedef struct settings
       unsigned video_scale_integer_axis;
       unsigned video_scale_integer_scaling;
       unsigned video_max_swapchain_images;
-      unsigned video_max_frame_latency;
       unsigned video_swap_interval;
       unsigned video_hard_sync_frames;
       unsigned video_frame_delay;

--- a/gfx/common/d3d11_defines.h
+++ b/gfx/common/d3d11_defines.h
@@ -39,23 +39,22 @@ enum d3d11_state_flags
 {
    D3D11_ST_FLAG_VSYNC               = (1 << 0),
    D3D11_ST_FLAG_WAITABLE_SWAPCHAINS = (1 << 1),
-   D3D11_ST_FLAG_WAIT_FOR_VBLANK     = (1 << 2),
-   D3D11_ST_FLAG_RESIZE_CHAIN        = (1 << 3),
-   D3D11_ST_FLAG_KEEP_ASPECT         = (1 << 4),
-   D3D11_ST_FLAG_RESIZE_VIEWPORT     = (1 << 5),
-   D3D11_ST_FLAG_RESIZE_RTS          = (1 << 6), /* RT = Render Target */
-   D3D11_ST_FLAG_INIT_HISTORY        = (1 << 7),
-   D3D11_ST_FLAG_HAS_FLIP_MODEL      = (1 << 8),
-   D3D11_ST_FLAG_HAS_ALLOW_TEARING   = (1 << 9),
-   D3D11_ST_FLAG_HW_IFACE_ENABLE     = (1 << 10),
-   D3D11_ST_FLAG_HDR_SUPPORT         = (1 << 11),
-   D3D11_ST_FLAG_HDR_ENABLE          = (1 << 12),
-   D3D11_ST_FLAG_SPRITES_ENABLE      = (1 << 13),
-   D3D11_ST_FLAG_OVERLAYS_ENABLE     = (1 << 14),
-   D3D11_ST_FLAG_OVERLAYS_FULLSCREEN = (1 << 15),
-   D3D11_ST_FLAG_MENU_ENABLE         = (1 << 16),
-   D3D11_ST_FLAG_MENU_FULLSCREEN     = (1 << 17),
-   D3D11_ST_FLAG_FRAME_DUPE_LOCK     = (1 << 18)
+   D3D11_ST_FLAG_RESIZE_CHAIN        = (1 << 2),
+   D3D11_ST_FLAG_KEEP_ASPECT         = (1 << 3),
+   D3D11_ST_FLAG_RESIZE_VIEWPORT     = (1 << 4),
+   D3D11_ST_FLAG_RESIZE_RTS          = (1 << 5), /* RT = Render Target */
+   D3D11_ST_FLAG_INIT_HISTORY        = (1 << 6),
+   D3D11_ST_FLAG_HAS_FLIP_MODEL      = (1 << 7),
+   D3D11_ST_FLAG_HAS_ALLOW_TEARING   = (1 << 8),
+   D3D11_ST_FLAG_HW_IFACE_ENABLE     = (1 << 9),
+   D3D11_ST_FLAG_HDR_SUPPORT         = (1 << 10),
+   D3D11_ST_FLAG_HDR_ENABLE          = (1 << 11),
+   D3D11_ST_FLAG_SPRITES_ENABLE      = (1 << 12),
+   D3D11_ST_FLAG_OVERLAYS_ENABLE     = (1 << 13),
+   D3D11_ST_FLAG_OVERLAYS_FULLSCREEN = (1 << 14),
+   D3D11_ST_FLAG_MENU_ENABLE         = (1 << 15),
+   D3D11_ST_FLAG_MENU_FULLSCREEN     = (1 << 16),
+   D3D11_ST_FLAG_FRAME_DUPE_LOCK     = (1 << 17)
 };
 
 enum d3d11_feature_level_hint
@@ -218,6 +217,7 @@ typedef struct
    DXGI_FORMAT           format;
    float                 clearcolor[4];
    unsigned              swap_interval;
+   int8_t                wait_for_vblank;
    uint32_t              flags;
    d3d11_shader_t        shaders[GFX_MAX_SHADERS];
 #ifdef HAVE_DXGI_HDR

--- a/gfx/common/d3d12_defines.h
+++ b/gfx/common/d3d12_defines.h
@@ -61,9 +61,8 @@ enum d3d12_video_flags
    D3D12_ST_FLAG_HDR_ENABLE            = (1 << 11),
    D3D12_ST_FLAG_VSYNC                 = (1 << 12),
    D3D12_ST_FLAG_WAITABLE_SWAPCHAINS   = (1 << 13),
-   D3D12_ST_FLAG_WAIT_FOR_VBLANK       = (1 << 14),
-   D3D12_ST_FLAG_HW_IFACE_ENABLE       = (1 << 15),
-   D3D12_ST_FLAG_FRAME_DUPE_LOCK       = (1 << 16)
+   D3D12_ST_FLAG_HW_IFACE_ENABLE       = (1 << 14),
+   D3D12_ST_FLAG_FRAME_DUPE_LOCK       = (1 << 15)
 };
 
 typedef enum
@@ -358,6 +357,7 @@ typedef struct
    D3D12Debug debugController;
 #endif
    uint32_t flags;
+   int8_t wait_for_vblank;
 } d3d12_video_t;
 
 /* end of auto-generated */

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -9947,7 +9947,7 @@ unsigned menu_displaylist_build_list(
                if (video_wait_swap)
                   if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
                            MENU_ENUM_LABEL_VIDEO_MAX_FRAME_LATENCY,
-                           PARSE_ONLY_UINT, false) == 0)
+                           PARSE_ONLY_INT, false) == 0)
                      count++;
             }
 
@@ -10536,7 +10536,7 @@ unsigned menu_displaylist_build_list(
                {
                   MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(list,
                         MENU_ENUM_LABEL_VIDEO_MAX_FRAME_LATENCY,
-                        PARSE_ONLY_UINT, false);
+                        PARSE_ONLY_INT, false);
                      count++;
                }
             }

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -13752,9 +13752,9 @@ static bool setting_append_list(
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
             MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
 
-            CONFIG_UINT(
+            CONFIG_INT(
                   list, list_info,
-                  &settings->uints.video_max_frame_latency,
+                  &settings->ints.video_max_frame_latency,
                   MENU_ENUM_LABEL_VIDEO_MAX_FRAME_LATENCY,
                   MENU_ENUM_LABEL_VALUE_VIDEO_MAX_FRAME_LATENCY,
                   DEFAULT_MAX_FRAME_LATENCY,
@@ -13764,7 +13764,7 @@ static bool setting_append_list(
                   general_write_handler,
                   general_read_handler);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-            (*list)[list_info->index - 1].offset_by = 0;
+            (*list)[list_info->index - 1].offset_by = -1;
             menu_settings_list_current_add_range(list, list_info, (*list)[list_info->index - 1].offset_by, MAXIMUM_MAX_FRAME_LATENCY, 1, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
             MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);


### PR DESCRIPTION
## Description

Add a snappy extra vsync presentation mode by using slightly tearing and vsyncless Present instead of normal non-tearing vsync, which waits for vblank before Present instead of after, and plays even better with Frame Delay.

