### PR TITLE
Vulkan Exclusive Fullscreen (VK_EXT_full_screen_exclusive)

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -39,6 +39,10 @@
 #include "../../verbosity.h"
 #include "../../configuration.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #define VENDOR_ID_AMD 0x1002
 #define VENDOR_ID_NV 0x10DE
 #define VENDOR_ID_INTEL 0x8086
@@ -522,6 +526,9 @@ static bool vulkan_context_init_gpu(gfx_ctx_vulkan_data_t *vk)
 
 static const char *vulkan_device_extensions[]  = {
    "VK_KHR_swapchain",
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+   "VK_EXT_full_screen_exclusive"
+#endif
 };
 
 static const char *vulkan_optional_device_extensions[] = {
@@ -885,6 +892,7 @@ static VkInstance vulkan_context_create_instance_wrapper(void *opaque, const VkI
          break;
       case VULKAN_WSI_WIN32:
          required_extensions[required_extension_count++] = "VK_KHR_win32_surface";
+         required_extensions[required_extension_count++] = "VK_KHR_get_surface_capabilities2";
          break;
       case VULKAN_WSI_XLIB:
          required_extensions[required_extension_count++] = "VK_KHR_xlib_surface";
@@ -2278,6 +2286,29 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    info.oldSwapchain = VK_NULL_HANDLE;
    if (old_swapchain != VK_NULL_HANDLE)
       vkDestroySwapchainKHR(vk->context.device, old_swapchain, NULL);
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+   /* Tie exclusive mode to the window's monitor. */
+   HMONITOR fse_monitor = MonitorFromWindow(GetActiveWindow(), MONITOR_DEFAULTTONEAREST);
+
+   VkSurfaceFullScreenExclusiveWin32InfoEXT fs_win32 = {
+       VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT,
+       NULL,
+       fse_monitor
+   };
+
+   /* Allow or disallow exclusive fullscreen based on user setting. */
+   VkSurfaceFullScreenExclusiveInfoEXT fs_info = {
+       VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT,
+       &fs_win32,
+       settings->bools.video_windowed_fullscreen
+           ? VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT
+           : VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT
+   };
+
+   /* Attach fullscreen info to swapchain creation struct. */
+   info.pNext = &fs_info;
+#endif
 
    if (vkCreateSwapchainKHR(vk->context.device,
             &info, NULL, &vk->swapchain) != VK_SUCCESS)


### PR DESCRIPTION
## Description
- Implementation of Vulkan exclusive fullscreen as an optional feature.
- Integrated with the existing "Windowed Fullscreen" toggle for simplicity (no new UI option required).
- Uses the extensions `VK_KHR_get_surface_capabilities2` and `VK_EXT_full_screen_exclusive`.
- Windows-only implementation, guarded by `VK_USE_PLATFORM_WIN32_KHR`.
- Tested on Windows 11 with NVIDIA RTX.
- Previously an issue occurred where after exiting and re-entering fullscreen the aspect ratio would switch to full (the menu option didn't reflect this, and changing it would reset it). After syncing with upstream this no longer happens; it also happened regardless of the video driver or fullscreen state, so I don't think it was directly due to FSE.

## Related Issues

This is a new feature, not a fix for an existing issue. Bypasses DWM and reduces latency, also gives the Windowed Fullscreen toggle an actual function.

## Related Pull Requests

No related PRs.

## Reviewers

@gouchi
@hizzlekizzle 