### PR TITLE
Small change for CD-i scans and log fallback to CRC.

### DIFF
--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -280,6 +280,7 @@ static int intfstream_get_serial(intfstream_t *fd, char *s, size_t len, const ch
                return 1;
          }
       }
+      /* Philips CD-i has no serial entry on disc, use default fallback to CRC */
    }
    return 0;
 }
@@ -695,6 +696,8 @@ static int task_database_iterate_playlist(
          else
          {
             db->type = DATABASE_TYPE_CRC_LOOKUP;
+            db_state->serial[0] = '\0';
+            RARCH_DBG("[Scanner] Cue file serial not detected, fallback to crc\n");
             return task_database_cue_get_crc_and_size(name, &db_state->crc, &db_state->size);
          }
          break;
@@ -706,6 +709,8 @@ static int task_database_iterate_playlist(
          else
          {
             db->type = DATABASE_TYPE_CRC_LOOKUP;
+            db_state->serial[0] = '\0';
+            RARCH_DBG("[Scanner] GDI file serial not detected, fallback to crc\n");
             return task_database_gdi_get_crc_and_size(name, &db_state->crc, &db_state->size);
          }
          break;
@@ -729,6 +734,8 @@ static int task_database_iterate_playlist(
          else
          {
             db->type         = DATABASE_TYPE_CRC_LOOKUP;
+            db_state->serial[0] = '\0';
+            RARCH_DBG("[Scanner] CHD file serial not detected, fallback to crc\n");
             return task_database_chd_get_crc_and_size(name, &db_state->crc, &db_state->size);
          }
          break;

--- a/tasks/task_database_cue.c
+++ b/tasks/task_database_cue.c
@@ -62,7 +62,8 @@ static struct magic_entry MAGIC_NUMBERS[] = {
    { "Sony - PlayStation 2",        "PLAYSTATION",      0x008008}, /* PS2 DVD */
    { "Sony - PlayStation 2",        "           ",      0x008008}, /* PS2 DVD */
    { "Sony - PlayStation Portable", "PSP GAME",         0x008008},
-   { "Philips - CD-i",              "\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00", 0x000000},
+   /* CD-i magic number should start with \0 at position 0 but it throws off later strlen() */
+   { "Philips - CD-i",              "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00", 0x000001},
    { NULL,                          NULL,               0}
 };
 


### PR DESCRIPTION
## Description

Adjust Philips CD-i magic number to fit matching logic, but it is actually a cosmetical change - logs will now show that system is recognized. But, since CD-i serial is not present on the disc (to the best of my short research), serial scan can not be done for these entries, fallback to CRC works.

## Related Pull Requests

#18424 
