### PR TITLE
Add Irish Gaelic as a language option

### DIFF
--- a/gfx/drivers_font_renderer/bitmapfont_6x10.c
+++ b/gfx/drivers_font_renderer/bitmapfont_6x10.c
@@ -94,6 +94,7 @@ bitmapfont_lut_t *bitmapfont_6x10_load(unsigned language)
 	   case RETRO_LANGUAGE_SWEDISH:
 	   case RETRO_LANGUAGE_CZECH:
 	   case RETRO_LANGUAGE_HUNGARIAN:
+	   case RETRO_LANGUAGE_IRISH:
 #if 0
 	   /* These languages are not yet added */
 	   case RETRO_LANGUAGE_ROMANIAN:

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -484,6 +484,7 @@ enum retro_language
    RETRO_LANGUAGE_BELARUSIAN          = 32,
    RETRO_LANGUAGE_GALICIAN            = 33,
    RETRO_LANGUAGE_NORWEGIAN           = 34,
+   RETRO_LANGUAGE_IRISH               = 35,
    RETRO_LANGUAGE_LAST,
 
    /** Defined to ensure that <tt>sizeof(retro_language) == sizeof(int)</tt>. Do not use. */

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -1478,6 +1478,7 @@ static bool rgui_fonts_init(rgui_t *rgui)
       case RETRO_LANGUAGE_CATALAN:
       case RETRO_LANGUAGE_GALICIAN:
       case RETRO_LANGUAGE_NORWEGIAN:
+      case RETRO_LANGUAGE_IRISH:
          /* We have at least partial support for
           * these languages, but extended ASCII
           * is required */

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7012,6 +7012,7 @@ static size_t setting_get_string_representation_uint_user_language(
    LANG_DATA(BELARUSIAN)
    LANG_DATA(GALICIAN)
    LANG_DATA(NORWEGIAN)
+   LANG_DATA(IRISH)
 
    if (*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE) == RETRO_LANGUAGE_ENGLISH)
       return strlcpy(s, modes[*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE)], len);

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -138,6 +138,8 @@ const char *get_user_language_iso639_1(bool limit)
           return "gl";
       case RETRO_LANGUAGE_NORWEGIAN:
           return "no";
+      case RETRO_LANGUAGE_IRISH:
+          return "ga";
    }
    return "en";
 }
@@ -183,7 +185,7 @@ static const char *msg_hash_to_str_eo(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      #include "intl/msg_hash_eo.h"
+#include "intl/msg_hash_eo.h"
       default:
          break;
    }
@@ -291,7 +293,7 @@ static const char *msg_hash_to_str_nl(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      #include "intl/msg_hash_nl.h"
+#include "intl/msg_hash_nl.h"
       default:
          break;
    }
@@ -375,7 +377,7 @@ static const char *msg_hash_to_str_de(enum msg_hash_enums msg)
 {
    switch (msg)
    {
-      #include "intl/msg_hash_de.h"
+#include "intl/msg_hash_de.h"
       default:
          break;
    }
@@ -551,6 +553,17 @@ static const char *msg_hash_to_str_no(enum msg_hash_enums msg)
    return "null";
 }
 
+static const char *msg_hash_to_str_ga(enum msg_hash_enums msg)
+{
+   switch (msg)
+   {
+#include "intl/msg_hash_ga.h"
+      default:
+         break;
+   }
+
+   return "null";
+}
 #endif
 
 const char *msg_hash_to_str(enum msg_hash_enums msg)
@@ -661,6 +674,9 @@ const char *msg_hash_to_str(enum msg_hash_enums msg)
          break;
       case RETRO_LANGUAGE_NORWEGIAN:
          ret = msg_hash_to_str_no(msg);
+         break;
+      case RETRO_LANGUAGE_IRISH:
+         ret = msg_hash_to_str_ga(msg);
          break;
       default:
          break;

--- a/retroarch.c
+++ b/retroarch.c
@@ -8715,6 +8715,7 @@ enum retro_language retroarch_get_language_from_iso(const char *iso639)
       {"be", RETRO_LANGUAGE_BELARUSIAN},
       {"gl", RETRO_LANGUAGE_GALICIAN},
       {"no", RETRO_LANGUAGE_NORWEGIAN},
+      {"ga", RETRO_LANGUAGE_IRISH},
    };
 
    if (string_is_empty(iso639))


### PR DESCRIPTION
## Description

As >30% of the main app are already translated, the new Irish Gaelic language option seems ready to be added.

The language has been enabled for RGUI as well. <- **Please, someone test this.**
Extended ASCII seemed sufficient, but if any characters are not displayed correctly, the Latin Extended fonts will need to be used.

Narrator support was _not_ added, at least for Mac and Windows. I don't think Windows even has a voice model for Irish.

## Reviewers

@IlDucci 
