### PR TITLE
Fix use-after-free in gfx_widgets.

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -188,6 +188,7 @@ void gfx_widgets_msg_queue_push(
 
          msg_widget->offset_y                   = 0;
          msg_widget->alpha                      = 1.0f;
+         msg_widget->alternative_look           = task && (task->flags & RETRO_TASK_FLG_ALTERNATIVE_LOOK);
 
          msg_widget->width                      = 0;
 
@@ -358,7 +359,7 @@ void gfx_widgets_msg_queue_push(
             msg_widget->msg_len                    = _len;
             msg_widget->msg_transition_animation   = 0;
 
-            if (!((task->flags & RETRO_TASK_FLG_ALTERNATIVE_LOOK) > 0))
+            if (!msg_widget->alternative_look)
             {
                gfx_animation_ctx_entry_t entry;
 
@@ -1168,7 +1169,7 @@ static void gfx_widgets_draw_task_msg(
    size_t task_percentage_offset     = 0;
    char task_percentage[256]         = "";
    bool draw_msg_new                 = false;
-   bool msg_alternative              = (task_get_flags(msg->task_ptr) & RETRO_TASK_FLG_ALTERNATIVE_LOOK);
+   bool msg_alternative              = msg->alternative_look;
 
    if (msg->msg_new)
       draw_msg_new                   = !string_is_equal(msg->msg_new, msg->msg);

--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -185,6 +185,7 @@ typedef struct disp_widget_msg
    int8_t task_progress;
    /* How many tasks have used this notification? */
    uint8_t task_count;
+   bool alternative_look;
 } disp_widget_msg_t;
 
 typedef struct dispgfx_widget


### PR DESCRIPTION
Holding on to the task pointer is risky, because when the task queue is popped a message is pushed but the task may be freed.  I made a very small-scale fix to just the new use-after-free that started happening with the alternative look.