### PR TITLE
ANDROID Set display refresh rate based on the video->output->vertical refresh rate config value

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -56,6 +56,10 @@
 
 #include "list_special.h"
 
+#if defined(ANDROID)
+#include "pkg/android/phoenix-common/jni/ra_android_bridge.h"
+#endif
+
 #if defined(__WINRT__) || defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP
 #include "uwp/uwp_func.h"
 #endif
@@ -2383,7 +2387,11 @@ static struct config_float_setting *populate_settings_float(
 #endif
 
    *size = count;
-
+#if defined(__ANDROID__) || defined(ANDROID)
+   if (settings && settings->floats.video_refresh_rate > 0.0f) {
+      ra_notify_refresh_rate(settings->floats.video_refresh_rate);
+   }
+#endif
    return tmp;
 }
 
@@ -2995,6 +3003,7 @@ void config_set_defaults(void *data)
          g_defaults.settings_video_refresh_rate != DEFAULT_REFRESH_RATE)
       settings->floats.video_refresh_rate      = g_defaults.settings_video_refresh_rate;
 
+      
    if (DEFAULT_AUDIO_DEVICE)
       configuration_set_string(settings,
             settings->arrays.audio_device,
@@ -4543,6 +4552,12 @@ static bool config_load_file(global_t *global,
    if (size_settings)
       free(size_settings);
    first_load = false;
+
+#if defined(__ANDROID__) || defined(ANDROID)
+   if (settings && settings->floats.video_refresh_rate > 0.0f) {
+      ra_notify_refresh_rate(settings->floats.video_refresh_rate);
+   }
+#endif
    return true;
 }
 
@@ -4746,6 +4761,12 @@ bool config_load_override(void *data)
    else
       runloop_state_get_ptr()->flags &= ~RUNLOOP_FLAG_OVERRIDES_ACTIVE;
 
+
+#if defined(__ANDROID__) || defined(ANDROID)
+   if (settings && settings->floats.video_refresh_rate > 0.0f) {
+      ra_notify_refresh_rate(settings->floats.video_refresh_rate);
+   }
+#endif
    return true;
 }
 
@@ -4788,6 +4809,11 @@ bool config_load_override_file(const char *config_path)
    else
       runloop_state_get_ptr()->flags &= ~RUNLOOP_FLAG_OVERRIDES_ACTIVE;
 
+#if defined(__ANDROID__) || defined(ANDROID)
+   if (settings && settings->floats.video_refresh_rate > 0.0f) {
+      ra_notify_refresh_rate(settings->floats.video_refresh_rate);
+   }
+#endif
    return true;
 }
 

--- a/pkg/android/phoenix-common/jni/Android.mk
+++ b/pkg/android/phoenix-common/jni/Android.mk
@@ -3,6 +3,7 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 RARCH_DIR := ../../../..
+RA_ROOT := $(LOCAL_PATH)/$(RARCH_DIR)
 
 HAVE_NEON   := 1
 HAVE_LOGGER := 0
@@ -56,6 +57,14 @@ LOCAL_MODULE := retroarch-activity
 
 LOCAL_SRC_FILES  +=	$(RARCH_DIR)/griffin/griffin.c \
 							$(RARCH_DIR)/griffin/griffin_cpp.cpp
+
+LOCAL_SRC_FILES += \
+    ra_android_bridge.c
+
+LOCAL_C_INCLUDES += \
+    $(RA_ROOT) \
+    $(RA_ROOT)/libretro-common/include \
+    $(RA_ROOT)/gfx/include
 
 ifeq ($(HAVE_LOGGER), 1)
    DEFINES += -DHAVE_LOGGER
@@ -173,13 +182,14 @@ LOCAL_CPPFLAGS := -fexceptions -fpermissive -std=gnu++11 -fno-rtti -Wno-reorder 
 LOCAL_CFLAGS := $(subst -O3,-O2,$(LOCAL_CFLAGS))
 
 LOCAL_LDLIBS	 := -landroid -lEGL $(GLES_LIB) $(LOGGER_LDLIBS) -ldl
-LOCAL_C_INCLUDES := \
-		    $(LOCAL_PATH)/$(RARCH_DIR)/libretro-common/include \
-		    $(LOCAL_PATH)/$(RARCH_DIR)/deps \
-		    $(LOCAL_PATH)/$(RARCH_DIR)/deps/stb \
-		    $(LOCAL_PATH)/$(RARCH_DIR)/deps/7zip
+LOCAL_C_INCLUDES += \
+    $(RA_ROOT)/libretro-common/include \
+    $(RA_ROOT)/deps \
+    $(RA_ROOT)/deps/stb \
+    $(RA_ROOT)/deps/7zip
 
-INCLUDE_DIRS     := \
+
+INCLUDE_DIRS := \
 		    -I$(LOCAL_PATH)/$(DEPS_DIR)/stb/ \
 		    -I$(LOCAL_PATH)/$(DEPS_DIR)/7zip/ \
 		    -I$(LOCAL_PATH)/$(DEPS_DIR)/libFLAC/include

--- a/pkg/android/phoenix-common/jni/ra_android_bridge.c
+++ b/pkg/android/phoenix-common/jni/ra_android_bridge.c
@@ -1,0 +1,79 @@
+#include <jni.h>
+#include <libretro.h>
+#include "runloop.h"
+#include "verbosity.h"
+#include "configuration.h"
+
+// ---------- Cached JNI handles ----------
+static JavaVM *g_vm = NULL;
+static jclass g_cls_RetroActivityFuture = NULL;       // GlobalRef
+static jmethodID g_mid_nativePushContentFps = NULL;   // (F)V
+
+// Small helper: get/attach JNIEnv for the current thread
+static JNIEnv* ra_get_env(bool *out_attached)
+{
+    if (out_attached) *out_attached = false;
+    if (!g_vm) return NULL;
+
+    JNIEnv *env = NULL;
+    jint r = (*g_vm)->GetEnv(g_vm, (void**)&env, JNI_VERSION_1_6);
+    if (r == JNI_OK && env) return env;
+
+    // Not attached -> attach
+    if ((*g_vm)->AttachCurrentThread(g_vm, &env, NULL) != 0)
+        return NULL;
+    if (out_attached) *out_attached = true;
+    return env;
+}
+
+// ---------- JNI load/unload ----------
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    g_vm = vm;
+    JNIEnv *env = NULL;
+    if ((*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_6) != JNI_OK || !env)
+        return JNI_ERR;
+
+    jclass local = (*env)->FindClass(env, "com/retroarch/browser/retroactivity/RetroActivityFuture");
+    if (!local) return JNI_ERR;
+
+    g_cls_RetroActivityFuture = (jclass)(*env)->NewGlobalRef(env, local);
+    (*env)->DeleteLocalRef(env, local);
+    if (!g_cls_RetroActivityFuture) return JNI_ERR;
+
+    // Cache static push method: public static void nativePushContentFps(float)
+    g_mid_nativePushContentFps = (*env)->GetStaticMethodID(env, g_cls_RetroActivityFuture,
+                                                           "nativePushContentFps", "(F)V");
+    // It's fine if Java side doesn't have it yet; we just won't call it
+    return JNI_VERSION_1_6;
+}
+
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved)
+{
+    JNIEnv *env = NULL;
+    if ((*vm)->GetEnv(vm, (void**)&env, JNI_VERSION_1_6) == JNI_OK && env) {
+        if (g_cls_RetroActivityFuture) {
+            (*env)->DeleteGlobalRef(env, g_cls_RetroActivityFuture);
+            g_cls_RetroActivityFuture = NULL;
+        }
+    }
+    g_vm = NULL;
+    g_mid_nativePushContentFps = NULL;
+}
+
+// ---------- Public C API: push fresh FPS to Java (optional) ----------
+void ra_notify_refresh_rate(float fps)
+{
+    if (fps <= 0.f) return;
+    if (!g_vm || !g_cls_RetroActivityFuture || !g_mid_nativePushContentFps) return;
+
+    bool attached = false;
+    JNIEnv *env = ra_get_env(&attached);
+    if (!env) return;
+
+    (*env)->CallStaticVoidMethod(env, g_cls_RetroActivityFuture,
+                                 g_mid_nativePushContentFps, (jfloat)fps);
+
+    if (attached)
+        (*g_vm)->DetachCurrentThread(g_vm);
+}

--- a/pkg/android/phoenix-common/jni/ra_android_bridge.h
+++ b/pkg/android/phoenix-common/jni/ra_android_bridge.h
@@ -1,0 +1,13 @@
+#ifndef RA_ANDROID_BRIDGE_H
+#define RA_ANDROID_BRIDGE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ra_notify_refresh_rate(float fps);
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
## Description

Added feature for Android that sets the display's refresh rate to a supported refresh rate mode based on the value set in the configuration vertical refresh rate variable. For example my device has a 120hz capable display but can be set to 90hz or 60hz when requested by an App. 

Added a call to ra_notify_refresh_rate() when the config is loaded in configuration.c which in turn communicates with the Android app through JNI to set the refresh rate. The Android app will check supported refresh rates and requests Android OS to set the refresh rate to the closest supported refresh rate mode of the requested refresh rate. 

This way you can run games at 60hz with vsync on in Android without the need to adjust the display refresh rate in Android settings itself. This way you can set refresh rates also per override config etc  without ever needing to change it in Android settings itself all the time. 

Main part added is ra_android_bridge.c which can also be used for any future communications from Retroarch back to the Android app
