### PR TITLE
Fix incorrect mouse left-click selection in ozone menu driver

### DIFF
--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -10410,7 +10410,8 @@ static void ozone_render(void *data,
          if (   (cursor_x_delta >  ozone->pointer_active_delta)
              || (cursor_x_delta < -ozone->pointer_active_delta)
              || (cursor_y_delta >  ozone->pointer_active_delta)
-             || (cursor_y_delta < -ozone->pointer_active_delta))
+             || (cursor_y_delta < -ozone->pointer_active_delta)
+             || (ozone->pointer.flags & MENU_INP_PTR_FLG_PRESSED))
             ozone->flags |=  OZONE_FLAG_CURSOR_MODE;
       }
       /* On touchscreens, just check for any movement */


### PR DESCRIPTION
This fixes a longstanding issue in the Ozone menu driver where a mouse left click would occasionally select a previously selected menu item, instead of the menu item that is currently under the mouse pointer.

With this change, left click will now always select the menu item that is currently under the mouse pointer.

See my comments [here](https://github.com/libretro/RetroArch/issues/13719#issuecomment-3699763540) and [here](https://github.com/libretro/RetroArch/issues/13719#issuecomment-3699955577) in #13719 for reproduction steps and comparison videos demonstrating the behaviour before and after this fix. 