### PR TITLE
Fix core suggestion with manual core load

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -5151,7 +5151,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_CORE_SUGGEST_ALWAYS,
-   "Suggest available cores even when a core is already loaded."
+   "Suggest available cores even when a core is manually loaded."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_USE_BUILTIN_PLAYER,

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1948,8 +1948,8 @@ static bool menu_content_find_first_core(
             &supported);
 
 #ifdef HAVE_DYNAMIC
-   /* Don't suggest cores if a core is already loaded. */
-   if (     !path_is_empty(RARCH_PATH_CORE)
+   /* Don't suggest cores if a core is manually loaded. */
+   if (     !path_is_empty(RARCH_PATH_CORE_LAST)
          && !config_get_ptr()->bools.core_suggest_always)
       load_content_with_current_core = true;
 #endif

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -8114,6 +8114,14 @@ int generic_menu_entry_action(
       menu_st->flags &= ~(MENU_ST_FLAG_PENDING_CLOSE_CONTENT
                         | MENU_ST_FLAG_PENDING_ENV_SHUTDOWN_FLUSH);
       menu_st->pending_env_shutdown_content_path[0] = '\0';
+
+      /* Reload core on launch failure if manually loaded */
+      if (     !path_is_empty(RARCH_PATH_CORE_LAST)
+            && !(menu_st->flags & MENU_ST_FLAG_PENDING_RELOAD_CORE))
+      {
+         menu_st->flags |= MENU_ST_FLAG_PENDING_RELOAD_CORE;
+         menu_st->flags |= MENU_ST_FLAG_PENDING_ENV_SHUTDOWN_FLUSH;
+      }
    }
    else if (menu_st->flags & MENU_ST_FLAG_PENDING_RELOAD_CORE)
    {

--- a/runloop.c
+++ b/runloop.c
@@ -4291,6 +4291,10 @@ static bool event_init_content(
       /* Single-click playlist return */
       if (settings->bools.input_menu_singleclick_playlists)
          menu_state_get_ptr()->flags |= MENU_ST_FLAG_PENDING_CLOSE_CONTENT;
+
+      /* Return from empty Quick Menu if core is manually loaded and needs reloading */
+      if (!path_is_empty(RARCH_PATH_CORE_LAST))
+         menu_state_get_ptr()->flags |= MENU_ST_FLAG_PENDING_CLOSE_CONTENT;
 #endif
       return false;
    }


### PR DESCRIPTION
## Description

- Core suggestion option was supposed to force next content launch without closing first on the current core only when core is loaded manually
- Fixed menu location and core reloading when forced load fails

## Related Issues

Closes #18392
