### PR TITLE
Core info sublabel cleanup

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -549,11 +549,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE_IN_CONTENT_DIRECTORY,
-   "- Note: 'System Files are in Content Directory' is currently enabled."
+   "Note: 'System Files are in Content Directory' is enabled."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_CORE_INFO_FIRMWARE_PATH,
-   "- Looking in: %s"
+   "Looking in: %s"
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_MISSING_REQUIRED,

--- a/menu/cbs/menu_cbs_sublabel.c
+++ b/menu/cbs/menu_cbs_sublabel.c
@@ -1486,11 +1486,16 @@ static int action_bind_sublabel_core_info_entry(
       const char *label, const char *path,
       char *s, size_t len)
 {
-   if (list && list->list[i].label && strstr(list->list[i].label, "(md5)"))
+   if (!list || string_is_empty(list->list[i].label))
+      return 0;
+
+   if (strstr(list->list[i].label, "(md5)"))
    {
       int pos = string_find_index_substring_string(list->list[i].label, "(md5)");
       strlcpy(s, list->list[i].label + pos, len);
    }
+   else
+      strlcpy(s, list->list[i].label, len);
 
    return 0;
 }


### PR DESCRIPTION
## Description

Minor tidying by more sublabel usage where suitable:
- Core path
- Firmware path
- Note about system files being in content dir

Also moved full path before firmware listing.