### PR TITLE
Fixes an off-by-one error in checkpoint restores during replay playback

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -188,6 +188,7 @@ void gfx_widgets_msg_queue_push(
 
          msg_widget->offset_y                   = 0;
          msg_widget->alpha                      = 1.0f;
+         msg_widget->alternative_look           = (task && (task->flags & RETRO_TASK_FLG_ALTERNATIVE_LOOK));
 
          msg_widget->width                      = 0;
 
@@ -1168,7 +1169,7 @@ static void gfx_widgets_draw_task_msg(
    size_t task_percentage_offset     = 0;
    char task_percentage[256]         = "";
    bool draw_msg_new                 = false;
-   bool msg_alternative              = (task_get_flags(msg->task_ptr) & RETRO_TASK_FLG_ALTERNATIVE_LOOK);
+   bool msg_alternative              = msg->alternative_look;
 
    if (msg->msg_new)
       draw_msg_new                   = !string_is_equal(msg->msg_new, msg->msg);

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -185,6 +185,7 @@ typedef struct disp_widget_msg
    int8_t task_progress;
    /* How many tasks have used this notification? */
    uint8_t task_count;
+   bool alternative_look;
 } disp_widget_msg_t;
 
 typedef struct dispgfx_widget

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -277,6 +277,7 @@ struct bsv_movie
 #endif
 
    uint8_t checkpoint_compression, checkpoint_encoding;
+   bool make_checkpoint_frame;
 
    uint8_t *last_save, *cur_save;
    size_t last_save_size, cur_save_size;
@@ -1104,6 +1105,7 @@ void input_overlay_check_mouse_cursor(void);
 
 #ifdef HAVE_BSV_MOVIE
 void bsv_movie_frame_rewind(void);
+void bsv_movie_start_frame(input_driver_state_t *input_st);
 void bsv_movie_next_frame(input_driver_state_t *input_st);
 bool bsv_movie_read_next_events(bsv_movie_t *handle, replay_checkpoint_behavior checkpoint_behavior, bool end_movie_on_eof);
 bool bsv_movie_reset_playback(bsv_movie_t *handle);
@@ -1112,6 +1114,7 @@ void bsv_movie_finish_rewind(input_driver_state_t *input_st);
 void bsv_movie_deinit(input_driver_state_t *input_st);
 void bsv_movie_deinit_full(input_driver_state_t *input_st);
 void bsv_movie_enqueue(input_driver_state_t *input_st, bsv_movie_t *state, enum bsv_flags flags);
+void bsv_movie_dequeue_next(input_driver_state_t *input_st);
 
 bool movie_commit_checkpoint(input_driver_state_t *input_st);
 bool movie_skip_to_prev_checkpoint(input_driver_state_t *input_st);


### PR DESCRIPTION
The issue was that when recording, the recorded checkpoint incorporates the current frame's inputs.  But when playing back, the checkpoint was deserialized *before* the current frame was simulated.  The fix was to serialize the current frame at the beginning of the frame, before inputs were applied, during recording.  An alternative fix would be to defer deserializing the frame until after the next frame is simulated, but that seemed more complicated.  A frame (including checkpoint) now means "the inputs of frame K and, if a checkpoint, the state as of the beginning of frame K".

If the maintainers would prefer that a replay checkpoint means "The inputs of frame K and the state as of the end of frame K" I could make that change instead.

Either solution should account for the "jank" I experienced in some cores which were particularly sensitive to the offset.

The change in msgqueue is an unrelated fix that I needed so I could run GDB without erroring out on a use-after-free.