### PR TITLE
Improve multidisk game scanning

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -815,7 +815,17 @@ static int database_info_list_iterate_found_match(
    /* Use database name for label if found,
     * otherwise use filename without extension */
    if (!string_is_empty(db_info_entry->name))
+   {
+      /* Use the archive as path instead of the file inside the archive
+       * if the file is a multidisk game, because database entry
+       * matches with the last disk, which is never bootable */
+      char *delim = (char*)strchr(entry_path_str, '#');
+
+      if (delim && strcasestr(entry_path_str, " (Disk "))
+         *delim = '\0';
+
       strlcpy(entry_lbl, db_info_entry->name, sizeof(entry_lbl));
+   }
    else if (!string_is_empty(entry_path))
    {
       char *delim = (char*)strchr(entry_path, '#');
@@ -838,15 +848,15 @@ static int database_info_list_iterate_found_match(
        *hash = '\0';
 
 #if !defined(RARCH_INTERNAL)
-   fprintf(stderr, "Found match in database !\n");
+   fprintf(stderr, "*** Found match in database! ***\n");
 
-   fprintf(stderr, "Path: %s\n", db_path);
-   fprintf(stderr, "CRC : %s\n", db_crc);
-   fprintf(stderr, "Playlist Path: %s\n", db_playlist_path);
-   fprintf(stderr, "Entry Path: %s\n", entry_path);
-   fprintf(stderr, "Playlist not NULL: %d\n", playlist != NULL);
-   fprintf(stderr, "ZIP entry: %s\n", archive_name);
-   fprintf(stderr, "entry path str: %s\n", entry_path_str);
+   fprintf(stderr, "\tPath: %s\n", db_path);
+   fprintf(stderr, "\tCRC : %s\n", db_crc);
+   fprintf(stderr, "\tPlaylist Path: %s\n", db_playlist_path);
+   fprintf(stderr, "\tEntry Path: %s\n", entry_path);
+   fprintf(stderr, "\tPlaylist not NULL: %d\n", playlist != NULL);
+   fprintf(stderr, "\tZIP entry: %s\n", archive_name);
+   fprintf(stderr, "\tentry path str: %s\n", entry_path_str);
 #endif
 
    if (!playlist_entry_exists(playlist, entry_path_str))


### PR DESCRIPTION
## Description

Because at least with Amiga database the last disk in a multidisk game is the one used for hash matching, thus it gets picked as the playlist entry path, which will never work for actual launching, forcing users to use manual scan instead for these particular cases.

So let's simply use the archive itself as the path just as single disk games if the database entry used for matching contains a hint of being a multidisk game.

This way both archives containing one game (core is getting the whole archive) and archives containing different games (core is getting a specific file from the archive) get scanned as playlist items.


## Related Issues

Closes https://github.com/libretro/libretro-database/issues/1387

