### PR TITLE
Prevent uninitialized memory when searching for serial in database.

### DIFF
--- a/database_info.c
+++ b/database_info.c
@@ -496,6 +496,7 @@ char *bin_to_hex_alloc(const uint8_t *data, size_t len)
    if (len && !ret)
       return NULL;
 
+   ret[0] = '\0';
    for (i = 0; i < len; i++)
       snprintf(ret+i * 2, 3, "%02X", data[i]);
    return ret;


### PR DESCRIPTION
## Description

When serial can not be retrieved from the image (length is 0), the translation for the database search syntax may return uninitialized memory, resulting in bogus database hits (which are not written to playlist), but also in endless scanning.

Scanning one such image was failing (running endlessly) at least once in ten tries, with the modification, the endless scan can not be reproduced any more.

## Related Issues

Closes #16906 (most probably). Maybe also #10876 , as the trace also points to serial scanning.
