### PR TITLE
Strip byte-order mark from input_osk_utf8_pages.h to fix older GCC

### DIFF
--- a/input/input_osk_utf8_pages.h
+++ b/input/input_osk_utf8_pages.h
@@ -1,4 +1,4 @@
-﻿/*  RetroArch - A frontend for libretro.
+/*  RetroArch - A frontend for libretro.
  *  Copyright (C) 2011-2017 - Daniel De Matteis
  *  Copyright (C) 2016-2019 - Brad Parker
  *


### PR DESCRIPTION
Old versions of GCC get hung up on this file because of the included [BOM](https://en.wikipedia.org/wiki/Byte_order_mark). As the file is UTF-8 the byte order is the same on every machine so this should be able to be safely removed.

This fixes the following error on old versions of GCC:

```
In file included from menu/menu_driver.c:62:
menu/../input/input_osk_utf8_pages.h:1: error: stray '\357' in program
menu/../input/input_osk_utf8_pages.h:1: error: stray '\273' in program
menu/../input/input_osk_utf8_pages.h:1: error: stray '\277' in program
```

<img width="2052" height="1386" alt="image" src="https://github.com/user-attachments/assets/59b02bb6-9a75-4841-b4b8-0a5713326f28" />

See: https://www.unicode.org/versions/Unicode5.0.0/ch02.pdf

- **Use of a BOM is neither required nor recommended for UTF-8**, but may be encountered in contexts where UTF-8 data is converted from other encoding forms that use a BOM or where the BOM is used as a UTF-8 signature.