### PR TITLE
Fix build with disable-pipewire on systems with pipewire installed

### DIFF
--- a/camera/camera_driver.c
+++ b/camera/camera_driver.c
@@ -55,7 +55,7 @@ const camera_driver_t *camera_drivers[] = {
 #ifdef HAVE_V4L2
    &camera_v4l2,
 #endif
-#ifdef HAVE_PIPEWIRE_STABLE
+#if defined(HAVE_PIPEWIRE) && defined(HAVE_PIPEWIRE_STABLE)
    &camera_pipewire,
 #endif
 #ifdef EMSCRIPTEN


### PR DESCRIPTION
## Description

On systems where pipewire is installed but the build is configured with --disable-pipewire, HAVE_PIPEWIRE_STABLE is set to 1 while HAVE_PIPEWIRE is 0. Checking only HAVE_PIPEWIRE_STABLE leads to a build failure.

```
LD retroarch
/usr/lib/gcc/x86_64-pc-linux-gnu/15/../../../../x86_64-pc-linux-gnu/bin/ld: obj-unix/release/camera/camera_driver.o:(.data.rel+0x0): undefined reference to `camera_pipewire'
collect2: error: ld returned 1 exit status
```

Downstream Bug: https://bugs.gentoo.org/960043