### PR TITLE
webOS: sdl2 nav should continue not return

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -506,7 +506,7 @@ static void sdl_input_poll(void *data)
             case SDL_SCANCODE_UP:
                /* navigation only, skip text insertion */
                if (osk_active)
-                  return;
+                  continue;
                break;
             case SDL_SCANCODE_RETURN:
                // remap wheel click to confirm selection in virtual keyboard


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

webOS: Minor correction although it doesn't seem to have any negative effects, it should be a continue not a return as we are in a loop when checking for sdl2 input

## Related Issues

## Related Pull Requests

## Reviewers

