### PR TITLE
Remove interval for XInput rumbles

### DIFF
--- a/input/drivers_joypad/xinput_joypad.c
+++ b/input/drivers_joypad/xinput_joypad.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
-#include <time.h>
 
 #include <boolean.h>
 #include <retro_inline.h>
@@ -52,8 +51,6 @@ typedef struct
    bool         connected;
 } xinput_joypad_state;
 
-#define RUMBLE_INTERVAL 0.005
-
 /* Function pointer, to be assigned with dylib_proc */
 typedef uint32_t (__stdcall *XInputGetStateEx_t)(uint32_t, XINPUT_STATE*);
 typedef uint32_t (__stdcall *XInputSetState_t)(uint32_t, XINPUT_VIBRATION*);
@@ -75,7 +72,6 @@ static XINPUT_VIBRATION    g_xinput_rumble_states[4];
 #endif
 static xinput_joypad_state g_xinput_states[4];
 static bool xinput_active_port[4] = {0};
-static clock_t last_rumble_time[4] = {0};
 
 static unsigned xinput_hotplug_index = 0;
 static unsigned xinput_poll_counter  = 0;
@@ -351,7 +347,9 @@ static int16_t xinput_joypad_state_func(
 static void xinput_joypad_poll(void)
 {
    int i;
+#ifdef __WINRT__
    bool has_active_ports = false;
+#endif
 
    /* Hotplugging detection: scanning one port at a time every few frames,
     * to avoid polling overload and framerate drops. */
@@ -382,11 +380,13 @@ static void xinput_joypad_poll(void)
       xinput_hotplug_index = (xinput_hotplug_index + 1) % 4;
    }
 
+#ifdef __WINRT__
    for (i = 0; i < 4; ++i)
    {
       if (xinput_active_port[i])
          has_active_ports = true;
    }
+#endif
 
    for (i = 0; i < 4; ++i)
    {
@@ -397,8 +397,8 @@ static void xinput_joypad_poll(void)
        * If no ports are currently active, we need to poll all ports
        * to catch any late arriving controllers. */
 #ifdef __WINRT__
-if (!xinput_active_port[i] && has_active_ports)
-   continue;
+      if (!xinput_active_port[i] && has_active_ports)
+         continue;
 #else
       if (!xinput_active_port[i])
          continue;
@@ -434,44 +434,27 @@ if (!xinput_active_port[i] && has_active_ports)
 static bool xinput_joypad_rumble(unsigned pad,
       enum retro_rumble_effect effect, uint16_t strength)
 {
-   clock_t now;
-   double time_since_last_rumble;
-   XINPUT_VIBRATION *state, new_state;
-   int xuser   = pad_index_to_xuser_index(pad);
+   XINPUT_VIBRATION *state, prev;
+   int xuser = pad_index_to_xuser_index(pad);
 
    if (xuser == -1)
       return false;
 
-   state     = &g_xinput_rumble_states[xuser];
-   new_state = *state;
+   state = &g_xinput_rumble_states[xuser];
+   prev  = *state;
 
    /* Consider the low frequency (left) motor the "strong" one. */
    if (effect == RETRO_RUMBLE_STRONG)
-      new_state.wLeftMotorSpeed = strength;
+      state->wLeftMotorSpeed  = strength;
    else if (effect == RETRO_RUMBLE_WEAK)
-      new_state.wRightMotorSpeed = strength;
+      state->wRightMotorSpeed = strength;
 
    /* Rumble state unchanged? */
-   if (   (new_state.wLeftMotorSpeed  == state->wLeftMotorSpeed)
-       && (new_state.wRightMotorSpeed == state->wRightMotorSpeed))
+   if (   (state->wLeftMotorSpeed  == prev.wLeftMotorSpeed)
+       && (state->wRightMotorSpeed == prev.wRightMotorSpeed))
       return true;
 
-   now                    = clock();
-   time_since_last_rumble = (double)(now - last_rumble_time[xuser]) / CLOCKS_PER_SEC;
-
-   /* Rumble interval unelapsed? */
-   if (time_since_last_rumble < RUMBLE_INTERVAL)
-      return true;
-
-   if (g_XInputSetState)
-   {
-      *state = new_state;
-      last_rumble_time[xuser] = now;
-      if (g_XInputSetState(xuser, state) == ERROR_SUCCESS)
-         return true;
-   }
-
-   return false;
+   return g_XInputSetState && (g_XInputSetState(xuser, state) == ERROR_SUCCESS);
 }
 
 input_device_driver_t xinput_joypad = {


### PR DESCRIPTION
## Description

As mentioned here: https://github.com/libretro/RetroArch/pull/17954#issuecomment-3230808993 the added interval added in the XInput rumble mechanism breaks rumble (e.g. when a game/core requests start/stop for both weak and strong rumbles at the same time).
This PR simply removes that interval while keeping the "if rumble hasn't changed, return before calling `g_XInputSetState()`" logic which was the main reason for improved performances.

**edit:** Unrelated but also silenced a warning about `has_active_ports` being initialized but not used.

## Related Issues

Fixes #18172

## Related Pull Requests

#17954

## Reviewers

@Ryunam @sonninnos would you mind testing on your end? I tested with multiple cores (especially mGBA as mentioned in Ryunam's PR) and didn't notice any difference in FPS.
