### PR TITLE
iOS/tvOS: don't use draw observer unless fast forwarding

### DIFF
--- a/menu/menu_defines.h
+++ b/menu/menu_defines.h
@@ -50,7 +50,8 @@ enum menu_state_flags
    MENU_ST_FLAG_SCREENSAVER_SUPPORTED       = (1 << 10),
    MENU_ST_FLAG_SCREENSAVER_ACTIVE          = (1 << 11),
    MENU_ST_FLAG_PENDING_RELOAD_CORE         = (1 << 12),
-   MENU_ST_FLAG_PENDING_STARTUP_PAGE        = (1 << 13)
+   MENU_ST_FLAG_PENDING_STARTUP_PAGE        = (1 << 13),
+   MENU_ST_FLAG_BLOCK_ALL_INPUT             = (1 << 14)
 };
 
 enum menu_scroll_mode

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5318,6 +5318,10 @@ unsigned menu_event(
       RETRO_DEVICE_ID_JOYPAD_Y
    };
 
+   /* Check if all menu input is blocked */
+   if (menu_st->flags & MENU_ST_FLAG_BLOCK_ALL_INPUT)
+      return MENU_ACTION_NOOP;
+
    ok_old                                          = ok_current;
 
    /* Get pointer (mouse + touchscreen) input

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -860,8 +860,6 @@ enum
       appicon_setting->values = options;
    }
 
-   rarch_start_draw_observer();
-
 #if TARGET_OS_TV
    update_topshelf();
 #endif
@@ -928,6 +926,14 @@ enum
 #endif
    rarch_stop_draw_observer();
    command_event(CMD_EVENT_SAVE_FILES, NULL);
+
+   /* Clear any stuck or stale touches when backgrounding */
+   cocoa_input_data_t *apple = (cocoa_input_data_t*)input_state_get_ptr()->current_data;
+   if (apple)
+   {
+      apple->touch_count = 0;
+      memset(apple->touches, 0, sizeof(apple->touches));
+   }
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application
@@ -940,11 +946,18 @@ enum
 {
    self.bgDate = [NSDate date];
    rarch_stop_draw_observer();
+
+   /* Clear any stuck or stale touches when losing focus */
+   cocoa_input_data_t *apple = (cocoa_input_data_t*)input_state_get_ptr()->current_data;
+   if (apple)
+   {
+      apple->touch_count = 0;
+      memset(apple->touches, 0, sizeof(apple->touches));
+   }
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
-   rarch_start_draw_observer();
    NSError *error;
    settings_t *settings            = config_get_ptr();
    bool ui_companion_start_on_boot = settings->bools.ui_companion_start_on_boot;


### PR DESCRIPTION
On iPhone, when running at 120Hz, the draw observer sometimes gets called so aggressively that it starves touch input (among others).

Right now retroarch uses a combination of the draw observer and a CADisplayLink, which is supposed to be invoked each frame. The display link sometimes isn't called each frame because the draw observer is starving it as well. Both of them do the same thing, which is to call runloop_iterate once.

On iOS there isn't a great way of pumping the UIKit loop manually (unlike on macOS). Instead if we need to be called more often (like when we're fast forwarding), the proper way is to use a draw observer. However this has drawbacks.

This PR tries to set it up so "normally" it will only use the display link (which allows input to be processed in a reasonable time), and only start the draw observer while fast forwarding.

Also included in this change is a fix for tvOS: When it starts up it presents what is supposed to be a modal dialog (with brief instructions for copying user content over), but because we listen for inputs independent of UIKit, it still ends up driving the menu system underneath. So now it tells the menu to stop handling input (but still allows the rest of the runloop to run).