### PR TITLE
RGUI: Layout + date format adjustments

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5297,16 +5297,12 @@ static void rgui_render(void *data, unsigned width, unsigned height,
    {
       /* Render usual text */
       unsigned title_x;
-      size_t title_len;
       size_t title_max_len;
       char title_buf[NAME_MAX_LENGTH];
       size_t selection               = menu_st->selection_ptr;
-      unsigned title_y               = rgui->term_layout.start_y - rgui->font_height_stride;
+      unsigned title_y               = rgui->term_layout.start_y - rgui->font_height_stride - 1;
+      unsigned sublabel_y            = (rgui->term_layout.height * rgui->font_height_stride) + rgui->term_layout.start_y + 4;
       unsigned term_end_x            = rgui->term_layout.start_x + (rgui->term_layout.width * rgui->font_width_stride);
-      unsigned timedate_x            = term_end_x - (5 * rgui->font_width_stride);
-      unsigned core_name_len         = menu_timedate_enable
-            ? ((timedate_x - rgui->term_layout.start_x) / rgui->font_width_stride) - 3
-            : rgui->term_layout.width - 1;
       bool show_mini_thumbnails      = rgui_inline_thumbnails
             && rgui->playlist_index >= 0
             && (   (rgui->flags & RGUI_FLAG_IS_PLAYLIST)
@@ -5320,6 +5316,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
       unsigned thumbnail_panel_width = 0;
       unsigned term_mid_point        = 0;
       size_t powerstate_len          = 0;
+      size_t timedate_len            = 0;
 
       /* Cache mini thumbnail related parameters, if required */
       if (show_mini_thumbnails)
@@ -5401,26 +5398,60 @@ static void rgui_render(void *data, unsigned width, unsigned height,
                percent_str[powerstate_len - 1] = '\0';
 
                powerstate_x = (unsigned)(term_end_x -
-                     (RGUI_SYMBOL_WIDTH_STRIDE + (powerstate_len * rgui->font_width_stride)));
+                     (powerstate_len * rgui->font_width_stride));
 
                /* Draw symbol */
-               rgui_blit_symbol(rgui, fb_width, powerstate_x, title_y, powerstate_symbol,
-                     powerstate_color, rgui->colors.shadow_color);
+               rgui_blit_symbol(rgui,
+                     fb_width,
+                     powerstate_x,
+                     title_y,
+                     powerstate_symbol,
+                     powerstate_color,
+                     rgui->colors.shadow_color);
 
                /* Print text */
-               rgui_blit_line(rgui, fb_width,
-                     powerstate_x + RGUI_SYMBOL_WIDTH_STRIDE + rgui->font_width_stride, title_y,
-                     percent_str, powerstate_color, rgui->colors.shadow_color);
-
-               /* Final length of battery indicator is 'powerstate_len' + a
-                * spacer of 3 characters */
-               powerstate_len += 3;
+               rgui_blit_line(rgui,
+                     fb_width,
+                     powerstate_x + rgui->font_width_stride,
+                     title_y,
+                     percent_str,
+                     powerstate_color,
+                     rgui->colors.shadow_color);
             }
          }
       }
 
+      /* Print clock (if required) */
+      if (menu_timedate_enable)
+      {
+         char timedate[20];
+         gfx_display_ctx_datetime_t datetime;
+         datetime.time_mode      = settings->uints.menu_timedate_style;
+         datetime.date_separator = settings->uints.menu_timedate_date_separator;
+
+         menu_display_timedate(&datetime, timedate, sizeof(timedate));
+         timedate_len = utf8len(timedate);
+
+         /* Add battery spacer */
+         if (powerstate_len)
+            powerstate_len++;
+
+         rgui_blit_line(rgui,
+               fb_width,
+               term_end_x
+                     - (powerstate_len * rgui->font_width_stride)
+                     - (timedate_len * rgui->font_width_stride),
+               title_y,
+               timedate,
+               rgui->colors.hover_color,
+               rgui->colors.shadow_color);
+      }
+
       /* Print title */
-      title_max_len = rgui->term_layout.width - 5 - (powerstate_len > 5 ? powerstate_len : 5);
+      title_max_len = rgui->term_layout.width - powerstate_len - timedate_len;
+      if (powerstate_len || timedate_len)
+         title_max_len--;
+
       title_buf[0] = '\0';
 
       if (use_smooth_ticker)
@@ -5433,10 +5464,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          ticker_smooth.x_offset    = &ticker_x_offset;
 
          /* If title is scrolling, then title_len == title_max_len */
-         if (gfx_animation_ticker_smooth(&ticker_smooth))
-            title_len              = title_max_len;
-         else
-            title_len              = utf8len(title_buf);
+         gfx_animation_ticker_smooth(&ticker_smooth);
       }
       else
       {
@@ -5446,23 +5474,11 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          ticker.selected = true;
 
          gfx_animation_ticker(&ticker);
-
-         title_len = utf8len(title_buf);
       }
 
       string_to_upper(title_buf);
 
-      title_x = (unsigned)(ticker_x_offset
-               +  rgui->term_layout.start_x
-               + (rgui->term_layout.width - title_len)
-               *  rgui->font_width_stride / 2);
-
-      /* Title is always centred, unless it is long enough
-       * to infringe upon the battery indicator, in which case
-       * we shift it to the left */
-      if (powerstate_len > 5)
-         if (title_len > title_max_len - (powerstate_len - 5))
-            title_x -= (powerstate_len - 5) * rgui->font_width_stride / 2;
+      title_x = (unsigned)(ticker_x_offset + rgui->term_layout.start_x);
 
       rgui_blit_line(rgui, fb_width, title_x, title_y,
             title_buf, rgui->colors.title_color, rgui->colors.shadow_color);
@@ -5748,7 +5764,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          if (use_smooth_ticker)
          {
             ticker_smooth.selected    = true;
-            ticker_smooth.field_width = core_name_len * rgui->font_width_stride;
+            ticker_smooth.field_width = rgui->term_layout.width * rgui->font_width_stride;
             ticker_smooth.src_str     = rgui->menu_sublabel;
             ticker_smooth.dst_str     = sublabel_buf;
             ticker_smooth.dst_str_len = sizeof(sublabel_buf);
@@ -5759,7 +5775,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          else
          {
             ticker.s                  = sublabel_buf;
-            ticker.len                = core_name_len;
+            ticker.len                = rgui->term_layout.width;
             ticker.str                = rgui->menu_sublabel;
             ticker.selected           = true;
 
@@ -5768,8 +5784,8 @@ static void rgui_render(void *data, unsigned width, unsigned height,
 
          rgui_blit_line(rgui,
                fb_width,
-               ticker_x_offset + rgui->term_layout.start_x + rgui->font_width_stride,
-               (rgui->term_layout.height * rgui->font_height_stride) + rgui->term_layout.start_y + 2,
+               ticker_x_offset + rgui->term_layout.start_x,
+               sublabel_y,
                sublabel_buf,
                rgui->colors.hover_color,
                rgui->colors.shadow_color);
@@ -5785,7 +5801,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          if (use_smooth_ticker)
          {
             ticker_smooth.selected    = true;
-            ticker_smooth.field_width = core_name_len * rgui->font_width_stride;
+            ticker_smooth.field_width = rgui->term_layout.width * rgui->font_width_stride;
             ticker_smooth.src_str     = core_title;
             ticker_smooth.dst_str     = core_title_buf;
             ticker_smooth.dst_str_len = sizeof(core_title_buf);
@@ -5796,7 +5812,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          else
          {
             ticker.s                  = core_title_buf;
-            ticker.len                = core_name_len;
+            ticker.len                = rgui->term_layout.width;
             ticker.str                = core_title;
             ticker.selected           = true;
 
@@ -5805,28 +5821,9 @@ static void rgui_render(void *data, unsigned width, unsigned height,
 
          rgui_blit_line(rgui,
                fb_width,
-               ticker_x_offset + rgui->term_layout.start_x + rgui->font_width_stride,
-               (rgui->term_layout.height * rgui->font_height_stride) + rgui->term_layout.start_y + 2,
+               ticker_x_offset + rgui->term_layout.start_x,
+               sublabel_y,
                core_title_buf,
-               rgui->colors.hover_color,
-               rgui->colors.shadow_color);
-      }
-
-      /* Print clock (if required) */
-      if (menu_timedate_enable)
-      {
-         char timedate[16];
-         gfx_display_ctx_datetime_t datetime;
-         datetime.time_mode      = MENU_TIMEDATE_STYLE_HM;
-         datetime.date_separator = MENU_TIMEDATE_DATE_SEPARATOR_HYPHEN;
-
-         menu_display_timedate(&datetime, timedate, sizeof(timedate));
-
-         rgui_blit_line(rgui,
-               fb_width,
-               timedate_x,
-               (rgui->term_layout.height * rgui->font_height_stride) + rgui->term_layout.start_y + 2,
-               timedate,
                rgui->colors.hover_color,
                rgui->colors.shadow_color);
       }


### PR DESCRIPTION
## Description

Minor adjustments for better match with other drivers:
- Time follows the common timedate style option instead of hardcoded HH:MM
- Time moved from bottom footer to top header in order to allow more room for sublabel
- Top title alignment set to left instead of center in order to waste less space

<img width="1920" height="1080" alt="retroarch_2025_08_04_05_41_48_178" src="https://github.com/user-attachments/assets/8d38f897-a793-409b-8c42-4d4603a281af" />

## Related Issues

Closes #13090
