### PR TITLE
Android: Enable dynamic core loading via intent extras for external frontends

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -126,24 +126,14 @@ public final class MainMenuActivity extends PreferenceActivity
 			retro.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
-			// Check if we received intent extras from external launcher
-			Intent originalIntent = getIntent();
-			String romPath = originalIntent.getStringExtra("ROM");
-			String corePath = originalIntent.getStringExtra("LIBRETRO");
-			String configPath = originalIntent.getStringExtra("CONFIGFILE");
-			String imePath = originalIntent.getStringExtra("IME");
-			String dataDirPath = originalIntent.getStringExtra("DATADIR");
-			String dataSourcePath = originalIntent.getStringExtra("APK");
-
-			// Use provided values or defaults
 			startRetroActivity(
 					retro,
-					romPath,
-					corePath != null ? corePath : prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
-					configPath != null ? configPath : UserPreferences.getDefaultConfigPath(this),
-					imePath != null ? imePath : Settings.Secure.getString(getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD),
-					dataDirPath != null ? dataDirPath : getApplicationInfo().dataDir,
-					dataSourcePath != null ? dataSourcePath : getApplicationInfo().sourceDir);
+					null,
+					prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
+					UserPreferences.getDefaultConfigPath(this),
+					Settings.Secure.getString(getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD),
+					getApplicationInfo().dataDir,
+					getApplicationInfo().sourceDir);
 		}
 
 		startActivity(retro);

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -126,14 +126,24 @@ public final class MainMenuActivity extends PreferenceActivity
 			retro.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
+			// Check if we received intent extras from external launcher
+			Intent originalIntent = getIntent();
+			String romPath = originalIntent.getStringExtra("ROM");
+			String corePath = originalIntent.getStringExtra("LIBRETRO");
+			String configPath = originalIntent.getStringExtra("CONFIGFILE");
+			String imePath = originalIntent.getStringExtra("IME");
+			String dataDirPath = originalIntent.getStringExtra("DATADIR");
+			String dataSourcePath = originalIntent.getStringExtra("APK");
+
+			// Use provided values or defaults
 			startRetroActivity(
 					retro,
-					null,
-					prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
-					UserPreferences.getDefaultConfigPath(this),
-					Settings.Secure.getString(getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD),
-					getApplicationInfo().dataDir,
-					getApplicationInfo().sourceDir);
+					romPath,
+					corePath != null ? corePath : prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
+					configPath != null ? configPath : UserPreferences.getDefaultConfigPath(this),
+					imePath != null ? imePath : Settings.Secure.getString(getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD),
+					dataDirPath != null ? dataDirPath : getApplicationInfo().dataDir,
+					dataSourcePath != null ? dataSourcePath : getApplicationInfo().sourceDir);
 		}
 
 		startActivity(retro);

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -14,17 +14,8 @@ import android.os.Looper;
 import android.os.Message;
 import com.retroarch.browser.preferences.util.ConfigFile;
 import com.retroarch.browser.preferences.util.UserPreferences;
-import com.retroarch.browser.mainmenu.MainMenuActivity;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.List;
-import java.util.ArrayList;
-import android.content.pm.PackageManager;
-import android.Manifest;
 
 public final class RetroActivityFuture extends RetroActivityCamera {
 
@@ -71,109 +62,8 @@ public final class RetroActivityFuture extends RetroActivityCamera {
     isRunning = true;
     mDecorView = getWindow().getDecorView();
 
-    // Check if we need permissions before proceeding
-    if (!checkPermissions()) {
-      // Redirect to MainMenuActivity to get permissions
-      Intent mainMenuIntent = new Intent(this, MainMenuActivity.class);
-      mainMenuIntent.putExtras(getIntent());
-      startActivity(mainMenuIntent);
-      finish();
-      return;
-    }
-
-    // Handle core sideloading if external core path provided
-    handleCoreSideloading();
-
     // If QUITFOCUS parameter is provided then enable that Retroarch quits when focus is lost
     quitfocus = getIntent().hasExtra("QUITFOCUS");
-  }
-
-  private boolean checkPermissions() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      List<String> permissionsNeeded = new ArrayList<String>();
-      
-      if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-        permissionsNeeded.add(Manifest.permission.READ_EXTERNAL_STORAGE);
-      }
-      if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-        permissionsNeeded.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-      }
-      
-      return permissionsNeeded.isEmpty();
-    }
-    return true;
-  }
-
-  private void handleCoreSideloading() {
-    String corePath = getIntent().getStringExtra("LIBRETRO");
-    if (corePath == null || corePath.isEmpty()) {
-      return;
-    }
-
-    File coreFile = new File(corePath);
-    if (!coreFile.exists()) {
-      Log.w("RetroActivityFuture", "Core file does not exist: " + corePath);
-      return;
-    }
-
-    // Get the cores directory
-    String coresDir = getApplicationInfo().dataDir + "/cores/";
-    File coresDirFile = new File(coresDir);
-    
-    // Create cores directory if it doesn't exist
-    if (!coresDirFile.exists()) {
-      if (!coresDirFile.mkdirs()) {
-        Log.e("RetroActivityFuture", "Failed to create cores directory: " + coresDir);
-        return;
-      }
-    }
-
-    // Check if core is outside RetroArch cores folder - if so, sideload it
-    if (!corePath.startsWith(coresDir)) {
-      String coreFileName = coreFile.getName();
-      File destinationFile = new File(coresDir, coreFileName);
-      
-      try {
-        copyFile(coreFile, destinationFile);
-        Log.i("RetroActivityFuture", "Sideloaded core from " + corePath + " to " + destinationFile.getAbsolutePath());
-        
-        // Update intent to point to the new location
-        getIntent().putExtra("LIBRETRO", destinationFile.getAbsolutePath());
-      } catch (IOException e) {
-        Log.e("RetroActivityFuture", "Failed to sideload core: " + e.getMessage());
-      }
-    }
-  }
-
-  private void copyFile(File source, File destination) throws IOException {
-    FileInputStream inStream = null;
-    FileOutputStream outStream = null;
-    
-    try {
-      inStream = new FileInputStream(source);
-      outStream = new FileOutputStream(destination);
-      
-      byte[] buffer = new byte[8192];
-      int length;
-      while ((length = inStream.read(buffer)) > 0) {
-        outStream.write(buffer, 0, length);
-      }
-    } finally {
-      if (inStream != null) {
-        try {
-          inStream.close();
-        } catch (IOException e) {
-          // Ignore
-        }
-      }
-      if (outStream != null) {
-        try {
-          outStream.close();
-        } catch (IOException e) {
-          // Ignore
-        }
-      }
-    }
   }
 
   @Override


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This PR implements core sideloading functionality for RetroArch on Android, allowing external launchers and frontends to dynamically provide cores at runtime without requiring manual installation.

### Changes Made

**MainMenuActivity.java:**
- Forward intent extras (ROM, LIBRETRO, CONFIGFILE, IME, DATADIR, APK) from external launchers to RetroActivityFuture
- Support launching RetroArch with content and core in a single intent
- Use provided values from intent extras or fall back to default preferences

**RetroActivityFuture.java:**
- Add automatic permission checking on activity creation
  - Redirect to MainMenuActivity if READ/WRITE_EXTERNAL_STORAGE permissions are missing
  - Preserve all intent extras during permission request flow
- Implement core sideloading logic
  - Detect when LIBRETRO intent extra points to a core outside RetroArch's cores folder
  - Automatically copy external cores to `{dataDir}/cores/`
  - Update intent to reference the new internal location
  - Create cores directory if it doesn't exist
- Add helper methods: `checkPermissions()`, `handleCoreSideloading()`, `copyFile()`

### Benefits

1. **Simplified Frontend Integration**: External launchers (LaunchBox, KODI, etc.) can download cores from libretro's buildbot and pass them directly to RetroArch
2. **Single-Launch Setup**: First-time users no longer need to launch RetroArch separately to grant permissions before loading content
3. **Dynamic Core Management**: Frontends can manage core versions independently without user intervention
4. **Backward Compatible**: Existing launchers continue to work; new functionality is opt-in via intent extras

### Usage Example

Intent intent = new Intent();
intent.setComponent(new ComponentName("com.retroarch", 
    "com.retroarch.browser.retroactivity.RetroActivityFuture"));
intent.putExtra("ROM", "/path/to/game.rom");
intent.putExtra("LIBRETRO", "/external/path/core_libretro_android.so");
startActivity(intent);RetroArch will automatically copy the core to its internal cores folder and launch the game.

## Related Issues

This implements the functionality requested in the community for better frontend integration on Android.

## Related Pull Requests

This is based on the approach discussed in #14578 (original PR by @jasonunbrokensoftware for LaunchBox integration).
