### PR TITLE
sdl : Fix typo SDL_SUPPORTS_RUMBLE

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -507,7 +507,7 @@ static bool sdl_joypad_set_rumble(unsigned pad, enum retro_rumble_effect effect,
          return false;
    }
 
-#if SDK_SUPPORTS_RUMBLE
+#if SDL_SUPPORTS_RUMBLE
    if (joypad->rumble_effect == -3)
    {
       if (SDL_JoystickRumble(joypad->joypad, efx.leftright.large_magnitude, efx.leftright.small_magnitude, efx.leftright.length) == -1)


### PR DESCRIPTION
[SDK_SUPPORTS_RUMBLE](https://github.com/libretro/RetroArch/blob/6bf2950b1683b5e0e726046284e93ca173edb322/input/drivers_joypad/sdl_joypad.c#L510) should be [SDL_SUPPORTS_RUMBLE](https://github.com/libretro/RetroArch/blob/6bf2950b1683b5e0e726046284e93ca173edb322/input/drivers_joypad/sdl_joypad.c#L30)