### PR TITLE
Fix udev touch detection for multitouch devices

### DIFF
--- a/input/drivers/udev_input.c
+++ b/input/drivers/udev_input.c
@@ -3209,7 +3209,11 @@ static int udev_input_add_device(udev_input_t *udev,
 
       if (ioctl(fd, EVIOCGBIT(EV_ABS, sizeof (abscaps)), abscaps) != -1)
       {
+#ifdef UDEV_TOUCH_SUPPORT
+         if ( ( test_bit(abscaps, ABS_X) && test_bit(abscaps, ABS_Y) ) || ( test_bit(abscaps, ABS_MT_POSITION_X) && test_bit(abscaps, ABS_MT_POSITION_Y) ) )
+#else
          if ( (test_bit(abscaps, ABS_X)) && (test_bit(abscaps, ABS_Y)) )
+#endif
          {
             mouse = 1;
 


### PR DESCRIPTION
No real multi touch screen actually reports abs_x or abs_y This is mentioned in comment here: https://github.com/libretro/RetroArch/blob/master/input/drivers/udev_input.c#L1494 from original.dev, so i have no idea why this check wasnt updated when support was added originally. This doesn't enable support by default, and touch support should be expanded, as this basically works like a laptop pad mouse, and isn't seen by RetroArch touch handler at all.(From what I can tell)

At a minimum that would require proper support for ABS_MT_SLOT to be handled, and for the device to be recognized as touchscreen in RetroArch, and not be forced to be mouse emulation.

At the very least, this should get the existing support to work with pretty much all touchscreens.

