### PR TITLE
Deprecate `intfstream_open_writable_memory`

### DIFF
--- a/libretro-common/formats/png/rpng_encode.c
+++ b/libretro-common/formats/png/rpng_encode.c
@@ -410,7 +410,7 @@ uint8_t* rpng_save_image_bgr24_string(const uint8_t *data,
    if (!buf)
       GOTO_END_ERROR();
 
-   intf_s = intfstream_open_writable_memory(buf,
+   intf_s = intfstream_open_memory(buf,
          RETRO_VFS_FILE_ACCESS_WRITE,
          RETRO_VFS_FILE_ACCESS_HINT_NONE,
          _len);

--- a/libretro-common/include/streams/interface_stream.h
+++ b/libretro-common/include/streams/interface_stream.h
@@ -121,6 +121,8 @@ intfstream_t *intfstream_open_file(const char *path,
 intfstream_t *intfstream_open_memory(void *data,
       unsigned mode, unsigned hints, uint64_t size);
 
+/* Deprecated.  Has the same effect as `intfstream_open_memory` with
+   a mode including `RETRO_VFS_FILE_ACCESS_WRITE`. */
 intfstream_t *intfstream_open_writable_memory(void *data,
       unsigned mode, unsigned hints, uint64_t size);
 

--- a/libretro-common/streams/interface_stream.c
+++ b/libretro-common/streams/interface_stream.c
@@ -713,7 +713,7 @@ intfstream_t *intfstream_open_memory(void *data,
    info.type            = INTFSTREAM_MEMORY;
    info.memory.buf.data = (uint8_t*)data;
    info.memory.buf.size = size;
-   info.memory.writable = false;
+   info.memory.writable = (mode & RETRO_VFS_FILE_ACCESS_WRITE) != 0;
 
    if (!(fd = (intfstream_t*)intfstream_init(&info)))
       return NULL;
@@ -729,23 +729,7 @@ intfstream_t *intfstream_open_memory(void *data,
 intfstream_t *intfstream_open_writable_memory(void *data,
       unsigned mode, unsigned hints, uint64_t size)
 {
-   intfstream_info_t info;
-   intfstream_t *fd     = NULL;
-
-   info.type            = INTFSTREAM_MEMORY;
-   info.memory.buf.data = (uint8_t*)data;
-   info.memory.buf.size = size;
-   info.memory.writable = true;
-
-   if (!(fd = (intfstream_t*)intfstream_init(&info)))
-      return NULL;
-
-   if (intfstream_open(fd, NULL, mode, hints))
-      return fd;
-
-   intfstream_close(fd);
-   free(fd);
-   return NULL;
+   return intfstream_open_memory(data, mode | RETRO_VFS_FILE_ACCESS_WRITE, hints, size);
 }
 
 intfstream_t *intfstream_open_chd_track(const char *path,


### PR DESCRIPTION
Having both functions is a bit of a footgun since `intfstream_open_memory` ignores the given mode and always opens with `writable=false`, while `intfstream_open_writable_memory` ignores the given mode and always opens with `writable=true`.

So, I rewrote the `writable` variant in terms of the other one, and deprecated it in the process.  Now whether the memory is marked writable depends on the input `mode` for `intfstream_open_memory`, and the `writable` variant has the same behavior as before.

I also replaced the sole use of `intfstream_open_writable_memory` in the retroarch codebase, but I don't know whether any cores or other users of libretro-common used the function so it can't be removed completely.