### PR TITLE
Fix info disable button

### DIFF
--- a/menu/cbs/menu_cbs_info.c
+++ b/menu/cbs/menu_cbs_info.c
@@ -43,7 +43,7 @@ static int action_info_default(unsigned type, const char *label)
 #endif
 
    if (settings->bools.menu_disable_info_button)
-      goto error;
+      return 0;
 
    menu_displaylist_info_init(&info);
 


### PR DESCRIPTION
## Description

Fix crashing depending on current element when pressing info button if info button is disabled.

## Related Issues

Closes #18042

