### PR TITLE
Emscripten makefile should use INCLUDE_DIRS from Makefile.common

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -260,7 +260,10 @@ endif
 
 include Makefile.common
 
-CFLAGS += $(DEF_FLAGS) -Ideps -Ideps/stb
+DEF_FLAGS += $(INCLUDE_DIRS) -Ideps -Ideps/stb
+
+CFLAGS += $(DEF_FLAGS)
+CXXFLAGS += $(DEF_FLAGS) -D__STDC_CONSTANT_MACROS
 
 libretro     =
 libretro_new =


### PR DESCRIPTION
With this change, HAVE_ZSTD or HAVE_CHD can successfully be set for emscripten builds.

This mirrors how other Makefiles use Makefile.common.