### PR TITLE
Preserve the OpenGL context on Android when the app is paused

### DIFF
--- a/gfx/common/egl_common.c
+++ b/gfx/common/egl_common.c
@@ -688,6 +688,9 @@ bool egl_create_surface(egl_ctx_data_t *egl, void *native_window)
 	   EGL_NONE,
    };
 
+   if (!egl_destroy_surface(egl))
+      return false;
+
    egl->surf = _egl_create_window_surface(egl->dpy, egl->config, (NativeWindowType)native_window, window_attribs);
 
    if (egl->surf == EGL_NO_SURFACE)
@@ -695,9 +698,28 @@ bool egl_create_surface(egl_ctx_data_t *egl, void *native_window)
 
    /* Connect the context to the surface. */
    if (!_egl_make_current(egl->dpy, egl->surf, egl->surf, egl->ctx))
+   {
+      _egl_destroy_surface(egl->dpy, egl->surf);
+      egl->surf = EGL_NO_SURFACE;
       return false;
+   }
 
    RARCH_LOG("[EGL] Current context: %p.\n", (void*)_egl_get_current_context());
 
+   return true;
+}
+
+bool egl_destroy_surface(egl_ctx_data_t *egl)
+{
+   if (egl->surf == EGL_NO_SURFACE)
+      return true;
+
+   if (!_egl_make_current(egl->dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT))
+      return false;
+
+   if (!_egl_destroy_surface(egl->dpy, egl->surf))
+      return false;
+
+   egl->surf = EGL_NO_SURFACE;
    return true;
 }

--- a/gfx/common/egl_common.h
+++ b/gfx/common/egl_common.h
@@ -118,6 +118,8 @@ bool egl_create_context(egl_ctx_data_t *egl, const EGLint *egl_attribs);
 
 bool egl_create_surface(egl_ctx_data_t *egl, void *native_window);
 
+bool egl_destroy_surface(egl_ctx_data_t *egl);
+
 bool egl_get_native_visual_id(egl_ctx_data_t *egl, EGLint *value);
 
 bool egl_get_config_attrib(EGLDisplay dpy, EGLConfig config,

--- a/gfx/drivers_context/android_ctx.c
+++ b/gfx/drivers_context/android_ctx.c
@@ -274,6 +274,27 @@ static uint32_t android_gfx_ctx_get_flags(void *data)
 
 static void android_gfx_ctx_set_flags(void *data, uint32_t flags) { }
 
+static bool android_gfx_ctx_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   struct android_app *android_app = (struct android_app*)g_android;
+   android_ctx_data_t *and = (android_ctx_data_t*)data;
+   return egl_create_surface(&and->egl, android_app->window);
+#else
+   return false;
+#endif
+}
+
+static bool android_gfx_ctx_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   android_ctx_data_t *and = (android_ctx_data_t*)data;
+   return egl_destroy_surface(&and->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_android = {
    android_gfx_ctx_init,
    android_gfx_ctx_destroy,
@@ -309,5 +330,7 @@ const gfx_ctx_driver_t gfx_ctx_android = {
    android_gfx_ctx_set_flags,
    android_gfx_ctx_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   android_gfx_ctx_create_surface,
+   android_gfx_ctx_destroy_surface
 };

--- a/gfx/drivers_context/android_vk_ctx.c
+++ b/gfx/drivers_context/android_vk_ctx.c
@@ -280,5 +280,7 @@ const gfx_ctx_driver_t gfx_ctx_vk_android = {
    android_gfx_ctx_vk_set_flags,
    android_gfx_ctx_vk_bind_hw_render,
    android_gfx_ctx_vk_get_context_data,
-   NULL                                      /* make_current */
+   NULL,                                     /* make_current */
+   NULL,                                     /* create_surface */
+   NULL                                      /* destroy_surface */
 };

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -636,5 +636,7 @@ const gfx_ctx_driver_t gfx_ctx_cocoagl = {
    cocoa_gl_gfx_ctx_set_flags,
    cocoa_gl_gfx_ctx_bind_hw_render,
    NULL, /* get_context_data */
-   NULL  /* make_current */
+   NULL, /* make_current */
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/cocoa_vk_ctx.m
+++ b/gfx/drivers_context/cocoa_vk_ctx.m
@@ -438,5 +438,7 @@ const gfx_ctx_driver_t gfx_ctx_cocoavk = {
    cocoa_vk_gfx_ctx_set_flags,
    cocoa_vk_gfx_ctx_bind_hw_render,
    cocoa_vk_gfx_ctx_get_context_data,
-   NULL  /* make_current */
+   NULL, /* make_current */
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -1065,6 +1065,26 @@ static void gfx_ctx_drm_set_flags(void *data, uint32_t flags)
       drm->core_hw_context_enable = true;
 }
 
+static bool gfx_ctx_drm_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   gfx_ctx_drm_data_t *drm = (gfx_ctx_drm_data_t*)data;
+   return egl_create_surface(&drm->egl, (EGLNativeWindowType)drm->gbm_surface);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_drm_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   gfx_ctx_drm_data_t *drm = (gfx_ctx_drm_data_t*)data;
+   return egl_destroy_surface(&drm->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_drm = {
    gfx_ctx_drm_init,
    gfx_ctx_drm_destroy,
@@ -1100,5 +1120,7 @@ const gfx_ctx_driver_t gfx_ctx_drm = {
    gfx_ctx_drm_set_flags,
    gfx_ctx_drm_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_drm_create_surface,
+   gfx_ctx_drm_destroy_surface
 };

--- a/gfx/drivers_context/drm_go2_ctx.c
+++ b/gfx/drivers_context/drm_go2_ctx.c
@@ -424,5 +424,7 @@ const gfx_ctx_driver_t gfx_ctx_go2_drm = {
    gfx_ctx_go2_drm_set_flags,
    gfx_ctx_go2_drm_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/emscriptenegl_ctx.c
+++ b/gfx/drivers_context/emscriptenegl_ctx.c
@@ -245,6 +245,26 @@ static uint32_t gfx_ctx_emscripten_get_flags(void *data)
 
 static void gfx_ctx_emscripten_set_flags(void *data, uint32_t flags) { }
 
+static bool gfx_ctx_emscripten_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   emscripten_ctx_data_t *emscripten = (emscripten_ctx_data_t*)data;
+   return egl_create_surface(&emscripten->egl, 0);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_emscripten_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   emscripten_ctx_data_t *emscripten = (emscripten_ctx_data_t*)data;
+   return egl_destroy_surface(&emscripten->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_emscripten = {
    gfx_ctx_emscripten_init,
    gfx_ctx_emscripten_destroy,
@@ -280,5 +300,7 @@ const gfx_ctx_driver_t gfx_ctx_emscripten = {
    gfx_ctx_emscripten_set_flags,
    gfx_ctx_emscripten_bind_hw_render,
    NULL, /* get_context_data */
-   NULL  /* make_current */
+   NULL, /* make_current */
+   gfx_ctx_emscripten_create_surface,
+   gfx_ctx_emscripten_destroy_surface
 };

--- a/gfx/drivers_context/emscriptenwebgl_ctx.c
+++ b/gfx/drivers_context/emscriptenwebgl_ctx.c
@@ -248,5 +248,7 @@ const gfx_ctx_driver_t gfx_ctx_emscripten_webgl = {
    gfx_ctx_emscripten_webgl_set_flags,
    gfx_ctx_emscripten_webgl_bind_hw_render,
    NULL, /* get_context_data */
-   NULL  /* make_current */
+   NULL, /* make_current */
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/gfx_null_ctx.c
+++ b/gfx/drivers_context/gfx_null_ctx.c
@@ -81,5 +81,7 @@ const gfx_ctx_driver_t gfx_ctx_null = {
    gfx_ctx_null_set_flags,
    gfx_ctx_null_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/khr_display_ctx.c
+++ b/gfx/drivers_context/khr_display_ctx.c
@@ -301,5 +301,7 @@ const gfx_ctx_driver_t gfx_ctx_khr_display = {
    gfx_ctx_khr_display_set_flags,
    NULL,
    gfx_ctx_khr_display_get_context_data,
-   NULL                                         /* make_current */
+   NULL,                                        /* make_current */
+   NULL,                                        /* create_surface */
+   NULL                                         /* destroy_surface */
 };

--- a/gfx/drivers_context/mali_fbdev_ctx.c
+++ b/gfx/drivers_context/mali_fbdev_ctx.c
@@ -386,6 +386,26 @@ static float gfx_ctx_mali_fbdev_get_refresh_rate(void *data)
    return mali->refresh_rate;
 }
 
+static bool gfx_ctx_mali_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   mali_ctx_data_t *mali = (mali_ctx_data_t*)data;
+   return egl_create_surface(&mali->egl, &mali->native_window);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_mali_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   mali_ctx_data_t *mali = (mali_ctx_data_t*)data;
+   return egl_destroy_surface(&mali->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_mali_fbdev = {
    gfx_ctx_mali_fbdev_init,
    gfx_ctx_mali_fbdev_destroy,
@@ -421,5 +441,7 @@ const gfx_ctx_driver_t gfx_ctx_mali_fbdev = {
    gfx_ctx_mali_fbdev_set_flags,
    gfx_ctx_mali_fbdev_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_mali_create_surface,
+   gfx_ctx_mali_destroy_surface
 };

--- a/gfx/drivers_context/opendingux_fbdev_ctx.c
+++ b/gfx/drivers_context/opendingux_fbdev_ctx.c
@@ -221,6 +221,26 @@ static uint32_t gfx_ctx_opendingux_get_flags(void *data)
    return flags;
 }
 
+static bool gfx_ctx_opendingux_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   opendingux_ctx_data_t *viv = (opendingux_ctx_data_t*)data;
+   return egl_create_surface(&viv->egl, viv->native_window);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_opendingux_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   opendingux_ctx_data_t *viv = (opendingux_ctx_data_t*)data;
+   return egl_destroy_surface(&viv->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_opendingux_fbdev = {
    gfx_ctx_opendingux_init,
    gfx_ctx_opendingux_destroy,
@@ -256,5 +276,7 @@ const gfx_ctx_driver_t gfx_ctx_opendingux_fbdev = {
    gfx_ctx_opendingux_set_flags,
    gfx_ctx_opendingux_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_opendingux_create_surface,
+   gfx_ctx_opendingux_destroy_surface
 };

--- a/gfx/drivers_context/orbis_ctx.c
+++ b/gfx/drivers_context/orbis_ctx.c
@@ -333,6 +333,26 @@ static float orbis_ctx_get_refresh_rate(void *data)
    return ctx_orbis->refresh_rate;
 }
 
+static bool orbis_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t*)data;
+   return egl_create_surface(&ctx_orbis->egl, &ctx_orbis->native_window);
+#else
+   return false;
+#endif
+}
+
+static bool orbis_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   orbis_ctx_data_t *ctx_orbis = (orbis_ctx_data_t*)data;
+   return egl_destroy_surface(&ctx_orbis->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t orbis_ctx = {
     orbis_ctx_init,
     orbis_ctx_destroy,
@@ -368,4 +388,7 @@ const gfx_ctx_driver_t orbis_ctx = {
     orbis_ctx_set_flags,
     orbis_ctx_bind_hw_render,
     NULL,
-    NULL};
+    NULL,
+    orbis_create_surface,
+    orbis_destroy_surface
+};

--- a/gfx/drivers_context/osmesa_ctx.c
+++ b/gfx/drivers_context/osmesa_ctx.c
@@ -362,5 +362,7 @@ const gfx_ctx_driver_t gfx_ctx_osmesa =
    osmesa_ctx_set_flags,
    NULL, /* bind_hw_render */
    NULL,
-   NULL
+   NULL,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/ps3_ctx.c
+++ b/gfx/drivers_context/ps3_ctx.c
@@ -414,5 +414,7 @@ const gfx_ctx_driver_t gfx_ctx_ps3 = {
    gfx_ctx_ps3_get_flags,
    gfx_ctx_ps3_set_flags,
    NULL,
-   NULL
+   NULL,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/qnx_ctx.c
+++ b/gfx/drivers_context/qnx_ctx.c
@@ -391,6 +391,26 @@ static uint32_t gfx_ctx_qnx_get_flags(void *data)
 
 static void gfx_ctx_qnx_set_flags(void *data, uint32_t flags) { }
 
+static bool gfx_ctx_qnx_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   qnx_ctx_data_t *qnx = (qnx_ctx_data_t*)data;
+   return egl_create_surface(&qnx->egl, screen_win);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_qnx_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   qnx_ctx_data_t *qnx = (qnx_ctx_data_t*)data;
+   return egl_destroy_surface(&qnx->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_qnx = {
    gfx_ctx_qnx_init,
    gfx_ctx_qnx_destroy,
@@ -426,5 +446,7 @@ const gfx_ctx_driver_t gfx_ctx_qnx = {
    gfx_ctx_qnx_set_flags,
    gfx_ctx_qnx_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_qnx_create_surface,
+   gfx_ctx_qnx_destroy_surface
 };

--- a/gfx/drivers_context/sdl_gl_ctx.c
+++ b/gfx/drivers_context/sdl_gl_ctx.c
@@ -456,5 +456,7 @@ const gfx_ctx_driver_t gfx_ctx_sdl_gl =
    sdl_ctx_set_flags,
    NULL, /* bind_hw_render */
    NULL,
-   NULL
+   NULL,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/switch_ctx.c
+++ b/gfx/drivers_context/switch_ctx.c
@@ -303,6 +303,26 @@ bool switch_ctx_get_metrics(void *data,
    return false;
 }
 
+static bool switch_ctx_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   switch_ctx_data_t *ctx_nx = (switch_ctx_data_t*)data;
+   return egl_create_surface(&ctx_nx->egl, ctx_nx->win);
+#else
+   return false;
+#endif
+}
+
+static bool switch_ctx_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   switch_ctx_data_t *ctx_nx = (switch_ctx_data_t*)data;
+   return egl_destroy_surface(&ctx_nx->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t switch_ctx = {
     switch_ctx_init,
     switch_ctx_destroy,
@@ -338,5 +358,7 @@ const gfx_ctx_driver_t switch_ctx = {
     switch_ctx_set_flags,
     switch_ctx_bind_hw_render,
     NULL,
-    NULL
+    NULL,
+    switch_ctx_create_surface,
+    switch_ctx_destroy_surface
 };

--- a/gfx/drivers_context/uwp_egl_ctx.c
+++ b/gfx/drivers_context/uwp_egl_ctx.c
@@ -253,6 +253,24 @@ static uint32_t gfx_ctx_uwp_get_flags(void *data)
    return flags;
 }
 
+static bool gfx_ctx_uwp_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   return egl_create_surface(&uwp_egl, uwp_get_corewindow());
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_uwp_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   return egl_destroy_surface(&uwp_egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_uwp = {
    gfx_ctx_uwp_init,
    gfx_ctx_uwp_destroy,
@@ -284,5 +302,7 @@ const gfx_ctx_driver_t gfx_ctx_uwp = {
    NULL, /* set flags */
    gfx_ctx_uwp_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_uwp_create_surface,
+   gfx_ctx_uwp_destroy_surface
 };

--- a/gfx/drivers_context/vc_egl_ctx.c
+++ b/gfx/drivers_context/vc_egl_ctx.c
@@ -672,6 +672,26 @@ static uint32_t gfx_ctx_vc_get_flags(void *data)
 
 static void gfx_ctx_vc_set_flags(void *data, uint32_t flags) { }
 
+static bool gfx_ctx_vc_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   vc_ctx_data_t *vc = (vc_ctx_data_t*)data;
+   return egl_create_surface(&vc->egl, &vc->native_window);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_vc_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   vc_ctx_data_t *vc = (vc_ctx_data_t*)data;
+   return egl_destroy_surface(&vc->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_videocore = {
    gfx_ctx_vc_init,
    gfx_ctx_vc_destroy,
@@ -707,5 +727,7 @@ const gfx_ctx_driver_t gfx_ctx_videocore = {
    gfx_ctx_vc_set_flags,
    gfx_ctx_vc_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_vc_create_surface,
+   gfx_ctx_vc_destroy_surface
 };

--- a/gfx/drivers_context/vita_ctx.c
+++ b/gfx/drivers_context/vita_ctx.c
@@ -251,6 +251,26 @@ static float vita_get_refresh_rate(void *data)
 }
 #endif
 
+static bool vita_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   vita_ctx_data_t *ctx_vita = (vita_ctx_data_t*)data;
+   return egl_create_surface(&ctx_vita->egl, ctx_vita->native_window);
+#else
+   return false;
+#endif
+}
+
+static bool vita_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   vita_ctx_data_t *ctx_vita = (vita_ctx_data_t*)data;
+   return egl_destroy_surface(&ctx_vita->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t vita_ctx = {
    vita_init,
    vita_destroy,
@@ -290,5 +310,7 @@ const gfx_ctx_driver_t vita_ctx = {
    vita_set_flags,
    vita_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   vita_create_surface,
+   vita_destroy_surface
 };

--- a/gfx/drivers_context/vivante_fbdev_ctx.c
+++ b/gfx/drivers_context/vivante_fbdev_ctx.c
@@ -225,6 +225,26 @@ static uint32_t gfx_ctx_vivante_get_flags(void *data)
    return flags;
 }
 
+static bool gfx_ctx_vivante_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   vivante_ctx_data_t *viv = (vivante_ctx_data_t*)data;
+   return egl_create_surface(&viv->egl, viv->native_window);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_vivante_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   vivante_ctx_data_t *viv = (vivante_ctx_data_t*)data;
+   return egl_destroy_surface(&viv->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_vivante_fbdev = {
    gfx_ctx_vivante_init,
    gfx_ctx_vivante_destroy,
@@ -260,5 +280,7 @@ const gfx_ctx_driver_t gfx_ctx_vivante_fbdev = {
    gfx_ctx_vivante_set_flags,
    gfx_ctx_vivante_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_vivante_create_surface,
+   gfx_ctx_vivante_destroy_surface
 };

--- a/gfx/drivers_context/w_vk_ctx.c
+++ b/gfx/drivers_context/w_vk_ctx.c
@@ -327,5 +327,7 @@ const gfx_ctx_driver_t gfx_ctx_w_vk = {
    gfx_ctx_w_vk_set_flags,
    gfx_ctx_w_vk_bind_hw_render,
    gfx_ctx_w_vk_get_context_data,
-   NULL                             /* make_current */
+   NULL,                            /* make_current */
+   NULL,                            /* create_surface */
+   NULL                             /* destroy_surface */
 };

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -595,6 +595,26 @@ static void gfx_ctx_wl_set_flags(void *data, uint32_t flags)
       wl->core_hw_context_enable = true;
 }
 
+static bool gfx_ctx_wl_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   return egl_create_surface(&wl->egl, (void*)wl->win);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_wl_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   return egl_destroy_surface(&wl->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_wayland = {
    gfx_ctx_wl_init,
    gfx_ctx_wl_destroy,
@@ -631,4 +651,6 @@ const gfx_ctx_driver_t gfx_ctx_wayland = {
    gfx_ctx_wl_bind_hw_render,
    NULL,
    NULL,
+   gfx_ctx_wl_create_surface,
+   gfx_ctx_wl_destroy_surface
 };

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -312,4 +312,6 @@ const gfx_ctx_driver_t gfx_ctx_vk_wayland = {
    gfx_ctx_wl_bind_hw_render,
    gfx_ctx_wl_get_context_data,
    NULL,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -843,6 +843,24 @@ static void gfx_ctx_wgl_set_flags(void *data, uint32_t flags)
 static void gfx_ctx_wgl_get_video_output_prev(void *data) { }
 static void gfx_ctx_wgl_get_video_output_next(void *data) { }
 
+static bool gfx_ctx_wgl_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   return egl_create_surface(&win32_egl, win32_get_window());
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_wgl_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   return egl_destroy_surface(&win32_egl);
+#else
+   return false;
+#endif
+}
+
 /* TODO: maybe create an uwp_mesa_common.c? */
 #ifdef __WINRT__
 
@@ -917,5 +935,7 @@ const gfx_ctx_driver_t gfx_ctx_wgl = {
    gfx_ctx_wgl_set_flags,
    gfx_ctx_wgl_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_wgl_create_surface,
+   gfx_ctx_wgl_destroy_surface
 };

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -1183,5 +1183,7 @@ const gfx_ctx_driver_t gfx_ctx_x = {
 
    gfx_ctx_x_bind_hw_render,
    NULL,
-   gfx_ctx_x_make_current
+   gfx_ctx_x_make_current,
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/x_vk_ctx.c
+++ b/gfx/drivers_context/x_vk_ctx.c
@@ -586,5 +586,7 @@ const gfx_ctx_driver_t gfx_ctx_vk_x = {
 
    gfx_ctx_x_vk_bind_hw_render,
    gfx_ctx_x_vk_get_context_data,
-   NULL /* make_current */
+   NULL, /* make_current */
+   NULL, /* create_surface */
+   NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -581,6 +581,26 @@ static uint32_t gfx_ctx_xegl_get_flags(void *data)
 
 static void gfx_ctx_xegl_set_flags(void *data, uint32_t flags) { }
 
+static bool gfx_ctx_xegl_create_surface(void *data)
+{
+#ifdef HAVE_EGL
+   xegl_ctx_data_t *xegl = (xegl_ctx_data_t*)data;
+   return egl_create_surface(&xegl->egl, (void*)g_x11_win);
+#else
+   return false;
+#endif
+}
+
+static bool gfx_ctx_xegl_destroy_surface(void *data)
+{
+#ifdef HAVE_EGL
+   xegl_ctx_data_t *xegl = (xegl_ctx_data_t*)data;
+   return egl_destroy_surface(&xegl->egl);
+#else
+   return false;
+#endif
+}
+
 const gfx_ctx_driver_t gfx_ctx_x_egl =
 {
    gfx_ctx_xegl_init,
@@ -617,5 +637,7 @@ const gfx_ctx_driver_t gfx_ctx_x_egl =
    gfx_ctx_xegl_set_flags,
    gfx_ctx_xegl_bind_hw_render,
    NULL,
-   NULL
+   NULL,
+   gfx_ctx_xegl_create_surface,
+   gfx_ctx_xegl_destroy_surface
 };

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -618,6 +618,16 @@ typedef struct gfx_ctx_driver
    /* Optional. Makes driver context (only GL right now)
     * active for this thread. */
    void (*make_current)(bool release);
+
+   /* Optional. Creates and binds a new window surface, destroying the original
+    * window surface if applicable. Returns true on success and false on error.
+    * Currently only for OpenGL. */
+   bool (*create_surface)(void *data);
+
+   /* Optional. Destroys the current window surface. Returns true on success or
+    * or if there is no currently bound window surface and false on error.
+    * Currently only for OpenGL. */
+   bool (*destroy_surface)(void *data);
 } gfx_ctx_driver_t;
 
 typedef struct gfx_ctx_mode


### PR DESCRIPTION
## Description

The RetroArch Android apps currently have a problem where if an OpenGL video driver is being used, the OpenGL context is lost whenever you pause the app (e.g. by opening the app switcher, locking the device or receiving a phone call). This does not happen when using Vulkan on Android or any video driver on iOS. **Edit:** It actually does also happen when using Vulkan on Android. See the other comments on this pull request.

This means libretro cores that use OpenGL on Android need to correctly implement the `context_reset` callback in `struct retro_hw_render_callback` in the libretro API to be able to survive the app being paused, otherwise pausing the app will result in the the libretro core rendering its graphics incorrectly or crashing.

Some libretro cores that use OpenGL currently do not implement `context_reset` correctly for whatever reason, which results in poor user experience since pausing the app is a relatively common thing for users to do.

It turns out we don't need to reinitialize the OpenGL context when the app is paused. We only need to reinitialize the EGL window surface since the window may change after the app is paused. This should work on all Android devices except for extremely old ones that don't support multiple OpenGL contexts, in which case it will fall back to the old code path and reinitialize the OpenGL context.

I've added two new fields, `create_surface` and `destroy_surface`, to `gfx_ctx_driver_t` for creating and destroying the window surface to implement this.

## Related Issues

* https://github.com/libretro/mupen64plus-libretro-nx/issues/554
* https://github.com/libretro/mupen64plus-libretro-nx/issues/364
