### PR TITLE
Don't clear default core info on missing list

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -2191,10 +2191,9 @@ bool core_info_list_get_info(core_info_list_t *core_info_list,
       core_info_t *info = core_info_find_internal(
             core_info_list, core_path);
 
-      memset(out_info, 0, sizeof(*out_info));
-
       if (info)
       {
+         memset(out_info, 0, sizeof(*out_info));
          *out_info = *info;
          return true;
       }


### PR DESCRIPTION
This fixes an edge-case bug that I noticed in #18174. The bug seems only possible in emscripten since the core files currently don't contain the core itself (so they don't have to exist).

When the frontend knows the core extension (with `frontend_driver_get_core_extension`) but the core file is missing, savestate support was disabled due to `core_info_list_get_info` clearing the default core info (as set by `core_info_init_current_core`) without checking if the new info was valid. Effectively it set the `savestate_support_level` back to `CORE_INFO_SAVESTATE_DISABLED` when the default should be `CORE_INFO_SAVESTATE_DETERMINISTIC`.