### PR TITLE
Fix a bug in the open() function in the Storage Access Framework VFS backend

### DIFF
--- a/libretro-common/vfs/saf/src/com/libretro/common/vfs/VfsImplementationSaf.java
+++ b/libretro-common/vfs/saf/src/com/libretro/common/vfs/VfsImplementationSaf.java
@@ -93,7 +93,7 @@ public final class VfsImplementationSaf
          }
          catch (FileNotFoundException | IllegalArgumentException e)
          {
-            if (createdFile || !write)
+            if (createdFile || !write || !truncate)
                return -1;
             createdFile = true;
             final Path parentPath = filePath.getParent();


### PR DESCRIPTION
## Description

Support for the Storage Access Framework was added to the libretro-common VFS code in #18336, but the function for opening files in that VFS backend has a bug where if the file you're trying to open doesn't already exist, it is created if and only if `(mode & RETRO_VFS_FILE_ACCESS_WRITE) != 0` (otherwise the file is not created and the function returns null).

The actual correct behaviour that would be consistent with the other existing VFS backends is if the file doesn't exist, the file should be created if and only if `(mode & RETRO_VFS_FILE_ACCESS_WRITE) != 0 && (mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING) == 0` is true, which I've corrected the function to do in this pull request.