### PR TITLE
Add support for archived file size query along with crc32

### DIFF
--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -655,6 +655,21 @@ const struct file_archive_file_backend* file_archive_get_file_backend(const char
  **/
 uint32_t file_archive_get_file_crc32(const char *path)
 {
+   uint64_t file_size;
+   return file_archive_get_file_crc32_and_size(path, &file_size);
+}
+
+/**
+ * file_archive_get_file_crc32_and_size:
+ * @path                         : filename path of archive
+ * @size                         : size of the file inside the archive
+ *
+ * Returns: CRC32 of the specified file in the archive, otherwise 0.
+ * If no path within the archive is specified, the first
+ * file found inside is used.
+ **/
+uint32_t file_archive_get_file_crc32_and_size(const char *path, uint64_t *size)
+{
    file_archive_transfer_t state;
    struct archive_extract_userdata userdata        = {0};
    bool returnerr                                  = false;
@@ -713,6 +728,6 @@ uint32_t file_archive_get_file_crc32(const char *path)
    }
 
    file_archive_parse_file_iterate_stop(&state);
-
+   *size = userdata.size;
    return userdata.crc;
 }

--- a/libretro-common/file/archive_file_7z.c
+++ b/libretro-common/file/archive_file_7z.c
@@ -493,6 +493,7 @@ static int sevenzip_parse_file_iterate_step(void *context,
       return ret;
 
    userdata->crc                 = checksum;
+   userdata->size                = size;
 
    if (file_cb && !file_cb(userdata->current_file_path, valid_exts,
             cdata, cmode,

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -527,7 +527,8 @@ static int zip_parse_file_iterate_step(void *context,
    if (ret != 1)
       return ret;
 
-   userdata->crc = checksum;
+   userdata->crc  = checksum;
+   userdata->size = size;
 
    if (file_cb && !file_cb(userdata->current_file_path, valid_exts, cdata, cmode,
             csize, size, checksum, userdata))

--- a/libretro-common/include/file/archive_file.h
+++ b/libretro-common/include/file/archive_file.h
@@ -97,6 +97,7 @@ struct archive_extract_userdata
    decompress_state_t *dec;
    void* cb_data;
    uint32_t crc;
+   uint64_t size;
    char archive_path[PATH_MAX_LENGTH];
    char current_file_path[PATH_MAX_LENGTH];
    bool found_file;
@@ -201,6 +202,17 @@ const struct file_archive_file_backend* file_archive_get_file_backend(const char
  * file found inside is used.
  **/
 uint32_t file_archive_get_file_crc32(const char *path);
+
+/**
+ * file_archive_get_file_crc32_and_size:
+ * @path                         : filename path of archive
+ * @size                         : size of the file inside the archive
+ *
+ * Returns: CRC32 of the specified file in the archive, otherwise 0.
+ * If no path within the archive is specified, the first
+ * file found inside is used.
+ **/
+uint32_t file_archive_get_file_crc32_and_size(const char *path, uint64_t *size);
 
 extern const struct file_archive_file_backend zlib_backend;
 extern const struct file_archive_file_backend sevenzip_backend;


### PR DESCRIPTION
## Description

Extend the interface with file_archive_get_file_crc32_and_size, which also returns the uncompressed size of the file. Needed for optimizing content scanning in an upcoming PR.