### PR TITLE
Fix deadlock in `flush_wayland_fd()` when using Wayland Vulkan driver

### DIFF
--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -1163,23 +1163,33 @@ void flush_wayland_fd(void *data)
    struct pollfd fd             = {0};
    input_ctx_wayland_data_t *wl = (input_ctx_wayland_data_t*)data;
 
-   wl_display_dispatch_pending(wl->dpy);
-   wl_display_flush(wl->dpy);
-
    fd.fd                        = wl->fd;
    fd.events                    = POLLIN | POLLOUT | POLLERR | POLLHUP;
 
+   while (wl_display_prepare_read(wl->dpy))
+      wl_display_dispatch_pending(wl->dpy);
+
+   wl_display_flush(wl->dpy);
+
    if (poll(&fd, 1, 0) > 0)
    {
+      if (fd.revents & POLLIN)
+      {
+         wl_display_read_events(wl->dpy);
+         wl_display_dispatch_pending(wl->dpy);
+      }
+      else
+         wl_display_cancel_read(wl->dpy);
+
+      if (fd.revents & POLLOUT)
+         wl_display_flush(wl->dpy);
+
       if (fd.revents & (POLLERR | POLLHUP))
       {
          close(wl->fd);
          frontend_driver_set_signal_handler_state(1);
       }
-
-      if (fd.revents & POLLIN)
-         wl_display_dispatch(wl->dpy);
-      if (fd.revents & POLLOUT)
-         wl_display_flush(wl->dpy);
    }
+   else
+      wl_display_cancel_read(wl->dpy);
 }


### PR DESCRIPTION
## Description

This pull request fixes a deadlock that can occur when using the Vulkan video driver when using Wayland on Linux. It was being caused by incorrect usage of the Wayland API: [the documentation for `wl_display_dispatch()`](https://wayland.freedesktop.org/docs/html/apb.html#Client-classwl__display_1a30a9c4f020f3e77581c7a81ecdb4913d) says that using `poll()` to wait for events before calling `wl_display_dispatch()` can cause a deadlock and proposes an alternative involving `wl_display_prepare_read()` followed by either `wl_display_read_events()` or `wl_display_cancel_read()`.

In practice, this deadlock has been difficult to manifest. Currently it appears when using the KDE Plasma desktop environment on Arch Linux with Wayland 1.24.0 or later: downgrading Wayland or using GNOME instead of KDE Plasma results in the deadlock not appearing. That doesn't mean the code doesn't need to be fixed, though.

## Related Issues

* Fixes #18148