### PR TITLE
wayland: Don't try to guess the display size

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -247,16 +247,13 @@ void gfx_ctx_wl_get_video_size_common(void *data,
 
       wl->reported_display_size = true;
 
-      /* If window is not ready get any monitor */
-      if (!oi)
-         wl_list_for_each(od, &wl->all_outputs, link)
-         {
-            oi = od->output;
-            break;
-         };
-
-      *width  = oi->width;
-      *height = oi->height;
+      /* We won't know which monitor we're targeting until the surface enters it.
+       * This only happens once we've attached a buffer to it. */
+      if (oi)
+      {
+         *width  = oi->width;
+         *height = oi->height;
+      }
    }
    else
    {


### PR DESCRIPTION
On wayland the display the surface will be mapped to is not known in advance. I think it's more correct to not try to guess in case it triggers large unnecessary allocations.

Currently the splash screen means that this value is correctly set, however the issue the splash screen was working around will be fixed in mutter 49.

I've marked this as draft as I'm not sure if leaving the width and height values unchanged is correct per the RetroArch API.