### PR TITLE
PS2: Fix booting from internal HDD

### DIFF
--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -310,6 +310,16 @@ static void common_init_drivers(bool extra_drivers)
    poweroffSetCallback(&poweroffHandler, NULL);
 
    getcwd(cwd, sizeof(cwd));
+
+   // Workaround for PS2SDK issue: https://github.com/ps2dev/ps2sdk/issues/805
+   // PS2SDK's initialization routine does not properly set the CWD for HDD
+   // paths, leading to all slashes being converted to backslashes. Manually
+   // convert them back to slashes to work around the issue until it is
+   // properly fixed in PS2SDK.
+   int bootDeviceID  = getBootDeviceID(cwd);
+   if (bootDeviceID == BOOT_DEVICE_HDD || bootDeviceID == BOOT_DEVICE_HDD0)
+      pathname_conform_slashes_to_os(cwd);
+
 #if !defined(IS_SALAMANDER) && !defined(DEBUG)
    /* If it is not Salamander, we need to go one level
     * up for setting the CWD. */


### PR DESCRIPTION
## Description

Fixes booting from the internal HDD which has been broken for quite some time:

- Loads the missing dev9 module.
- Fixes construction of the partition name.
- Updates "path is absolute" check to take device names into account.
- Prevents double slashes from appearing in user configuration paths.
- Normalizes the CWD to work around a reported bug in PS2SDK.

Also see the commits' descriptions for more details and the rationale behind each change.

## Related Issues

Fixes: #16010

## Reviewers

@fjtrujy @AKuHAK 

(Referencing users with recent activity, edit if required)