### PR TITLE
ios: Add pd777 core for Epoch Cassette Vision to App Store builds

### DIFF
--- a/pkg/apple/update-cores.sh
+++ b/pkg/apple/update-cores.sh
@@ -244,6 +244,7 @@ appstore_cores=(
     nxengine
     opera
     pcsx_rearmed
+    pd777
     picodrive
     #play
     pocketcdg


### PR DESCRIPTION
## Description

ios: Add pd777 core for Epoch Cassette Vision to App Store builds

Tested with a debug build on a physical iPhone 13 running iOS 26; core and playlist both worked well (with https://github.com/libretro/libretro-super/pull/1950 changes manually added to info files).

## Related Issues

None.

## Related Pull Requests

1. https://github.com/libretro/libretro-super/pull/1950 has been merged, but wasn't in the assets package I downloaded --- had to manually add that to my phone.  Hopefully that'll be in the package before this change goes live.
1. https://github.com/libretro/retroarch-assets/pull/494 for playlist icons would be nice, but isn't blocking.


## Reviewers

@warmenhoven !