### PR TITLE
Add a note for translators, directing them to Crowdin

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -6,6 +6,20 @@
 #pragma warning(disable:4566)
 #endif
 
+/*
+##### NOTE FOR TRANSLATORS ####
+
+PLEASE do NOT modify any `msg_hash_*.h` files, besides `msg_hash_us.h`!
+
+Translations are handled using the localization platform Crowdin:
+https://crowdin.com/project/retroarch
+
+Translations from Crowdin are applied automatically and will overwrite
+any changes made to the other localization files.
+As a result, any submissions directly altering `msg_hash_*.h` files
+other than `msg_hash_us.h` will be rejected.
+*/
+
 /* Top-Level Menu */
 
 MSG_HASH(


### PR DESCRIPTION
## Description

Adds a note to the main text file `msg_hash_us.h`, with the intent to prevent people from committing translations directly to the source files and to direct them to the Crowdin localization platform instead.

Hopefully this will further reduce unnecessary Pull Requests.

## Related Pull Requests
https://github.com/libretro/RetroArch/pull/18493 as an example, of what this aims to prevent.

## Reviewers
@hizzlekizzle , @sonninnos , @IlDucci 
