### PR TITLE
Adds Windows ARM 64 Build script and related fixes

### DIFF
--- a/.github/workflows/MSYS2.yml
+++ b/.github/workflows/MSYS2.yml
@@ -14,8 +14,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sys: [MINGW64, UCRT64,CLANG64]
-    runs-on: windows-latest
+        include:
+          # Existing x64 builds
+          - sys: MINGW64
+            runner: windows-latest
+          - sys: UCRT64
+            runner: windows-latest
+          - sys: CLANG64
+            runner: windows-latest
+
+          # New ARM64 build (native Windows on ARM)
+          - sys: CLANGARM64
+            runner: windows-11-arm
+
+    runs-on: ${{ matrix.runner }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,7 +38,9 @@ jobs:
         with:
           msystem: ${{ matrix.sys }}
           update: true
-          install: base-devel git
+          install: >-
+            base-devel
+            git
           pacboy: >-
             gettext:p
             gobject-introspection:p
@@ -57,17 +72,18 @@ jobs:
       - name: Configure and build RetroArch
         shell: msys2 {0}
         run: |
-          echo "Building RetroArch in ${{ matrix.sys }} environment"
+          echo "Building RetroArch in ${{ matrix.sys }} on ${{ matrix.runner }}"
           ./configure
-          make -j$(nproc) info all
+          make -j"$(nproc)" info all
 
       - name: Collect DLLs and binaries
         shell: msys2 {0}
         run: |
           echo "Collecting DLLs and binaries"
+          rm -rf dist
           mkdir -p dist
           cp retroarch.exe dist/
-          ldd retroarch.exe|grep $MINGW_PREFIX |awk '{print $3}'|xargs -I {} cp {} dist/
+          ldd retroarch.exe | grep "$MINGW_PREFIX" | awk '{print $3}' | xargs -I {} cp {} dist/ || true
 
       - name: Archive build artifacts
         if: success()

--- a/.github/workflows/Windows-ARM64.yml
+++ b/.github/workflows/Windows-ARM64.yml
@@ -1,0 +1,44 @@
+name: CI Windows ARM64 (MSVC)
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+permissions:
+  contents: read
+
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  msvc:
+    runs-on: windows-11-arm
+    strategy:
+      matrix:
+        version: [2022]
+        configuration: [Debug, Release]
+        platform: [ARM64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Compile RA
+        working-directory: "${{ github.workspace }}/pkg/msvc"
+        run: |
+          msbuild -p:"Configuration=${{ matrix.configuration }}" -p:"Platform=${{ matrix.platform }}" .\RetroArch-msvc${{ matrix.version }}.sln
+
+      - name: Get short SHA
+        id: slug
+        shell: powershell
+        run: echo "sha8=$('${{ github.sha }}'.Substring(0,8))"  >> $env:GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: retroarch-${{ matrix.version }}-${{ matrix.configuration }}-${{ matrix.platform }}-${{ steps.slug.outputs.sha8 }}
+          path: |
+            pkg/msvc/${{ matrix.platform }}/${{ matrix.configuration }}/RetroArch-msvc${{ matrix.version }}.exe

--- a/config.def.h
+++ b/config.def.h
@@ -1847,6 +1847,9 @@
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/windows/x86_64/latest/"
 #elif defined(__i386__) || defined(__i486__) || defined(__i686__) || defined(_M_IX86) || defined(_M_IA64)
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/windows/x86/latest/"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+/* No official MinGW/clang ARM64 buildbot yet – use empty default */
+#define DEFAULT_BUILDBOT_SERVER_URL ""
 #endif
 #endif
 #elif defined(__linux__)

--- a/deps/mbedtls/timing.c
+++ b/deps/mbedtls/timing.c
@@ -43,6 +43,13 @@
 #include <windows.h>
 #include <winbase.h>
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+/* MSYS2/MinGW: provide struct timeval + gettimeofday() for the
+ * fallback timing implementation used when HAVE_HARDCLOCK
+ * isn't defined (e.g., on aarch64-w64-mingw32 / clangarm64). */
+#include <sys/time.h>
+#endif
+
 struct _hr_time
 {
     LARGE_INTEGER start;


### PR DESCRIPTION
## Description

Adds new Windows ARM 64 MSVC build. 
Modifies MSYS2 build and adds CLANGARM64 Windows ARM build to the matrix. 

Both modifications use GitHub's free public Windows 11 ARM runner.

timing.c fix so MSYS2 build suceeds.
Stubbed out DEFAULT_BUILDBOT_SERVER_URL  as empty string for WIndows ARM 64 build. 

## Related Issues

https://github.com/libretro/RetroArch/issues/15975

