### PR TITLE
Fix game switching to work in single tap from external launchers

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -80,11 +80,13 @@ public final class RetroActivityFuture extends RetroActivityCamera {
     String currentCore = currentIntent != null ? currentIntent.getStringExtra("LIBRETRO") : null;
     
     
-    // Check if we're trying to launch different content  
+    // Check if we're trying to launch different content
     if ((newRom != null && !newRom.equals(currentRom)) ||
         (newCore != null && !newCore.equals(currentCore))) {
-      // Different game content - exit cleanly and let launcher restart us
-      finish();
+      // Different game content - start fresh instance then exit
+      Intent restartIntent = new Intent(intent);
+      restartIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+      startActivity(restartIntent);
       System.exit(0);
     } else {
       // Same content, just update intent


### PR DESCRIPTION
When launching a different game via FLAG_ACTIVITY_CLEAR_TOP (e.g., from Daijishou), the `onNewIntent()` handler added in #18210 was calling `finish()` + `System.exit(0)`, which killed the app without restarting. Users had to tap twice to launch a new game - once to kill RetroArch, and again to actually launch the new content.

This fix queues a fresh activity with `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK` before calling `System.exit(0)`. This starts the new game in a clean task, then kills the current process so Android starts fresh. The result is single-tap game switching from external launchers.

## Related Pull Requests

https://github.com/libretro/RetroArch/pull/18210 - _Add onNewIntent handler to support game launch with FLAG_ACTIVITY_CLEAR_TOP_
https://github.com/libretro/RetroArch/pull/18231 - _Add activity state detection to prevent parameter conflicts when resuming from home screen after external game launch_

## Related Issues

https://github.com/TapiocaFox/Daijishou/issues/703