### PR TITLE
Force "Filter Unknown Extensions" for overlay files

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -245,7 +245,9 @@ static int filebrowser_parse(
    else if (!string_is_empty(path))
    {
       if (   type_default == FILE_TYPE_SHADER_PRESET
-          || type_default == FILE_TYPE_SHADER)
+          || type_default == FILE_TYPE_SHADER
+          || type_default == FILE_TYPE_OVERLAY
+          || type_default == FILE_TYPE_OSK_OVERLAY)
          filter_ext = true;
 
       if (string_is_equal(label,


### PR DESCRIPTION
I noticed overlay image files were moved to 'img' folders, but that shouldn't be necessary. This keeps the image files hidden when browsing for overlays, regardless of the filter-by-extension setting.