### PR TITLE
[webOS] Update to SDL 2.30.12

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -17,7 +17,7 @@ WEBOS_INC_DIR         ?= $(STAGING_DIR)/usr/include
 WEBOS_LIB_DIR         ?= $(STAGING_DIR)/usr/lib
 
 ADD_SDL2_LIB          ?= 0
-SDL2_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/download/release-2.30.8-webos.3/SDL2-2.30.8-webos-abi.tar.gz
+SDL2_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/download/release-2.30.12-webos.1/SDL2-2.30.12-webos-abi.tar.gz
 
 #########################
 #########################

--- a/retroarch.c
+++ b/retroarch.c
@@ -5938,9 +5938,12 @@ int rarch_main(int argc, char *argv[], void *data)
 
 #if defined(WEBOS)
    // compatibility with webOS 3 - 5
+   if (getenv("EGL_PLATFORM") == NULL) {
+      setenv("EGL_PLATFORM", "wayland", 0);
+   }
    if(getenv("XDG_RUNTIME_DIR") == NULL) {
       setenv("XDG_RUNTIME_DIR", "/tmp/xdg", 0);
-    }
+   }
 
    struct rlimit limit = {0, 0};
    setrlimit(RLIMIT_CORE, &limit);

--- a/webos/README.md
+++ b/webos/README.md
@@ -10,5 +10,5 @@ make -f Makefile.webos -j$(getconf _NPROCESSORS_ONLN) ipk
 make -f Makefile.webos launch
 
 # Start installed application via SSH
-XDG_RUNTIME_DIR=/tmp/xdg /usr/bin/jailer -t native_devmode -i com.retroarch -p /media/developer/apps/usr/palm/applications/com.retroarch /media/developer/apps/usr/palm/applications/com.retroarch/retroarch --verbose --verbose
+XDG_RUNTIME_DIR=/tmp/xdg /usr/bin/jailer -t native_devmode -i com.retroarch.webos -p /media/developer/apps/usr/palm/applications/com.retroarch.webos /media/developer/apps/usr/palm/applications/com.retroarch.webos/retroarch --verbose --verbose
 ```


### PR DESCRIPTION
## Description

On webOS 3.0~3.4, a bug in SDL-webOS causes the screen to freeze. This PR uses the updated SDL2 library to fix the issue.

## Related Pull Requests

https://github.com/webosbrew/SDL-webOS/commit/4b367ad615a1928e062fb91b9750375a0c9f7343

## Reviewers

[If possible @mention all the people that should review your pull request]
