### PR TITLE
Allow dupebinding menu toggle and hotkey enabler

### DIFF
--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -181,7 +181,9 @@ enum input_driver_state_flags
    INP_FLAG_GRAB_MOUSE_STATE         = (1 << 6),
    INP_FLAG_REMAPPING_CACHE_ACTIVE   = (1 << 7),
    INP_FLAG_DEFERRED_WAIT_KEYS       = (1 << 8),
-   INP_FLAG_WAIT_INPUT_RELEASE       = (1 << 9)
+   INP_FLAG_WAIT_INPUT_RELEASE       = (1 << 9),
+   INP_FLAG_MENU_PRESS_PENDING       = (1 << 10),
+   INP_FLAG_MENU_PRESS_CANCEL        = (1 << 11)
 };
 
 #ifdef HAVE_BSV_MOVIE


### PR DESCRIPTION
## Description

Menu toggle happens now always on release, also menu Resume. This allows combining hotkey enabler on the same button, and pressing alone acts as menu toggle.

Select and Start in menu also always act on release instead of based on menu controller combo buttons, and they prevent navigation when pressed.

## Related Issues

Closes #16818

