### PR TITLE
New Smart integer scaling implementation to address #18154

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -2535,7 +2535,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_VIDEO_SCALE_INTEGER_SCALING,
-   "Round down or up to the next integer. 'Smart' drops to underscale when image is cropped too much."
+   "Round down or up to the next integer. 'Smart' drops to underscale when image is cropped too much, and finally falls back to non-integer scaling if the underscale margins are too large."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_VIDEO_SCALE_INTEGER_SCALING_UNDERSCALE,


### PR DESCRIPTION
## Description
This pull request proposes a different approach to smart scaling. It chooses overscaling for 240p and 480p content when it would result in at least 192 or 384 lines being shown (i.e. the title safe area); other content (mainly handhelds) is allowed up to 6 cropped lines to accommodate a few resolutions which almost match the overscaled content. Otherwise, underscaling is chosen, as long as it doesn't result in a margin larger than 12% (a threshold I chose by testing various content/display combinations.) If neither condition is satisfied, non-integer scaling is used. In other words, it only opts for integer scaling when it's "close enough."

I've tried to follow the Coding Standards as best I could, but this is my first contribution to RetroArch and I don't typically code in C, so I apologize in advance for any missteps.

## Related Issues
["Smart" integer scaling is bugged #18154](#18154)
In short, this change is trying to address the fact that the current Smart scaling implementation 1) doesn't behave consistently with regards to choosing underscaling or overscaling, and 2) sometimes allows excessive amounts of cropping or letterboxing. My guiding principle was to choose heuristics that would be simple for the end user to understand and unlikely to annoy.

## Examples

### 224p scaled to 1280x720
Underscaled with 6.67% margin.
<img width="1280" height="720" alt="224p-to-1280x720" src="https://github.com/user-attachments/assets/3895fae7-04f8-4495-8342-301381e1c7b1" />

### 224p scaled to 1280x800 (Steam Deck)
Overscaled with 16.67% cropping
<img width="1280" height="800" alt="224p-to-1280x800" src="https://github.com/user-attachments/assets/1cf70c7c-92a3-4e02-bcb4-327bc3312591" />

### 224p scaled to 1920x1080
Overscaled with 10% cropping.
<img width="1920" height="1080" alt="224p-to-1920x1080" src="https://github.com/user-attachments/assets/881e1a65-a8cf-4b94-b3b8-d333289e2ff7" />

### 480p scaled to 1280x720
Stretched to fit. Overscaling would crop 25%, underscaling would waste 1/3 of the screen's height.
<img width="1280" height="720" alt="480p-to-1280x720" src="https://github.com/user-attachments/assets/4c68db3d-e072-484c-babc-43d086c16266" />

### 480p scaled to 1920x1080
Underscaled with 11.11% margin.
<img width="1920" height="1080" alt="480p-to-1920x1080" src="https://github.com/user-attachments/assets/4668ad48-7070-49bd-8e05-5fc6a1282594" />
 
### GBA (160p) scaled to 1280x720
Underscaled with 11.11% margin.
<img width="1280" height="720" alt="gba-to-1280x720" src="https://github.com/user-attachments/assets/409f8099-505b-4475-89cb-89cc41b2f081" />

### GBA (160p) scaled to 1920x1080
Overscaled with 3 lines cropped from the top and bottom each.
<img width="1920" height="1080" alt="gba-to-1920x1080" src="https://github.com/user-attachments/assets/20d58098-b3f3-490d-a0c2-f3f717671160" />

### PSP (272p) scaled to 1280x720
Stretched to fit. Overscaling would crop 16 lines from the top and bottom each, underscaling would waste 24.4% of the screen height.
<img width="1280" height="720" alt="psp-to-1280x720" src="https://github.com/user-attachments/assets/90ae7580-5d99-4fd7-a1fb-67fbb65876ee" />

### PSP (272p) scaled to 1280x800 (Steam Deck)
Also stretched to fit, but this example demonstrates that the scaling works correctly when the screen aspect ratio is taller than the content.
<img width="1280" height="800" alt="psp-to-1280x800" src="https://github.com/user-attachments/assets/33e0792d-8ded-4af1-ac5f-4dab5d8d53a2" />

### PSP (272p) scaled to 1920x1080
Overscaled with 2 lines cropped from the top and bottom each.
<img width="1920" height="1080" alt="psp-to-1920x1080" src="https://github.com/user-attachments/assets/af488cb1-775d-44ca-994f-0796739a542e" />

## Future work
Ideally the cutoff for choosing between underscaling and stretching would be configurable, but I have no experience implementing new config settings.

## Reviewers
@sonninnos According to Git blame, they wrote the initial Smart scaling implementation.
