### PR TITLE
Touchscreen support for PS Vita

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -84,7 +84,7 @@
 
 #define DEFAULT_TOUCH_SCALE 1
 
-#if defined(RARCH_MOBILE) || defined(HAVE_LIBNX) || defined(__WINRT__) || defined(EMSCRIPTEN)
+#if defined(RARCH_MOBILE) || defined(HAVE_LIBNX) || defined(__WINRT__) || defined(EMSCRIPTEN) || defined (VITA)
 #define DEFAULT_POINTER_ENABLE true
 #else
 #define DEFAULT_POINTER_ENABLE false

--- a/gfx/drivers/vita2d_gfx.c
+++ b/gfx/drivers/vita2d_gfx.c
@@ -1042,6 +1042,9 @@ static void vita2d_set_viewport_wrapper(void *data, unsigned vp_width,
       vita->vp.height = vp_height;
    }
 
+   vita->vp.full_width  = vita->vp.width;
+   vita->vp.full_height = vita->vp.height;
+
    vita2d_set_viewport(vita->vp.x, vita->vp.y, vita->vp.width, vita->vp.height);
    vita2d_set_projection(vita, &ortho, allow_rotate);
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -1154,7 +1154,11 @@ static float menu_input_get_dpi(
       mets.type         = DISPLAY_METRIC_DPI;
       mets.value        = &dpi;
       if (!video_context_driver_get_metrics(&mets))
+#ifdef VITA
+         dpi            = 220.0f;
+#else
          dpi            = 0.0f;
+#endif
 
       dpi_cached        = true;
       last_video_width  = video_width;


### PR DESCRIPTION
## Description

Enable touch input for PS Vita. Tested in menu (ozone and glui), works as expected.

Back touch is disabled for now. Front touch support multi-touch (up to 6, although no RA built-in function needs that many).

DPI value was required to get the menu scrolling working, since there is no other reason right now to implement a full Vita video context driver, the value is hardcoded.

## Related Issues

Fixes #4100 

Edit: updates from subsequent commit.