### PR TITLE
Change RFILE to intfstream_t in libretro-db

### DIFF
--- a/libretro-db/Makefile
+++ b/libretro-db/Makefile
@@ -13,6 +13,8 @@ endif
 
 LIBRETRO_COMMON_C = \
 			 $(LIBRETRO_COMM_DIR)/string/stdstring.c \
+			 $(LIBRETRO_COMM_DIR)/streams/interface_stream.c \
+			 $(LIBRETRO_COMM_DIR)/streams/memory_stream.c \
 			 $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
 			 $(LIBRETRO_COMM_DIR)/time/rtime.c \
@@ -20,6 +22,7 @@ LIBRETRO_COMMON_C = \
 			 $(LIBRETRO_COMM_DIR)/file/file_path_io.c \
 			 $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
 			 $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+			 $(LIBRETRO_COMM_DIR)/encodings/encoding_crc32.c \
 			 $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 			 $(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c
 

--- a/libretro-db/c_converter.c
+++ b/libretro-db/c_converter.c
@@ -769,7 +769,7 @@ int main(int argc, char** argv)
 {
    const char* rdb_path;
    dat_converter_match_key_t* match_key = NULL;
-   RFILE* rdb_file;
+   intfstream_t* rdb_file;
 
    if (argc < 2)
    {
@@ -829,9 +829,7 @@ int main(int argc, char** argv)
       dat_buffer++;
    }
 
-   rdb_file = filestream_open(rdb_path,
-         RETRO_VFS_FILE_ACCESS_WRITE,
-         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   rdb_file = intfstream_open_file(rdb_path, RETRO_VFS_FILE_ACCESS_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
    if (!rdb_file)
    {
@@ -852,7 +850,7 @@ int main(int argc, char** argv)
          &current_item);
    dat_converter_value_provider_free();
 
-   filestream_close(rdb_file);
+   intfstream_close(rdb_file);
 
    dat_converter_list_free(dat_parser_list);
 

--- a/libretro-db/libretrodb.h
+++ b/libretro-db/libretrodb.h
@@ -45,7 +45,7 @@ typedef struct libretrodb_index libretrodb_index_t;
 
 typedef int (*libretrodb_value_provider)(void *ctx, struct rmsgpack_dom_value *out);
 
-int libretrodb_create(RFILE *fd, libretrodb_value_provider value_provider, void *ctx);
+int libretrodb_create(intfstream_t *fd, libretrodb_value_provider value_provider, void *ctx);
 
 void libretrodb_close(libretrodb_t *db);
 

--- a/libretro-db/lua/lua_converter.c
+++ b/libretro-db/lua/lua_converter.c
@@ -71,7 +71,7 @@ int main(int argc, char ** argv)
    lua_State *L;
    const char *db_file;
    const char *lua_file;
-   RFILE *dst;
+   intfstream_t *dst;
    int rv = 0;
 
    if (argc < 3)
@@ -92,7 +92,7 @@ int main(int argc, char ** argv)
 
    call_init(L, argc - 2, (const char **) argv + 2);
 
-   dst = filestream_open(db_file,
+   dst = intfstream_open_file(db_file,
          RETRO_VFS_FILE_ACCESS_WRITE,
          RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
@@ -111,6 +111,6 @@ int main(int argc, char ** argv)
 
 clean:
    lua_close(L);
-   filestream_close(dst);
+   intfstream_close(dst);
    return rv;
 }

--- a/libretro-db/lua/testlib.c
+++ b/libretro-db/lua/testlib.c
@@ -16,7 +16,7 @@
 
 struct libretrodb
 {
-	RFILE *fd;
+	intfstream_t *fd;
 	uint64_t root;
 	uint64_t count;
 	uint64_t first_index_offset;
@@ -96,7 +96,7 @@ static int value_provider(void *ctx, struct rmsgpack_dom_value *out)
 
 static int create_db(lua_State *L)
 {
-   RFILE *dst;
+   intfstream_t *dst;
    const char *db_file = luaL_checkstring(L, -2);
 
    if (!lua_isfunction(L, -1))
@@ -106,9 +106,9 @@ static int create_db(lua_State *L)
    }
    lua_setfield(L, LUA_REGISTRYINDEX, "testlib_get_value");
 
-   dst = filestream_open(db_file,
-         RETRO_VFS_FILE_ACCESS_WRITE,
-         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   dst = intfstream_open_file(db_file,
+                              RETRO_VFS_FILE_ACCESS_WRITE,
+                              RETRO_VFS_FILE_ACCESS_HINT_NONE);
    if (!dst)
    {
       lua_pushstring(L, "Could not open destination file");
@@ -116,7 +116,7 @@ static int create_db(lua_State *L)
    }
 
    libretrodb_create(dst, &value_provider, L);
-   filestream_close(dst);
+   intfstream_close(dst);
 
    return 0;
 }

--- a/libretro-db/rmsgpack.c
+++ b/libretro-db/rmsgpack.c
@@ -74,86 +74,86 @@ static const uint8_t MPF_FIXSTR   = _MPF_FIXSTR;
 
 static const uint8_t MPF_NIL      = _MPF_NIL;
 
-int rmsgpack_write_array_header(RFILE *fd, uint32_t size)
+int rmsgpack_write_array_header(intfstream_t *fd, uint32_t size)
 {
    if (size < 16)
    {
       size = (size | MPF_FIXARRAY);
-      if (filestream_write(fd, &size, sizeof(int8_t)) != -1)
+      if (intfstream_write(fd, &size, sizeof(int8_t)) != -1)
          return sizeof(int8_t);
    }
    else if (size == (uint16_t)size)
    {
       static const uint8_t MPF_ARRAY16  = _MPF_ARRAY16;
-      if (filestream_write(fd, &MPF_ARRAY16, sizeof(MPF_ARRAY16)) != -1)
+      if (intfstream_write(fd, &MPF_ARRAY16, sizeof(MPF_ARRAY16)) != -1)
       {
          uint16_t tmp_i16 = swap_if_little16(size);
-         if (filestream_write(fd, (void *)(&tmp_i16), sizeof(uint16_t)) != -1)
+         if (intfstream_write(fd, (void *)(&tmp_i16), sizeof(uint16_t)) != -1)
             return sizeof(int8_t) + sizeof(uint16_t);
       }
    }
    else
    {
       static const uint8_t MPF_ARRAY32  = _MPF_ARRAY32;
-      if (filestream_write(fd, &MPF_ARRAY32, sizeof(MPF_ARRAY32)) != -1)
+      if (intfstream_write(fd, &MPF_ARRAY32, sizeof(MPF_ARRAY32)) != -1)
       {
          uint32_t tmp_i32 = swap_if_little32(size);
-         if (filestream_write(fd, (void *)(&tmp_i32), sizeof(uint32_t)) != -1)
+         if (intfstream_write(fd, (void *)(&tmp_i32), sizeof(uint32_t)) != -1)
             return sizeof(int8_t) + sizeof(uint32_t);
       }
    }
    return -1;
 }
 
-int rmsgpack_write_map_header(RFILE *fd, uint32_t size)
+int rmsgpack_write_map_header(intfstream_t *fd, uint32_t size)
 {
    if (size < 16)
    {
       size = (size | MPF_FIXMAP);
-      if (filestream_write(fd, &size, sizeof(int8_t)) != -1)
+      if (intfstream_write(fd, &size, sizeof(int8_t)) != -1)
          return sizeof(int8_t);
    }
    else if (size == (uint16_t)size)
    {
       static const uint8_t MPF_MAP16    = _MPF_MAP16;
-      if (filestream_write(fd, &MPF_MAP16, sizeof(MPF_MAP16)) != -1)
+      if (intfstream_write(fd, &MPF_MAP16, sizeof(MPF_MAP16)) != -1)
       {
          uint16_t tmp_i16 = swap_if_little16(size);
-         if (filestream_write(fd, (void *)(&tmp_i16), sizeof(uint16_t)) != -1)
+         if (intfstream_write(fd, (void *)(&tmp_i16), sizeof(uint16_t)) != -1)
             return sizeof(uint8_t) + sizeof(uint16_t);
       }
    }
    else
    {
-      if (filestream_write(fd, &MPF_MAP32, sizeof(MPF_MAP32)) != -1)
+      if (intfstream_write(fd, &MPF_MAP32, sizeof(MPF_MAP32)) != -1)
       {
          uint32_t tmp_i32 = swap_if_little32(size);
-         if (filestream_write(fd, (void *)(&tmp_i32), sizeof(uint32_t)) != -1)
+         if (intfstream_write(fd, (void *)(&tmp_i32), sizeof(uint32_t)) != -1)
             return sizeof(int8_t) + sizeof(uint32_t);
       }
    }
    return -1;
 }
 
-int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len)
+int rmsgpack_write_string(intfstream_t *fd, const char *s, uint32_t len)
 {
    if (len < 32)
    {
       uint8_t tmp_i8 = len | MPF_FIXSTR;
-      if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
-         if (filestream_write(fd, s, len) != -1)
+      if (intfstream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
+         if (intfstream_write(fd, s, len) != -1)
             return (sizeof(uint8_t) + len);
    }
    else if (len == (uint8_t)len)
    {
       static const uint8_t MPF_STR8     = _MPF_STR8;
-      if (filestream_write(fd, &MPF_STR8, sizeof(MPF_STR8)) != -1)
+      if (intfstream_write(fd, &MPF_STR8, sizeof(MPF_STR8)) != -1)
       {
          uint8_t tmp_i8 = (uint8_t)len;
-         if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
+         if (intfstream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
          {
             int written = sizeof(uint8_t) + sizeof(uint8_t);
-            if (filestream_write(fd, s, len) != -1)
+            if (intfstream_write(fd, s, len) != -1)
                return written + len;
          }
       }
@@ -161,13 +161,13 @@ int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len)
    else if (len == (uint16_t)len)
    {
       static const uint8_t MPF_STR16    = _MPF_STR16;
-      if (filestream_write(fd, &MPF_STR16, sizeof(MPF_STR16)) != -1)
+      if (intfstream_write(fd, &MPF_STR16, sizeof(MPF_STR16)) != -1)
       {
          uint16_t tmp_i16 = swap_if_little16(len);
-         if (filestream_write(fd, &tmp_i16, sizeof(uint16_t)) != -1)
+         if (intfstream_write(fd, &tmp_i16, sizeof(uint16_t)) != -1)
          {
             int written = sizeof(uint8_t) + sizeof(uint16_t);
-            if (filestream_write(fd, s, len) != -1)
+            if (intfstream_write(fd, s, len) != -1)
                return written + len;
          }
       }
@@ -175,13 +175,13 @@ int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len)
    else
    {
       static const uint8_t MPF_STR32    = _MPF_STR32;
-      if (filestream_write(fd, &MPF_STR32, sizeof(MPF_STR32)) != -1)
+      if (intfstream_write(fd, &MPF_STR32, sizeof(MPF_STR32)) != -1)
       {
          uint32_t tmp_i32 = swap_if_little32(len);
-         if (filestream_write(fd, &tmp_i32, sizeof(uint32_t)) != -1)
+         if (intfstream_write(fd, &tmp_i32, sizeof(uint32_t)) != -1)
          {
             int written = sizeof(uint8_t) + sizeof(uint32_t);
-            if (filestream_write(fd, s, len) != -1)
+            if (intfstream_write(fd, s, len) != -1)
                return written + len;
          }
       }
@@ -189,118 +189,118 @@ int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len)
    return -1;
 }
 
-int rmsgpack_write_bin(RFILE *fd, const void *s, uint32_t len)
+int rmsgpack_write_bin(intfstream_t *fd, const void *s, uint32_t len)
 {
    if (len == (uint8_t)len)
    {
       static const uint8_t MPF_BIN8     = _MPF_BIN8;
-      if (filestream_write(fd, &MPF_BIN8, sizeof(MPF_BIN8)) != -1)
+      if (intfstream_write(fd, &MPF_BIN8, sizeof(MPF_BIN8)) != -1)
       {
          uint8_t tmp_i8 = (uint8_t)len;
-         if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
-            if (filestream_write(fd, s, len) != -1)
+         if (intfstream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
+            if (intfstream_write(fd, s, len) != -1)
                return 0;
       }
    }
    else if (len == (uint16_t)len)
    {
       static const uint8_t MPF_BIN16    = _MPF_BIN16;
-      if (filestream_write(fd, &MPF_BIN16, sizeof(MPF_BIN16)) != -1)
+      if (intfstream_write(fd, &MPF_BIN16, sizeof(MPF_BIN16)) != -1)
       {
          uint16_t tmp_i16 = swap_if_little16(len);
-         if (filestream_write(fd, &tmp_i16, sizeof(uint16_t)) != -1)
-            if (filestream_write(fd, s, len) != -1)
+         if (intfstream_write(fd, &tmp_i16, sizeof(uint16_t)) != -1)
+            if (intfstream_write(fd, s, len) != -1)
                return 0;
       }
    }
    else
    {
       static const uint8_t MPF_BIN32    = _MPF_BIN32;
-      if (filestream_write(fd, &MPF_BIN32, sizeof(MPF_BIN32)) != -1)
+      if (intfstream_write(fd, &MPF_BIN32, sizeof(MPF_BIN32)) != -1)
       {
          uint32_t tmp_i32 = swap_if_little32(len);
-         if (filestream_write(fd, &tmp_i32, sizeof(uint32_t)) != -1)
-            if (filestream_write(fd, s, len) != -1)
+         if (intfstream_write(fd, &tmp_i32, sizeof(uint32_t)) != -1)
+            if (intfstream_write(fd, s, len) != -1)
                return 0;
       }
    }
    return -1;
 }
 
-int rmsgpack_write_nil(RFILE *fd)
+int rmsgpack_write_nil(intfstream_t *fd)
 {
-   if (filestream_write(fd, &MPF_NIL, sizeof(MPF_NIL)) == -1)
+   if (intfstream_write(fd, &MPF_NIL, sizeof(MPF_NIL)) == -1)
       return -1;
    return sizeof(uint8_t);
 }
 
-int rmsgpack_write_bool(RFILE *fd, int value)
+int rmsgpack_write_bool(intfstream_t *fd, int value)
 {
    static const uint8_t MPF_FALSE    = _MPF_FALSE;
    if (value)
    {
       static const uint8_t MPF_TRUE  = _MPF_TRUE;
-      if (filestream_write(fd, &MPF_TRUE, sizeof(MPF_TRUE)) == -1)
+      if (intfstream_write(fd, &MPF_TRUE, sizeof(MPF_TRUE)) == -1)
          return -1;
    }
 
-   if (filestream_write(fd, &MPF_FALSE, sizeof(MPF_FALSE)) == -1)
+   if (intfstream_write(fd, &MPF_FALSE, sizeof(MPF_FALSE)) == -1)
       return -1;
 
    return sizeof(uint8_t);
 }
 
-int rmsgpack_write_int(RFILE *fd, int64_t value)
+int rmsgpack_write_int(intfstream_t *fd, int64_t value)
 {
    if (value >= 0 && value < 128)
    {
       uint8_t tmpval = (uint8_t)value;
-      if (filestream_write(fd, &tmpval, sizeof(uint8_t)) != -1)
+      if (intfstream_write(fd, &tmpval, sizeof(uint8_t)) != -1)
          return sizeof(uint8_t);
    }
    else if (value >= -32 && value < 0)
    {
       uint8_t tmpval = (uint8_t)(value + 256); /* -32..-1 => 0xE0 .. 0xFF */
-      if (filestream_write(fd, &tmpval, sizeof(uint8_t)) != -1)
+      if (intfstream_write(fd, &tmpval, sizeof(uint8_t)) != -1)
          return sizeof(uint8_t);
    }
    else if (value == (int8_t)value)
    {
       static const uint8_t MPF_INT8     = _MPF_INT8;
-      if (filestream_write(fd, &MPF_INT8, sizeof(MPF_INT8)) != -1)
+      if (intfstream_write(fd, &MPF_INT8, sizeof(MPF_INT8)) != -1)
       {
          int8_t tmp_i8 = (int8_t)value;
-         if (filestream_write(fd, &tmp_i8, sizeof(int8_t)) != -1)
+         if (intfstream_write(fd, &tmp_i8, sizeof(int8_t)) != -1)
             return (sizeof(uint8_t) + sizeof(int8_t));
       }
    }
    else if (value == (int16_t)value)
    {
       static const uint8_t MPF_INT16    = _MPF_INT16;
-      if (filestream_write(fd, &MPF_INT16, sizeof(MPF_INT16)) != -1)
+      if (intfstream_write(fd, &MPF_INT16, sizeof(MPF_INT16)) != -1)
       {
          int16_t tmp_i16 = swap_if_little16((uint16_t)value);
-         if (filestream_write(fd, &tmp_i16, sizeof(int16_t)) != -1)
+         if (intfstream_write(fd, &tmp_i16, sizeof(int16_t)) != -1)
             return (sizeof(uint8_t) + sizeof(int16_t));
       }
    }
    else if (value == (int32_t)value)
    {
       static const uint8_t MPF_INT32    = _MPF_INT32;
-      if (filestream_write(fd, &MPF_INT32, sizeof(MPF_INT32)) != -1)
+      if (intfstream_write(fd, &MPF_INT32, sizeof(MPF_INT32)) != -1)
       {
          int32_t tmp_i32 = swap_if_little32((uint32_t)value);
-         if (filestream_write(fd, &tmp_i32, sizeof(int32_t)) != -1)
+         if (intfstream_write(fd, &tmp_i32, sizeof(int32_t)) != -1)
             return (sizeof(uint8_t) + sizeof(int32_t));
       }
    }
    else
    {
       static const uint8_t MPF_INT64    = _MPF_INT64;
-      if (filestream_write(fd, &MPF_INT64, sizeof(MPF_INT64)) != -1)
+      if (intfstream_write(fd, &MPF_INT64, sizeof(MPF_INT64)) != -1)
       {
          value = swap_if_little64(value);
-         if (filestream_write(fd, &value, sizeof(int64_t)) != -1)
+         if (intfstream_write(fd, &value, sizeof(int64_t)) != -1)
             return (sizeof(uint8_t) + sizeof(int64_t));
       }
    }
@@ -308,56 +308,56 @@ int rmsgpack_write_int(RFILE *fd, int64_t value)
    return -1;
 }
 
-int rmsgpack_write_uint(RFILE *fd, uint64_t value)
+int rmsgpack_write_uint(intfstream_t *fd, uint64_t value)
 {
    if (value == (uint8_t)value)
    {
       static const uint8_t MPF_UINT8    = _MPF_UINT8;
-      if (filestream_write(fd, &MPF_UINT8, sizeof(MPF_UINT8)) != -1)
+      if (intfstream_write(fd, &MPF_UINT8, sizeof(MPF_UINT8)) != -1)
       {
          uint8_t tmp_i8 = (uint8_t)value;
-         if (filestream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
+         if (intfstream_write(fd, &tmp_i8, sizeof(uint8_t)) != -1)
             return (sizeof(uint8_t) + sizeof(uint8_t));
       }
    }
    else if (value == (uint16_t)value)
    {
       static const uint8_t MPF_UINT16   = _MPF_UINT16;
-      if (filestream_write(fd, &MPF_UINT16, sizeof(MPF_UINT16)) != -1)
+      if (intfstream_write(fd, &MPF_UINT16, sizeof(MPF_UINT16)) != -1)
       {
          uint16_t tmp_i16 = swap_if_little16((uint16_t)value);
-         if (filestream_write(fd, &tmp_i16, sizeof(uint16_t)) != -1)
+         if (intfstream_write(fd, &tmp_i16, sizeof(uint16_t)) != -1)
             return (sizeof(uint8_t) + sizeof(uint16_t));
       }
    }
    else if (value == (uint32_t)value)
    {
       static const uint8_t MPF_UINT32   = _MPF_UINT32;
-      if (filestream_write(fd, &MPF_UINT32, sizeof(MPF_UINT32)) != -1)
+      if (intfstream_write(fd, &MPF_UINT32, sizeof(MPF_UINT32)) != -1)
       {
          uint32_t tmp_i32 = swap_if_little32((uint32_t)value);
-         if (filestream_write(fd, &tmp_i32, sizeof(uint32_t)) != -1)
+         if (intfstream_write(fd, &tmp_i32, sizeof(uint32_t)) != -1)
             return (sizeof(uint8_t) + sizeof(uint32_t));
       }
    }
    else
    {
       static const uint8_t MPF_UINT64   = _MPF_UINT64;
-      if (filestream_write(fd, &MPF_UINT64, sizeof(MPF_UINT64)) != -1)
+      if (intfstream_write(fd, &MPF_UINT64, sizeof(MPF_UINT64)) != -1)
       {
          value = swap_if_little64(value);
-         if (filestream_write(fd, &value, sizeof(uint64_t)) != -1)
+         if (intfstream_write(fd, &value, sizeof(uint64_t)) != -1)
             return (sizeof(uint8_t) + sizeof(uint64_t));
       }
    }
    return -1;
 }
 
-static int rmsgpack_read_uint(RFILE *fd, uint64_t *s, size_t len)
+static int rmsgpack_read_uint(intfstream_t *fd, uint64_t *s, size_t len)
 {
    union { uint64_t u64; uint32_t u32; uint16_t u16; uint8_t u8; } tmp;
 
-   if (filestream_read(fd, &tmp, len) == -1)
+   if (intfstream_read(fd, &tmp, len) == -1)
       return -1;
 
    switch (len)
@@ -378,11 +378,11 @@ static int rmsgpack_read_uint(RFILE *fd, uint64_t *s, size_t len)
    return 0;
 }
 
-static int rmsgpack_read_int(RFILE *fd, int64_t *s, size_t len)
+static int rmsgpack_read_int(intfstream_t *fd, int64_t *s, size_t len)
 {
    union { uint64_t u64; uint32_t u32; uint16_t u16; uint8_t u8; } tmp;
 
-   if (filestream_read(fd, &tmp, len) == -1)
+   if (intfstream_read(fd, &tmp, len) == -1)
       return -1;
 
    switch (len)
@@ -403,7 +403,7 @@ static int rmsgpack_read_int(RFILE *fd, int64_t *s, size_t len)
    return 0;
 }
 
-static int rmsgpack_read_buff(RFILE *fd, size_t size, char **pbuff, uint64_t *len)
+static int rmsgpack_read_buff(intfstream_t *fd, size_t size, char **pbuff, uint64_t *len)
 {
    ssize_t read_len;
    uint64_t tmp_len   = 0;
@@ -413,7 +413,7 @@ static int rmsgpack_read_buff(RFILE *fd, size_t size, char **pbuff, uint64_t *le
 
    *pbuff             = (char *)malloc((size_t)(tmp_len + 1) * sizeof(char));
 
-   if ((read_len      = filestream_read(fd, *pbuff, (size_t)tmp_len)) == -1)
+   if ((read_len      = intfstream_read(fd, *pbuff, (size_t)tmp_len)) == -1)
    {
       free(*pbuff);
       *pbuff = NULL;
@@ -427,7 +427,7 @@ static int rmsgpack_read_buff(RFILE *fd, size_t size, char **pbuff, uint64_t *le
    return 0;
 }
 
-static int rmsgpack_read_map(RFILE *fd, uint32_t len,
+static int rmsgpack_read_map(intfstream_t *fd, uint32_t len,
         struct rmsgpack_read_callbacks *callbacks, void *data)
 {
    int rv;
@@ -448,7 +448,7 @@ static int rmsgpack_read_map(RFILE *fd, uint32_t len,
    return 0;
 }
 
-static int rmsgpack_read_array(RFILE *fd, uint32_t len,
+static int rmsgpack_read_array(intfstream_t *fd, uint32_t len,
       struct rmsgpack_read_callbacks *callbacks, void *data)
 {
    int rv;
@@ -467,7 +467,7 @@ static int rmsgpack_read_array(RFILE *fd, uint32_t len,
    return 0;
 }
 
-int rmsgpack_read(RFILE *fd,
+int rmsgpack_read(intfstream_t *fd,
       struct rmsgpack_read_callbacks *callbacks, void *data)
 {
    int rv;
@@ -477,7 +477,7 @@ int rmsgpack_read(RFILE *fd,
    uint8_t type      = 0;
    char *buff        = NULL;
 
-   if (filestream_read(fd, &type, sizeof(uint8_t)) == -1)
+   if (intfstream_read(fd, &type, sizeof(uint8_t)) == -1)
       return -1;
 
    if (type < MPF_FIXMAP)
@@ -502,7 +502,7 @@ int rmsgpack_read(RFILE *fd,
       tmp_len          = type - MPF_FIXSTR;
       if (!(buff = (char *)malloc((size_t)(tmp_len + 1) * sizeof(char))))
          return -1;
-      if ((read_len = filestream_read(fd, buff, (ssize_t)tmp_len)) == -1)
+      if ((read_len = intfstream_read(fd, buff, (ssize_t)tmp_len)) == -1)
       {
          free(buff);
          return -1;

--- a/libretro-db/rmsgpack.h
+++ b/libretro-db/rmsgpack.h
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 
-#include <streams/file_stream.h>
+#include <streams/interface_stream.h>
 
 struct rmsgpack_read_callbacks
 {
@@ -39,22 +39,22 @@ struct rmsgpack_read_callbacks
    int (*read_array_start)(uint32_t, void *);
 };
 
-int rmsgpack_write_array_header(RFILE *fd, uint32_t size);
+int rmsgpack_write_array_header(intfstream_t *stream, uint32_t size);
 
-int rmsgpack_write_map_header(RFILE *fd, uint32_t size);
+int rmsgpack_write_map_header(intfstream_t *stream, uint32_t size);
 
-int rmsgpack_write_string(RFILE *fd, const char *s, uint32_t len);
+int rmsgpack_write_string(intfstream_t *stream, const char *s, uint32_t len);
 
-int rmsgpack_write_bin(RFILE *fd, const void *s, uint32_t len);
+int rmsgpack_write_bin(intfstream_t *stream, const void *s, uint32_t len);
 
-int rmsgpack_write_nil(RFILE *fd);
+int rmsgpack_write_nil(intfstream_t *stream);
 
-int rmsgpack_write_bool(RFILE *fd, int value);
+int rmsgpack_write_bool(intfstream_t *stream, int value);
 
-int rmsgpack_write_int(RFILE *fd, int64_t value);
+int rmsgpack_write_int(intfstream_t *stream, int64_t value);
 
-int rmsgpack_write_uint(RFILE *fd, uint64_t value );
+int rmsgpack_write_uint(intfstream_t *stream, uint64_t value );
 
-int rmsgpack_read(RFILE *fd, struct rmsgpack_read_callbacks *callbacks, void *data);
+int rmsgpack_read(intfstream_t *stream, struct rmsgpack_read_callbacks *callbacks, void *data);
 
 #endif

--- a/libretro-db/rmsgpack_dom.c
+++ b/libretro-db/rmsgpack_dom.c
@@ -342,7 +342,7 @@ void rmsgpack_dom_value_print(struct rmsgpack_dom_value *obj)
    }
 }
 
-int rmsgpack_dom_write(RFILE *fd, const struct rmsgpack_dom_value *obj)
+int rmsgpack_dom_write(intfstream_t *fd, const struct rmsgpack_dom_value *obj)
 {
    unsigned i;
    int rv = 0;
@@ -403,7 +403,7 @@ static struct rmsgpack_read_callbacks dom_reader_callbacks = {
 	dom_read_array_start
 };
 
-int rmsgpack_dom_read(RFILE *fd, struct rmsgpack_dom_value *out)
+int rmsgpack_dom_read(intfstream_t *fd, struct rmsgpack_dom_value *out)
 {
    int rv;
    struct dom_reader_state s;
@@ -417,7 +417,7 @@ int rmsgpack_dom_read(RFILE *fd, struct rmsgpack_dom_value *out)
    return rv;
 }
 
-int rmsgpack_dom_read_into(RFILE *fd, ...)
+int rmsgpack_dom_read_into(intfstream_t *fd, ...)
 {
    int rv;
    va_list ap;

--- a/libretro-db/rmsgpack_dom.h
+++ b/libretro-db/rmsgpack_dom.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 #include <retro_common_api.h>
-#include <streams/file_stream.h>
+#include <streams/interface_stream.h>
 
 RETRO_BEGIN_DECLS
 
@@ -89,11 +89,11 @@ struct rmsgpack_dom_value *rmsgpack_dom_value_map_value(
         const struct rmsgpack_dom_value *map,
         const struct rmsgpack_dom_value *key);
 
-int rmsgpack_dom_read(RFILE *fd, struct rmsgpack_dom_value *out);
+int rmsgpack_dom_read(intfstream_t *stream, struct rmsgpack_dom_value *out);
 
-int rmsgpack_dom_write(RFILE *fd, const struct rmsgpack_dom_value *obj);
+int rmsgpack_dom_write(intfstream_t *stream, const struct rmsgpack_dom_value *obj);
 
-int rmsgpack_dom_read_into(RFILE *fd, ...);
+int rmsgpack_dom_read_into(intfstream_t *stream, ...);
 
 RETRO_END_DECLS
 

--- a/libretro-db/rmsgpack_test.c
+++ b/libretro-db/rmsgpack_test.c
@@ -186,9 +186,9 @@ static struct rmsgpack_read_callbacks stub_callbacks = {
 int main(void)
 {
    struct stub_state state;
-   RFILE *fd = filestream_open("test.msgpack",
-         RETRO_VFS_FILE_ACCESS_READ,
-         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   intfstream_t *fd = intfstream_open_file("test.msgpack",
+                                           RETRO_VFS_FILE_ACCESS_READ,
+                                           RETRO_VFS_FILE_ACCESS_HINT_NONE);
 
    state.i        = 0;
    state.stack[0] = 0;
@@ -196,7 +196,7 @@ int main(void)
    rmsgpack_read(fd, &stub_callbacks, &state);
 
    printf("Test succeeded.\n");
-   filestream_close(fd);
+   intfstream_close(fd);
 
    return 0;
 }

--- a/menu/menu_explore.c
+++ b/menu/menu_explore.c
@@ -23,6 +23,7 @@
 #include <formats/rjson.h>
 #include <formats/rjson_helpers.h>
 #include <retro_endianness.h>
+#include <streams/file_stream.h>
 
 #include "menu_driver.h"
 #include "menu_cbs.h"


### PR DESCRIPTION
This is a non-functional change to the rmsgpack implementation.  Instead of using `RFILE *` ("file streams"), rmsgpack should use `intfstream_t *` (interface streams).  This way, the rmsgpack code can be used to read and write msgpack to zipped streams, in-memory streams, etc (interestingly, network streams are not covered by interface streams).

The change to `menu_explore.c` is just because it had transitively imported filestreams from rmsgpack.h via libretrodb.h; now it explicitly imports that header.