### PR TITLE
net_http: remove unnecessary receive in connection pool polling

### DIFF
--- a/libretro-common/net/net_http.c
+++ b/libretro-common/net/net_http.c
@@ -703,23 +703,11 @@ static void net_http_conn_pool_remove_expired(void)
    {
       if (!entry->in_use && FD_ISSET(entry->fd, &fds))
       {
-         char buf[4096];
-         bool err = false;
-#ifdef HAVE_SSL
-         if (entry->ssl && entry->ssl_ctx)
-            ssl_socket_receive_all_nonblocking(entry->ssl_ctx, &err, buf, sizeof(buf));
-         else
-#endif
-            socket_receive_all_nonblocking(entry->fd, &err, buf, sizeof(buf));
-
-         if (!err)
-            continue;
-
+         /* if it's not in use and it's reaadable we assume that means it's closed without checking recv */
          if (prev)
             prev->next = entry->next;
          else
             conn_pool = entry->next;
-         /* if it's not in use and it's reaadable we assume that means it's closed without checking recv */
          net_http_conn_pool_free(entry);
          entry = prev ? prev->next : conn_pool;
       }


### PR DESCRIPTION
Previously in the `!err` case this would potentially end up in an infinite loop, if the socket was marked readable but *socket_receive_all_nonblocking kept reading data (when it's not supposed to be in_use, meaning not in an active http transaction, which is a bug), or kept not reading data despite being readable and not indicating an error.

If we get into this case we can safely assume we don't really understand the state of the socket anymore. It's fine to just close it here, it can just get reopened when someone needs it again.