### PR TITLE
(cheevos) fix crash trying to identify N64 ROM

### DIFF
--- a/deps/rcheevos/include/rc_hash.h
+++ b/deps/rcheevos/include/rc_hash.h
@@ -154,6 +154,7 @@ typedef struct rc_hash_iterator {
   uint8_t consoles[12];
   int index;
   const char* path;
+  void* userdata;
 
   rc_hash_callbacks_t callbacks;
 } rc_hash_iterator_t;

--- a/deps/rcheevos/src/rc_client.c
+++ b/deps/rcheevos/src/rc_client.c
@@ -2796,16 +2796,14 @@ rc_hash_iterator_t* rc_client_get_load_state_hash_iterator(rc_client_t* client)
 
 static void rc_client_log_hash_message_verbose(const char* message, const rc_hash_iterator_t* iterator)
 {
-  rc_client_load_state_t unused;
-  rc_client_load_state_t* load_state = (rc_client_load_state_t*)(((uint8_t*)iterator) - RC_OFFSETOF(unused, hash_iterator));
+  rc_client_load_state_t* load_state = (rc_client_load_state_t*)iterator->userdata;
   if (load_state->client->state.log_level >= RC_CLIENT_LOG_LEVEL_INFO)
     rc_client_log_message(load_state->client, message);
 }
 
 static void rc_client_log_hash_message_error(const char* message, const rc_hash_iterator_t* iterator)
 {
-  rc_client_load_state_t unused;
-  rc_client_load_state_t* load_state = (rc_client_load_state_t*)(((uint8_t*)iterator) - RC_OFFSETOF(unused, hash_iterator));
+  rc_client_load_state_t* load_state = (rc_client_load_state_t*)iterator->userdata;
   if (load_state->client->state.log_level >= RC_CLIENT_LOG_LEVEL_ERROR)
     rc_client_log_message(load_state->client, message);
 }
@@ -2875,6 +2873,7 @@ rc_client_async_handle_t* rc_client_begin_identify_and_load_game(rc_client_t* cl
   /* initialize the iterator */
   rc_hash_initialize_iterator(&load_state->hash_iterator, file_path, data, data_size);
   rc_hash_merge_callbacks(&load_state->hash_iterator, &client->callbacks.hash);
+  load_state->hash_iterator.userdata = load_state;
 
   if (!load_state->hash_iterator.callbacks.verbose_message)
     load_state->hash_iterator.callbacks.verbose_message = rc_client_log_hash_message_verbose;

--- a/deps/rcheevos/src/rhash/hash.c
+++ b/deps/rcheevos/src/rhash/hash.c
@@ -487,6 +487,7 @@ static int rc_hash_file_from_buffer(char hash[33], uint32_t console_id, const rc
   buffered_file_iterator.callbacks.filereader.seek = rc_file_seek_buffered_file;
   buffered_file_iterator.callbacks.filereader.tell = rc_file_tell_buffered_file;
   buffered_file_iterator.path = "memory stream";
+  buffered_file_iterator.userdata = iterator->userdata;
 
   rc_buffered_file.data = rc_buffered_file.read_ptr = iterator->buffer;
   rc_buffered_file.data_size = iterator->buffer_size;
@@ -650,6 +651,7 @@ int rc_hash_buffered_file(char hash[33], uint32_t console_id, const rc_hash_iter
     rc_hash_iterator_t buffer_iterator;
     memset(&buffer_iterator, 0, sizeof(buffer_iterator));
     memcpy(&buffer_iterator.callbacks, &iterator->callbacks, sizeof(iterator->callbacks));
+    buffer_iterator.userdata = iterator->userdata;
     buffer_iterator.path = iterator->path;
     buffer_iterator.buffer = buffer;
     buffer_iterator.buffer_size = (size_t)size;
@@ -773,6 +775,7 @@ static int rc_hash_generate_from_playlist(char hash[33], uint32_t console_id, co
 
   memset(&first_file_iterator, 0, sizeof(first_file_iterator));
   memcpy(&first_file_iterator.callbacks, &iterator->callbacks, sizeof(iterator->callbacks));
+  first_file_iterator.userdata = iterator->userdata;
   first_file_iterator.path = disc_path; /* rc_hash_destory_iterator will free */
 
   result = rc_hash_from_file(hash, console_id, &first_file_iterator);


### PR DESCRIPTION
## Description

Fixes https://discord.com/channels/184109094070779904/434713532341288961/1399875820171956294

Not specific to Android, but is (mostly) limited to N64. There was logic in the logging code for the hashing functions that made an assumption about how the data was structured, and something that was happening in the N64 identification code caused that assumption to be wrong.

## Related Issues

https://github.com/libretro/RetroArch/pull/18117#issuecomment-3134345273

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
