### PR TITLE
Fix raw input mouse position jumping after window state changes

### DIFF
--- a/input/drivers/winraw_input.c
+++ b/input/drivers/winraw_input.c
@@ -94,11 +94,38 @@ typedef struct
    unsigned mouse_cnt;
    uint8_t kb_keys[SC_LAST];
    uint8_t flags;
+   bool last_focus;
 } winraw_input_t;
 
 /* TODO/FIXME - static globals */
 static winraw_mouse_t *g_mice        = NULL;
 static bool winraw_focus             = false;
+
+/* Sync internal mouse coordinates with the OS cursor position.
+ * Used after events such as window mode, size, and focus changes */
+static bool winraw_sync_mouse_to_cursor(winraw_input_t *wr)
+{
+   HWND wnd;
+   POINT p;
+   unsigned i;
+
+   if (!wr || !wr->mouse_cnt)
+      return false;
+
+   wnd = (HWND)video_driver_window_get();
+   if (!wnd || !GetCursorPos(&p))
+      return false;
+
+   ScreenToClient(wnd, &p);
+
+   for (i = 0; i < wr->mouse_cnt; ++i)
+   {
+      g_mice[i].x = (LONG)p.x;
+      g_mice[i].y = (LONG)p.y;
+   }
+
+   return true;
+}
 
 #define WINRAW_KEYBOARD_PRESSED(wr, key) (wr->kb_keys[rarch_keysym_lut[(enum retro_key)(key)]])
 
@@ -290,24 +317,31 @@ static bool winraw_mouse_button_pressed(
 static void winraw_init_mouse_xy_mapping(winraw_input_t *wr)
 {
    struct video_viewport viewport;
+   int mouse_x;
+   int mouse_y;
+   unsigned i;
 
-   if (video_driver_get_viewport_info(&viewport))
+   if (!video_driver_get_viewport_info(&viewport))
+      return;
+
+   /* Default fallback: center of the viewport */
+   mouse_x = viewport.x + viewport.width  / 2;
+   mouse_y = viewport.y + viewport.height / 2;
+
+   /* Sync to OS cursor position; fall back to center if it fails */
+   if (!winraw_sync_mouse_to_cursor(wr))
    {
-      unsigned i;
-      int center_x               = viewport.x + viewport.width / 2;
-      int center_y               = viewport.y + viewport.height / 2;
-
-      for (i = 0; i < wr->mouse_cnt; ++i)
+      for (i = 0; i < wr->mouse_cnt; i++)
       {
-         g_mice[i].x             = center_x;
-         g_mice[i].y             = center_y;
+         g_mice[i].x      = mouse_x;
+         g_mice[i].y      = mouse_y;
       }
-
-      wr->view_abs_ratio_x       = (double)viewport.full_width  / 65535.0f;
-      wr->view_abs_ratio_y       = (double)viewport.full_height / 65535.0f;
-
-      wr->flags                 |= WRAW_INP_FLG_MOUSE_XY_MAPPING_READY;
    }
+
+   wr->view_abs_ratio_x   = (double)viewport.full_width  / 65535.0;
+   wr->view_abs_ratio_y   = (double)viewport.full_height / 65535.0;
+
+   wr->flags             |= WRAW_INP_FLG_MOUSE_XY_MAPPING_READY;
 }
 
 static void winraw_update_mouse_state(winraw_input_t *wr,
@@ -634,6 +668,12 @@ static void winraw_poll(void *data)
 {
    unsigned i;
    winraw_input_t *wr     = (winraw_input_t*)data;
+
+   /* Sync coordinates when window regains focus */
+   if (winraw_focus && !wr->last_focus)
+      winraw_sync_mouse_to_cursor(wr);
+
+   wr->last_focus = winraw_focus;
 
    for (i = 0; i < wr->mouse_cnt; ++i)
    {


### PR DESCRIPTION
This fixes multiple Windows `raw` input issues that can occur after the window state changes, which can cause the mouse pointer to jump around and make incorrect selections on the menu.

Things that can cause this to happen:

1. Switching between windowed and fullscreen modes.
2. Window resizes, such as those triggered by cores.
3. Losing and regaining window focus while in windowed mode.


It's hard to describe exactly how to reproduce each issue, so i've created the video below which shows the behaviour before and after this fix:

https://github.com/user-attachments/assets/1d798777-76b0-4e96-81d2-e6236e14c9c9





The behaviour can vary depending on what menu item was previously selected before the window resize/refocus happened, but it's all the same kind of problems where the mouse jumps around and will do something unintended when clicked. This PR fixes all of these issues by syncing the internal mouse coordinates with the OS cursor position when these window state changes occur.

The `raw` input mouse behaviour now also matches `dinput` in these cases (dinput does not have any of these issues).