### PR TITLE
webOS: add compatibility for older Wayland compositors found on webOS 1 to 3

### DIFF
--- a/.github/workflows/webOS.yml
+++ b/.github/workflows/webOS.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download ares-cli-rs
-        uses: robinraju/release-downloader@v1.11
+        uses: robinraju/release-downloader@v1
         with:
           repository: "webosbrew/ares-cli-rs"
           latest: true
@@ -33,7 +33,7 @@ jobs:
           out-file-path: "temp"
 
       - name: Download Manifest Generator
-        uses: robinraju/release-downloader@v1.9
+        uses: robinraju/release-downloader@v1
         with:
           repository: "webosbrew/dev-toolbox-cli"
           latest: true
@@ -47,7 +47,7 @@ jobs:
         run: sudo apt-get -yq install ./temp/*.deb
 
       - name: Download webOS NDK
-        uses: robinraju/release-downloader@v1.11
+        uses: robinraju/release-downloader@v1
         with:
           repository: "openlgtv/buildroot-nc4"
           latest: true
@@ -68,7 +68,26 @@ jobs:
           RARCH_VERSION=$(grep -Po '(?<=#define PACKAGE_VERSION ")[^"]+' version.all)
           echo "RARCH_VERSION=$RARCH_VERSION" >> "$GITHUB_ENV"
 
-      - name: Compile RA (GLES3 and Wayland variant)
+      - name: Compile RA (GLES2, no wayland legacy variant)
+        shell: bash
+        run: |
+          . /tmp/arm-webos-linux-gnueabi_sdk-buildroot/environment-setup
+          export SDK_PATH=/tmp/arm-webos-linux-gnueabi_sdk-buildroot
+          make -f Makefile.webos clean
+          make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 \
+          -j"$(getconf _NPROCESSORS_ONLN)"
+          mv webos/com.retroarch.webos_${RARCH_VERSION}_arm.ipk \
+             webos/com.retroarch.webos-legacy-gles2-no-wayland_${RARCH_VERSION}_arm.ipk
+        env:
+          DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
+
+      - name: Upload GLES2 artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_${{ github.sha }}_arm.ipk
+          path: webos/com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_arm.ipk
+
+      - name: Compile RA (default)
         shell: bash
         run: |
           . /tmp/arm-webos-linux-gnueabi_sdk-buildroot/environment-setup
@@ -76,30 +95,13 @@ jobs:
           make -f Makefile.webos clean
           bash gfx/common/wayland/generate_wayland_protos.sh
           make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 \
-            HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 HAVE_WAYLAND=1 \
-            HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1 -j"$(getconf _NPROCESSORS_ONLN)"
-          mv webos/com.retroarch.webos_${RARCH_VERSION}_arm.ipk \
-             webos/com.retroarch.webos.gles3w_${RARCH_VERSION}_arm.ipk
-        env:
-          DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
-
-      - name: Upload GLES3 and Wayland artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: com.retroarch.webos.gles3w_${{ env.RARCH_VERSION }}_${{ github.sha }}_arm.ipk
-          path: webos/com.retroarch.webos.gles3w_${{ env.RARCH_VERSION }}_arm.ipk
-
-      - name: Compile RA (default)
-        shell: bash
-        run: |
-          . /tmp/arm-webos-linux-gnueabi_sdk-buildroot/environment-setup
-          make -f Makefile.webos clean
-          make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 -j"$(getconf _NPROCESSORS_ONLN)"
+          HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 HAVE_WAYLAND=1 \
+          HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1 -j"$(getconf _NPROCESSORS_ONLN)"
         env:
           DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
 
       - name: Upload default artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: com.retroarch.webos_${{ env.RARCH_VERSION }}_${{ github.sha }}_arm.ipk
           path: webos/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk
@@ -125,5 +127,5 @@ jobs:
           omitPrereleaseDuringUpdate: true
           artifacts: |
             webos/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk
-            webos/com.retroarch.webos.gles3w_${{ env.RARCH_VERSION }}_arm.ipk
+            webos/com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_arm.ipk
             webos/${{ env.PACKAGE_NAME }}.manifest.json

--- a/Makefile.common
+++ b/Makefile.common
@@ -1307,6 +1307,10 @@ ifeq ($(HAVE_WAYLAND), 1)
     DEF_FLAGS += $(LIBDECOR_CFLAGS)
  endif
 
+ ifeq ($(HAVE_WAYLAND_BACKPORT),1)
+    DEFINES += -DHAVE_WAYLAND_BACKPORT=1
+    OBJ += gfx/common/wayland_common_backport.o
+ endif
 endif
 
 # XML

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -136,6 +136,7 @@ HAVE_USERLAND ?= 0
 HAVE_WEBOS_EXTRA_PROTOS ?= 0
 HAVE_CORE_INFO_CACHE = 1
 HAVE_WAYLAND ?= 0
+HAVE_WAYLAND_BACKPORT ?= 1
 
 OS = Linux
 TARGET = retroarch
@@ -340,6 +341,9 @@ ipk: prebuild $(TARGET) sdl2
 	echo "$$APPINFO" > webos/dist/appinfo.json
 	cp -t webos/dist -vf $(TARGET) webos/icon160.png
 	cp -t webos/dist/lib -vf $(WEBOS_USR_LIB_DIR)/libstdc++.so.6
+ifeq ($(HAVE_XKBCOMMON), 1)
+	cp -t webos/dist/lib -vf $(WEBOS_USR_LIB_DIR)/libxkbcommon.so.0
+endif
 	cp -t webos/dist/lib -vf $(WEBOS_LIB_DIR)/libatomic.so.1
 ifeq ($(ADD_SDL2_LIB), 1)
 	cp -t webos/dist/lib -vf SDL/lib/libSDL2-2.0.so.0

--- a/gfx/common/wayland_common_backport.c
+++ b/gfx/common/wayland_common_backport.c
@@ -1,0 +1,372 @@
+/*  RetroArch - A frontend for libretro.
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <time.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <dlfcn.h>
+
+#include "wayland_common.h"
+#include "wayland_common_backport.h"
+#include "../../verbosity.h"
+
+/*
+   Backwards compatibility for older versions of libwayland-client that
+   which do not have:
+   wl_proxy_marshal_constructor_versioned
+   wl_proxy_marshal_array_constructor_versioned
+   wl_proxy_get_version
+   wl_display_prepare_read
+   wl_display_read_events
+   wl_display_cancel_read
+*/
+
+/* Function pointers for dynamic dispatch */
+static uint32_t (*real_wl_proxy_get_version)(struct wl_proxy *) = NULL;
+
+static struct wl_proxy *(*real_wl_proxy_marshal_constructor)(
+    struct wl_proxy *, uint32_t, const struct wl_interface *, ...) = NULL;
+
+static struct wl_proxy *(*real_wl_proxy_marshal_constructor_versioned)(
+    struct wl_proxy *, uint32_t, const struct wl_interface *, uint32_t, ...) = NULL;
+
+static int (*real_wl_display_prepare_read)(struct wl_display *) = NULL;
+static int (*real_wl_display_read_events)(struct wl_display *) = NULL;
+static void (*real_wl_display_cancel_read)(struct wl_display *) = NULL;
+
+static bool wayland_init_done = false;
+
+static void wayland_init_fallbacks(void)
+{
+   void *wl_handle;
+
+   if (wayland_init_done)
+      return;
+
+   wayland_init_done = true;
+
+   /* Try to dynamically load the real functions */
+   wl_handle = dlopen(NULL, RTLD_LAZY);
+   if (wl_handle)
+   {
+      real_wl_proxy_get_version =
+         dlsym(wl_handle, "wl_proxy_get_version");
+      real_wl_proxy_marshal_constructor =
+         dlsym(wl_handle, "wl_proxy_marshal_constructor");
+      real_wl_proxy_marshal_constructor_versioned =
+         dlsym(wl_handle, "wl_proxy_marshal_constructor_versioned");
+      real_wl_display_prepare_read =
+         dlsym(wl_handle, "wl_display_prepare_read");
+      real_wl_display_read_events =
+         dlsym(wl_handle, "wl_display_read_events");
+      real_wl_display_cancel_read =
+         dlsym(wl_handle, "wl_display_cancel_read");
+
+      dlclose(wl_handle);
+   }
+
+   if (!real_wl_proxy_get_version)
+      RARCH_LOG("[Wayland] Using fallback wl_proxy_get_version\n");
+
+   if (!real_wl_proxy_marshal_constructor)
+      RARCH_LOG("[Wayland] Using fallback wl_proxy_marshal_constructor\n");
+
+   if (!real_wl_proxy_marshal_constructor_versioned)
+      RARCH_LOG("[Wayland] Using fallback wl_proxy_marshal_constructor_versioned\n");
+
+   if (!real_wl_display_prepare_read)
+      RARCH_LOG("[Wayland] Using fallback wl_display_prepare_read\n");
+
+   if (!real_wl_display_read_events)
+      RARCH_LOG("[Wayland] Using fallback wl_display_read_events\n");
+
+   if (!real_wl_display_cancel_read)
+      RARCH_LOG("[Wayland] Using fallback wl_display_cancel_read\n");
+}
+
+uint32_t FALLBACK_wl_proxy_get_version(struct wl_proxy *proxy)
+{
+   (void)proxy;
+   return 0;
+}
+
+/* Wrapper for wl_proxy_get_version */
+uint32_t WRAPPER_wl_proxy_get_version(struct wl_proxy *proxy)
+{
+   uint32_t result;
+
+   wayland_init_fallbacks();
+
+   if (real_wl_proxy_get_version)
+      result = real_wl_proxy_get_version(proxy);
+   else
+      result = FALLBACK_wl_proxy_get_version(proxy);
+
+   return result;
+}
+
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+static int parse_msg_signature(const char *signature, int *new_id_index)
+{
+   int count = 0;
+   for (; *signature; ++signature)
+   {
+      switch (*signature)
+      {
+      case 'n':
+         *new_id_index = count;
+         /* Intentional fallthrough */
+      case 'i':
+      case 'u':
+      case 'f':
+      case 's':
+      case 'o':
+      case 'a':
+      case 'h':
+         ++count;
+         break;
+      }
+   }
+
+   return count;
+}
+
+struct wl_proxy *FALLBACK_wl_proxy_marshal_constructor(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   ...)
+{
+   va_list ap;
+   void *varargs[WL_CLOSURE_MAX_ARGS];
+   int num_args;
+   int new_id_index = -1;
+   struct wl_interface *proxy_interface;
+   struct wl_proxy *id;
+
+   id = wl_proxy_create(proxy, interface);
+
+   if (!id)
+      return NULL;
+
+   proxy_interface = (*(struct wl_interface **)proxy);
+   if (opcode > proxy_interface->method_count)
+      return NULL;
+
+   num_args = parse_msg_signature(
+      proxy_interface->methods[opcode].signature,
+      &new_id_index);
+
+   if (new_id_index < 0)
+      return NULL;
+
+   memset(varargs, 0, sizeof(varargs));
+   va_start(ap, interface);
+   for (int i = 0; i < num_args; i++)
+      varargs[i] = va_arg(ap, void *);
+   va_end(ap);
+
+   varargs[new_id_index] = id;
+
+   wl_proxy_marshal(proxy, opcode,
+                    varargs[0], varargs[1], varargs[2], varargs[3],
+                    varargs[4], varargs[5], varargs[6], varargs[7],
+                    varargs[8], varargs[9], varargs[10], varargs[11],
+                    varargs[12], varargs[13], varargs[14], varargs[15],
+                    varargs[16], varargs[17], varargs[18], varargs[19]);
+
+   return id;
+}
+
+struct wl_proxy *FALLBACK_wl_proxy_marshal_constructor_versioned(
+    struct wl_proxy *proxy,
+    uint32_t opcode,
+    const struct wl_interface *interface,
+    uint32_t version,
+    ...)
+{
+   va_list ap;
+   void *varargs[WL_CLOSURE_MAX_ARGS];
+   int num_args;
+   int new_id_index = -1;
+   struct wl_interface *proxy_interface;
+   struct wl_proxy *id;
+
+   (void)version; /* version parameter not available */
+
+   id = wl_proxy_create(proxy, interface);
+
+   if (!id)
+      return NULL;
+
+   proxy_interface = (*(struct wl_interface **)proxy);
+   if (opcode > proxy_interface->method_count)
+      return NULL;
+
+   num_args = parse_msg_signature(
+      proxy_interface->methods[opcode].signature,
+      &new_id_index);
+
+   if (new_id_index < 0)
+      return NULL;
+
+   memset(varargs, 0, sizeof(varargs));
+   va_start(ap, version);
+   for (int i = 0; i < num_args; i++)
+      varargs[i] = va_arg(ap, void *);
+   va_end(ap);
+
+   varargs[new_id_index] = id;
+
+   wl_proxy_marshal(proxy, opcode,
+                    varargs[0], varargs[1], varargs[2], varargs[3],
+                    varargs[4], varargs[5], varargs[6], varargs[7],
+                    varargs[8], varargs[9], varargs[10], varargs[11],
+                    varargs[12], varargs[13], varargs[14], varargs[15],
+                    varargs[16], varargs[17], varargs[18], varargs[19]);
+
+   return id;
+}
+
+int FALLBACK_wl_display_prepare_read(struct wl_display *display)
+{
+   (void)display;
+   return 0;
+}
+
+int FALLBACK_wl_display_read_events(struct wl_display *display)
+{
+   /* Fallback to dispatch */
+   return wl_display_dispatch(display);
+}
+
+void FALLBACK_wl_display_cancel_read(struct wl_display *display)
+{
+   (void)display;
+   /* no-op */
+}
+
+struct wl_proxy *WRAPPER_wl_proxy_marshal_constructor(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   ...)
+{
+   va_list ap;
+   struct wl_proxy *result;
+
+   wayland_init_fallbacks();
+
+   va_start(ap, interface);
+
+   result = FALLBACK_wl_proxy_marshal_constructor(proxy, opcode, interface,
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*));
+
+   va_end(ap);
+
+   return result;
+}
+
+struct wl_proxy *WRAPPER_wl_proxy_marshal_constructor_versioned(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   uint32_t version,
+   ...)
+{
+   va_list ap;
+   struct wl_proxy *result;
+
+   wayland_init_fallbacks();
+
+   va_start(ap, version);
+
+   result = FALLBACK_wl_proxy_marshal_constructor_versioned(proxy, opcode, interface, version,
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*), va_arg(ap, void*),
+      va_arg(ap, void*), va_arg(ap, void*));
+
+   va_end(ap);
+
+   return result;
+}
+
+int WRAPPER_wl_display_prepare_read(struct wl_display *display)
+{
+   int result;
+
+   wayland_init_fallbacks();
+
+   if (real_wl_display_prepare_read)
+      result = real_wl_display_prepare_read(display);
+   else
+      result = FALLBACK_wl_display_prepare_read(display);
+
+   return result;
+}
+
+int WRAPPER_wl_display_read_events(struct wl_display *display)
+{
+   int result;
+
+   wayland_init_fallbacks();
+
+   if (real_wl_display_read_events)
+      result = real_wl_display_read_events(display);
+   else
+      result = FALLBACK_wl_display_read_events(display);
+
+   return result;
+}
+
+void WRAPPER_wl_display_cancel_read(struct wl_display *display)
+{
+   wayland_init_fallbacks();
+
+   if (real_wl_display_cancel_read)
+      real_wl_display_cancel_read(display);
+   else
+      FALLBACK_wl_display_cancel_read(display);
+}

--- a/gfx/common/wayland_common_backport.h
+++ b/gfx/common/wayland_common_backport.h
@@ -1,0 +1,68 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#define WL_CLOSURE_MAX_ARGS 20
+
+struct wl_interface;
+struct wl_proxy;
+struct wl_display;
+
+extern uint32_t FALLBACK_wl_proxy_get_version(struct wl_proxy *proxy);
+
+extern struct wl_proxy *FALLBACK_wl_proxy_marshal_constructor(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   ...);
+
+extern struct wl_proxy *FALLBACK_wl_proxy_marshal_constructor_versioned(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   uint32_t version,
+   ...);
+
+extern int FALLBACK_wl_display_prepare_read(struct wl_display *display);
+extern int FALLBACK_wl_display_read_events(struct wl_display *display);
+extern void FALLBACK_wl_display_cancel_read(struct wl_display *display);
+
+#define wl_proxy_get_version                   WRAPPER_wl_proxy_get_version
+#define wl_proxy_marshal_constructor           WRAPPER_wl_proxy_marshal_constructor
+#define wl_proxy_marshal_constructor_versioned WRAPPER_wl_proxy_marshal_constructor_versioned
+#define wl_display_prepare_read                WRAPPER_wl_display_prepare_read
+#define wl_display_read_events                 WRAPPER_wl_display_read_events
+#define wl_display_cancel_read                 WRAPPER_wl_display_cancel_read
+
+extern uint32_t WEBOS_wl_proxy_get_version(struct wl_proxy *proxy);
+extern struct wl_proxy *WEBOS_wl_proxy_marshal_constructor(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   ...);
+
+extern struct wl_proxy *WRAPPER__wl_proxy_marshal_constructor_versioned(
+   struct wl_proxy *proxy,
+   uint32_t opcode,
+   const struct wl_interface *interface,
+   uint32_t version,
+   ...);
+
+extern int WRAPPER_wl_display_prepare_read(struct wl_display *display);
+extern int WRAPPER_wl_display_read_events(struct wl_display *display);
+extern void WRAPPER_wl_display_cancel_read(struct wl_display *display);

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -16,6 +16,10 @@
 
 #include <unistd.h>
 
+#ifdef HAVE_WAYLAND_BACKPORT
+#include "../../gfx/common/wayland_common_backport.h"
+#endif
+
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 
@@ -123,10 +127,10 @@ static bool gfx_ctx_wl_set_resize(void *data, unsigned width, unsigned height)
    gfx_ctx_wayland_data_t *wl    = (gfx_ctx_wayland_data_t*)data;
    wl->last_buffer_scale         = wl->buffer_scale;
    wl->last_fractional_scale_num = wl->fractional_scale_num;
-   if (!wl->fractional_scale)
-      wl_surface_set_buffer_scale(wl->surface, wl->buffer_scale);
-
-   wl->ignore_configuration = false;
+   if (!wl->fractional_scale &&
+       wl_compositor_get_version(wl->compositor) >=
+       WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
+      wl->ignore_configuration = false;
 #ifdef HAVE_EGL
    wl_egl_window_resize(wl->win, width, height, 0, 0);
 #endif

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -16,6 +16,10 @@
 
 #include <unistd.h>
 
+#ifdef HAVE_WAYLAND_BACKPORT
+#include "../../gfx/common/wayland_client_backport.h"
+#endif
+
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -20,6 +20,11 @@
 #include <boolean.h>
 
 #include <linux/input.h>
+
+#ifdef HAVE_WAYLAND_BACKPORT
+#include "../../gfx/common/wayland_common_backport.h"
+#endif
+
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 
@@ -49,6 +54,8 @@
 #ifdef WEBOS
 #include "wayland_common_webos.h"
 #endif
+
+#define WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION 3
 
 #define FRACTIONAL_SCALE_V1_DEN 120
 #define FRACTIONAL_SCALE_MULT(v, scale_num) \

--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -1,5 +1,4 @@
 /*  RetroArch - A frontend for libretro.
- *  Copyright (C) 2011-2024 - Daniel De Matteis
  *
  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
  *  of the GNU General Public License as published by the Free Software Found-

--- a/input/drivers/wayland_input.c
+++ b/input/drivers/wayland_input.c
@@ -24,6 +24,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef HAVE_WAYLAND_BACKPORT
+#include "../../gfx/common/wayland_common_backport.h"
+#endif
+
 #include <wayland-client.h>
 #include <wayland-cursor.h>
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

This PR adds a generic HAVE_WAYLAND_BACKPORT flag which when set to 1 will implement fallbacks for wayland compositors (such as those in webOS 1 to 3) which lack support for:

-    wl_proxy_marshal_constructor_versioned
-    wl_proxy_marshal_array_constructor_versioned
-    wl_proxy_get_version
-    wl_display_prepare_read
-    wl_display_read_events
-    wl_display_cancel_read

This has been tested on webOS 1.4 TV (GLES 2 only) device.

wl_surface_set_buffer_scale is only available on V3 of the protocol so that is checked for before using.

GLES 3 is now enabled by default, as my test user has confirmed that it falls back to GLES 2 and they were able to play it.

For legacy sake, I have included an older IPK with GLES 2 and no wayland, just in case any issues arise I can point them at that version to download instead.

It also updates the various github action versions (v1 should point to the latest release for most).

## Related Issues


## Related Pull Requests


## Reviewers

