### PR TITLE
Enable sdl12-compat and sdl2-compat detection

### DIFF
--- a/qb/config.libs.sh
+++ b/qb/config.libs.sh
@@ -271,8 +271,8 @@ check_val '' JACK -ljack '' jack 0.120.1 '' false
 check_val '' PULSE -lpulse '' libpulse '' '' false
 check_val '' PIPEWIRE -lpipewire-0.3 '' libpipewire-0.3 '' '' false
 check_val '' PIPEWIRE_STABLE -lpipewire-0.3 '' libpipewire-0.3 1.0.0 '' false
-check_val '' SDL -lSDL SDL sdl 1.2.10 '' false
-check_val '' SDL2 -lSDL2 SDL2 sdl2 2.0.0 '' false
+check_val '' SDL -lSDL SDL sdl 1.2.10 '' true
+check_val '' SDL2 -lSDL2 SDL2 sdl2 2.0.0 '' true
 
 if [ "$HAVE_SDL2" = 'yes' ] && [ "$HAVE_SDL" = 'yes' ]; then
    die : 'Notice: SDL drivers will be replaced by SDL2 ones.'


### PR DESCRIPTION
## Description

As requested on Discord (#linux-packaging), building with SDL2 (and actually with SDL1.2, if needed for some reason) will now work if the support is provided by the sdl2-compat (sdl12-compat) package. Checked on Fedora 42 Server.
