### PR TITLE
webOS: allow user to decide about the screensaver

### DIFF
--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -702,6 +702,9 @@ static bool screenSaverCallback(LSHandle* sh, LSMessage* reply, void* context)
    if (strcmp(state, "Active") != 0)
       return true;
 
+   settings_t *settings = config_get_ptr();
+   bool suspend_screensaver = settings->bools.ui_suspend_screensaver_enable;
+
    rjsonwriter_t *w = rjsonwriter_open_memory();
    rjsonwriter_raw(w, "{", 1);
    rjsonwriter_add_string(w, "clientName");
@@ -710,7 +713,7 @@ static bool screenSaverCallback(LSHandle* sh, LSMessage* reply, void* context)
    rjsonwriter_raw(w, ",", 1);
    rjsonwriter_add_string(w, "ack");
    rjsonwriter_raw(w, ":", 1);
-   rjsonwriter_rawf(w, "%s", "false");
+   rjsonwriter_rawf(w, "%s", suspend_screensaver ? "false" : "true");
    rjsonwriter_raw(w, ",", 1);
    rjsonwriter_add_string(w, "timestamp");
    rjsonwriter_raw(w, ":", 1);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This just wires up the front end suppress screensaver setting so users can chose whether or not the screensaver can interrupt gameplay when left idle.

## Related Issues

## Related Pull Requests

## Reviewers

