### PR TITLE
Built-in playlist path rework

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -963,7 +963,7 @@ bool playlist_push_runtime(playlist_t *playlist,
 
    if (string_is_empty(entry->core_path))
    {
-      RARCH_ERR("Cannot push NULL or empty core path into the playlist.\n");
+      RARCH_ERR("[Playlist]: Cannot push NULL or empty core path into the playlist.\n");
       goto error;
    }
 
@@ -980,7 +980,7 @@ bool playlist_push_runtime(playlist_t *playlist,
 
    if (string_is_empty(real_core_path))
    {
-      RARCH_ERR("Cannot push NULL or empty core path into the playlist.\n");
+      RARCH_ERR("[Playlist]: Cannot push NULL or empty core path into the playlist.\n");
       goto error;
    }
 
@@ -1295,7 +1295,7 @@ bool playlist_push(playlist_t *playlist,
 
    if (string_is_empty(entry->core_path))
    {
-      RARCH_ERR("Cannot push NULL or empty core path into the playlist.\n");
+      RARCH_ERR("[Playlist]: Cannot push NULL or empty core path into the playlist.\n");
       goto error;
    }
 
@@ -1312,7 +1312,7 @@ bool playlist_push(playlist_t *playlist,
 
    if (string_is_empty(real_core_path))
    {
-      RARCH_ERR("Cannot push NULL or empty core path into the playlist.\n");
+      RARCH_ERR("[Playlist]: Cannot push NULL or empty core path into the playlist.\n");
       goto error;
    }
 
@@ -1326,7 +1326,7 @@ bool playlist_push(playlist_t *playlist,
 
       if (string_is_empty(core_name))
       {
-         RARCH_ERR("Cannot push NULL or empty core name into the playlist.\n");
+         RARCH_ERR("[Playlist]: Cannot push NULL or empty core name into the playlist.\n");
          goto error;
       }
    }
@@ -1558,13 +1558,13 @@ void playlist_write_runtime_file(playlist_t *playlist)
    if (!(file = intfstream_open_file(playlist->config.path,
          RETRO_VFS_FILE_ACCESS_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE)))
    {
-      RARCH_ERR("Failed to write to playlist file: \"%s\".\n", playlist->config.path);
+      RARCH_ERR("[Playlist]: Failed to write to file: \"%s\".\n", playlist->config.path);
       return;
    }
 
    if (!(writer = rjsonwriter_open_stream(file)))
    {
-      RARCH_ERR("Failed to create JSON writer\n");
+      RARCH_ERR("[Playlist]: Failed to create JSON writer\n");
       goto end;
    }
 
@@ -1697,7 +1697,7 @@ void playlist_write_runtime_file(playlist_t *playlist)
                                | CNT_PLAYLIST_FLG_OLD_FMT
                                | CNT_PLAYLIST_FLG_COMPRESSED);
 
-   RARCH_LOG("[Playlist]: Written to playlist file: \"%s\".\n", playlist->config.path);
+   RARCH_LOG("[Playlist]: Written to file: \"%s\".\n", playlist->config.path);
 end:
    intfstream_close(file);
    free(file);
@@ -1720,11 +1720,13 @@ void playlist_write_file(playlist_t *playlist)
    bool pl_old_fmt      = ((playlist->flags & CNT_PLAYLIST_FLG_OLD_FMT)    > 0);
 
    if (   !playlist
-       || !((playlist->flags & CNT_PLAYLIST_FLG_MOD)
+       || string_is_empty(playlist->config.path)
+       || !( (playlist->flags & CNT_PLAYLIST_FLG_MOD)
 #if defined(HAVE_ZLIB)
-       || (pl_compressed != playlist->config.compress)
+          || (pl_compressed != playlist->config.compress)
 #endif
-       || (pl_old_fmt    != playlist->config.old_format)))
+          || (pl_old_fmt    != playlist->config.old_format)
+          ))
       return;
 
 #if defined(HAVE_ZLIB)
@@ -1739,7 +1741,7 @@ void playlist_write_file(playlist_t *playlist)
 
    if (!file)
    {
-      RARCH_ERR("Failed to write to playlist file: \"%s\".\n", playlist->config.path);
+      RARCH_ERR("[Playlist]: Failed to write to file: \"%s\".\n", playlist->config.path);
       return;
    }
 
@@ -1784,7 +1786,7 @@ void playlist_write_file(playlist_t *playlist)
       rjsonwriter_t* writer = rjsonwriter_open_stream(file);
       if (!writer)
       {
-         RARCH_ERR("Failed to create JSON writer\n");
+         RARCH_ERR("[Playlist]: Failed to create JSON writer\n");
          goto end;
       }
       /*  When compressing playlists, human readability
@@ -2088,7 +2090,7 @@ void playlist_write_file(playlist_t *playlist)
 
       if (!rjsonwriter_free(writer))
       {
-         RARCH_ERR("Failed to write to playlist file: \"%s\".\n", playlist->config.path);
+         RARCH_ERR("[Playlist]: Failed to write to file: \"%s\".\n", playlist->config.path);
       }
 
       playlist->flags  &= ~(CNT_PLAYLIST_FLG_OLD_FMT);
@@ -2101,7 +2103,7 @@ void playlist_write_file(playlist_t *playlist)
    else
       playlist->flags  &= ~(CNT_PLAYLIST_FLG_COMPRESSED);
 
-   RARCH_LOG("[Playlist]: Written to playlist file: \"%s\".\n", playlist->config.path);
+   RARCH_LOG("[Playlist]: Written to file: \"%s\".\n", playlist->config.path);
 end:
    intfstream_close(file);
    free(file);
@@ -2268,7 +2270,7 @@ static bool JSONStartObjectHandler(void *context)
             /* Hit max item limit.
              * Note: We can't just abort here, since there may
              * be more metadata to read at the end of the file... */
-            RARCH_WARN("JSON file contains more entries than current playlist capacity. Excess entries will be discarded.\n");
+            RARCH_WARN("[Playlist]: JSON file contains more entries than current playlist capacity. Excess entries will be discarded.\n");
             pCtx->flags             |= JSON_CTX_FLG_CAPACITY_EXCEEDED;
             pCtx->current_entry      = NULL;
             /* In addition, since we are discarding excess entries,
@@ -2625,7 +2627,7 @@ static bool playlist_read_file(playlist_t *playlist)
 
       if (!(parser = rjson_open_stream(file)))
       {
-         RARCH_ERR("Failed to create JSON parser\n");
+         RARCH_ERR("[Playlist]: Failed to create JSON parser\n");
          goto end;
       }
 
@@ -2649,15 +2651,15 @@ static bool playlist_read_file(playlist_t *playlist)
       {
          if (context.flags & JSON_CTX_FLG_OOM)
          {
-            RARCH_WARN("Ran out of memory while parsing JSON playlist\n");
+            RARCH_WARN("[Playlist]: Ran out of memory while parsing JSON playlist\n");
             res = false;
          }
          else
          {
-            RARCH_WARN("Error parsing chunk:\n---snip---\n%.*s\n---snip---\n",
+            RARCH_WARN("[Playlist]: Error parsing chunk:\n---snip---\n%.*s\n---snip---\n",
                   rjson_get_source_context_len(parser),
                   rjson_get_source_context_buf(parser));
-            RARCH_WARN("Error: Invalid JSON at line %d, column %d - %s.\n",
+            RARCH_WARN("[Playlist]: Error: Invalid JSON at line %d, column %d - %s.\n",
                   (int)rjson_get_source_line(parser),
                   (int)rjson_get_source_column(parser),
                   (*rjson_get_error(parser) ? rjson_get_error(parser) : "format error"));

--- a/retroarch.c
+++ b/retroarch.c
@@ -4122,36 +4122,48 @@ bool command_event(enum event_command cmd, void *data)
 
             /* Note: Sorting is disabled by default for
              * all content history playlists */
-            RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
-                  path_content_history);
-            playlist_config_set_path(&playlist_config, path_content_history);
-            g_defaults.content_history = playlist_init(&playlist_config);
-            playlist_set_sort_mode(
-                  g_defaults.content_history, PLAYLIST_SORT_MODE_OFF);
-
-            RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
-                  path_content_music_history);
-            playlist_config_set_path(&playlist_config, path_content_music_history);
-            g_defaults.music_history = playlist_init(&playlist_config);
-            playlist_set_sort_mode(
-                  g_defaults.music_history, PLAYLIST_SORT_MODE_OFF);
-
-#if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
-            RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
-                  path_content_video_history);
-            playlist_config_set_path(&playlist_config, path_content_video_history);
-            g_defaults.video_history = playlist_init(&playlist_config);
-            playlist_set_sort_mode(
-                  g_defaults.video_history, PLAYLIST_SORT_MODE_OFF);
-#endif
+            if (!string_is_empty(path_content_history))
+            {
+               RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
+                     path_content_history);
+               playlist_config_set_path(&playlist_config, path_content_history);
+               g_defaults.content_history = playlist_init(&playlist_config);
+               playlist_set_sort_mode(
+                     g_defaults.content_history, PLAYLIST_SORT_MODE_OFF);
+            }
 
 #ifdef HAVE_IMAGEVIEWER
-            RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
-                  path_content_image_history);
-            playlist_config_set_path(&playlist_config, path_content_image_history);
-            g_defaults.image_history = playlist_init(&playlist_config);
-            playlist_set_sort_mode(
-                  g_defaults.image_history, PLAYLIST_SORT_MODE_OFF);
+            if (!string_is_empty(path_content_image_history))
+            {
+               RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
+                     path_content_image_history);
+               playlist_config_set_path(&playlist_config, path_content_image_history);
+               g_defaults.image_history = playlist_init(&playlist_config);
+               playlist_set_sort_mode(
+                     g_defaults.image_history, PLAYLIST_SORT_MODE_OFF);
+            }
+#endif
+
+            if (!string_is_empty(path_content_music_history))
+            {
+               RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
+                     path_content_music_history);
+               playlist_config_set_path(&playlist_config, path_content_music_history);
+               g_defaults.music_history = playlist_init(&playlist_config);
+               playlist_set_sort_mode(
+                     g_defaults.music_history, PLAYLIST_SORT_MODE_OFF);
+            }
+
+#if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
+            if (!string_is_empty(path_content_video_history))
+            {
+               RARCH_LOG("[Playlist]: %s: \"%s\".\n", _msg,
+                     path_content_video_history);
+               playlist_config_set_path(&playlist_config, path_content_video_history);
+               g_defaults.video_history = playlist_init(&playlist_config);
+               playlist_set_sort_mode(
+                     g_defaults.video_history, PLAYLIST_SORT_MODE_OFF);
+            }
 #endif
          }
          break;
@@ -4665,7 +4677,8 @@ bool command_event(enum event_command cmd, void *data)
                   settings->paths.directory_menu_config,
                   as_path, sizeof(conf_path));
 
-            path_set(RARCH_PATH_CONFIG, conf_path);
+            if (!string_is_empty(conf_path))
+               path_set(RARCH_PATH_CONFIG, conf_path);
 #ifdef HAVE_CONFIGFILE
             command_event_save_current_config(OVERRIDE_NONE);
 #endif
@@ -8737,7 +8750,7 @@ void retroarch_favorites_init(void)
 
    retroarch_favorites_deinit();
 
-   if (!playlist_config.capacity)
+   if (!playlist_config.capacity || string_is_empty(path_content_favorites))
       return;
 
    RARCH_LOG("[Playlist]: %s: \"%s\".\n",

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1490,8 +1490,8 @@ static bool content_load(content_ctx_info_t *info,
 #endif
 #endif
 
-   command_event(CMD_EVENT_HISTORY_INIT, NULL);
    retroarch_favorites_init();
+   command_event(CMD_EVENT_HISTORY_INIT, NULL);
    command_event(CMD_EVENT_RESUME, NULL);
    command_event(CMD_EVENT_VIDEO_SET_ASPECT_RATIO, NULL);
 


### PR DESCRIPTION
## Description

- Move built-in existing and future history playlists silently away from default path root - or wherever it happens to be in the particular platform - to a more sensible place `playlists/builtin`, since the current path is for unknown reason based on current config path, which is bad when manually loading configurations under `config` or any other dir than the default config
- Fix reading and writing empty playlist paths when creating a new cfg from scratch with `-c`
- Logging cleanups

