### PR TITLE
macos: adjust CADisplaylink stutter-fix version conditions

### DIFF
--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -128,7 +128,7 @@ static void rarch_draw_observer(CFRunLoopObserverRef observer,
    else
       rarch_stop_draw_observer();
 #elif defined(OSX)
-   else if (!(@available(macOS 14.0, *)))
+   else if (!(@available(macOS 15.0, *)))
       CFRunLoopWakeUp(CFRunLoopGetMain());
 #endif
 }


### PR DESCRIPTION
## Description

On macOS, apply CADisplaylink stutter fix to 14.x.x as well as older versions.

## Related Issues

None.

Tested on Apple Silicon, 14.8.2.

## Related Pull Requests

Follow-on to https://github.com/libretro/RetroArch/commit/03a0530596c448951afa01e0919c179cd6d8997c .

## Reviewers

@warmenhoven 