### PR TITLE
webOS: preload libstdc++ from IPK to prevent ABI mismatch

### DIFF
--- a/libretro-common/dynamic/dylib.c
+++ b/libretro-common/dynamic/dylib.c
@@ -34,6 +34,8 @@
 
 #ifdef NEED_DYNAMIC
 
+#include "../../verbosity.h"
+
 #ifdef _WIN32
 #include <compat/posix_string.h>
 #include <windows.h>
@@ -144,6 +146,13 @@ dylib_t dylib_load(const char *path)
     }
     else
         lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
+#elif defined(WEBOS)
+    /* pre-load libstdc++ from RetroArch IPK to prevent mismatched ABI */
+   const char *stdc_path = "lib/libstdc++.so.6";
+   if(!dlopen(stdc_path, RTLD_GLOBAL | RTLD_NOW))
+      RARCH_WARN("libstdc++ not found at %s\n", stdc_path);
+
+   dylib_t lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
 #else
    dylib_t lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
 #endif


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Some cores might need libstdc++ compiled statically, this is a testing nightmare due to the amount of cores and webOS versions as they may have a substantially older version of libstdc++ installed compared to the compiler.

We can simply preload libstdc++ in the IPK first, to prevent the system libstdc++ from being loaded if libstdc++ was never statically linked. This seems more sensible than editing 100s of Makefiles to static link libstdc++ which may not be required anyway for a lot of users.

## Related Issues


## Related Pull Requests


## Reviewers

