### PR TITLE
standardize usage of video_driver_update_viewport

### DIFF
--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1453,7 +1453,7 @@ static void d3d10_gfx_set_rotation(void* data, unsigned rotation)
 static void d3d10_update_viewport(d3d10_video_t *d3d10, bool force_full)
 {
    video_driver_update_viewport(&d3d10->vp, force_full,
-         (d3d10->flags & D3D10_ST_FLAG_KEEP_ASPECT) ? true : false);
+         (d3d10->flags & D3D10_ST_FLAG_KEEP_ASPECT) ? true : false, true);
 
    d3d10->frame.viewport.TopLeftX  = d3d10->vp.x;
    d3d10->frame.viewport.TopLeftY  = d3d10->vp.y;

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1717,7 +1717,7 @@ static void d3d11_gfx_set_rotation(void* data, unsigned rotation)
 static void d3d11_update_viewport(d3d11_video_t *d3d11, bool force_full)
 {
    video_driver_update_viewport(&d3d11->vp, force_full,
-         (d3d11->flags & D3D11_ST_FLAG_KEEP_ASPECT) ? true : false);
+         (d3d11->flags & D3D11_ST_FLAG_KEEP_ASPECT) ? true : false, true);
 
    d3d11->frame.viewport.TopLeftX = d3d11->vp.x;
    d3d11->frame.viewport.TopLeftY = d3d11->vp.y;

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1978,7 +1978,7 @@ static void d3d12_gfx_set_rotation(void* data, unsigned rotation)
 static void d3d12_update_viewport(d3d12_video_t *d3d12, bool force_full)
 {
    video_driver_update_viewport(&d3d12->vp, force_full,
-         (d3d12->flags & D3D12_ST_FLAG_KEEP_ASPECT) ? true : false);
+         (d3d12->flags & D3D12_ST_FLAG_KEEP_ASPECT) ? true : false, true);
 
    d3d12->frame.viewport.TopLeftX = d3d12->vp.x;
    d3d12->frame.viewport.TopLeftY = d3d12->vp.y;

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -1302,36 +1302,10 @@ static void gl1_set_viewport(gl1_t *gl1,
       unsigned vp_width, unsigned vp_height,
       bool force_full, bool allow_rotate)
 {
-   settings_t *settings     = config_get_ptr();
-   float device_aspect      = (float)vp_width / vp_height;
-
-   if (gl1->ctx_driver->translate_aspect)
-      device_aspect         = gl1->ctx_driver->translate_aspect(
-            gl1->ctx_data, vp_width, vp_height);
-
-   if (settings->bools.video_scale_integer && !force_full)
-   {
-      video_viewport_get_scaled_integer(&gl1->vp,
-            vp_width, vp_height,
-            video_driver_get_aspect_ratio(),
-            gl1->flags & GL1_FLAG_KEEP_ASPECT, false);
-      vp_width              = gl1->vp.width;
-      vp_height             = gl1->vp.height;
-   }
-   else if ((gl1->flags & GL1_FLAG_KEEP_ASPECT) && !force_full)
-   {
-      gl1->vp.full_height = gl1->video_height;
-      video_viewport_get_scaled_aspect2(&gl1->vp, vp_width, vp_height,
-            false, device_aspect, video_driver_get_aspect_ratio());
-      vp_width              = gl1->vp.width;
-      vp_height             = gl1->vp.height;
-   }
-   else
-   {
-      gl1->vp.x             = gl1->vp.y = 0;
-      gl1->vp.width         = vp_width;
-      gl1->vp.height        = vp_height;
-   }
+   gl1->vp.full_width  = vp_width;
+   gl1->vp.full_height = vp_height;
+   video_driver_update_viewport(&gl1->vp, force_full,
+         (gl1->flags & GL1_FLAG_KEEP_ASPECT) ? true : false, false);
 
    glViewport(gl1->vp.x, gl1->vp.y, gl1->vp.width, gl1->vp.height);
    gl1_set_projection(gl1, &gl1_default_ortho, allow_rotate);
@@ -1339,8 +1313,8 @@ static void gl1_set_viewport(gl1_t *gl1,
    /* Set last backbuffer viewport. */
    if (!force_full)
    {
-      gl1->out_vp_width  = vp_width;
-      gl1->out_vp_height = vp_height;
+      gl1->out_vp_width  = gl1->vp.width;
+      gl1->out_vp_height = gl1->vp.height;
    }
 }
 

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -320,8 +320,7 @@ static const GLfloat white_color[16] = {
  */
 static void gl2_set_viewport(gl2_t *gl,
       unsigned vp_width, unsigned vp_height,
-      bool force_full, bool allow_rotate,
-      bool video_scale_integer);
+      bool force_full, bool allow_rotate);
 
 #ifdef IOS
 /* There is no default frame buffer on iOS. */
@@ -947,7 +946,7 @@ static void gl2_raster_font_setup_viewport(
       bool full_screen,
       bool video_scale_integer)
 {
-   gl2_set_viewport(gl, width, height, full_screen, true, video_scale_integer);
+   gl2_set_viewport(gl, width, height, full_screen, true);
 
    glEnable(GL_BLEND);
    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -1059,7 +1058,7 @@ static void gl2_raster_font_render_msg(
       /* Restore viewport */
       glBindTexture(GL_TEXTURE_2D, gl->texture[gl->tex_index]);
       glDisable(GL_BLEND);
-      gl2_set_viewport(gl, width, height, false, true, video_scale_integer);
+      gl2_set_viewport(gl, width, height, false, true);
    }
 }
 
@@ -1091,7 +1090,7 @@ static void gl2_raster_font_flush_block(unsigned width, unsigned height,
    glBindTexture(GL_TEXTURE_2D, gl->texture[gl->tex_index]);
 
    glDisable(GL_BLEND);
-   gl2_set_viewport(gl, width, height, block->fullscreen, true, video_scale_integer);
+   gl2_set_viewport(gl, width, height, block->fullscreen, true);
 }
 
 static void gl2_raster_font_bind_block(void *data, void *userdata)
@@ -1274,39 +1273,12 @@ static void gl2_set_projection(gl2_t *gl,
 static void gl2_set_viewport(gl2_t *gl,
       unsigned vp_width,
       unsigned vp_height,
-      bool force_full, bool allow_rotate,
-      bool video_scale_integer)
+      bool force_full, bool allow_rotate)
 {
-   float device_aspect      = (float)vp_width / (float)vp_height;
-
-   if (gl->ctx_driver->translate_aspect)
-      device_aspect         = gl->ctx_driver->translate_aspect(
-            gl->ctx_data, vp_width, vp_height);
-
-   if (video_scale_integer && !force_full)
-   {
-      video_viewport_get_scaled_integer(&gl->vp,
-            vp_width, vp_height,
-            video_driver_get_aspect_ratio(),
-            (gl->flags & GL2_FLAG_KEEP_ASPECT) ? true : false,
-            false);
-      vp_width     = gl->vp.width;
-      vp_height    = gl->vp.height;
-   }
-   else if ((gl->flags & GL2_FLAG_KEEP_ASPECT) && !force_full)
-   {
-      gl->vp.full_height = gl->video_height;
-      video_viewport_get_scaled_aspect2(&gl->vp, vp_width, vp_height,
-            false, device_aspect, video_driver_get_aspect_ratio());
-      vp_width      = gl->vp.width;
-      vp_height     = gl->vp.height;
-   }
-   else
-   {
-      gl->vp.x      = gl->vp.y = 0;
-      gl->vp.width  = vp_width;
-      gl->vp.height = vp_height;
-   }
+   gl->vp.full_width  = vp_width;
+   gl->vp.full_height = vp_height;
+   video_driver_update_viewport(&gl->vp, force_full,
+         (gl->flags & GL2_FLAG_KEEP_ASPECT) ? true : false, false);
 
    glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
    gl2_set_projection(gl, &default_ortho, allow_rotate);
@@ -1314,8 +1286,8 @@ static void gl2_set_viewport(gl2_t *gl,
    /* Set last backbuffer viewport. */
    if (!force_full)
    {
-      gl->out_vp_width  = vp_width;
-      gl->out_vp_height = vp_height;
+      gl->out_vp_width  = gl->vp.width;
+      gl->out_vp_height = gl->vp.height;
    }
 }
 
@@ -1382,8 +1354,7 @@ static void gl2_renderchain_render(
 
       /* Render to FBO with certain size. */
       gl2_set_viewport(gl,
-            rect->img_width, rect->img_height, true, false,
-            video_scale_integer);
+            rect->img_width, rect->img_height, true, false);
 
       params.vp_width      = gl->out_vp_width;
       params.vp_height     = gl->out_vp_height;
@@ -1449,7 +1420,7 @@ static void gl2_renderchain_render(
       glGenerateMipmap(GL_TEXTURE_2D);
 
    glClear(GL_COLOR_BUFFER_BIT);
-   gl2_set_viewport(gl, width, height, false, true, video_scale_integer);
+   gl2_set_viewport(gl, width, height, false, true);
 
    params.vp_width      = gl->out_vp_width;
    params.vp_height     = gl->out_vp_height;
@@ -1866,8 +1837,7 @@ static void gl2_renderchain_start_render(gl2_t *gl,
 
    gl2_set_viewport(gl,
          gl->fbo_rect[0].img_width,
-         gl->fbo_rect[0].img_height, true, false,
-         video_scale_integer);
+         gl->fbo_rect[0].img_height, true, false);
 
    /* Need to preserve the "flipped" state when in FBO
     * as well to have consistent texture coordinates.
@@ -2768,10 +2738,7 @@ static void gl2_set_viewport_wrapper(void *data, unsigned vp_width,
       unsigned vp_height, bool force_full, bool allow_rotate)
 {
    gl2_t              *gl = (gl2_t*)data;
-   gl2_set_viewport(gl,
-      vp_width, vp_height, force_full, allow_rotate,
-      config_get_ptr()->bools.video_scale_integer
-      );
+   gl2_set_viewport(gl, vp_width, vp_height, force_full, allow_rotate);
 }
 
 /* Shaders */
@@ -3105,8 +3072,7 @@ static INLINE void gl2_set_shader_viewports(gl2_t *gl, bool video_scale_integer)
    for (i = 0; i < 2; i++)
    {
       gl->shader->use(gl, gl->shader_data, i, true);
-      gl2_set_viewport(gl, width, height, false, true,
-            video_scale_integer);
+      gl2_set_viewport(gl, width, height, false, true);
    }
 }
 
@@ -3220,8 +3186,7 @@ static void gl2_render_osd_background(gl2_t *gl, bool video_scale_integer, const
 
    gl2_set_viewport(gl,
          gl->video_width,
-         gl->video_height, true, false,
-         video_scale_integer);
+         gl->video_height, true, false);
 
    gl->shader->use(gl, gl->shader_data,
          VIDEO_SHADER_STOCK_BLEND, true);
@@ -3269,7 +3234,7 @@ static void gl2_render_osd_background(gl2_t *gl, bool video_scale_integer, const
 
    gl2_set_viewport(gl,
          gl->video_width,
-         gl->video_height, false, true, video_scale_integer);
+         gl->video_height, false, true);
 }
 
 static void gl2_show_mouse(void *data, bool state)
@@ -3415,7 +3380,7 @@ static bool gl2_frame(void *data, const void *frame,
 
 #ifdef IOS
    /* Apparently the viewport is lost each frame, thanks Apple. */
-   gl2_set_viewport(gl, width, height, false, true, video_scale_integer);
+   gl2_set_viewport(gl, width, height, false, true);
 #endif
 
    /* Render to texture in first pass. */
@@ -3490,7 +3455,7 @@ static bool gl2_frame(void *data, const void *frame,
          gl2_renderchain_start_render(gl, chain, video_scale_integer);
       }
       else
-         gl2_set_viewport(gl, width, height, false, true, video_scale_integer);
+         gl2_set_viewport(gl, width, height, false, true);
    }
 
    if (frame)
@@ -3524,7 +3489,7 @@ static bool gl2_frame(void *data, const void *frame,
       if (!(gl->flags & GL2_FLAG_FBO_INITED))
       {
          gl2_renderchain_bind_backbuffer();
-         gl2_set_viewport(gl, width, height, false, true, video_scale_integer);
+         gl2_set_viewport(gl, width, height, false, true);
       }
 
       gl2_renderchain_restore_default_state(gl);

--- a/gfx/drivers/gl3.c
+++ b/gfx/drivers/gl3.c
@@ -1926,37 +1926,10 @@ static void gl3_set_viewport(gl3_t *gl,
       unsigned vp_width, unsigned vp_height,
       bool force_full, bool allow_rotate)
 {
-   settings_t *settings            = config_get_ptr();
-   float device_aspect             = (float)vp_width / vp_height;
-   bool video_scale_integer        = settings->bools.video_scale_integer;
-
-   if (gl->ctx_driver->translate_aspect)
-      device_aspect         = gl->ctx_driver->translate_aspect(
-            gl->ctx_data, vp_width, vp_height);
-
-   if (video_scale_integer && !force_full)
-   {
-      video_viewport_get_scaled_integer(&gl->vp,
-            vp_width, vp_height,
-            video_driver_get_aspect_ratio(),
-            (gl->flags & GL3_FLAG_KEEP_ASPECT) ? true : false,
-            false);
-      vp_width  = gl->vp.width;
-      vp_height = gl->vp.height;
-   }
-   else if ((gl->flags & GL3_FLAG_KEEP_ASPECT) && !force_full)
-   {
-      gl->vp.full_height = gl->video_height;
-      video_viewport_get_scaled_aspect2(&gl->vp, vp_width, vp_height, false, device_aspect, video_driver_get_aspect_ratio());
-      vp_width           = gl->vp.width;
-      vp_height          = gl->vp.height;
-   }
-   else
-   {
-      gl->vp.x           = gl->vp.y = 0;
-      gl->vp.width       = vp_width;
-      gl->vp.height      = vp_height;
-   }
+   gl->vp.full_width  = vp_width;
+   gl->vp.full_height = vp_height;
+   video_driver_update_viewport(&gl->vp, force_full,
+         (gl->flags & GL3_FLAG_KEEP_ASPECT) ? true : false, false);
 
    glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
    gl3_set_projection(gl, &gl3_default_ortho, allow_rotate);
@@ -1964,13 +1937,13 @@ static void gl3_set_viewport(gl3_t *gl,
    /* Set last backbuffer viewport. */
    if (!force_full)
    {
-      gl->out_vp_width  = vp_width;
-      gl->out_vp_height = vp_height;
+      gl->out_vp_width  = gl->vp.width;
+      gl->out_vp_height = gl->vp.height;
    }
 
-   gl->filter_chain_vp.x = gl->vp.x;
-   gl->filter_chain_vp.y = gl->vp.y;
-   gl->filter_chain_vp.width = gl->vp.width;
+   gl->filter_chain_vp.x      = gl->vp.x;
+   gl->filter_chain_vp.y      = gl->vp.y;
+   gl->filter_chain_vp.width  = gl->vp.width;
    gl->filter_chain_vp.height = gl->vp.height;
 }
 

--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -916,7 +916,7 @@ font_renderer_t metal_raster_font = {
    _viewport->full_height  = height;
    video_driver_set_size(_viewport->full_width, _viewport->full_height);
    _layer.drawableSize     = CGSizeMake(width, height);
-   video_driver_update_viewport(_viewport, forceFull, _keepAspect);
+   video_driver_update_viewport(_viewport, forceFull, _keepAspect, YES);
    _context.viewport       = _viewport; /* Update matrix */
    _viewportMVP.outputSize = simd_make_float2(_viewport->full_width, _viewport->full_height);
 }
@@ -1033,7 +1033,7 @@ font_renderer_t metal_raster_font = {
 - (void)_beginFrame
 {
    video_viewport_t vp = *_viewport;
-   video_driver_update_viewport(_viewport, NO, _keepAspect);
+   video_driver_update_viewport(_viewport, NO, _keepAspect, YES);
 
    if (memcmp(&vp, _viewport, sizeof(vp)) != 0)
       _context.viewport = _viewport;

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -227,24 +227,12 @@ static void sdl_refresh_renderer(sdl2_video_t *vid)
 static void sdl_refresh_viewport(sdl2_video_t *vid)
 {
    int win_w, win_h;
-   settings_t *settings      = config_get_ptr();
-   bool video_scale_integer  = settings->bools.video_scale_integer;
 
    SDL_GetWindowSize(vid->window, &win_w, &win_h);
 
-   vid->vp.x           = 0;
-   vid->vp.y           = 0;
-   vid->vp.width       = win_w;
-   vid->vp.height      = win_h;
    vid->vp.full_width  = win_w;
    vid->vp.full_height = win_h;
-
-   if (video_scale_integer)
-      video_viewport_get_scaled_integer(&vid->vp,
-            win_w, win_h, video_driver_get_aspect_ratio(),
-            vid->video.force_aspect, true);
-   else if (vid->video.force_aspect)
-      video_viewport_get_scaled_aspect(&vid->vp, win_w, win_h, true);
+   video_driver_update_viewport(&vid->vp, false, vid->video.force_aspect, true);
 
    vid->flags &= ~SDL2_FLAG_SHOULD_RESIZE;
 

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -593,25 +593,9 @@ static void xv_calc_out_rect(bool keep_aspect,
       struct video_viewport *vp,
       unsigned vp_width, unsigned vp_height)
 {
-   settings_t *settings = config_get_ptr();
-   bool scale_integer   = settings->bools.video_scale_integer;
-
-   vp->full_width       = vp_width;
-   vp->full_height      = vp_height;
-
-   /* TODO: Does xvideo have its origin in top left or bottom-left? Assuming top left. */
-   if (scale_integer)
-      video_viewport_get_scaled_integer(vp, vp_width, vp_height,
-           video_driver_get_aspect_ratio(), keep_aspect, true);
-   else if (!keep_aspect)
-   {
-      vp->x      = 0;
-      vp->y      = 0;
-      vp->width  = vp_width;
-      vp->height = vp_height;
-   }
-   else
-      video_viewport_get_scaled_aspect(vp, vp_width, vp_height, true);
+   vp->full_width  = vp_width;
+   vp->full_height = vp_height;
+   video_driver_update_viewport(vp, false, keep_aspect, true);
 }
 
 static void *xv_init(const video_info_t *video,

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -958,7 +958,8 @@ void video_driver_monitor_reset(void);
 
 void video_driver_set_aspect_ratio(void);
 
-void video_driver_update_viewport(struct video_viewport* vp, bool force_full, bool keep_aspect);
+void video_driver_update_viewport(struct video_viewport* vp,
+      bool force_full, bool keep_aspect, bool y_down);
 
 void video_driver_apply_state_changes(void);
 


### PR DESCRIPTION
`video_driver_update_viewport()` is supposed to be able to handle all of the video scaling and aspect ratio settings but right now is only being used by metal and the d3d video drivers. All the other drivers do basically exactly the same thing but inline. This cleans it up a little.

Originally this included almost all of the graphics drivers. I've since reduced it to just the ones I've tested directly, so this should be safe. I'll create another PR after this one is merged with the ones I haven't tested yet. For now they can continue without having problems.

I have another smaller more targeted PR coming, to allow overlays to change the position/aspect ratio of the viewport, that uses `video_driver_update_viewport()`, so to make it work broadly, it's helpful to have the video drivers actually use it. The ones that haven't been updated just won't be able to have that until they move to `video_driver_update_viewport()`.