### PR TITLE
[d3d12] calculate mipmaps properly for internal textures

### DIFF
--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -708,13 +708,13 @@ static void d3d12_init_texture(D3D12Device device, d3d12_texture_t* texture)
    if (!texture->desc.MipLevels)
       texture->desc.MipLevels          = 1;
 
-   if (   !(texture->desc.Width  >> (texture->desc.MipLevels - 1))
-       && !(texture->desc.Height >> (texture->desc.MipLevels - 1)))
+   /* Calculate mipmap count */
+   if (texture->desc.Width > 1 || texture->desc.Height > 1)
    {
-      unsigned width                   = texture->desc.Width >> 5;
-      unsigned height                  = texture->desc.Height >> 5;
-      texture->desc.MipLevels          = 1;
-      while (width && height)
+      unsigned width                   = texture->desc.Width;
+      unsigned height                  = texture->desc.Height;
+      texture->desc.MipLevels          = 0;
+      while ((width > 1) || (height > 1))
       {
          width  >>= 1;
          height >>= 1;


### PR DESCRIPTION
## Description

D3D12 didn't calculate mipmaps properly for internal textures, but it did for external textures (e.g., LUTs). This resulted in some shaders looking funky because they depend on mipmaps.

## Related Issues

https://github.com/libretro/RetroArch/issues/16567

## Related Pull Requests

none

## Reviewers

[If possible @mention all the people that should review your pull request]
