### PR TITLE
fix three bugs with replays and rewinding

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5985,8 +5985,8 @@ void bsv_movie_frame_rewind(void)
          /* If recording, we simply reset
           * the starting point. Nice and easy. */
 
-         intfstream_seek(handle->file, 4 * sizeof(uint32_t), SEEK_SET);
-         intfstream_truncate(handle->file, 4 * sizeof(uint32_t));
+         intfstream_seek(handle->file, 6 * sizeof(uint32_t), SEEK_SET);
+         intfstream_truncate(handle->file, 6 * sizeof(uint32_t));
 
          serial_info.data = handle->state;
          serial_info.size = handle->state_size;
@@ -6878,6 +6878,9 @@ int16_t input_driver_state_wrapper(unsigned port, unsigned device,
 #ifdef HAVE_BSV_MOVIE
    /* Save input to BSV record, if enabled */
    if (BSV_MOVIE_IS_RECORDING())
+#ifdef HAVE_REWIND
+   if (!state_manager_frame_is_reversed())
+#endif
       bsv_movie_handle_push_input_event(
             input_st->bsv_movie_state_handle,
             port,
@@ -7701,6 +7704,9 @@ void input_keyboard_event(bool down, unsigned code,
 #ifdef HAVE_BSV_MOVIE
             /* Save input to BSV record, if recording */
             if (BSV_MOVIE_IS_RECORDING())
+#ifdef HAVE_REWIND
+               if (!state_manager_frame_is_reversed())
+#endif
                bsv_movie_handle_push_key_event(
                      input_st->bsv_movie_state_handle, down, mod,
                      code, character);

--- a/state_manager.c
+++ b/state_manager.c
@@ -776,7 +776,17 @@ bool state_manager_check_rewind(
       }
       else
       {
-         content_deserialize_state(buf, rewind_st->size);
+         input_driver_state_t *input_st = input_state_get_ptr();
+#ifdef HAVE_BSV_MOVIE
+         /* Don't end reversing during playback or recording */
+         if(BSV_MOVIE_IS_PLAYBACK_ON() || BSV_MOVIE_IS_RECORDING())
+         {
+            rewind_st->flags |= STATE_MGR_REWIND_ST_FLAG_FRAME_IS_REVERSED;
+            bsv_movie_frame_rewind();
+         }
+         else
+#endif
+            content_deserialize_state(buf, rewind_st->size);
 
 #ifdef HAVE_NETWORKING
          /* Tell netplay we're done */


### PR DESCRIPTION
- rewinding past the start clobbers part of the header; it assumed 4 ints in the header, but we actually have 6.
- if rewinding during a record, should not push input events; this was causing writes to happen to the input recording during rewinding.
- during recording or playback, hitting the beginning of the rewind buffer should not halt the movie