### PR TITLE
webOS: add Wayland support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,14 @@ gfx/common/wayland/single-pixel-buffer-v1.h
 gfx/common/wayland/single-pixel-buffer-v1.c
 gfx/common/wayland/xdg-toplevel-icon-v1.h
 gfx/common/wayland/xdg-toplevel-icon-v1.c
+gfx/common/wayland/webos-foreign.c
+gfx/common/wayland/webos-foreign.h
+gfx/common/wayland/webos-input-manager.c
+gfx/common/wayland/webos-input-manager.h
+gfx/common/wayland/webos-shell.c
+gfx/common/wayland/webos-shell.h
+gfx/common/wayland/webos-surface-group.c
+gfx/common/wayland/webos-surface-group.h
 
 # libretro-common samples
 libretro-common/samples/streams/rzip/rzip

--- a/Makefile.common
+++ b/Makefile.common
@@ -1289,6 +1289,14 @@ ifeq ($(HAVE_WAYLAND), 1)
       OBJ += gfx/drivers_context/wayland_vk_ctx.o
    endif
 
+ifeq ($(WEBOS), 1)
+ OBJ += input/common/wayland_common_webos.o
+ OBJ += gfx/common/wayland/webos-foreign.o
+ OBJ += gfx/common/wayland/webos-input-manager.o
+ OBJ += gfx/common/wayland/webos-shell.o
+ OBJ += gfx/common/wayland/webos-surface-group.o
+endif
+
  DEF_FLAGS += $(WAYLAND_CFLAGS) $(WAYLAND_CURSOR_CFLAGS)
  LIBS += $(WAYLAND_LIBS) $(WAYLAND_CURSOR_LIBS)
 

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -26,6 +26,7 @@ SDL2_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/downloa
 APP_PACKAGE_NAME ?= com.retroarch.webos
 IPK_VERSION := $(shell grep '#define PACKAGE_VERSION' version.all | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
 
+WEBOS = 1
 DEBUG ?= 0
 
 HAVE_CLOUDSYNC = 1
@@ -60,7 +61,7 @@ HAVE_CXX = 1
 HAVE_DR_MP3 = 1
 HAVE_DYNAMIC = 1
 HAVE_DYLIB = 1
-HAVE_EGL = 0
+HAVE_EGL ?= 0
 HAVE_FREETYPE = 1
 HAVE_GDI = 0
 HAVE_GETADDRINFO = 1
@@ -76,6 +77,7 @@ HAVE_GLSLANG_SPIRV_TOOLS_OPT = 0
 HAVE_HID = 1
 HAVE_IBXM = 1
 HAVE_IMAGEVIEWER = 1
+HAVE_XKBCOMMON ?= 0
 HAVE_LANGEXTRA = 1
 HAVE_LIBRETRODB = 1
 HAVE_MENU = 1
@@ -94,9 +96,9 @@ HAVE_OPENGL = 0
 HAVE_OPENGL1 = 0
 HAVE_OPENGL_CORE = 0
 HAVE_OPENGLES = 1
-HAVE_OPENGLES3 = 0
-HAVE_OPENGLES3_1 = 0
-HAVE_OPENGLES3_2 = 0
+HAVE_OPENGLES3 ?= 0
+HAVE_OPENGLES3_1 ?= 0
+HAVE_OPENGLES3_2 ?= 0
 HAVE_OPENSSL = 0
 HAVE_OVERLAY = 1
 HAVE_PULSE = 1
@@ -129,7 +131,9 @@ HAVE_LIBSHAKE = 1
 HAVE_UPDATE_ASSETS = 1
 HAVE_UPDATE_CORES = 1
 HAVE_UPDATE_CORE_INFO = 1
+HAVE_USERLAND ?= 0
 HAVE_CORE_INFO_CACHE = 1
+HAVE_WAYLAND ?= 0
 
 OS = Linux
 TARGET = retroarch
@@ -147,6 +151,7 @@ else
   HAVE_NEON = 1
 endif
 CFLAGS := $(ARCHFLAGS)
+CFLAGS += -DWEBOS_APP_ID=\"$(APP_PACKAGE_NAME)\"
 CXXFLAGS := $(ARCHFLAGS) -fno-exceptions -fno-rtti -std=c++11 -D__STDC_CONSTANT_MACROS
 ASFLAGS := $(ARCHFLAGS)
 LDFLAGS := -Wl,-rpath=\$$ORIGIN/lib,--gc-sections
@@ -162,21 +167,35 @@ DEFINES += -DHAVE_NETWORKING -DHAVE_IFINFO -DHAVE_ONLINE_UPDATER -DHAVE_UPDATE_A
 DEFINES += -DHAVE_NETWORKGAMEPAD
 DEFINES += -DHAVE_FREETYPE
 DEFINES += -DHAVE_UPDATE_CORE_INFO
+EGL_LIBS = -lEGL
+OPENGLES_LIBS = -lGLESv2
+XKBCOMMON_LIBS = -lxkbcommon
+WAYLAND_PROTO_SCRIPT := ./gfx/common/wayland/generate_wayland_protos.sh
+ifeq ($(HAVE_XKBCOMMON), 1)
+  DEFINES += -DHAVE_XKBCOMMON=1
+endif
 ifneq (,$(filter 1,$(HAVE_OPENGLES3) $(HAVE_OPENGLES3_1) $(HAVE_OPENGLES3_2)))
   DEFINES += -DHAVE_OPENGLES3
 endif
 ifeq ($(HAVE_OPENGLES3_1),1)
-DEFINES += -DHAVE_OPENGLES3_1
+  DEFINES += -DHAVE_OPENGLES3_1
 endif
 ifeq ($(HAVE_OPENGLES3_2),1)
-DEFINES += -DHAVE_OPENGLES3_2
+  DEFINES += -DHAVE_OPENGLES3_2
+endif
+ifeq ($(HAVE_WAYLAND),1)
+  DEFINES += -DHAVE_WAYLAND=1
+  WAYLAND_LIBS = -lwayland-client -lwayland-cursor -lwayland-egl
+endif
+ifeq ($(HAVE_USERLAND),1)
+  DEFINES += -DHAVE_USERLAND
+  WAYLAND_LIBS += -lhelpers
 endif
 
 PKG_CONFIG=pkg-config
 
 SDL2_CFLAGS := $(shell $(PKG_CONFIG) --cflags sdl2)
 SDL2_LIBS := $(shell $(PKG_CONFIG) --libs sdl2)
-OPENGLES_LIBS = -lGLESv2
 PULSE_LIBS = $(shell $(PKG_CONFIG) --libs libpulse)
 FREETYPE_CFLAGS := $(shell $(PKG_CONFIG) --cflags freetype2)
 FREETYPE_LIBS := $(shell $(PKG_CONFIG) --libs freetype2)
@@ -260,6 +279,12 @@ endif
 
 SYMBOL_MAP := -Wl,-Map=output.map
 
+prebuild:
+ifeq ($(HAVE_WAYLAND),1)
+	@echo "Generating Wayland protocols..."
+	@$(SHELL) $(WAYLAND_PROTO_SCRIPT)
+endif
+
 $(TARGET): $(RARCH_OBJ)
 	@$(if $(Q), $(shell echo echo LD $@),)
 	$(Q)$(LINK) -o $@ $(RARCH_OBJ) $(LIBS) $(LDFLAGS) $(LIBRARY_DIRS)
@@ -300,7 +325,7 @@ ifeq ($(ADD_SDL2_LIB), 1)
 	wget -qO - $(SDL2_PREBUILT_ARCHIVE) | tar -C SDL -zxvf -
 endif
 
-ipk: $(TARGET) sdl2
+ipk: prebuild $(TARGET) sdl2
 	rm -rf webos/dist
 	mkdir -p webos/dist/lib
 	echo "$$APPINFO" > webos/dist/appinfo.json
@@ -321,7 +346,7 @@ install: ipk
 launch: install
 	ares-launch $(APP_PACKAGE_NAME)
 
-.PHONY: all clean ipk
+.PHONY: all clean prebuild ipk
 
 print-%:
 	@echo '$*=$($*)'

--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -31,6 +31,14 @@ while [ $# -gt 0 ]; do
 done
 
 WAYSCAN="$(exists wayland-scanner || :)"
+
+if [ -n "${CROSS_COMPILE:-}" ] && echo "${CROSS_COMPILE:-}" | grep -q "webos"; then
+   if [ -z "${SDK_PATH:-}" ]; then
+      die 1 "Error: WEBOS=1 but SDK_PATH not set"
+   fi
+   WAYSCAN="$SDK_PATH/bin/wayland-scanner"
+fi
+
 PKGCONFIG="$(exists pkg-config || :)"
 
 [ "${WAYSCAN}" ] || die 1 "Error: No wayscan in ($PATH)"
@@ -38,7 +46,7 @@ PKGCONFIG="$(exists pkg-config || :)"
 WAYLAND_PROTOS=''
 
 if [ "$PROTOS" != 'no' -a "$PKGCONFIG" ]; then
-   WAYLAND_PROTOS="$($PKGCONFIG wayland-protocols --variable=pkgdatadir)"
+   WAYLAND_PROTOS="$($PKGCONFIG wayland-protocols --variable=pkgdatadir 2>/dev/null || true)"
 fi
 
 if [ -z "${WAYLAND_PROTOS}" ]; then
@@ -74,3 +82,15 @@ generate_source 'unstable/tablet' 'tablet-unstable-v2'
 generate_source 'staging/content-type' 'content-type-v1'
 generate_source 'staging/single-pixel-buffer' 'single-pixel-buffer-v1'
 generate_source 'staging/xdg-toplevel-icon' 'xdg-toplevel-icon-v1'
+
+if [ -n "${CROSS_COMPILE:-}" ] && echo "${CROSS_COMPILE:-}" | grep -q "webos"; then
+   if [ -z "${SDK_PATH:-}" ]; then
+      die 1 "Error: WEBOS=1 but SDK_PATH not set"
+   fi
+   WAYLAND_PROTOS="$SDK_PATH/arm-webos-linux-gnueabi/sysroot/usr/share"
+
+   generate_source 'wayland-webos' 'webos-shell'
+   generate_source 'wayland-webos' 'webos-foreign'
+   generate_source 'wayland-webos' 'webos-surface-group'
+   generate_source 'wayland-webos' 'webos-input-manager'
+fi

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -46,6 +46,26 @@
 #define EGL_PLATFORM_WAYLAND_KHR 0x31D8
 #endif
 
+#ifdef WEBOS
+extern void gfx_ctx_wl_get_video_size_webos(void*, unsigned*, unsigned*);
+extern void gfx_ctx_wl_destroy_resources_webos(gfx_ctx_wayland_data_t*);
+extern void gfx_ctx_wl_update_title_webos(void*);
+extern bool gfx_ctx_wl_init_webos(const toplevel_listener_t*, gfx_ctx_wayland_data_t**);
+extern bool gfx_ctx_wl_set_video_mode_common_size_webos(gfx_ctx_wayland_data_t*, unsigned, unsigned, bool);
+extern bool gfx_ctx_wl_set_video_mode_common_fullscreen_webos(gfx_ctx_wayland_data_t*, bool);
+extern bool gfx_ctx_wl_suppress_screensaver_webos(void*, bool);
+extern void gfx_ctx_wl_check_window_webos(gfx_ctx_wayland_data_t*, void (*)(void*, unsigned*, unsigned*), bool*, bool*, unsigned*, unsigned*);
+
+#define gfx_ctx_wl_get_video_size_common gfx_ctx_wl_get_video_size_webos
+#define gfx_ctx_wl_destroy_resources_common gfx_ctx_wl_destroy_resources_webos
+#define gfx_ctx_wl_update_title_common gfx_ctx_wl_update_title_webos
+#define gfx_ctx_wl_init_common gfx_ctx_wl_init_webos
+#define gfx_ctx_wl_set_video_mode_common_size gfx_ctx_wl_set_video_mode_common_size_webos
+#define gfx_ctx_wl_set_video_mode_common_fullscreen gfx_ctx_wl_set_video_mode_common_fullscreen_webos
+#define gfx_ctx_wl_suppress_screensaver gfx_ctx_wl_suppress_screensaver_webos
+#define gfx_ctx_wl_check_window_common gfx_ctx_wl_check_window_webos
+#endif
+
 static enum gfx_ctx_api wl_api   = GFX_CTX_NONE;
 
 /* Shell surface callbacks. */

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -1120,7 +1120,11 @@ const struct wl_keyboard_listener keyboard_listener = {
    wl_keyboard_handle_keymap,
    wl_keyboard_handle_enter,
    wl_keyboard_handle_leave,
+#ifdef WEBOS
+   wl_keyboard_handle_key_webos,
+#else
    wl_keyboard_handle_key,
+#endif
    wl_keyboard_handle_modifiers,
    wl_keyboard_handle_repeat_info
 };

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -46,6 +46,10 @@
 #include "../../gfx/common/wayland/xdg-shell.h"
 #include "../../gfx/common/wayland/xdg-toplevel-icon-v1.h"
 
+#ifdef WEBOS
+#include "wayland_common_webos.h"
+#endif
+
 #define FRACTIONAL_SCALE_V1_DEN 120
 #define FRACTIONAL_SCALE_MULT(v, scale_num) \
    (((v) * (scale_num) + FRACTIONAL_SCALE_V1_DEN / 2) / FRACTIONAL_SCALE_V1_DEN)
@@ -171,6 +175,15 @@ typedef struct gfx_ctx_wayland_data
    struct wl_shm *shm;
    struct wl_data_device_manager *data_device_manager;
    struct wl_data_device *data_device;
+#ifdef WEBOS
+   struct wl_shell *shell;
+   struct wl_shell_surface *shell_surface;
+   struct wl_webos_shell *webos_shell;
+   struct wl_webos_shell_surface *webos_shell_surface;
+   struct wl_webos_foreign *webos_foreign;
+   struct wl_webos_surface_group_compositor *webos_surface_group_compositor;
+   struct wl_webos_input_manager *webos_input_manager;
+#endif
    data_offer_ctx *current_drag_offer;
 #ifdef HAVE_LIBDECOR_H
    struct libdecor *libdecor_context;
@@ -201,6 +214,9 @@ typedef struct gfx_ctx_wayland_data
    struct wl_list all_outputs;
    struct wl_list current_outputs;
 
+#ifdef WEBOS
+   struct wl_list all_seats;
+#endif
    struct
    {
       struct wl_cursor *default_cursor;
@@ -225,7 +241,9 @@ typedef struct gfx_ctx_wayland_data
    unsigned last_fractional_scale_num;
    unsigned pending_fractional_scale_num;
    unsigned fractional_scale_num;
-
+#ifdef WEBOS
+   uint32_t webos_surface_state;
+#endif
    bool core_hw_context_enable;
    bool fullscreen;
    bool maximized;
@@ -279,5 +297,10 @@ extern const struct wl_buffer_listener shm_buffer_listener;
 extern const struct wl_data_device_listener data_device_listener;
 
 extern const struct wl_data_offer_listener data_offer_listener;
+
+#ifdef WEBOS
+extern void wl_keyboard_handle_key_webos(void *data, struct wl_keyboard *keyboard, uint32_t serial,
+   uint32_t time, uint32_t key, uint32_t state);
+#endif
 
 #endif

--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -1,0 +1,863 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2011-2024 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <poll.h>
+#include <unistd.h>
+#include <string/stdstring.h>
+
+#include "wayland_common.h"
+#include "wayland_common_webos.h"
+#include "config.def.h"
+#include "../../frontend/frontend_driver.h"
+#include "../../gfx/common/wayland_common.h"
+#include "../../gfx/video_driver.h"
+#include "../../verbosity.h"
+#include "../input_keymaps.h"
+
+#include "../../gfx/common/wayland/webos-shell.h"
+#include "../../gfx/common/wayland/webos-foreign.h"
+#include "../../gfx/common/wayland/webos-surface-group.h"
+#include "../../gfx/common/wayland/webos-input-manager.h"
+
+#ifdef HAVE_USERLAND
+#include <webos-helpers/libhelpers.h>
+#include "formats/rjson.h"
+HContext *g_register_ctx = NULL;
+HContext *g_screensaver_ctx = NULL;
+#endif
+
+uint8_t webos_wl_special_keymap[webos_wl_key_size] = {0};
+
+typedef struct seat_info
+{
+   struct wl_seat *seat;
+   uint32_t global_id;
+   struct wl_keyboard *wl_keyboard;
+   struct wl_pointer *wl_pointer;
+   struct wl_touch *wl_touch;
+   struct wp_cursor_shape_device_v1 *cursor_shape_device;
+   struct zwp_relative_pointer_v1 *relative_pointer;
+   struct wl_data_device *data_device;
+   struct wl_list link;
+   gfx_ctx_wayland_data_t *wl;
+} seat_info_t;
+
+const char *get_app_id()
+{
+   const char *appId = getenv("APPID");
+   if (!appId || !*appId || strcmp(appId, "com.palm.devmode.openssh") == 0)
+       appId = WEBOS_APP_ID;
+
+   return appId;
+}
+
+bool LunaRequest(const char *uri,
+   const char *payload,
+   void *context)
+{
+#ifdef HAVE_USERLAND
+   int ret = HLunaServiceCall(uri, payload, context);
+   if (ret != 0)
+   {
+      RARCH_LOG("LunaRequest: call to %s failed (code %d)\n", uri, ret);
+      return false;
+   }
+#endif
+   return true;
+}
+
+#ifdef HAVE_USERLAND
+static bool registerAppCallback(LSHandle* sh, LSMessage* msg, void* context)
+{
+   RARCH_DBG("[LunaRequest] registerAppCallback returned.\n");
+   return true;
+}
+
+void RegisterApp()
+{
+   g_register_ctx = (HContext*)malloc(sizeof(HContext));
+   if (!g_register_ctx)
+      return;
+   memset(g_register_ctx, 0, sizeof(HContext));
+
+   g_register_ctx->pub = true;
+   g_register_ctx->multiple = true;
+   g_register_ctx->callback = &registerAppCallback;
+   g_register_ctx->userdata = NULL;
+
+   LunaRequest("luna://com.webos.service.applicationmanager/registerApp",
+      "{}", g_register_ctx);
+}
+#endif
+
+static void webos_shell_surface_handle_state_changed(void *data,
+      struct wl_webos_shell_surface *webos_shell_surface,
+      uint32_t state)
+{
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   
+   wl->webos_surface_state = state;
+   
+   switch (state)
+   {
+      case WL_WEBOS_SHELL_SURFACE_STATE_FULLSCREEN:
+         wl->fullscreen = true;
+         wl->maximized = false;
+         break;
+      case WL_WEBOS_SHELL_SURFACE_STATE_MAXIMIZED:
+         wl->fullscreen = false;
+         wl->maximized = true;
+         break;
+      case WL_WEBOS_SHELL_SURFACE_STATE_MINIMIZED:
+         wl->fullscreen = false;
+         wl->maximized = false;
+         break;
+      case WL_WEBOS_SHELL_SURFACE_STATE_DEFAULT:
+      default:
+         wl->fullscreen = false;
+         wl->maximized = false;
+         break;
+   }
+}
+
+static void webos_shell_surface_handle_position_changed(void *data,
+      struct wl_webos_shell_surface *webos_shell_surface,
+      int32_t x, int32_t y)
+{
+}
+
+static void webos_shell_surface_handle_close(void *data,
+      struct wl_webos_shell_surface *webos_shell_surface)
+{
+   frontend_driver_set_signal_handler_state(1);
+}
+
+static void webos_shell_surface_handle_exposed(void *data,
+      struct wl_webos_shell_surface *webos_shell_surface,
+      struct wl_array *rectangles)
+{
+}
+
+static void webos_shell_surface_handle_state_about_to_change(void *data,
+      struct wl_webos_shell_surface *webos_shell_surface,
+      uint32_t state)
+{
+}
+
+static void wl_seat_handle_name_webos(void *data,
+   struct wl_seat *seat,
+   const char *name)
+{
+}
+
+const struct wl_webos_shell_surface_listener webos_shell_surface_listener = {
+   .state_changed = webos_shell_surface_handle_state_changed,
+   .position_changed = webos_shell_surface_handle_position_changed,
+   .close = webos_shell_surface_handle_close,
+   .exposed = webos_shell_surface_handle_exposed,
+   .state_about_to_change = webos_shell_surface_handle_state_about_to_change,
+};
+
+static void wl_seat_handle_capabilities_webos(void *data,
+   struct wl_seat *seat, unsigned caps)
+{
+   seat_info_t *si = (seat_info_t*)data;
+
+   if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !si->wl_keyboard)
+   {
+      si->wl_keyboard = wl_seat_get_keyboard(seat);
+      wl_keyboard_add_listener(si->wl_keyboard, &keyboard_listener, si->wl);
+   }
+   else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && si->wl_keyboard)
+   {
+      wl_keyboard_destroy(si->wl_keyboard);
+      si->wl_keyboard = NULL;
+   }
+   if ((caps & WL_SEAT_CAPABILITY_POINTER) && !si->wl_pointer)
+   {
+      si->wl_pointer = wl_seat_get_pointer(seat);
+      wl_pointer_add_listener(si->wl_pointer, &pointer_listener, si->wl);
+   }
+   else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && si->wl_pointer)
+   {
+      wl_pointer_destroy(si->wl_pointer);
+      si->wl_pointer = NULL;
+   }
+}
+
+const struct wl_seat_listener webos_seat_listener = {
+   wl_seat_handle_capabilities_webos,
+   wl_seat_handle_name_webos,
+};
+
+static void wl_registry_handle_global_webos(void *data,
+      struct wl_registry *reg,
+      uint32_t id,
+      const char *interface,
+      uint32_t version)
+{
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+
+   RARCH_DBG("[Wayland/webOS] Registry: %s (id=%u, version=%u)\n",
+             interface, id, version);
+
+   if (string_is_equal(interface, "wl_compositor"))
+      wl->compositor = (struct wl_compositor*)wl_registry_bind(reg,
+            id, &wl_compositor_interface, MIN(version, 3));
+   else if (string_is_equal(interface, "wl_output"))
+   {
+      display_output_t *od   = (display_output_t*)calloc(1, sizeof(*od));
+      output_info_t *oi      = (output_info_t*)calloc(1, sizeof(*oi));
+      od->output             = oi;
+      oi->output             = (struct wl_output*)wl_registry_bind(reg,
+         id, &wl_output_interface, MIN(version, 2));
+      oi->global_id          = id;
+      oi->scale              = 1;
+      wl_output_add_listener(oi->output, &output_listener, oi);
+      wl_list_insert(&wl->all_outputs, &od->link);
+   }
+   else if (string_is_equal(interface, "wl_seat"))
+   {
+      seat_info_t *si = calloc(1, sizeof(*si));
+      si->seat = (struct wl_seat*)wl_registry_bind(reg, id, &wl_seat_interface, MIN(version, 4));
+      si->global_id = id;
+      si->wl = wl;
+      wl_seat_add_listener(si->seat, &webos_seat_listener, si);
+      wl_list_insert(&wl->all_seats, &si->link);
+   }
+   else if (string_is_equal(interface, "wl_shm"))
+      wl->shm = (struct wl_shm*)wl_registry_bind(reg,
+         id, &wl_shm_interface, 1);
+   else if (string_is_equal(interface, "wl_data_device_manager"))
+      wl->data_device_manager = (struct wl_data_device_manager*)wl_registry_bind(reg,
+         id, &wl_data_device_manager_interface, MIN(version, 1));
+   else if (string_is_equal(interface, "wl_shell"))
+   {
+      wl->shell = (struct wl_shell*)wl_registry_bind(reg,
+         id, &wl_shell_interface, 1);
+   }
+   else if (string_is_equal(interface, "wl_webos_shell"))
+   {
+      wl->webos_shell = (struct wl_webos_shell*)wl_registry_bind(reg,
+         id, &wl_webos_shell_interface, 1);
+   }
+   else if (string_is_equal(interface, "wl_webos_foreign"))
+   {
+      wl->webos_foreign = (struct wl_webos_foreign*)wl_registry_bind(reg,
+         id, &wl_webos_foreign_interface, MIN(version, 1));
+   }
+   else if (string_is_equal(interface, "wl_webos_surface_group_compositor"))
+   {
+      wl->webos_surface_group_compositor = 
+         (struct wl_webos_surface_group_compositor*)wl_registry_bind(reg,
+         id, &wl_webos_surface_group_compositor_interface, 1);
+   }
+   else if (string_is_equal(interface, "wl_webos_input_manager"))
+   {
+      wl->webos_input_manager = (struct wl_webos_input_manager*)wl_registry_bind(reg,
+         id, &wl_webos_input_manager_interface, 1);
+   }
+}
+
+static void wl_registry_handle_global_remove_webos(void *data,
+      struct wl_registry *registry,
+      uint32_t id)
+{
+   display_output_t *od, *tmp;
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+
+   wl_list_for_each_safe(od, tmp, &wl->all_outputs, link)
+   {
+      output_info_t *oi = od->output;
+      if (oi->global_id == id)
+      {
+         wl_output_destroy(oi->output);
+         wl_list_remove(&od->link);
+         free(oi->make);
+         free(oi->model);
+         free(oi);
+         free(od);
+         break;
+      }
+   }
+
+   seat_info_t *si, *tmp_seat;
+   wl_list_for_each_safe(si, tmp_seat, &wl->all_seats, link)
+   {
+      if (si->global_id == id)
+      {
+         if (si->wl_keyboard) wl_keyboard_destroy(si->wl_keyboard);
+         if (si->wl_pointer) wl_pointer_destroy(si->wl_pointer);
+         if (si->wl_touch) wl_touch_destroy(si->wl_touch);
+         if (si->relative_pointer) zwp_relative_pointer_v1_destroy(si->relative_pointer);
+         if (si->cursor_shape_device) wp_cursor_shape_device_v1_destroy(si->cursor_shape_device);
+         if (si->data_device) wl_data_device_destroy(si->data_device);
+         wl_seat_destroy(si->seat);
+         wl_list_remove(&si->link);
+         free(si);
+      }
+   }
+}
+
+const struct wl_registry_listener registry_listener_webos = {
+   .global = wl_registry_handle_global_webos,
+   .global_remove = wl_registry_handle_global_remove_webos,
+};
+
+void gfx_ctx_wl_get_video_size_webos(void *data,
+      unsigned *width, unsigned *height)
+{
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   if (!wl)
+      return;
+      
+   if (!wl->reported_display_size)
+   {
+      display_output_t *od;
+      output_info_t *oi = wl->current_output;
+
+      wl->reported_display_size = true;
+
+      if (!oi)
+         wl_list_for_each(od, &wl->all_outputs, link)
+         {
+            oi = od->output;
+            break;
+         }
+
+      if (oi)
+      {
+         *width  = oi->width;
+         *height = oi->height;
+      }
+      else
+      {
+         *width  = DEFAULT_WINDOW_WIDTH;
+         *height = DEFAULT_WINDOW_HEIGHT;
+      }
+   }
+   else
+   {
+      *width  = wl->width  * wl->buffer_scale;
+      *height = wl->height * wl->buffer_scale;
+   }
+}
+
+void gfx_ctx_wl_destroy_resources_webos(gfx_ctx_wayland_data_t *wl)
+{
+#ifdef HAVE_XKBCOMMON
+   free_xkb();
+#endif
+
+   if (wl->wl_keyboard)
+      wl_keyboard_destroy(wl->wl_keyboard);
+   if (wl->wl_pointer)
+      wl_pointer_destroy(wl->wl_pointer);
+   if (wl->wl_touch)
+      wl_touch_destroy(wl->wl_touch);
+
+   if (wl->cursor.theme)
+      wl_cursor_theme_destroy(wl->cursor.theme);
+   if (wl->cursor.surface)
+      wl_surface_destroy(wl->cursor.surface);
+
+   if (wl->webos_shell_surface)
+      wl_webos_shell_surface_destroy(wl->webos_shell_surface);
+   if (wl->surface)
+      wl_surface_destroy(wl->surface);
+
+   if (wl->webos_input_manager)
+      wl_webos_input_manager_destroy(wl->webos_input_manager);
+   if (wl->webos_surface_group_compositor)
+      wl_webos_surface_group_compositor_destroy(wl->webos_surface_group_compositor);
+   if (wl->webos_foreign)
+      wl_webos_foreign_destroy(wl->webos_foreign);
+   if (wl->seat)
+      wl_seat_destroy(wl->seat);
+   if (wl->webos_shell)
+      wl_webos_shell_destroy(wl->webos_shell);
+   if (wl->data_device_manager)
+      wl_data_device_manager_destroy(wl->data_device_manager);
+
+   while (!wl_list_empty(&wl->current_outputs))
+   {
+      surface_output_t *os = wl_container_of(wl->current_outputs.next, os, link);
+      wl_list_remove(&os->link);
+      free(os);
+   }
+   while (!wl_list_empty(&wl->all_outputs))
+   {
+      display_output_t *od = wl_container_of(wl->all_outputs.next, od, link);
+      output_info_t *oi    = od->output;
+      wl_output_destroy(oi->output);
+      wl_list_remove(&od->link);
+      free(oi->make);
+      free(oi->model);
+      free(oi);
+      free(od);
+   }
+   while (!wl_list_empty(&wl->all_seats))
+   {
+      seat_info_t *si = wl_container_of(wl->all_seats.next, si, link);
+      if (si->wl_keyboard) wl_keyboard_destroy(si->wl_keyboard);
+      if (si->wl_pointer) wl_pointer_destroy(si->wl_pointer);
+      if (si->wl_touch) wl_touch_destroy(si->wl_touch);
+      if (si->relative_pointer) zwp_relative_pointer_v1_destroy(si->relative_pointer);
+      if (si->cursor_shape_device) wp_cursor_shape_device_v1_destroy(si->cursor_shape_device);
+      if (si->data_device) wl_data_device_destroy(si->data_device);
+      wl_seat_destroy(si->seat);
+      wl_list_remove(&si->link);
+      free(si);
+   }
+
+   if (wl->shm)
+      wl_shm_destroy(wl->shm);
+   if (wl->compositor)
+      wl_compositor_destroy(wl->compositor);
+   if (wl->registry)
+      wl_registry_destroy(wl->registry);
+
+   if (wl->input.dpy)
+   {
+      wl_display_flush(wl->input.dpy);
+      wl_display_disconnect(wl->input.dpy);
+   }
+
+   wl->input.dpy                = NULL;
+   wl->registry                 = NULL;
+   wl->compositor               = NULL;
+   wl->shm                      = NULL;
+   wl->webos_shell              = NULL;
+   wl->seat                     = NULL;
+   wl->surface                  = NULL;
+   wl->webos_shell_surface      = NULL;
+   wl->wl_touch                 = NULL;
+   wl->wl_pointer               = NULL;
+   wl->wl_keyboard              = NULL;
+
+   wl->width         = 0;
+   wl->height        = 0;
+   wl->buffer_width  = 0;
+   wl->buffer_height = 0;
+}
+
+void gfx_ctx_wl_update_title_webos(void *data)
+{
+   char title[128];
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+
+   title[0] = '\0';
+   video_driver_get_window_title(title, sizeof(title));
+
+   if (wl && wl->webos_shell_surface && title[0])
+   {
+      wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+            "title", title);
+      wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+            "appId", get_app_id());
+   }
+}
+
+bool gfx_ctx_wl_init_webos(
+      const toplevel_listener_t *toplevel_listener, gfx_ctx_wayland_data_t **wwl)
+{
+   int i;
+   gfx_ctx_wayland_data_t *wl;
+
+   *wwl = calloc(1, sizeof(gfx_ctx_wayland_data_t));
+   wl = *wwl;
+
+   if (!wl)
+      return false;
+
+#ifdef HAVE_USERLAND
+   RegisterApp();
+#endif
+
+   wl_list_init(&wl->all_outputs);
+   wl_list_init(&wl->current_outputs);
+   wl_list_init(&wl->all_seats);
+
+   frontend_driver_destroy_signal_handler_state();
+
+   wl->input.dpy       = wl_display_connect(NULL);
+   wl->buffer_scale    = 1;
+   wl->floating_width  = DEFAULT_WINDOW_WIDTH;
+   wl->floating_height = DEFAULT_WINDOW_HEIGHT;
+
+   if (!wl->input.dpy)
+   {
+      RARCH_ERR("[Wayland/webOS] Failed to connect to Wayland server.\n");
+      return false;
+   }
+
+   frontend_driver_install_signal_handler();
+
+   wl->registry = wl_display_get_registry(wl->input.dpy);
+   wl_registry_add_listener(wl->registry, &registry_listener_webos, wl);
+   /* first roundtrip to bind compositor globals */
+   wl_display_dispatch(wl->input.dpy);
+   /* second roundtrip for listeners on bound globals (wl_output, wl_seat) */
+   wl_display_roundtrip(wl->input.dpy);
+
+   if (!wl->compositor)
+   {
+      RARCH_ERR("[wayland/webOS] Failed to bind compositor.\n");
+      return false;
+   }
+
+   if (!wl->shm)
+   {
+      RARCH_ERR("[wayland/webOS] Failed to bind shm.\n");
+      return false;
+   }
+
+   if (!wl->shell)
+   {
+      RARCH_ERR("[wayland/webOS] Failed to bind shell.\n");
+      return false;
+   }
+
+   if (!wl->webos_shell)
+   {
+      RARCH_ERR("[wayland/webOS] Failed to bind webOS shell.\n");
+      return false;
+   }
+
+   wl->surface = wl_compositor_create_surface(wl->compositor);
+
+   wl->shell_surface = wl_shell_get_shell_surface(wl->shell, wl->surface);
+
+   if (wl->shell_surface == NULL)
+   {
+      RARCH_LOG("[wayland/webOS] Can't create shell surface");
+   }
+
+   wl_shell_surface_set_toplevel(wl->shell_surface);
+
+   wl->webos_shell_surface = wl_webos_shell_get_shell_surface(
+      wl->webos_shell, wl->surface);
+
+   if (wl->webos_shell_surface == NULL)
+   {
+      RARCH_LOG("[wayland/webOS] Can't create webos shell surface");
+   }
+
+   wl_webos_shell_surface_add_listener(wl->webos_shell_surface,
+      &webos_shell_surface_listener, wl);
+
+   const char *appId = get_app_id();
+
+   const char *displayId = getenv("DISPLAY_ID");
+   if (!displayId || !*displayId)
+      displayId = "0";
+
+   wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+      "appId", appId);
+   wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+      "title", "RetroArch");
+   wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+      "displayAffinity", displayId);
+
+   wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+      "_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
+
+   // Allow long press of the remote back button
+   wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+      "_WEBOS_ACCESS_POLICY_KEYS_EXIT", "true");
+
+   wl_webos_shell_surface_set_property(wl->webos_shell_surface,
+      "_WEBOS_CURSOR_SLEEP_TIME", "5000");
+
+   wl_surface_commit(wl->surface);
+
+   wl_display_dispatch(wl->input.dpy);
+   wl->configured = true;
+
+   wl_display_roundtrip(wl->input.dpy);
+
+   wl->input.fd = wl_display_get_fd(wl->input.dpy);
+
+   wl->input.keyboard_focus = true;
+   wl->input.mouse.focus    = true;
+
+   wl->cursor.surface        = wl_compositor_create_surface(wl->compositor);
+   wl->cursor.theme          = wl_cursor_theme_load(NULL, 16, wl->shm);
+
+   if (wl->cursor.theme)
+      wl->cursor.default_cursor = wl_cursor_theme_get_cursor(wl->cursor.theme, "left_ptr");
+
+   wl->num_active_touches = 0;
+
+   for (i = 0; i < MAX_TOUCHES; i++)
+   {
+      wl->active_touch_positions[i].active = false;
+      wl->active_touch_positions[i].id     = -1;
+      wl->active_touch_positions[i].x      = 0;
+      wl->active_touch_positions[i].y      = 0;
+   }
+
+   flush_wayland_fd(&wl->input);
+
+   return true;
+}
+
+bool gfx_ctx_wl_set_video_mode_common_size_webos(gfx_ctx_wayland_data_t *wl,
+      unsigned width, unsigned height, bool fullscreen)
+{
+   if (!wl)
+      return false;
+
+   wl->width         = width  ? width  : DEFAULT_WINDOW_WIDTH;
+   wl->height        = height ? height : DEFAULT_WINDOW_HEIGHT;
+   wl->buffer_width  = wl->width;
+   wl->buffer_height = wl->height;
+
+   return true;
+}
+
+bool gfx_ctx_wl_set_video_mode_common_fullscreen_webos(gfx_ctx_wayland_data_t *wl,
+      bool fullscreen)
+{
+   if (!wl)
+      return false;
+
+   if (fullscreen)
+   {
+      wl_webos_shell_surface_set_state(wl->webos_shell_surface,
+            WL_WEBOS_SHELL_SURFACE_STATE_FULLSCREEN);
+      wl->fullscreen = true;
+      wl->cursor.visible = false;
+      gfx_ctx_wl_show_mouse(wl, false);
+   }
+   else
+   {
+      wl_webos_shell_surface_set_state(wl->webos_shell_surface,
+            WL_WEBOS_SHELL_SURFACE_STATE_DEFAULT);
+      wl->fullscreen = false;
+      wl->cursor.visible = true;
+   }
+
+   wl_surface_commit(wl->surface);
+   flush_wayland_fd(&wl->input);
+
+   return true;
+}
+
+#ifdef HAVE_USERLAND
+static bool screenSaverCallback(LSHandle* sh, LSMessage* reply, void* context)
+{
+   const char *msg = HLunaServiceMessage(reply);
+   size_t len = msg ? strlen(msg) : 0;
+   char state[32] = {0};
+   char timestamp[64] = {0};
+   const char *clientName = (context && ((HContext*)context)->userdata)
+                            ? (const char *)((HContext*)context)->userdata
+                            : "";
+
+   RARCH_DBG("[LunaRequest] screenSaverCallback: %s\n", msg ? msg : "(null)");
+   if (!msg || !len)
+      return true;
+
+   rjson_t *json = rjson_open_string(msg, len);
+   enum rjson_type t;
+   const char *key = NULL, *val = NULL;
+   while ((t = rjson_next(json)) != RJSON_DONE && t != RJSON_ERROR)
+   {
+      if (t == RJSON_STRING)
+      {
+         key = rjson_get_string(json, NULL);
+         t = rjson_next(json);
+         if (t == RJSON_STRING || t == RJSON_NUMBER)
+         {
+            val = rjson_get_string(json, NULL);
+            if (strcmp(key, "state") == 0)
+               strlcpy(state, val, sizeof(state));
+            else if (strcmp(key, "timestamp") == 0)
+               strlcpy(timestamp, val, sizeof(timestamp));
+         }
+      }
+   }
+   rjson_free(json);
+
+   if (strcmp(state, "Active") != 0)
+      return true;
+
+   rjsonwriter_t *w = rjsonwriter_open_memory();
+   rjsonwriter_raw(w, "{", 1);
+   rjsonwriter_add_string(w, "clientName");
+   rjsonwriter_raw(w, ":", 1);
+   rjsonwriter_add_string(w, clientName);
+   rjsonwriter_raw(w, ",", 1);
+   rjsonwriter_add_string(w, "ack");
+   rjsonwriter_raw(w, ":", 1);
+   rjsonwriter_rawf(w, "%s", "false");
+   rjsonwriter_raw(w, ",", 1);
+   rjsonwriter_add_string(w, "timestamp");
+   rjsonwriter_raw(w, ":", 1);
+   rjsonwriter_add_string(w, timestamp);
+   rjsonwriter_raw(w, "}", 1);
+
+   char *resp = rjsonwriter_get_memory_buffer(w, NULL);
+   RARCH_DBG("[LunaRequest] responseScreenSaverRequest payload: %s\n", resp);
+
+   HContext response_ctx;
+   memset(&response_ctx, 0, sizeof(response_ctx));
+   response_ctx.multiple = false;
+   response_ctx.pub = true;
+   response_ctx.callback = NULL;
+
+   HLunaServiceCall("luna://com.webos.service.tvpower/power/responseScreenSaverRequest",
+                    resp, &response_ctx);
+
+   rjsonwriter_free(w);
+   return true;
+}
+#endif
+
+bool gfx_ctx_wl_suppress_screensaver_webos(void *data, bool state)
+{
+#ifdef HAVE_USERLAND
+   const char *appId = get_app_id();
+   if (!g_screensaver_ctx)
+      g_screensaver_ctx = (HContext*)malloc(sizeof(HContext));
+   if (!g_screensaver_ctx)
+      return false;
+   memset(g_screensaver_ctx, 0, sizeof(HContext));
+   g_screensaver_ctx->pub = 1;
+   g_screensaver_ctx->multiple = 1;
+   g_screensaver_ctx->callback = &screenSaverCallback;
+
+   if (!g_screensaver_ctx->userdata) {
+      char *client_name = (char*)malloc(64);
+      if (!client_name)
+         return false;
+      snprintf(client_name, 64, "%s", appId);
+      g_screensaver_ctx->userdata = client_name;
+   }
+
+   char payload[256];
+   snprintf(payload, sizeof(payload),
+            "{\"clientName\":\"%s\",\"subscribe\":true}",
+            (const char *)g_screensaver_ctx->userdata);
+
+   return LunaRequest(
+      "luna://com.webos.service.tvpower/power/registerScreenSaverRequest",
+      payload,
+      g_screensaver_ctx);
+#else
+   return false;
+#endif
+}
+
+void gfx_ctx_wl_check_window_webos(gfx_ctx_wayland_data_t *wl,
+      void (*get_video_size)(void*, unsigned*, unsigned*),
+      bool *quit, bool *resize, unsigned *width, unsigned *height)
+{
+   unsigned new_width, new_height;
+
+   flush_wayland_fd(&wl->input);
+
+   get_video_size(wl, &new_width, &new_height);
+
+   if (new_width != *width || new_height != *height)
+   {
+      *width  = new_width;
+      *height = new_height;
+      *resize = true;
+   }
+
+   *quit = (bool)frontend_driver_get_signal_handler_state();
+}
+
+void wl_keyboard_handle_key_webos(void *data,
+      struct wl_keyboard *keyboard,
+      uint32_t serial,
+      uint32_t time,
+      uint32_t key,
+      uint32_t state)
+{
+   int value = (state == WL_KEYBOARD_KEY_STATE_PRESSED) ? 1 : 0;
+   gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
+   uint32_t keysym            = key;
+
+   /* Handle 'duplicate' inputs that correspond
+    * to the same RETROK_* key */
+   switch (key)
+   {
+      case KEY_WAYLAND_WEBOS_BACK:
+         webos_wl_special_keymap[webos_wl_key_back] = WL_KEYBOARD_KEY_STATE_PRESSED;
+         keysym = KEY_BACKSPACE;
+         break;
+      case KEY_WAYLAND_WEBOS_RED:
+         keysym = KEY_X;
+         break;
+      case KEY_WAYLAND_WEBOS_GREEN:
+         keysym = KEY_Z;
+         break;
+      case KEY_WAYLAND_WEBOS_YELLOW:
+         keysym = KEY_S;
+         break;
+      case KEY_WAYLAND_WEBOS_BLUE:
+         keysym = KEY_A;
+         break;
+      case KEY_OK:
+      case KEY_SELECT:
+         keysym = KEY_ENTER;
+         break;
+      case KEY_EXIT:
+         keysym = KEY_F1;
+         break;
+      default:
+         break;
+   }
+
+   if (state == WL_KEYBOARD_KEY_STATE_PRESSED)
+      BIT_SET(wl->input.key_state, keysym);
+   else if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
+      BIT_CLEAR(wl->input.key_state, keysym);
+
+#ifdef HAVE_XKBCOMMON
+   if (handle_xkb(keysym, value) == 0)
+      return;
+#endif
+
+   input_keyboard_event(value,
+         input_keymaps_translate_keysym_to_rk(keysym),
+         0, 0, RETRO_DEVICE_KEYBOARD);
+}
+
+void shutdown_webos_contexts()
+{
+#ifdef HAVE_USERLAND
+   if (g_register_ctx)
+   {
+      free(g_register_ctx);
+      g_register_ctx = NULL;
+   }
+   if (g_screensaver_ctx)
+   {
+      free(g_screensaver_ctx);
+      g_screensaver_ctx = NULL;
+   }
+#endif
+}

--- a/input/common/wayland_common_webos.h
+++ b/input/common/wayland_common_webos.h
@@ -1,0 +1,40 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _WAYLAND_COMMON_WEBOS_H
+#define _WAYLAND_COMMON_WEBOS_H
+
+#include <stdint.h>
+
+#ifndef SYS_memfd_create
+#define SYS_memfd_create 279
+#endif
+
+#define KEY_WAYLAND_WEBOS_BACK 412
+#define KEY_WAYLAND_WEBOS_RED 398
+#define KEY_WAYLAND_WEBOS_GREEN 399
+#define KEY_WAYLAND_WEBOS_YELLOW 400
+#define KEY_WAYLAND_WEBOS_BLUE 401
+
+enum webos_wl_special_keymap
+{
+   webos_wl_key_back,
+   webos_wl_key_size,
+};
+
+extern uint8_t webos_wl_special_keymap[webos_wl_key_size];
+extern void shutdown_webos_contexts();
+
+#endif

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -40,6 +40,9 @@
 
 #include "../common/linux_common.h"
 #include "../common/wayland_common.h"
+#ifdef WEBOS
+#include "../common/wayland_common_webos.h"
+#endif
 
 #include "../../retroarch.h"
 #include "../../verbosity.h"
@@ -248,6 +251,14 @@ static int16_t input_wl_state(
          }
          break;
       case RETRO_DEVICE_KEYBOARD:
+#ifdef WEBOS
+         if ((id && id < RETROK_LAST) && (id == RETROK_BACKSPACE) &&
+             webos_wl_special_keymap[webos_wl_key_back] == WL_KEYBOARD_KEY_STATE_PRESSED)
+         {
+            webos_wl_special_keymap[webos_wl_key_back] = 0;
+            return true;
+         }
+#endif
          return (id && id < RETROK_LAST) && BIT_GET(wl->key_state, rarch_keysym_lut[(enum retro_key)id]);
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:

--- a/retroarch.c
+++ b/retroarch.c
@@ -45,6 +45,7 @@
 
 #if defined(WEBOS)
 #include <sys/resource.h>
+#include "input/common/wayland_common_webos.h"
 #endif
 
 #include <stdio.h>
@@ -5992,6 +5993,11 @@ int rarch_main(int argc, char *argv[], void *data)
       setenv("EGL_PLATFORM", "wayland", 0);
    if (getenv("XDG_RUNTIME_DIR") == NULL)
       setenv("XDG_RUNTIME_DIR", "/tmp/xdg", 0);
+   /* wayland */
+   if (getenv("XKB_CONFIG_ROOT") == NULL)
+      setenv("XKB_CONFIG_ROOT", "/usr/share/X11/xkb", 0);
+   if (getenv("WAYLAND_DISPLAY") == NULL)
+      setenv("WAYLAND_DISPLAY", "wayland-0", 0);
 
    struct rlimit limit = {0, 0};
    setrlimit(RLIMIT_CORE, &limit);
@@ -8704,6 +8710,10 @@ bool retroarch_main_quit(void)
 
 #ifdef HAVE_GAME_AI
    game_ai_shutdown();
+#endif
+
+#if defined(WEBOS) && defined(HAVE_WAYLAND)
+   shutdown_webos_contexts();
 #endif
 
    return true;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

Adds wayland support to RetroArch. Previously we only had sdl2 as a graphics and input driver. This gives more choice to the user.

Tested on webOS 25.

Also tested compilation on Ubuntu (wayland) to make sure my changes to the .sh script still work for that.

## Related Issues

## Related Pull Requests

## Reviewers
