### PR TITLE
Make sure correct type is used when calling `retroarch_get_flags()`

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3801,7 +3801,7 @@ static bool config_load_file(global_t *global,
    struct config_array_setting *array_settings     = NULL;
    struct config_path_setting *path_settings       = NULL;
    config_file_t *conf                             = NULL;
-   uint16_t rarch_flags                            = retroarch_get_flags();
+   uint32_t rarch_flags                            = retroarch_get_flags();
 
    tmp_str[0]                                      = '\0';
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -2023,7 +2023,7 @@ global_t *global_get_ptr(void)
    return &global_driver_st;
 }
 
-uint16_t retroarch_get_flags(void)
+uint32_t retroarch_get_flags(void)
 {
    struct rarch_state *p_rarch = &rarch_st;
    return p_rarch->flags;

--- a/retroarch.h
+++ b/retroarch.h
@@ -209,7 +209,7 @@ void retroarch_fail(int error_code, const char *error);
 
 bool should_quit_on_close(void);
 
-uint16_t retroarch_get_flags(void);
+uint32_t retroarch_get_flags(void);
 
 RETRO_END_DECLS
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1913,7 +1913,7 @@ bool task_push_start_dummy_core(content_ctx_info_t *content_info)
    const char *path_dir_system             = settings->paths.directory_system;
    bool check_firmware_before_loading      = settings->bools.check_firmware_before_loading;
 #ifdef HAVE_PATCH
-   uint16_t rarch_flags                    = retroarch_get_flags();
+   uint32_t rarch_flags                    = retroarch_get_flags();
 #endif
 
    if (!content_info)
@@ -2014,7 +2014,7 @@ bool task_push_load_content_from_playlist_from_menu(
 #endif
    bool check_firmware_before_loading         = settings->bools.check_firmware_before_loading;
 #ifdef HAVE_PATCH
-   uint16_t rarch_flags                       = retroarch_get_flags();
+   uint32_t rarch_flags                       = retroarch_get_flags();
 #endif
 
    content_ctx.flags     = 0;
@@ -2166,7 +2166,7 @@ bool task_push_start_current_core(content_ctx_info_t *content_info)
       content_ctx.flags |= CONTENT_INFO_FLAG_CHECK_FW_BEFORE_LOADING;
 #ifdef HAVE_PATCH
    {
-      uint16_t rarch_flags = retroarch_get_flags();
+      uint32_t rarch_flags = retroarch_get_flags();
       if (rarch_flags & RARCH_FLAGS_IPS_PREF)
          content_ctx.flags |= CONTENT_INFO_FLAG_IS_IPS_PREF;
       if (rarch_flags & RARCH_FLAGS_BPS_PREF)
@@ -2412,7 +2412,7 @@ bool task_push_load_content_with_new_core_from_menu(
       content_ctx.flags |= CONTENT_INFO_FLAG_CHECK_FW_BEFORE_LOADING;
 #ifdef HAVE_PATCH
    {
-      uint16_t rarch_flags  = retroarch_get_flags();
+      uint32_t rarch_flags  = retroarch_get_flags();
       if (rarch_flags & RARCH_FLAGS_IPS_PREF)
          content_ctx.flags |= CONTENT_INFO_FLAG_IS_IPS_PREF;
       if (rarch_flags & RARCH_FLAGS_BPS_PREF)
@@ -2522,7 +2522,7 @@ static bool task_load_content_internal(
    const char *path_dir_system             = settings->paths.directory_system;
    const char *path_dir_cache              = settings->paths.directory_cache;
 #ifdef HAVE_PATCH
-   uint16_t rarch_flags                    = retroarch_get_flags();
+   uint32_t rarch_flags                    = retroarch_get_flags();
 #endif
    content_ctx.flags                       = 0;
 
@@ -3025,7 +3025,7 @@ bool content_init(void)
    const char *path_dir_system        = settings->paths.directory_system;
    const char *path_dir_cache         = settings->paths.directory_cache;
 #ifdef HAVE_PATCH
-   uint16_t rarch_flags               = retroarch_get_flags();
+   uint32_t rarch_flags               = retroarch_get_flags();
 #endif
 
    content_file_list_free(p_content->content_list);


### PR DESCRIPTION
There has been more than 16 flags for a while now, `flags` was changed to uint32_t a while ago already but `retroarch_get_flags()` and variables calling it were not updated.
https://github.com/libretro/RetroArch/blob/a16d651ba76bb3d5fca258c37d24ac19bee5bfaa/retroarch.c#L317
https://github.com/libretro/RetroArch/blob/a16d651ba76bb3d5fca258c37d24ac19bee5bfaa/retroarch.h#L91-L111