### PR TITLE
Use app-specific storage for Google Play versions of the Android app

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.gamepad" android:required="false"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
@@ -23,6 +25,7 @@
         android:isGame="true"
         android:banner="@drawable/banner"
         android:extractNativeLibs="true"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -1,5 +1,6 @@
 package com.retroarch.browser.mainmenu;
 
+import com.retroarch.BuildConfig;
 import com.retroarch.browser.preferences.util.UserPreferences;
 import com.retroarch.browser.retroactivity.RetroActivityFuture;
 
@@ -26,12 +27,97 @@ import android.util.Log;
  */
 public final class MainMenuActivity extends PreferenceActivity
 {
+	final private int REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS = 124;
 	public static String PACKAGE_NAME;
+	boolean checkPermissions = false;
+
+	public void showMessageOKCancel(String message, DialogInterface.OnClickListener onClickListener)
+	{
+		new AlertDialog.Builder(this).setMessage(message)
+			.setPositiveButton("OK", onClickListener).setCancelable(false)
+			.setNegativeButton("Cancel", null).create().show();
+	}
+
+	private boolean addPermission(List<String> permissionsList, String permission)
+	{
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+		{
+			if (checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED)
+			{
+				permissionsList.add(permission);
+
+				// Check for Rationale Option
+				if (!shouldShowRequestPermissionRationale(permission))
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	public void checkRuntimePermissions()
+	{
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
+		{
+			// Android 6.0+ needs runtime permission checks
+			List<String> permissionsNeeded = new ArrayList<String>();
+			final List<String> permissionsList = new ArrayList<String>();
+
+			if (!addPermission(permissionsList, Manifest.permission.READ_EXTERNAL_STORAGE))
+				permissionsNeeded.add("Read External Storage");
+			if (!addPermission(permissionsList, Manifest.permission.WRITE_EXTERNAL_STORAGE))
+				permissionsNeeded.add("Write External Storage");
+
+			if (permissionsList.size() > 0)
+			{
+				checkPermissions = true;
+
+				if (permissionsNeeded.size() > 0)
+				{
+					// Need Rationale
+					Log.i("MainMenuActivity", "Need to request external storage permissions.");
+
+					String message = "You need to grant access to " + permissionsNeeded.get(0);
+
+					for (int i = 1; i < permissionsNeeded.size(); i++)
+						message = message + ", " + permissionsNeeded.get(i);
+
+					showMessageOKCancel(message,
+						new DialogInterface.OnClickListener()
+						{
+							@Override
+							public void onClick(DialogInterface dialog, int which)
+							{
+								if (which == AlertDialog.BUTTON_POSITIVE)
+								{
+									requestPermissions(permissionsList.toArray(new String[permissionsList.size()]),
+											REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
+
+									Log.i("MainMenuActivity", "User accepted request for external storage permissions.");
+								}
+							}
+						});
+				}
+				else
+				{
+					requestPermissions(permissionsList.toArray(new String[permissionsList.size()]),
+						REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
+
+					Log.i("MainMenuActivity", "Requested external storage permissions.");
+				}
+			}
+		}
+
+		if (!checkPermissions)
+		{
+			finalStartup();
+		}
+	}
 
 	public void finalStartup()
 	{
 		Intent retro = new Intent(this, RetroActivityFuture.class);
-		
+
 		if (RetroActivityFuture.isRunning) {
 			// RetroActivity is already running - just bring it to front
 			retro.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
@@ -39,7 +125,7 @@ public final class MainMenuActivity extends PreferenceActivity
 			// RetroActivity not running - full setup with parameters
 			retro.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-			
+
 			startRetroActivity(
 					retro,
 					null,
@@ -49,11 +135,38 @@ public final class MainMenuActivity extends PreferenceActivity
 					getApplicationInfo().dataDir,
 					getApplicationInfo().sourceDir);
 		}
-		
+
 		startActivity(retro);
 		finish();
 	}
-	
+
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults)
+	{
+		switch (requestCode)
+		{
+			case REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS:
+				for (int i = 0; i < permissions.length; i++)
+				{
+					if(grantResults[i] == PackageManager.PERMISSION_GRANTED)
+					{
+						Log.i("MainMenuActivity", "Permission: " + permissions[i] + " was granted.");
+					}
+					else
+					{
+						Log.i("MainMenuActivity", "Permission: " + permissions[i] + " was not granted.");
+					}
+				}
+
+				break;
+			default:
+				super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+				break;
+		}
+
+		finalStartup();
+	}
 
 	public static void startRetroActivity(Intent retro, String contentPath, String corePath,
 			String configFilePath, String imePath, String dataDirPath, String dataSourcePath)
@@ -67,7 +180,7 @@ public final class MainMenuActivity extends PreferenceActivity
 		retro.putExtra("DATADIR", dataDirPath);
 		retro.putExtra("APK", dataSourcePath);
 		String external = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + PACKAGE_NAME + "/files";
-		retro.putExtra("SDCARD", external);
+		retro.putExtra("SDCARD", BuildConfig.PLAY_STORE_BUILD ? external : Environment.getExternalStorageDirectory().getAbsolutePath());
 		retro.putExtra("EXTERNAL", external);
 	}
 
@@ -83,6 +196,9 @@ public final class MainMenuActivity extends PreferenceActivity
 
 		UserPreferences.updateConfigFile(this);
 
-		finalStartup();
+		if (BuildConfig.PLAY_STORE_BUILD)
+			finalStartup();
+		else
+			checkRuntimePermissions();
 	}
 }

--- a/pkg/android/phoenix/src/com/retroarch/browser/provider/RetroDocumentsProvider.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/provider/RetroDocumentsProvider.java
@@ -18,6 +18,7 @@ import android.provider.DocumentsContract.Root;
 import android.provider.DocumentsProvider;
 import android.webkit.MimeTypeMap;
 
+import com.retroarch.BuildConfig;
 import com.retroarch.R;
 
 import java.io.File;
@@ -73,27 +74,40 @@ public class RetroDocumentsProvider extends DocumentsProvider {
         final MatrixCursor result = new MatrixCursor(projection != null ? projection : DEFAULT_ROOT_PROJECTION);
         @SuppressWarnings("ConstantConditions") final String applicationName = getContext().getString(R.string.app_name);
 
-        final File CORE_DIR = new File(getContext().getFilesDir().getParent());
-        final MatrixCursor.RowBuilder core = result.newRow();
-        core.add(Root.COLUMN_ROOT_ID, getDocIdForFile(CORE_DIR));
-        core.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(CORE_DIR));
-        core.add(Root.COLUMN_SUMMARY, "Core Data");
-        core.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
-        core.add(Root.COLUMN_TITLE, applicationName);
-        core.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
-        core.add(Root.COLUMN_AVAILABLE_BYTES, CORE_DIR.getFreeSpace());
-        core.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+        if (BuildConfig.PLAY_STORE_BUILD) {
+            final File CORE_DIR = new File(getContext().getFilesDir().getParent());
+            final MatrixCursor.RowBuilder core = result.newRow();
+            core.add(Root.COLUMN_ROOT_ID, getDocIdForFile(CORE_DIR));
+            core.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(CORE_DIR));
+            core.add(Root.COLUMN_SUMMARY, "Core Data");
+            core.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
+            core.add(Root.COLUMN_TITLE, applicationName);
+            core.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
+            core.add(Root.COLUMN_AVAILABLE_BYTES, CORE_DIR.getFreeSpace());
+            core.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
 
-        final File USER_DIR = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + getContext().getPackageName() + "/files/RetroArch");
-        final MatrixCursor.RowBuilder user = result.newRow();
-        user.add(Root.COLUMN_ROOT_ID, getDocIdForFile(USER_DIR));
-        user.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(USER_DIR));
-        user.add(Root.COLUMN_SUMMARY, "User Data");
-        user.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
-        user.add(Root.COLUMN_TITLE, applicationName);
-        user.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
-        user.add(Root.COLUMN_AVAILABLE_BYTES, USER_DIR.getFreeSpace());
-        user.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+            final File USER_DIR = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + getContext().getPackageName() + "/files/RetroArch");
+            final MatrixCursor.RowBuilder user = result.newRow();
+            user.add(Root.COLUMN_ROOT_ID, getDocIdForFile(USER_DIR));
+            user.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(USER_DIR));
+            user.add(Root.COLUMN_SUMMARY, "User Data");
+            user.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
+            user.add(Root.COLUMN_TITLE, applicationName);
+            user.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
+            user.add(Root.COLUMN_AVAILABLE_BYTES, USER_DIR.getFreeSpace());
+            user.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+        } else {
+            final File BASE_DIR = new File(getContext().getFilesDir().getParent());
+            final MatrixCursor.RowBuilder row = result.newRow();
+            row.add(Root.COLUMN_ROOT_ID, getDocIdForFile(BASE_DIR));
+            row.add(Root.COLUMN_DOCUMENT_ID, getDocIdForFile(BASE_DIR));
+            row.add(Root.COLUMN_SUMMARY, null);
+            row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH | Root.FLAG_SUPPORTS_IS_CHILD);
+            row.add(Root.COLUMN_TITLE, applicationName);
+            row.add(Root.COLUMN_MIME_TYPES, ALL_MIME_TYPES);
+            row.add(Root.COLUMN_AVAILABLE_BYTES, BASE_DIR.getFreeSpace());
+            row.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+        }
 
         return result;
     }

--- a/pkg/android/phoenix/src/playStoreNormal/AndroidManifest.xml
+++ b/pkg/android/phoenix/src/playStoreNormal/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <application tools:remove="requestLegacyExternalStorage"/>
+</manifest>

--- a/pkg/android/phoenix/src/playStorePlus/AndroidManifest.xml
+++ b/pkg/android/phoenix/src/playStorePlus/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <application tools:remove="requestLegacyExternalStorage"/>
+</manifest>


### PR DESCRIPTION
The Google Play versions of the RetroArch Android app have not been updated for a while due to the scoped storage requirement in Android API level 30 and the Google Play store requiring all new apps and app updates to target Android API level 35, thus enforcing scoped storage for all new apps and app updates on Google Play.

There was a fix for this in #16393 that would make all versions of the RetroArch Android app use the app-specific storage, which is allowed, but that was reverted because it would break people's workflows. This pull request changes only the Google Play builds to use app-specific storage and does not change the non-Google Play builds, which is hopefully a good compromise. This would, at least, get the app back on Google Play without disrupting any users who are not using the Google Play version.

As mentioned in #12181, we could use the Storage Access Framework (SAF) in addition to, or instead of, this, to allow RetroArch and libretro cores to access persistent storage so that users' ROMs don't get deleted whenever they uninstall the app. However, all libretro cores that use full paths would need to be changed to use the libretro virtual filesystem (VFS) interface, since the SAF offers only a Java-based API for accessing the directories and doesn't expose them to C/C++. The SAF also introduces a performance penalty for that reason. I suppose it's the decision of the maintainer of this repository with regards to whether or not the SAF + VFS thing is worth it.