### PR TITLE
Implement fallback OpenGL symbol loader for Linux devices with EGL < 1.5

### DIFF
--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -313,7 +313,7 @@ void egl_destroy_gl_dll(void)
       dylib_close(g_egl_gl_dll);
       g_egl_gl_dll = NULL;
    }
-   gl_egl_gl_dll_version = 0;
+   g_egl_gl_dll_version = 0;
 #endif
 }
 

--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -611,7 +611,6 @@ bool egl_init_context(egl_ctx_data_t *egl,
       egl_accept_config_cb_t cb)
 {
 #ifdef HAVE_DYLIB
-   const EGLint *ptr = attrib_ptr;
    bool gles3_attrib_found = false;
    bool gles2_attrib_found = false;
    bool gl_attrib_found = false;
@@ -640,13 +639,13 @@ bool egl_init_context(egl_ctx_data_t *egl,
 #ifdef HAVE_DYLIB
    egl_destroy_gl_dll();
 
-   for (; *ptr != EGL_NONE; ++ptr)
+   for (; *attrib_ptr != EGL_NONE; ++attrib_ptr)
    {
-      if (*ptr == EGL_OPENGL_ES3_BIT_KHR)
+      if (*attrib_ptr == EGL_OPENGL_ES3_BIT_KHR)
          gles3_attrib_found = true;
-      else if (*ptr == EGL_OPENGL_ES2_BIT)
+      else if (*attrib_ptr == EGL_OPENGL_ES2_BIT)
          gles2_attrib_found = true;
-      else if (*ptr == EGL_OPENGL_BIT)
+      else if (*attrib_ptr == EGL_OPENGL_BIT)
          gl_attrib_found = true;
    }
 

--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -294,6 +294,17 @@ bool egl_bind_api(EGLenum egl_api)
    return _egl_bind_api(egl_api);
 }
 
+void egl_destroy_gl_dll(void)
+{
+#ifdef HAVE_DYLIB
+   if (g_egl_gl_dll)
+   {
+      dylib_close(g_egl_gl_dll);
+      g_egl_gl_dll = NULL;
+   }
+#endif
+}
+
 void egl_destroy(egl_ctx_data_t *egl)
 {
    if (egl->dpy)
@@ -321,13 +332,7 @@ void egl_destroy(egl_ctx_data_t *egl)
       egl_terminate(egl->dpy);
    }
 
-#ifdef HAVE_DYLIB
-   if (g_egl_gl_dll)
-   {
-      dylib_close(g_egl_gl_dll);
-      g_egl_gl_dll = NULL;
-   }
-#endif
+   egl_destroy_gl_dll();
 
    /* Be as careful as possible in deinit.
     * If we screw up, any TTY will not restore.
@@ -601,11 +606,7 @@ bool egl_init_context(egl_ctx_data_t *egl,
    bool gles2_attrib_found = false;
    bool gl_attrib_found = false;
 
-   if (g_egl_gl_dll)
-   {
-      dylib_close(g_egl_gl_dll);
-      g_egl_gl_dll = NULL;
-   }
+   egl_destroy_gl_dll();
 
    for (; *ptr != EGL_NONE; ++ptr)
    {
@@ -630,13 +631,7 @@ bool egl_init_context(egl_ctx_data_t *egl,
    if (dpy == EGL_NO_DISPLAY)
    {
       RARCH_ERR("[EGL] Couldn't get EGL display.\n");
-#ifdef HAVE_DYLIB
-      if (g_egl_gl_dll)
-      {
-         dylib_close(g_egl_gl_dll);
-         g_egl_gl_dll = NULL;
-      }
-#endif
+      egl_destroy_gl_dll();
       return false;
    }
 
@@ -644,13 +639,7 @@ bool egl_init_context(egl_ctx_data_t *egl,
 
    if (!egl_initialize(egl->dpy, major, minor))
    {
-#ifdef HAVE_DYLIB
-      if (g_egl_gl_dll)
-      {
-         dylib_close(g_egl_gl_dll);
-         g_egl_gl_dll = NULL;
-      }
-#endif
+      egl_destroy_gl_dll();
       return false;
    }
 
@@ -661,13 +650,7 @@ bool egl_init_context(egl_ctx_data_t *egl,
       return true;
    else
    {
-#ifdef HAVE_DYLIB
-      if (g_egl_gl_dll)
-      {
-         dylib_close(g_egl_gl_dll);
-         g_egl_gl_dll = NULL;
-      }
-#endif
+      egl_destroy_gl_dll();
       return false;
    }
 }

--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -636,8 +636,6 @@ bool egl_init_context(egl_ctx_data_t *egl,
       return false;
 
 #ifdef HAVE_DYLIB
-   egl_destroy_gl_dll();
-
    for (; *attrib_ptr != EGL_NONE; ++attrib_ptr)
    {
       if (*attrib_ptr == EGL_OPENGL_ES3_BIT_KHR)

--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -621,7 +621,6 @@ bool egl_init_context(egl_ctx_data_t *egl,
    if (dpy == EGL_NO_DISPLAY)
    {
       RARCH_ERR("[EGL] Couldn't get EGL display.\n");
-      egl_destroy_gl_dll();
       return false;
    }
 

--- a/gfx/common/egl_common.h
+++ b/gfx/common/egl_common.h
@@ -74,6 +74,8 @@ extern bool g_egl_inited;
 extern unsigned g_egl_major;
 extern unsigned g_egl_minor;
 
+void egl_destroy_gl_dll(void);
+
 void egl_destroy(egl_ctx_data_t *egl);
 
 gfx_ctx_proc_t egl_get_proc_address(const char *symbol);

--- a/gfx/drivers_context/vc_egl_ctx.c
+++ b/gfx/drivers_context/vc_egl_ctx.c
@@ -236,6 +236,10 @@ static void gfx_ctx_vc_destroy(void *data)
       egl_terminate(vc->egl.dpy);
    }
 
+#ifdef HAVE_EGL
+   egl_destroy_gl_dll();
+#endif
+
    vc->egl.ctx      = NULL;
    vc->egl.hw_ctx   = NULL;
    vc->eglimage_ctx = NULL;


### PR DESCRIPTION
## Description

OpenGL cores that use the libretro API's `get_proc_address` function to get all OpenGL functions don't work properly with graphics contexts that use EGL when running on devices with EGL versions older than 1.5. This is because `get_proc_address` is implemented using EGL's `eglGetProcAddress` in those graphics contexts, and `eglGetProcAddress` in EGL versions older than 1.5 can only get the addresses of OpenGL functions that are not mandatory for OpenGL implementations to implement. Trying to use `eglGetProcAddress` to get a required function like `glEnable` will always fail in those versions of EGL.

This pull request implements a fallback for Linux devices with EGL versions older than 1.5 that loads symbols directly from the OpenGL library when `eglGetProcAddress` fails to load them so that `get_proc_address` can still get all OpenGL functions.

Be aware that I haven't tested this since I don't have any devices with a sufficiently old EGL.

## Related Issues

* Probably fixes https://github.com/schellingb/dosbox-pure/issues/637.
