### PR TITLE
menu_state_get_ptr() needs to be behind HAVE_MENU

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5691,12 +5691,14 @@ static void input_keys_pressed(
       else
          input_st->flags |= INP_FLAG_BLOCK_HOTKEY;
    }
-
+      
+#ifdef HAVE_MENU
    /* Prevent triggering menu actions after binding */
    if (     !(input_st->flags & INP_FLAG_MENU_PRESS_PENDING)
          && menu_state_get_ptr()->input_driver_flushing_input)
       input_st->flags |= INP_FLAG_WAIT_INPUT_RELEASE;
-
+#endif
+   
    /* Check libretro input if emulated device type is active,
     * except device type must be always active in menu. */
    if (     !(input_st->flags & INP_FLAG_BLOCK_LIBRETRO_INPUT)


### PR DESCRIPTION
## Description

My VSCode wouldn't let me save this file after making changes unrelated to this PR because menu_state_get_ptr() was applying -> to an int instead of a pointer. This function is defined in menu/menu_driver.h, which is included in input/input_driver.c, but that inclusion is gated behind the HAVE_MENU macro, so if that's not defined, it gets autodefined as an int instead.

This change just gates this menu-specific functionality behind HAVE_MENU, as well, to avoid the issue.

## Related Issues

none

## Related Pull Requests

none

## Reviewers

@sonninnos 