### PR TITLE
add check also "dispserv_null" for "current_display_server" in video_display_server_destroy()

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1177,7 +1177,7 @@ void video_display_server_destroy(void)
    if (initial_screen_orientation != current_screen_orientation)
       video_display_server_set_screen_orientation(initial_screen_orientation);
 
-   if (current_display_server)
+   if (current_display_server && (current_display_server != &dispserv_null))
       if (video_st->current_display_server_data)
          current_display_server->destroy(video_st->current_display_server_data);
 }


### PR DESCRIPTION
## Description
In Lakka RPi4.aarch64 using vulkan driver, retroarch takes Segmentation fault when 2nd times start cores after 1st time core is closed via retroarch menu.

In this case, retroarch video_display_server_destroy () calls current_display_server->destroy() function that is NULL pointer.
It needs to check not only "current_display_server( != NULL)" but also "current_display_server != &dispserv_null".
please refer https://github.com/libretro/Lakka-LibreELEC/issues/2154

gl driver is not occured this issue.

## Related Issues
https://github.com/libretro/Lakka-LibreELEC/issues/2154

## Related Pull Requests
Nothing now. I will create same modification patch to Lakka if it accepted, later.

## Reviewers
I asked @gouchi ( and @zoltanvb ) about this issue via discord lakka channel.

Note.
This is my 1st Pull request. if this have any problem, please let me know.

Thanks
ASAI, Shigeaki