### PR TITLE
Fix input_overlay_track_touch_inputs

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -3411,11 +3411,11 @@ static void input_overlay_track_touch_inputs(
       outlier = 0;
 
       for (i = 0; i < state->touch_count; i++)
-         if (     min_sq_dist[i] > outlier
-               && old_index_lut[i] != -1)
+         if (min_sq_dist[i] > outlier)
          {
-            outlier = min_sq_dist[i];
-            new_idx = i;
+            outlier        = min_sq_dist[i];
+            new_idx        = i;
+            min_sq_dist[i] = 0;
          }
 
       old_index_lut[new_idx] = -1;


### PR DESCRIPTION
- Fixes bug introduced in 31014e99c0. Unmatched pointers were not considered outliers

Didn't think through my last PR.