### PR TITLE
Fix crash when requesting GLES 3.2 context, or when core requests GLES 2 when GLES 3 is compiled in

### DIFF
--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -4038,8 +4038,7 @@ static const gfx_ctx_driver_t *gl2_get_context(gl2_t *gl)
          minor = 0;
          break;
       case RETRO_HW_CONTEXT_OPENGLES_VERSION:
-         major = major;
-         minor = minor;
+         // passthrough version_major / version_minor unchanged
          break;
       default:
          major = 2;

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -175,7 +175,7 @@ static bool gfx_ctx_wl_egl_init_context(gfx_ctx_wayland_data_t *wl)
    };
 
 #ifdef HAVE_OPENGLES
-#ifdef HAVE_OPENGLES2
+#if defined(HAVE_OPENGLES2) || defined(HAVE_OPENGLES3)
    static const EGLint egl_attribs_gles[] = {
       WL_EGL_ATTRIBS_BASE,
       EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
@@ -221,7 +221,7 @@ static bool gfx_ctx_wl_egl_init_context(gfx_ctx_wayland_data_t *wl)
          else
 #endif
 #endif
-#ifdef HAVE_OPENGLES2
+#if defined(HAVE_OPENGLES2) || defined(HAVE_OPENGLES3)
             attrib_ptr = egl_attribs_gles;
 #endif
 #endif


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

I came across 2 bugs while implementing some other wayland code.

If you request GLES 3.2, major and minor will be returned as 2:0 which is incorrect and leads to a crash later on.

Secondly, if a core requests a GLES 2 context but HAVE_OPENGLES3 is compiled in, the else condition is not met so attrib_ptr is NULL. This now allows request of a GLES 2 context to succeed.

## Related Issues

## Related Pull Requests

## Reviewers

