### PR TITLE
Switch to relative mouse x/y for webOS, add developer dir

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2360,6 +2360,12 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
    }
 
 #elif defined(WEBOS)
+   if (path_is_directory("/media/developer/temp"))
+      menu_entries_append(list, "/media/developer/temp",
+         msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),
+         enum_idx,
+         FILE_TYPE_DIRECTORY, 0, 0, NULL);
+
    if (path_is_directory("/media/internal"))
       menu_entries_append(list, "/media/internal",
             msg_hash_to_str(MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR),

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -229,20 +229,16 @@ static int16_t sdl_input_state(
                       return 1;
                   }
                   break;
-               case RETRO_DEVICE_ID_MOUSE_X:
-                  return sdl->mouse_abs_x;
-               case RETRO_DEVICE_ID_MOUSE_Y:
-                  return sdl->mouse_abs_y;
 #else
                case RETRO_DEVICE_ID_MOUSE_WHEELUP:
                   return sdl->mouse_wu;
                case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
                   return sdl->mouse_wd;
+#endif
                case RETRO_DEVICE_ID_MOUSE_X:
                   return sdl->mouse_x;
                case RETRO_DEVICE_ID_MOUSE_Y:
                   return sdl->mouse_y;
-#endif
                case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                   return sdl->mouse_m;
                case RETRO_DEVICE_ID_MOUSE_BUTTON_4:


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

1. Real mouse hardware + magic remote now works with this PR on mouse related cores, e.g. scumm vm. 

Note: webOS only supports absolute positioning but changes made to SDL2 port since then have made relative kind of supported (but not officially)

2. Adds the /media/developer/temp directory which is what most people use to upload to if not using USB, network share

It's only a partial fix for first person shooters, with this fix you can now you can look to the left/right/up/down, but you cannot turn around yet. I haven't figured out how to get SDL_SetRelativeMouseMode(SDL_TRUE) working as the mouse keeps "bouncing back".

## Related Issues

https://github.com/webosbrew/retroarch-cores/issues/20

## Related Pull Requests

## Reviewers

