### PR TITLE
Remove an old emscripten hack around atomics

### DIFF
--- a/emscripten/pre.js
+++ b/emscripten/pre.js
@@ -1,6 +1,2 @@
 // To work around a bug in emscripten's polyfills for setImmediate in strict mode
 var setImmediate;
-
-// To work around a deadlock in firefox
-// Use platform_emscripten_has_async_atomics() to determine actual availability
-if (Atomics && !Atomics.waitAsync) Atomics.waitAsync = true;


### PR DESCRIPTION
In talking with @BinBashBanana it became clear this wasn't necessary, and it has started to conflict with some code in emscripten's libpthread in recent versions.