### PR TITLE
Save state slot improvements

### DIFF
--- a/command.h
+++ b/command.h
@@ -380,7 +380,7 @@ void command_event_init_controllers(rarch_system_info_t *info,
 
 bool command_event_load_entry_state(settings_t *settings);
 
-void command_event_load_auto_state(void);
+bool command_event_load_auto_state(void);
 
 void command_event_set_savestate_auto_index(
       settings_t *settings);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -2762,8 +2762,6 @@ static int action_ok_playlist_entry_collection(const char *path,
       playlist_resolve_path(PLAYLIST_LOAD, false, content_path, sizeof(content_path));
    }
 
-   runloop_st->entry_state_slot = entry->entry_slot;
-
    /* Cache entry label */
    if (!string_is_empty(entry->label))
       strlcpy(content_label, entry->label, sizeof(content_label));

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -4665,9 +4665,6 @@ bool menu_driver_init(bool video_is_threaded)
    settings_t             *settings  = config_get_ptr();
    struct menu_state       *menu_st  = &menu_driver_state;
 
-   command_event(CMD_EVENT_CORE_INFO_INIT, NULL);
-   command_event(CMD_EVENT_LOAD_CORE_PERSIST, NULL);
-
    if (     menu_st->driver_data
          || menu_driver_init_internal(
             menu_st, p_disp, settings,

--- a/playlist.c
+++ b/playlist.c
@@ -2008,7 +2008,8 @@ void playlist_write_file(playlist_t *playlist)
          /* Typecast required because playlist_entry.entry_slot is unsigned,
           * and 0 and -1 are redundant, but runloop.entry_state_slot is int16_t
           * and must be able to be negative, because 0 is a valid slot */
-         if ((int)playlist->entries[i].entry_slot > 0)
+         if (     (int)playlist->entries[i].entry_slot > 0
+               && !strstr(playlist->config.path, FILE_PATH_BUILTIN))
          {
             rjsonwriter_raw(writer, ",", 1);
             rjsonwriter_raw(writer, "\n", 1);

--- a/retroarch.c
+++ b/retroarch.c
@@ -7203,6 +7203,9 @@ static bool retroarch_parse_input_and_config(
    runloop_st->current_core.flags &= ~(RETRO_CORE_FLAG_HAS_SET_INPUT_DESCRIPTORS
                                      | RETRO_CORE_FLAG_HAS_SET_SUBSYSTEMS);
 
+   /* Reset entry slot */
+   runloop_st->entry_state_slot = -1;
+
    /* Load the config file now that we know what it is */
 #ifdef HAVE_CONFIGFILE
    if (!(p_rarch->flags & RARCH_FLAGS_BLOCK_CONFIG_READ))
@@ -7773,7 +7776,6 @@ bool retroarch_main_init(int argc, char *argv[])
    input_st->osk_idx             = OSK_LOWERCASE_LATIN;
    video_st->flags              |= VIDEO_FLAG_ACTIVE;
    audio_state_get_ptr()->flags |= AUDIO_FLAG_ACTIVE;
-   runloop_st->entry_state_slot  = -1;
 
    if (setjmp(global->error_sjlj_context) > 0)
    {
@@ -8104,8 +8106,6 @@ bool retroarch_main_init(int argc, char *argv[])
 #ifdef HAVE_GAME_AI
    game_ai_init();
 #endif
-
-
 
    return true;
 

--- a/runtime_file.h
+++ b/runtime_file.h
@@ -57,6 +57,7 @@ typedef struct
 {
    rtl_runtime_t runtime;           /* unsigned alignment */
    rtl_last_played_t last_played;   /* unsigned alignment */
+   unsigned state_slot;
    char path[PATH_MAX_LENGTH];
 } runtime_log_t;
 


### PR DESCRIPTION
## Description

- Save current state slot to runtime log on close and set it back on load without loading the state
  - CLI launch required moving core info init earlier to content init instead of menu driver init - which is a weird place anyway - as in same place where netplay band-aid already did it, so why not do it there always
- Stop saving bogus -1 entry_slot in playlists
- Indentation cleanups

Please test that I did not overlook anything crucial. I tried my best to keep current auto state and entry state loading operational both via CLI and playlist launch.

## Related Issues

Closes #13062
Closes #14780
Closes #16726
Closes #17520



