### PR TITLE
Resampler refactors

### DIFF
--- a/libretro-common/audio/resampler/drivers/sinc_resampler.c
+++ b/libretro-common/audio/resampler/drivers/sinc_resampler.c
@@ -45,7 +45,12 @@
 #endif
 
 #if defined(__AVX__)
-#include <immintrin.h>
+#ifdef __GNUC__
+  #include <x86intrin.h>
+#else
+  #include <immintrin.h>
+  #include <ammintrin.h>
+#endif
 #endif
 
 /* Rough SNR values for upsampling:


### PR DESCRIPTION
These resampler refactors were suggested by AI.

Suggested Improvements
1. Avoid Repeated Memory Accesses:
The current implementation repeatedly accesses buffer_l and buffer_r for each iteration of the inner loop. Instead, we can load these buffers once per iteration and reuse them.
2. Use _mm_loadu_ps Efficiently:
The code currently loads data from memory multiple times in the loop. We can optimize this by ensuring that we load the data only when needed and in a way that minimizes cache misses.
3. Reduce Branching:
The nested while loops can lead to branching, especially when checking conditions. This can be optimized by re-evaluating the logic to minimize branches.
4. Use SIMD Operations More Effectively:
The way sums are computed can be optimized. Instead of using shuffles and multiple additions, we can use horizontal addition to combine results more efficiently.
5. Precompute Constants:
If re->subphase_mask and re->subphase_mod are constants for the duration of the processing, they can be precomputed and reused.
6. Unroll Loops:
The inner loop that processes taps can be unrolled for better performance, as modern compilers can benefit from reduced loop overhead.

**Explanation of Changes**
1. Buffer Access: The buffers are accessed once per outer loop iteration, which reduces the number of memory accesses and improves cache locality.
2. Efficient Loading: The use of _mm_loadu_ps is retained, but the loading is streamlined to ensure we are not loading more data than necessary.
3. Reduced Branching: The code structure minimizes branching by ensuring that conditions are handled in a straightforward manner.
4. Horizontal Addition: The use of _mm_hadd_ps allows for a more efficient summation of the SIMD registers.

Overall Structure: The overall structure of the loops is kept similar, but the logic within has been optimized for clarity and performance.