### PR TITLE
Built-in playlist migration rework

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -2772,8 +2772,14 @@ static void video_driver_default_settings(global_t *global)
          sizeof(tmp_str)); \
    if (path_is_valid(playlist_path)) \
    { \
-      rename(playlist_path, new_file); \
-      if (!path_is_valid(new_file)) \
+      if (!filestream_copy(playlist_path, new_file)) \
+         RARCH_LOG("[Config]: Copied file \"%s\" to \"%s\".\n", playlist_path, new_file); \
+      if (path_is_valid(new_file) && !filestream_cmp(playlist_path, new_file)) \
+      { \
+         if (!filestream_delete(playlist_path)) \
+            RARCH_LOG("[Config]: Deleted file \"%s\".\n", playlist_path); \
+      } \
+      else \
          new_file[0] = '\0'; \
    } \
    if (!string_is_empty(new_file)) \

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -370,6 +370,26 @@ int filestream_delete(const char *path);
 int filestream_rename(const char *old_path, const char *new_path);
 
 /**
+ * Copies a file to a new location.
+ *
+ * @param src_path Path to the file to rename.
+ * @param dst_path The target name and location of the file.
+ * @return 0 if the file was copied successfully,
+ * or -1 if there was an error.
+ */
+int filestream_copy(const char *src_path, const char *dst_path);
+
+/**
+ * Compares and verifies files.
+ *
+ * @param src_path Path to the file.
+ * @param dst_path Path to the other file.
+ * @return 0 if the files are equal,
+ * or -1 if there was an error.
+ */
+int filestream_cmp(const char *src_path, const char *dst_path);
+
+/**
  * Get the path that was used to open a file.
  *
  * @param stream The file to get the path of.


### PR DESCRIPTION
## Description

Because `rename` only works within a filesystem, it does not work with Android due to the default paths. Therefore added 2 new simple helper filestream functions (`copy` + `cmp`) to allow proper moving by copy+verify+delete. 

## Related Pull Requests

#18024

