### PR TITLE
x11 : Add support for NET_WM_NAME

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -810,13 +810,16 @@ void x11_update_title(void *data)
 {
    size_t _len;
    char title[128];
+   Atom XA_NET_WM_NAME;
+   Atom XA_UTF8_STRING;
    title[0]                         = '\0';
    _len                             = video_driver_get_window_title(title, sizeof(title));
-   Atom XA_NET_WM_NAME              = XInternAtom(g_x11_dpy, "_NET_WM_NAME", False);
-   Atom XA_UTF8_STRING              = XInternAtom(g_x11_dpy, "UTF8_STRING", False);
 
    if (title[0])
    {
+      Atom XA_NET_WM_NAME              = XInternAtom(g_x11_dpy, "_NET_WM_NAME", False);
+      Atom XA_UTF8_STRING              = XInternAtom(g_x11_dpy, "UTF8_STRING", False);
+
       if (XA_NET_WM_NAME != None && XA_UTF8_STRING != None)
       {
          XChangeProperty(g_x11_dpy, g_x11_win, XA_NET_WM_NAME, XA_UTF8_STRING,

--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -810,11 +810,24 @@ void x11_update_title(void *data)
 {
    size_t _len;
    char title[128];
-   title[0]  = '\0';
-   _len      = video_driver_get_window_title(title, sizeof(title));
+   title[0]                         = '\0';
+   _len                             = video_driver_get_window_title(title, sizeof(title));
+   Atom XA_NET_WM_NAME              = XInternAtom(g_x11_dpy, "_NET_WM_NAME", False);
+   Atom XA_UTF8_STRING              = XInternAtom(g_x11_dpy, "UTF8_STRING", False);
+
    if (title[0])
-      XChangeProperty(g_x11_dpy, g_x11_win, XA_WM_NAME, XA_STRING,
+   {
+      if (XA_NET_WM_NAME != None && XA_UTF8_STRING != None)
+      {
+         XChangeProperty(g_x11_dpy, g_x11_win, XA_NET_WM_NAME, XA_UTF8_STRING,
             8, PropModeReplace, (const unsigned char*)title, _len);
+      }
+      else
+      {
+         XChangeProperty(g_x11_dpy, g_x11_win, XA_WM_NAME, XA_STRING,
+            8, PropModeReplace, (const unsigned char*)title, _len);
+      }
+   }
 }
 
 bool x11_input_ctx_new(bool true_full)


### PR DESCRIPTION
## Description

Add support for [_NET_WM_NAME, UTF8_STRING](https://specifications.freedesktop.org/wm/latest/ar01s05.html#id-1.6.2)

### Before using xprop

```
WM_NAME(STRING) = "RetroArch"
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW
_NET_WM_DESKTOP(CARDINAL) = 1
_NET_WM_STATE(ATOM) = _NET_WM_STATE_MAXIMIZED_VERT
WM_STATE(WM_STATE):
		window state: Normal
		icon window: 0x0
WM_CLIENT_MACHINE(STRING) = "pc"
_NET_WM_PID(CARDINAL) = 13942
WM_CLASS(STRING) = "retroarch", "retroarch"
_NET_WM_ICON(CARDINAL) = 	Icon (16 x 16):
```


### After using xprop

```
_NET_WM_NAME(UTF8_STRING) = "RetroArch"
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW
_NET_WM_DESKTOP(CARDINAL) = 1
_NET_WM_STATE(ATOM) = _NET_WM_STATE_MAXIMIZED_VERT
WM_STATE(WM_STATE):
		window state: Normal
		icon window: 0x0
WM_CLIENT_MACHINE(STRING) = "pc"
_NET_WM_PID(CARDINAL) = 13885
WM_CLASS(STRING) = "retroarch", "retroarch"
_NET_WM_ICON(CARDINAL) = 	Icon (16 x 16):
```
## Related Issues

Fix #18444