### PR TITLE
Improve GLSL ES version detection

### DIFF
--- a/gfx/drivers/gl_shaders/core_pipeline_xmb_ribbon.glsl.frag.h
+++ b/gfx/drivers/gl_shaders/core_pipeline_xmb_ribbon.glsl.frag.h
@@ -1,6 +1,6 @@
 #include "shaders_common.h"
 
-static const char *core_stock_fragment_xmb = GLSL(
+static const char *core_stock_fragment_xmb = GLSL_STANDARD_DERIVATIVES(
    uniform float time;
    in vec3 fragVertexEc;
    vec3 up = vec3(0, 0, 1);

--- a/gfx/drivers/gl_shaders/legacy_pipeline_xmb_ribbon.glsl.vert.h
+++ b/gfx/drivers/gl_shaders/legacy_pipeline_xmb_ribbon.glsl.vert.h
@@ -1,6 +1,6 @@
 #include "shaders_common.h"
 
-static const char *stock_vertex_xmb_ribbon_legacy = GLSL(
+static const char *stock_vertex_xmb_ribbon_legacy = GLSL_STANDARD_DERIVATIVES(
    attribute vec3 VertexCoord;
    uniform float time;
    varying vec3 fragVertexEc;

--- a/gfx/drivers/gl_shaders/modern_pipeline_xmb_ribbon.glsl.vert.h
+++ b/gfx/drivers/gl_shaders/modern_pipeline_xmb_ribbon.glsl.vert.h
@@ -1,6 +1,6 @@
 #include "shaders_common.h"
 
-static const char *stock_vertex_xmb_ribbon_modern = GLSL(
+static const char *stock_vertex_xmb_ribbon_modern = GLSL_STANDARD_DERIVATIVES(
    in vec3 VertexCoord;
    uniform float time;
    out vec3 fragVertexEc;

--- a/gfx/drivers/gl_shaders/pipeline_xmb_ribbon.glsl.frag.h
+++ b/gfx/drivers/gl_shaders/pipeline_xmb_ribbon.glsl.frag.h
@@ -1,6 +1,6 @@
 #include "shaders_common.h"
 
-static const char *stock_fragment_xmb = GLSL(
+static const char *stock_fragment_xmb = GLSL_STANDARD_DERIVATIVES(
    uniform float time;
    varying vec3 fragVertexEc;
    vec3 up = vec3(0, 0, 1);

--- a/gfx/drivers/gl_shaders/shaders_common.h
+++ b/gfx/drivers/gl_shaders/shaders_common.h
@@ -13,7 +13,8 @@
                   "#else\n" \
                   "  precision mediump float;\n" \
                   "#endif\n" #src
-#define GLSL_330(src) "#version 330 es\n" \
+#define GLSL_STANDARD_DERIVATIVES(src) "#version 130\n" \
+                  "#extension GL_OES_standard_derivatives : enable\n" \
                   "#ifdef GL_ES\n" \
                   "  #ifdef GL_FRAGMENT_PRECISION_HIGH\n" \
                   "    precision highp float;\n" \
@@ -26,8 +27,7 @@
 #else
 #define CG(src)   "" #src
 #define GLSL(src) "" #src
-#define GLSL_300(src)   "#version 300 es\n"   #src
-#define GLSL_330(src)   "#version 330 core\n"   #src
+#define GLSL_STANDARD_DERIVATIVES(src) "" #src
 #endif
 
 #endif

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -376,22 +376,27 @@ static bool gl_glsl_compile_shader(glsl_shader_data_t *glsl,
          strtoul(existing_version + 8, (char**)&program, 10);
 
 #ifdef HAVE_OPENGLES
-      if (version_no >= 130 && version_no < 330)
+      if (gl_check_capability(GL_CAPS_GLES3_SUPPORTED))
       {
-         version_extra = " es";
-         version_no    = 300;
+         if (version_no >= 130 && version_no < 330)
+         {
+            version_extra = " es";
+            version_no    = 300;
+         }
+         else if (version_no == 330)
+         {
+            version_extra = " es";
+            version_no    = 310;
+         }
+         else if (version_no > 330)
+         {
+            version_extra = " es";
+            version_no    = 320;
+         }
+         else version_no  = 100;
       }
-      else if (version_no == 330)
-      {
-         version_extra = " es";
-         version_no    = 310;
-      }
-      else if (version_no > 330)
-      {
-         version_extra = " es";
-         version_no    = 320;
-      }
-      else version_no  = 100;
+      /* Avoid versions that definitely aren't supported. */
+      else version_no     = 100;
 #endif
       snprintf(version,
             sizeof(version), "#version %u%s\n", version_no, version_extra);
@@ -895,7 +900,12 @@ static void gl_glsl_init_menu_shaders(void *data)
    shader_prog_info.vertex = stock_vertex_xmb_ribbon_modern;
    shader_prog_info.fragment = stock_fragment_xmb;
 #else
-   if (gl_query_extension("GL_OES_standard_derivatives"))
+   if (gl_check_capability(GL_CAPS_GLES3_SUPPORTED))
+   {
+      shader_prog_info.vertex = stock_vertex_xmb_ribbon_modern;
+      shader_prog_info.fragment = core_stock_fragment_xmb;
+   }
+   else if (gl_query_extension("GL_OES_standard_derivatives"))
    {
       shader_prog_info.vertex = glsl_core ? stock_vertex_xmb_ribbon_modern : stock_vertex_xmb_ribbon_legacy;
       shader_prog_info.fragment = glsl_core ? core_stock_fragment_xmb : stock_fragment_xmb;


### PR DESCRIPTION
This makes it so that in GLES2 contexts, GLSL versions higher than `100` will not be tried, because they are guaranteed to fail. Because of this change I was also able to enable the better XMB ribbon for GLES3 without also breaking GLES2. (`dFdx` and `dFdy` are enabled by the `GL_OES_standard_derivatives` extension in GLES2, but are core in GLES3. Any shaders using them in GLES3 contexts must use at least `#version 300 es` to compile though. I set the shaders that use those functions to use `#version 130`, which maps to `300 es` in GLES3 but works just fine as `100` on GLES2 as well.)