### PR TITLE
Switch: Configure audio drivers to be in blocking mode initially

### DIFF
--- a/audio/drivers/switch_audio.c
+++ b/audio/drivers/switch_audio.c
@@ -324,7 +324,7 @@ static void *switch_audio_init(const char *device,
    swa->latency        = latency;
    swa->last_append    = svcGetSystemTick();
 
-   swa->blocking       = block_frames;
+   swa->blocking       = true;
    swa->is_paused      = true;
 
    RARCH_LOG("[Switch audio] Audio initialized.\n");

--- a/audio/drivers/switch_libnx_audren_audio.c
+++ b/audio/drivers/switch_libnx_audren_audio.c
@@ -81,7 +81,7 @@ static void *libnx_audren_audio_init(
    real_latency = MAX(5, latency);
    RARCH_LOG("[Audren] real_latency is %u.\n", real_latency);
 
-   aud->nonblock     = !block_frames;
+   aud->nonblock     = false;
    aud->buffer_size  = (real_latency * sample_rate / 1000);
    aud->samples      = (aud->buffer_size / num_channels / sizeof(int16_t));
    aud->current_size = 0;

--- a/audio/drivers/switch_libnx_audren_thread_audio.c
+++ b/audio/drivers/switch_libnx_audren_thread_audio.c
@@ -162,7 +162,7 @@ static void *libnx_audren_thread_audio_init(const char *device, unsigned rate, u
 
    aud->running     = true;
    aud->paused      = false;
-   aud->nonblock    = !block_frames;
+   aud->nonblock    = false;
    aud->buffer_size = (real_latency * sample_rate / 1000);
    aud->samples     = (aud->buffer_size / num_channels / sizeof(int16_t));
 

--- a/audio/drivers/switch_thread_audio.c
+++ b/audio/drivers/switch_thread_audio.c
@@ -153,7 +153,7 @@ static void *switch_thread_audio_init(const char *device, unsigned rate, unsigne
       return NULL;
 
    swa->running     = true;
-   swa->nonblock    = true;
+   swa->nonblock    = false;
    swa->is_paused   = true;
    swa->latency     = MAX(latency, 8);
 


### PR DESCRIPTION
On switch homebrew all available audio drivers configure themselves into non blocking mode if the config setting [audio_block_frames](https://github.com/libretro/RetroArch/blob/35c5c51d4e1ca1e0235404982aed787af3680821/configuration.h#L181) is zero. This seems to be the [default](https://github.com/libretro/RetroArch/blob/35c5c51d4e1ca1e0235404982aed787af3680821/configuration.c#L2477). The setting doesn't seem to be reachable via the ui and the only other place I found it being used was the [OpenSL audio driver](https://github.com/libretro/RetroArch/blob/35c5c51d4e1ca1e0235404982aed787af3680821/audio/drivers/opensl.c#L129) where the setting can influence buffer sizes. 

There is also a [comment](https://github.com/libretro/RetroArch/blob/35c5c51d4e1ca1e0235404982aed787af3680821/audio/audio_driver.h#L110) stating that an audio driver should be in blocking mode by default. The result of switch audio drivers being in non blocking mode even though they shouldn't be is that a lot of audio frames are being dropped when the driver's buffer is full. This is more likely when using the audio callback as it is designed to continuously run until all buffers are full. 

The [Skeletor example project](https://github.com/libretro/skeletor) can be used to test the issue. With the fixes in this PR the example plays fine as on other platforms. 

