### PR TITLE
Fix x11 undefined behavior

### DIFF
--- a/input/drivers/x11_input.c
+++ b/input/drivers/x11_input.c
@@ -99,7 +99,7 @@ static void *x_input_init(const char *joypad_driver)
    for (i = 0; i < MAX_MOUSE_IDX; i++)
       x11->mouse_dev_list[i] = -1;
    x11->di = XIQueryDevice(x11->display, XIAllDevices, &cnt);
-   for (i = 0; i < cnt; i++)
+   for (i = 0; i < cnt && j < MAX_MOUSE_IDX; i++)
    {
       dev = &(x11->di[i]);
       RARCH_DBG("[X11] Device detected, %d \"%s\" attached to %d.\n", i, dev->name, dev->attachment);


### PR DESCRIPTION
It looks like the mouse device list was meant to be initialized with -1, but the mouse device list should contain only up to `j` values where j is the number of actual mice.  As is, the loop will iterate up to the number of X11 devices, rather than up to the number of possible mice.

If someone could review this to make sure I didn't mess anything up I'd appreciate it!