### PR TITLE
Set 272 for RGUI framebuffer size on Vita.

### DIFF
--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -101,6 +101,7 @@
 #define RGUI_DINGUX_FB_HEIGHT    240
 #endif
 #endif
+#define RGUI_VITA_FB_HEIGHT      272
 
 /* Maximum entry value length in characters
  * when using fixed with layouts
@@ -6112,6 +6113,10 @@ static bool rgui_set_aspect_ratio(
 #elif defined(DINGUX)
    /* Dingux devices use a fixed framebuffer size */
    rgui->frame_buf.height = RGUI_DINGUX_FB_HEIGHT;
+#elif defined(VITA)
+   /* Vita screen does not match 240 */
+   rgui->frame_buf.height = RGUI_VITA_FB_HEIGHT;
+   video_driver_get_viewport_info(&vp);
 #else
    /* If window height is less than RGUI default
     * height of 240, allow the frame buffer to


### PR DESCRIPTION
## Description

Since RGUI framebuffer height 240 does not match well with Vita native resolution (544), change it to the only reasonable value of 272 that is close to the default. It removes the remaining blurriness, although the difference is minimal.

As a side-effect, text becomes smaller. (Settings menu no longer needs scrolling, for a quick check). 

## Related Issues

Fixes #15967 

