### PR TITLE
fix v0 replay sync and a crash that occurs at the end of playback

### DIFF
--- a/input/bsv/bsvmovie.c
+++ b/input/bsv/bsvmovie.c
@@ -126,8 +126,6 @@ bool bsv_movie_reset_playback(bsv_movie_t *handle)
       if (!bsv_movie_load_checkpoint(handle, compression, encoding, REPLAY_CPBEHAVIOR_DESERIALIZE))
          return false;
    }
-   if(vsn == 0)
-      return true;
    return bsv_movie_read_next_events(handle, REPLAY_CPBEHAVIOR_DESERIALIZE, true);
 }
 
@@ -721,6 +719,12 @@ bool bsv_movie_read_next_events(bsv_movie_t *handle, replay_checkpoint_behavior 
          }
          if (!bsv_movie_load_checkpoint(handle, compression, encoding, checkpoint_behavior))
             RARCH_WARN("[Replay] Failed to load movie checkpoint\n");
+      }
+      else if (next_frame_type != REPLAY_TOKEN_REGULAR_FRAME)
+      {
+         RARCH_ERR("[Replay] Invalid replay token 0x%x\n", next_frame_type);
+         if (end_movie)
+            input_st->bsv_movie_state.flags |= BSV_FLAG_MOVIE_END;
       }
    }
    return true;

--- a/input/bsv/uint32s_index.c
+++ b/input/bsv/uint32s_index.c
@@ -323,6 +323,8 @@ void uint32s_index_clear(uint32s_index_t *index)
 void uint32s_index_free(uint32s_index_t *index)
 {
    size_t i, cap;
+   if (!index)
+      return;
    for(i = 0, cap = RHMAP_CAP(index->index); i != cap; i++)
       if(RHMAP_KEY(index->index, i))
          uint32s_bucket_free(&index->index[i]);
@@ -351,6 +353,8 @@ void uint32s_index_print_count_data(uint32s_index_t *index)
    /* TODO: don't count or differently count NULL objects entries */
    uint32_t max=1;
    uint32_t i;
+   if (!index)
+      return;
    for(i = 0; i < BIN_COUNT; i++)
       bins[i] = 0;
    for(i = 1; i < RBUF_LEN(index->counts); i++)


### PR DESCRIPTION
V0 replays broke sometime during the refactorings in the move to incremental states (probably because the first read moved later in `runloop.h`), but this code puts back an initial read that had previously been specialcased-out for v0 replays.

It also avoids freeing or printing debug output for null statestream block indices.