### PR TITLE
Fix OpenAL blocking regression

### DIFF
--- a/audio/drivers/openal.c
+++ b/audio/drivers/openal.c
@@ -237,15 +237,11 @@ static bool al_get_buffer(al_t *al, ALuint *buffer)
       if (al_unqueue_buffers(al))
          break;
 
-#ifndef EMSCRIPTEN
       if (al->nonblock)
-#endif
          return false;
 
-#ifndef _WIN32
       /* Must sleep as there is no proper blocking method. */
       retro_sleep(1);
-#endif
    }
 
    *buffer = al->res_buf[--al->res_ptr];


### PR DESCRIPTION
This fixes a regression in https://github.com/libretro/RetroArch/commit/1e2500f73685fb1c9eeb69c1932a0e8a3ddf57d7. Emscripten still needs to block here, but I think m4xw was going to update the driver to support external blocking at some point. I'm not sure about the win32 thing, every platform should be sleeping here to avoid a busy wait.