### PR TITLE
linux: sensors: illminance: Fix failure to open file.

### DIFF
--- a/input/common/linux_common.c
+++ b/input/common/linux_common.c
@@ -320,7 +320,7 @@ static double linux_read_illuminance_sensor(const linux_illuminance_sensor_t *se
    if (!in_illuminance_input)
    {
       RARCH_ERR("Failed to open \"%s\".\n", sensor->path);
-      return 0.0;
+      return -1.0;
    }
 
    /* Read the illuminance value from the file. If that fails... */


### PR DESCRIPTION
Fix an issue causing search loop to break and poller starting on wrong file.

While this fixes this issue, there is still an issue with mgba where if you set it to use sensor, it works, but if you exit core with that setting it doesn't work again until you switch back to a hardcoded value, then close the core, restart the core, then switch back.