### PR TITLE
Overlays: Reduce memory footprint and load time

### DIFF
--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -384,7 +384,9 @@ struct input_overlay
    const video_overlay_interface_t *iface;
    input_overlay_state_t overlay_state;
    input_overlay_pointer_state_t pointer_state;
+   struct texture_image **images;
 
+   size_t num_images;
    size_t index;
    size_t size;
 
@@ -435,6 +437,7 @@ typedef struct
    char *overlay_path;
    struct overlay *overlays;
    struct overlay *active;
+   struct string_list *image_list;
    size_t size;
    uint16_t overlay_types;
    uint8_t flags;

--- a/libretro-common/include/lists/string_list.h
+++ b/libretro-common/include/lists/string_list.h
@@ -59,7 +59,7 @@ struct string_list
  *
  * Searches for an element (@elem) inside the string list.
  *
- * @return Number of elements found, otherwise 0.
+ * @return 1-based index if element could be found, otherwise 0.
  */
 int string_list_find_elem(const struct string_list *list, const char *elem);
 


### PR DESCRIPTION
- Point to existing image when the overlay cfg reuses a path
- `images` array in `input_overlay_t` holds unique `texture_image`s
