### PR TITLE
allow passing HAVE_OGG_OGC to link to needed OGG libs in PPC portlibs on libOGC platforms (GameCube/Wii), needed for a few cores.

### DIFF
--- a/Makefile.griffin
+++ b/Makefile.griffin
@@ -116,6 +116,7 @@ else ifeq ($(platform), ps3-cobra)
 # NGC/Wii - libogc
 else ifeq ($(libogc_platform), 1)
    EXTERNAL_LIBOGC   ?= 0
+   HAVE_OGG_OGC      ?= 0
    GX_PTHREAD_LEGACY ?= 1
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
@@ -181,6 +182,10 @@ else ifeq ($(libogc_platform), 1)
       ifeq ($(BIG_STACK), 1)
         LDFLAGS += -T bootstrap/gx/rvl.ld
       endif
+   endif
+
+   ifeq ($(HAVE_OGG_OGC), 1)
+      LIBS += -L$(DEVKITPRO)/portlibs/ppc/lib -lvorbisfile -lvorbis -logg
    endif
 
    ifeq ($(EXTERNAL_LIBOGC), 1)

--- a/Makefile.ngc
+++ b/Makefile.ngc
@@ -58,6 +58,7 @@ LIBS               := $(WHOLE_START) $(LIB_CORE) $(WHOLE_END)
 libogc_platform    := 1
 
 EXTERNAL_LIBOGC   ?= 0
+HAVE_OGG_OGC      ?= 0
 GX_PTHREAD_LEGACY ?= 1
 CC                 = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 CXX                = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
@@ -100,6 +101,10 @@ LDFLAGS += $(MACHDEP) -Wl,-Map,$(notdir $(EXT_INTER_TARGET)).map
 
 ifeq ($(BIG_STACK), 1)
    LDFLAGS += -T bootstrap/gx/ogc.ld
+endif
+
+ifeq ($(HAVE_OGG_OGC), 1)
+   LIBS += -L$(DEVKITPRO)/portlibs/ppc/lib -lvorbisfile -lvorbis -logg
 endif
 
 ifeq ($(EXTERNAL_LIBOGC), 1)

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -61,6 +61,7 @@ LIBS               := $(WHOLE_START) $(LIB_CORE) $(WHOLE_END)
 libogc_platform    := 1
 
 EXTERNAL_LIBOGC   ?= 0
+HAVE_OGG_OGC      ?= 0
 GX_PTHREAD_LEGACY ?= 1
 CC                 = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 CXX                = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
@@ -103,6 +104,10 @@ LDFLAGS += $(MACHDEP) -Wl,-Map,$(notdir $(EXT_INTER_TARGET)).map,-wrap,malloc,-w
 
 ifeq ($(BIG_STACK), 1)
    LDFLAGS += -T bootstrap/gx/rvl.ld
+endif
+
+ifeq ($(HAVE_OGG_OGC), 1)
+   LIBS += -L$(DEVKITPRO)/portlibs/ppc/lib -lvorbisfile -lvorbis -logg
 endif
 
 ifeq ($(EXTERNAL_LIBOGC), 1)


### PR DESCRIPTION
pass the argument **HAVE_OGG_OGC=1** when compiling GameCube or Wii cores that use and/or need shared OGG libraries (ex. libvorbis).
Coming from my conversation with upcoming OGG support on PicoDrive: https://github.com/irixxxx/picodrive/issues/180

Works on **Makefile.wii**, **Makefile.ngc**, and **Makefile.griffin**.

Please take note that it will look for the libraries **libvorbisfile**, **libvorbis**, and **libogg** in the location **/opt/devkitpro/portlibs/ppc/lib**.