### PR TITLE
Fix an off-by-one error in replay checkpoint loading.

### DIFF
--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -267,6 +267,7 @@ struct bsv_movie
    bool playback;
    bool first_rewind;
    bool did_rewind;
+   bool checkpoint_ready;
 
 #ifdef HAVE_STATESTREAM
    /* Block index and superblock index for incremental checkpoints */
@@ -1112,6 +1113,7 @@ void bsv_movie_finish_rewind(input_driver_state_t *input_st);
 void bsv_movie_deinit(input_driver_state_t *input_st);
 void bsv_movie_deinit_full(input_driver_state_t *input_st);
 void bsv_movie_enqueue(input_driver_state_t *input_st, bsv_movie_t *state, enum bsv_flags flags);
+void bsv_movie_dequeue_next(input_driver_state_t *input_st);
 
 bool movie_commit_checkpoint(input_driver_state_t *input_st);
 bool movie_skip_to_prev_checkpoint(input_driver_state_t *input_st);

--- a/runloop.c
+++ b/runloop.c
@@ -7202,6 +7202,10 @@ int runloop_iterate(void)
    }
 #endif
 
+#ifdef HAVE_BSV_MOVIE
+   bsv_movie_dequeue_next(input_st);
+#endif
+   
    if (runloop_st->frame_time.callback)
    {
       /* Updates frame timing if frame timing callback is in use by the core.
@@ -7354,10 +7358,6 @@ int runloop_iterate(void)
       autosave_lock();
 #endif
 
-#ifdef HAVE_BSV_MOVIE
-   bsv_movie_next_frame(input_st);
-#endif
-
    if (     settings->bools.camera_allow
          && camera_st->cb.caps
          && camera_st->driver
@@ -7413,12 +7413,7 @@ int runloop_iterate(void)
    presence_update(PRESENCE_GAME);
 #endif
 #ifdef HAVE_BSV_MOVIE
-   bsv_movie_finish_rewind(input_st);
-   if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_END)
-   {
-      movie_stop_playback(input_st);
-      command_event(CMD_EVENT_PAUSE, NULL);
-   }
+   bsv_movie_next_frame(input_st);
    if (input_st->bsv_movie_state.flags & BSV_FLAG_MOVIE_END)
    {
       movie_stop_playback(input_st);


### PR DESCRIPTION
The issue is that a replay frame read on core frame K stores the inputs for frame K along with the core state as of *the end of frame K*, in other words the beginning of frame K+1. To fix it, and to make sure existing replays play back properly, the `core_unserialize` call in bsvmovie.c has been deferred to the following invocation of `bsv_movie_read_next_events`, so that frame K+1 is unserialized (restored) just before reading the inputs for frame K+1.

Some refactoring has also been done to simplify the number and timing of calls to bsv_movie functions from runloop.c.