### PR TITLE
Refactor remap menu left-right callbacks

### DIFF
--- a/input/input_defines.h
+++ b/input/input_defines.h
@@ -34,6 +34,7 @@
 #define RARCH_FIRST_META_KEY           RARCH_CUSTOM_BIND_LIST_END
 
 #define RARCH_UNMAPPED                 1024
+#define RARCH_NO_BIND                  "---"
 
 /* Specialized _MOUSE that targets the full screen regardless of viewport.
  */

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -3941,7 +3941,7 @@ size_t input_config_get_bind_string(
 
    /*completely empty?*/
    if (*s == '\0')
-      _len += strlcpy(s + _len, "---", len - _len);
+      _len += strlcpy(s + _len, RARCH_NO_BIND, len - _len);
    return _len;
 }
 

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -823,7 +823,7 @@ static size_t menu_action_setting_disp_set_label_input_desc(
       }
    }
    /* If descriptor was not found, set this instead */
-   return strlcpy(s, "---", len);
+   return strlcpy(s, RARCH_NO_BIND, len);
 }
 
 static size_t menu_action_setting_disp_set_label_input_desc_kbd(
@@ -860,7 +860,7 @@ static size_t menu_action_setting_disp_set_label_input_desc_kbd(
       _len += strlcpy(s + _len, key_descriptors[key_id].desc, len - _len);
    }
    else
-      _len  = strlcpy(s, "---", len);
+      _len  = strlcpy(s, RARCH_NO_BIND, len);
 
    *w = 19;
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -6866,7 +6866,7 @@ static size_t setting_get_string_representation_retropad_bind(
       int retro_id         = *setting->value.target.integer;
 
       if (retro_id < 0)
-         return strlcpy(s, "---", len);
+         return strlcpy(s, RARCH_NO_BIND, len);
       else
       {
          const struct retro_keybind *keyptr =


### PR DESCRIPTION
## Description

Current left+right logic in remap menu items fails with cores that skip input descriptors, such as Flycast not having Select and shoulder buttons, etc. Therefore the behavior is now matched with the dropdown order. Also moved the "unmapped" item as first in the dropdown like it already is with keyboard device type, and also unified and cleaned things up a bit.
