### PR TITLE
Fix 3DS scan

### DIFF
--- a/database_info.c
+++ b/database_info.c
@@ -718,7 +718,7 @@ static int database_cursor_iterate(libretrodb_cursor_t *cur,
       else if (string_is_equal(str, "analog"))
          db_info->analog_supported        = (int)val->val.uint_;
       else if (string_is_equal(str, "size"))
-         db_info->size                    = (unsigned)val->val.uint_;
+         db_info->size                    = (uint64_t)val->val.uint_;
       else if (string_is_equal(str, "crc"))
       {
          switch (val->val.binary.len)

--- a/database_info.h
+++ b/database_info.h
@@ -123,7 +123,7 @@ typedef struct
    int rumble_supported;
    int coop_supported;
    uint32_t crc32;
-   unsigned size;
+   uint64_t size;
    unsigned famitsu_magazine_rating;
    unsigned edge_magazine_rating;
    unsigned edge_magazine_issue;


### PR DESCRIPTION
## Description

Rom size was truncated to 32-bit. In case of 3DS database, the maximum size is exactly 0x100000000, so the maximum size came up as 0, as shown on extra debug logs (visible in debug builds):

`[DEBUG] [Scanner] Queried min/max, values 39018496 / 0, size yes serial yes crc yes`

Size field is updated to 64-bit to align with RDS contents.

`[DEBUG] [Scanner] Queried min/max, values 39018496 / 4294967296, size yes serial yes crc yes`

## Related Issues

https://github.com/libretro/RetroArch/pull/18341#issuecomment-3538755797

## Related Pull Requests

#18341 
