### PR TITLE
Allow overlays to position the viewport

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5438,6 +5438,9 @@ static void input_overlay_loaded(retro_task_t *task,
 
    input_overlay_set_eightway_diagonal_sensitivity();
 
+   /* Trigger viewport recalculation - overlay may have viewport override */
+   command_event(CMD_EVENT_VIDEO_SET_ASPECT_RATIO, NULL);
+
 #ifdef HAVE_MENU
    /* Update menu entries if this is the main overlay */
    if (!(ol->flags & INPUT_OVERLAY_IS_OSK))

--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -129,7 +129,9 @@ enum OVERLAY_FLAGS
    OVERLAY_BLOCK_X_SEPARATION = (1 << 2),
    OVERLAY_BLOCK_Y_SEPARATION = (1 << 3),
    OVERLAY_AUTO_X_SEPARATION  = (1 << 4),
-   OVERLAY_AUTO_Y_SEPARATION  = (1 << 5)
+   OVERLAY_AUTO_Y_SEPARATION  = (1 << 5),
+   OVERLAY_HAS_VIEWPORT       = (1 << 6),
+   OVERLAY_VIEWPORT_FILL      = (1 << 7)
 };
 
 enum OVERLAY_DESC_FLAGS
@@ -269,6 +271,15 @@ struct overlay
    float x, y, w, h;
    float center_x, center_y;
    float aspect_ratio;
+
+   /* Viewport override - normalized coordinates (0.0-1.0) */
+   struct
+   {
+      float x;
+      float y;
+      float w;
+      float h;
+   } viewport;
 
    struct
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -4002,6 +4002,9 @@ bool command_event(enum event_command cmd, void *data)
             ol->next_index                 =
                   (unsigned)((ol->index + 1) % ol->size);
 
+            /* Trigger viewport recalculation - overlay may have viewport override */
+            command_event(CMD_EVENT_VIDEO_SET_ASPECT_RATIO, NULL);
+
             /* Check orientation, if required */
             if (inp_overlay_auto_rotate)
                if (check_rotation)

--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -892,6 +892,69 @@ static void task_overlay_deferred_load(retro_task_t *task)
       overlay->center_x    = overlay->x + 0.5f * overlay->w;
       overlay->center_y    = overlay->y + 0.5f * overlay->h;
 
+      /* Parse viewport override (optional) */
+      strlcpy(conf_key + _len, "_viewport", sizeof(conf_key) - _len);
+      RARCH_LOG("[Overlay] Checking for viewport key: %s\n", conf_key);
+      if (config_get_array(conf, conf_key, tmp_str, sizeof(tmp_str)))
+      {
+         char *tok, *save      = NULL;
+         char *elem0           = NULL;
+         char *elem1           = NULL;
+         char *elem2           = NULL;
+         char *elem3           = NULL;
+         unsigned list_size    = 0;
+         char *cfg_vp_cpy      = strdup(tmp_str);
+         RARCH_LOG("[Overlay] Found viewport value: %s\n", tmp_str);
+
+         if ((tok = strtok_r(cfg_vp_cpy, ", ", &save)))
+         {
+            elem0 = strdup(tok);
+            list_size++;
+         }
+         if ((tok = strtok_r(NULL, ", ", &save)))
+         {
+            elem1 = strdup(tok);
+            list_size++;
+         }
+         if ((tok = strtok_r(NULL, ", ", &save)))
+         {
+            elem2 = strdup(tok);
+            list_size++;
+         }
+         if ((tok = strtok_r(NULL, ", ", &save)))
+         {
+            elem3 = strdup(tok);
+            list_size++;
+         }
+         free(cfg_vp_cpy);
+
+         if (list_size >= 4)
+         {
+            overlay->viewport.x  = (float)strtod(elem0, NULL);
+            overlay->viewport.y  = (float)strtod(elem1, NULL);
+            overlay->viewport.w  = (float)strtod(elem2, NULL);
+            overlay->viewport.h  = (float)strtod(elem3, NULL);
+            overlay->flags      |= OVERLAY_HAS_VIEWPORT;
+            RARCH_LOG("[Overlay] Parsed viewport: x=%.3f y=%.3f w=%.3f h=%.3f\n",
+                  overlay->viewport.x, overlay->viewport.y,
+                  overlay->viewport.w, overlay->viewport.h);
+         }
+         else
+            RARCH_WARN("[Overlay] viewport \"%s\" requires four tokens.\n", tmp_str);
+
+         free(elem0);
+         free(elem1);
+         free(elem2);
+         free(elem3);
+      }
+
+      /* Parse viewport_fill option (optional, default false) */
+      strlcpy(conf_key + _len, "_viewport_fill", sizeof(conf_key) - _len);
+      if (config_get_bool(conf, conf_key, &tmp_bool) && tmp_bool)
+         overlay->flags |= OVERLAY_VIEWPORT_FILL;
+      else
+         overlay->flags &= ~OVERLAY_VIEWPORT_FILL;
+
       /* Check whether x/y separation are force disabled
        * for this overlay */
       strlcpy(conf_key + _len, "_block_x_separation", sizeof(conf_key) - _len);


### PR DESCRIPTION
This creates two new fields for an overlay: overlayN_viewport and overlayN_viewport_fill, which an overlay can use to set up where in the screen the viewport is allowed to size itself in.