### PR TITLE
Turn some manual scan functions to non-static, as preparation for scan rework.

### DIFF
--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -1125,7 +1125,7 @@ error:
  * file path for use in playlists - i.e. handles
  * identification of content *inside* archive files.
  * Returns false if specified content is invalid. */
-static bool manual_content_scan_get_playlist_content_path(
+bool manual_content_scan_get_playlist_content_path(
       manual_content_scan_task_config_t *task_config,
       const char *content_path, int content_type,
       char *s, size_t len)
@@ -1210,7 +1210,7 @@ error:
  *   of content file name in an attempt to find a
  *   valid 'description' string.
  * Returns false if specified content is invalid. */
-static bool manual_content_scan_get_playlist_content_label(
+bool manual_content_scan_get_playlist_content_label(
       const char *content_path, logiqx_dat_t *dat_file,
       bool filter_dat_content,
       char *s, size_t len)

--- a/manual_content_scan.h
+++ b/manual_content_scan.h
@@ -273,6 +273,15 @@ void manual_content_scan_add_content_to_playlist(
       playlist_t *playlist, const char *content_path,
       int content_type, logiqx_dat_t *dat_file);
 
+bool manual_content_scan_get_playlist_content_label(
+      const char *content_path, logiqx_dat_t *dat_file,
+      bool filter_dat_content,
+      char *s, size_t len);
+bool manual_content_scan_get_playlist_content_path(
+      manual_content_scan_task_config_t *task_config,
+      const char *content_path, int content_type,
+      char *s, size_t len);
+
 RETRO_END_DECLS
 
 #endif


### PR DESCRIPTION
## Description

Trying to collect neutral changes for the manual-auto scan merge in separate PRs, so that the actual meaningful PR can be focused on just a few files (maybe one), which makes things easier if there is a need for revert.

This one is just exposing a few functions to be called from task_database.c later on.
