### PR TITLE
Fix crashes when scanning rdb/rmsgpack files using stack storage

### DIFF
--- a/libretro-db/rmsgpack_dom.c
+++ b/libretro-db/rmsgpack_dom.c
@@ -430,7 +430,7 @@ int rmsgpack_dom_read_with(intfstream_t *fd, struct rmsgpack_dom_value *out, str
    return rv;
 }
 
-struct rmsgpack_dom_reader_state *rmsgpack_dom_reader_state_new()
+struct rmsgpack_dom_reader_state *rmsgpack_dom_reader_state_new(void)
 {
    struct rmsgpack_dom_reader_state *s = calloc(1, sizeof(struct rmsgpack_dom_reader_state));
    s->i = 0;
@@ -451,7 +451,7 @@ int rmsgpack_dom_read(intfstream_t *fd, struct rmsgpack_dom_value *out)
    s.i = 0;
    s.growable = false;
    s.capacity = MAX_DEPTH;
-   s.stack = alloca(MAX_DEPTH);
+   s.stack = alloca(MAX_DEPTH*sizeof(struct rmsgpack_dom_value *));
    return rmsgpack_dom_read_with(fd, out, &s);
 }
 

--- a/libretro-db/rmsgpack_dom.h
+++ b/libretro-db/rmsgpack_dom.h
@@ -93,7 +93,7 @@ struct rmsgpack_dom_value *rmsgpack_dom_value_map_value(
 
 int rmsgpack_dom_read(intfstream_t *stream, struct rmsgpack_dom_value *out);
 
-struct rmsgpack_dom_reader_state *rmsgpack_dom_reader_state_new();
+struct rmsgpack_dom_reader_state *rmsgpack_dom_reader_state_new(void);
 int rmsgpack_dom_read_with(intfstream_t *stream, struct rmsgpack_dom_value *out, struct rmsgpack_dom_reader_state *state);
 void rmsgpack_dom_reader_state_free(struct rmsgpack_dom_reader_state *state);
 


### PR DESCRIPTION
I had mistakenly allocated only 128 bytes, not 128 * sizeof(pointer) bytes.