### PR TITLE
emscripten: add dice core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Future
+- EMSCRIPTEN: Added dice to core selection dropdown
 
 # 1.22.1
 - ANDROID: OnNewIntent handler to allow launchers start new content without closing first

--- a/pkg/emscripten/libretro-thread/core_list.js
+++ b/pkg/emscripten/libretro-thread/core_list.js
@@ -6,6 +6,7 @@ const libretroCores = {
 	"bk": "Elektronika - BK-0010/BK-0011 (BK)",
 	"chailove": "ChaiLove",
 	"craft": "Minecraft (Craft)",
+	"dice": "Arcade (DICE)",
 	"DoubleCherryGB": "Nintendo - Game Boy / Color (DoubleCherryGB)",
 	"ecwolf": "Wolfenstein 3D (ECWolf)",
 	"fbalpha2012": "Arcade (FB Alpha 2012)",

--- a/pkg/emscripten/libretro/core_list.js
+++ b/pkg/emscripten/libretro/core_list.js
@@ -6,6 +6,7 @@ const libretroCores = {
 	"bk": "Elektronika - BK-0010/BK-0011 (BK)",
 	"chailove": "ChaiLove",
 	"craft": "Minecraft (Craft)",
+	"dice": "Arcade (DICE)",
 	"DoubleCherryGB": "Nintendo - Game Boy / Color (DoubleCherryGB)",
 	"ecwolf": "Wolfenstein 3D (ECWolf)",
 	"fbalpha2012": "Arcade (FB Alpha 2012)",


### PR DESCRIPTION
## Description

Enable lr-dice core for emscripten web player.

Tested single-threaded using python http.server on macOS 14.8.2.

## Related Issues

None.

## Related Pull Requests

None.

## Reviewers

@BinBashBanana , @JoeOsborn : I've tested single-threaded, haven't tried multi-threaded with pthread/SSL/CORS.  Enabled the single-threaded core in the multi-threaded core following lr-gambatte's example.
