### PR TITLE
Add onNewIntent handler to support game launch with FLAG_ACTIVITY_CLEAR_TOP

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -63,6 +63,39 @@ public final class RetroActivityFuture extends RetroActivityCamera {
   }
 
   @Override
+  public void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    
+    // Check if this intent contains game launch parameters
+    String newRom = intent.getStringExtra("ROM");
+    String newCore = intent.getStringExtra("LIBRETRO");
+    
+    // Get current intent parameters for comparison
+    Intent currentIntent = getIntent();
+    String currentRom = currentIntent != null ? currentIntent.getStringExtra("ROM") : null;
+    String currentCore = currentIntent != null ? currentIntent.getStringExtra("LIBRETRO") : null;
+    
+    // Check if we're trying to launch different content
+    boolean isDifferentContent = false;
+    if (newRom != null && !newRom.equals(currentRom)) {
+      isDifferentContent = true;
+    }
+    if (newCore != null && !newCore.equals(currentCore)) {
+      isDifferentContent = true;
+    }
+    
+    if (isDifferentContent) {
+      // Exit cleanly and let the system restart us with new content
+      finish();
+      System.exit(0);
+    } else {
+      // Same content, just update intent
+      setIntent(intent);
+    }
+  }
+
+
+  @Override
   public void onResume() {
     super.onResume();
 


### PR DESCRIPTION
## Description

Launchers like Daijishou and Beacon rely on FLAG_ACTIVITY_CLEAR_TASK. This works if RetroArch is not already running in the background, but on many Android 13+ devices, FLAG_ACTIVITY_CLEAR_TASK doesn't work properly when RetroArch (or any process) is backgrounded. This is due to stricter background execution restrictions which prevent onCreate() from being called. (https://github.com/TapiocaFox/Daijishou/issues/703) This results in RetroArch stalling on a black screen and must be forced quit. On these devices, a user is unable to launch another game without first completely closing RetroArch.

This onNewIntent handler enables games to be launched using FLAG_ACTIVITY_CLEAR_TOP, even if a game is already running in the background. FLAG_ACTIVITY_CLEAR_TOP delivers new intents to the existing activity via onNewIntent(), avoiding the background process cleanup issues that affect FLAG_ACTIVITY_CLEAR_TASK on many Android 13+ devices.

Currently, launching with FLAG_ACTIVITY_CLEAR_TOP results in RetroArch foregrounding with whatever game was previously running regardless if a different game was launched. This addition checks if the launched game is the one already running (at which point it just foregrounds RetroArch) or if it's a new game (which now launches over the existing one).

Launchers like Daijishou and Beacon could adopt FLAG_ACTIVITY_CLEAR_TASK as a standard for improved functionality and user experience with launching multiple games on many Android 13+ devices. Users experiencing this issue can also manually edit the launch parameters themself within these launchers. FLAG_ACTIVITY_CLEAR_TASK will also work on previous Android versions. 

## Related Issues

https://github.com/TapiocaFox/Daijishou/issues/703