### PR TITLE
wayland: Move followup roundtrip out of registry::global

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -755,6 +755,9 @@ bool gfx_ctx_wl_init_common(
 
    wl->registry = wl_display_get_registry(wl->input.dpy);
    wl_registry_add_listener(wl->registry, &registry_listener, wl);
+   /* first roundtrip to bind compositor globals */
+   wl_display_roundtrip(wl->input.dpy);
+   /* second roundtrip for listeners on bound globals (wl_output, wl_seat) */
    wl_display_roundtrip(wl->input.dpy);
 
    if (!wl->compositor)

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -755,7 +755,6 @@ static void wl_registry_handle_global(void *data, struct wl_registry *reg,
             id, &wl_output_interface, MIN(version, 2));
       wl_output_add_listener(oi->output, &output_listener, oi);
       wl_list_insert(&wl->all_outputs, &od->link);
-      wl_display_roundtrip(wl->input.dpy);
    }
    else if (string_is_equal(interface, xdg_wm_base_interface.name) && found++)
       wl->xdg_shell = (struct xdg_wm_base*)


### PR DESCRIPTION
This should have no effect. It just reduces the number of roundtrip display syncs that happen on init.