### PR TITLE
Only allow pausing when there is an active core

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -4232,6 +4232,10 @@ bool command_event(enum event_command cmd, void *data)
             video_driver_state_t
                *video_st                         = video_state_get_ptr();
             rarch_system_info_t *sys_info        = &runloop_st->system;
+            
+            /* Restore unpaused state */
+            runloop_st->paused_hotkey = false;
+            command_event(CMD_EVENT_UNPAUSE, NULL);
 
             /* The platform that uses ram_state_save calls it when the content
              * ends and writes it to a file */
@@ -4743,7 +4747,9 @@ bool command_event(enum event_command cmd, void *data)
             unsigned accessibility_narrator_speech_speed
                                  = settings->uints.accessibility_narrator_speech_speed;
 #endif
-
+            /* Allow pause toggling only when there is an active core. */
+            if (!(runloop_st->flags & RUNLOOP_FLAG_CORE_RUNNING))
+               break;
 #ifdef HAVE_NETWORKING
             if (!netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL))
                break;
@@ -4784,6 +4790,9 @@ bool command_event(enum event_command cmd, void *data)
          runloop_pause_checks();
          break;
       case CMD_EVENT_PAUSE:
+         /* Allow pausing only when there is an active core. */
+         if (!(runloop_st->flags & RUNLOOP_FLAG_CORE_RUNNING))
+            break;
 #ifdef HAVE_NETWORKING
          if (!netplay_driver_ctl(RARCH_NETPLAY_CTL_ALLOW_PAUSE, NULL))
             break;

--- a/runloop.c
+++ b/runloop.c
@@ -5539,7 +5539,6 @@ static bool display_menu_libretro(
    }
 
 static void runloop_pause_toggle(
-      bool *runloop_paused_hotkey,
       bool pause_pressed, bool old_pause_pressed,
       bool focused, bool old_focus)
 {
@@ -5551,7 +5550,7 @@ static void runloop_pause_toggle(
       {
          /* Keep track of hotkey triggered pause to
           * distinguish it from menu triggered pause */
-         *runloop_paused_hotkey = !(runloop_st->flags & RUNLOOP_FLAG_PAUSED);
+         runloop_st->paused_hotkey = !(runloop_st->flags & RUNLOOP_FLAG_PAUSED);
          command_event(CMD_EVENT_PAUSE_TOGGLE, NULL);
       }
       else if (!old_focus)
@@ -5587,7 +5586,6 @@ static enum runloop_state_enum runloop_check_state(
    gfx_display_t            *p_disp    = disp_get_ptr();
    runloop_state_t *runloop_st         = &runloop_state;
    static bool old_focus               = true;
-   static bool runloop_paused_hotkey   = false;
    struct retro_callbacks *cbs         = &runloop_st->retro_ctx;
    bool is_focused                     = false;
    bool is_alive                       = false;
@@ -5669,10 +5667,10 @@ static enum runloop_state_enum runloop_check_state(
       {
          BIT256_CLEAR_ALL(current_bits);
          if (      runloop_paused
-               && !runloop_paused_hotkey
+               && !runloop_st->paused_hotkey
                &&  menu_pause_libretro)
             BIT256_SET(current_bits, RARCH_PAUSE_TOGGLE);
-         else if (runloop_paused_hotkey)
+         else if (runloop_st->paused_hotkey)
          {
             /* Restore pause if pause is triggered with both hotkey and menu,
              * and restore cached video frame to continue properly to
@@ -6518,7 +6516,7 @@ static enum runloop_state_enum runloop_check_state(
       bool pause_pressed            = BIT256_GET(current_bits, RARCH_PAUSE_TOGGLE);
 
       /* Decide pause hotkey */
-      runloop_pause_toggle(&runloop_paused_hotkey,
+      runloop_pause_toggle(
             pause_pressed, old_pause_pressed,
             focused, old_focus);
 
@@ -6595,7 +6593,7 @@ static enum runloop_state_enum runloop_check_state(
       }
 
       /* Decide pause hotkey */
-      runloop_pause_toggle(&runloop_paused_hotkey,
+      runloop_pause_toggle(
             pause_pressed, old_pause_pressed,
             focused, old_focus);
 

--- a/runloop.h
+++ b/runloop.h
@@ -300,6 +300,7 @@ struct runloop
    } name;
 
    bool perfcnt_enable;
+   bool paused_hotkey;
 };
 
 typedef struct runloop runloop_state_t;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Please see this forum [link](https://forums.libretro.com/t/pause-remains-active-after-content-has-been-closed/49348) for details. 

TLDR: This change blocks the `pause` action from taking effect when there is no active core. And forces an `unpause` action upon the closing of an active core. 

The intended result of which is a more consistent transition between game launches. Specifically when a custom `input_overlay` configuration has been defined which keys off of the pause action. For example:

```
overlays = 2
overlay0_overlay = "~/Library/Application Support/RetroArch/overlays/pause/empty.png"
overlay0_name = "pause"
overlay0_descs = 0

overlay1_overlay = "NES.png"
overlay1_rect = "0.0,0.0,1.0,1.0"
overlay1_full_screen = true
overlay1_descs = 1
overlay1_desc0 = "overlay_next,1,1,rect,1,1"
overlay1_desc0_next_target = "pause"
```

Prior to this change, toggling pause without a core being loaded could result in the pause action being 180° out of phase with the pause overlay being displayed.

PS - I apologize in advance if I am stepping on anyone's toes, or if this is the incorrect way to introduce such a change. I am a software engineer by trade, but it has probably been a decade or more since my last contribution to an open source project. And probably 2 decades since I last wrote anything in C... 🙃

## Related Issues

There is one additional manifestation of this issue. Specifically when 'hot swapping' between games via the quick menu, without first closing the open content. I was unable to determine how to properly resolve that without introducing unintended side effects. Suggestions are welcome.

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
