### PR TITLE
vfs: add retro_vfs_stat64_t

### DIFF
--- a/libretro-common/formats/logiqx_dat/logiqx_dat.c
+++ b/libretro-common/formats/logiqx_dat/logiqx_dat.c
@@ -57,7 +57,7 @@ const char *logiqx_dat_html_code_list[][2] = {
 bool logiqx_dat_path_is_valid(const char *path, uint64_t *file_size)
 {
    const char *file_ext = NULL;
-   int32_t file_size_int;
+   int64_t file_size_int;
 
    if (string_is_empty(path))
       return false;

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -36,6 +36,7 @@
 RETRO_BEGIN_DECLS
 
 #define PATH_REQUIRED_VFS_VERSION 3
+#define STAT64_REQUIRED_VFS_VERSION 4
 
 void path_vfs_init(const struct retro_vfs_interface_info* vfs_info);
 
@@ -681,7 +682,7 @@ int path_stat(const char *path);
 
 bool path_is_valid(const char *path);
 
-int32_t path_get_size(const char *path);
+int64_t path_get_size(const char *path);
 
 bool is_path_accessible_using_standard_io(const char *path);
 

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2936,6 +2936,19 @@ typedef int (RETRO_CALLCONV *retro_vfs_rename_t)(const char *old_path, const cha
 typedef int (RETRO_CALLCONV *retro_vfs_stat_t)(const char *path, int32_t *size);
 
 /**
+ * Gets information about the given file (64-bit size).
+ *
+ * @param path The path to the file to query.
+ * @param[out] size The reported size of the file in bytes.
+ * May be \c NULL, in which case this value is ignored.
+ * @return A bitmask of \c RETRO_VFS_STAT flags,
+ * or 0 if \c path doesn't refer to a valid file.
+ * @see RETRO_VFS_STAT
+ * @since VFS API v4
+ */
+typedef int (RETRO_CALLCONV *retro_vfs_stat_64_t)(const char *path, int64_t *size);
+
+/**
  * Creates a directory at the given path.
  *
  * @param dir The desired location of the new directory.
@@ -3090,6 +3103,10 @@ struct retro_vfs_interface
 
    /** @copydoc retro_vfs_closedir_t */
    retro_vfs_closedir_t closedir;
+
+   /* VFS API v4 */
+   /** @copydoc retro_vfs_stat_64_t */
+   retro_vfs_stat_64_t stat_64;
 };
 
 /**

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -59,6 +59,8 @@ const char *retro_vfs_file_get_path_impl(libretro_vfs_implementation_file *strea
 
 int retro_vfs_stat_impl(const char *path, int32_t *size);
 
+int retro_vfs_stat_64_impl(const char *path, int64_t *size);
+
 int retro_vfs_mkdir_impl(const char *dir);
 
 libretro_vfs_implementation_dir *retro_vfs_opendir_impl(const char *dir, bool include_hidden);

--- a/libretro-common/include/vfs/vfs_implementation_saf.h
+++ b/libretro-common/include/vfs/vfs_implementation_saf.h
@@ -91,7 +91,7 @@ int retro_vfs_file_remove_saf(const char *tree, const char *path);
 
 int retro_vfs_file_rename_saf(const char *old_tree, const char *old_path, const char *new_tree, const char *new_path);
 
-int retro_vfs_stat_saf(const char *tree, const char *path, int32_t *size);
+int retro_vfs_stat_saf(const char *tree, const char *path, int64_t *size);
 
 int retro_vfs_mkdir_saf(const char *tree, const char *dir);
 

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -1009,7 +1009,7 @@ const char *retro_vfs_file_get_path_impl(
    return stream->orig_path;
 }
 
-int retro_vfs_stat_impl(const char *path, int32_t *size)
+int retro_vfs_stat_64_impl(const char *path, int64_t *size)
 {
    int ret                   = RETRO_VFS_STAT_IS_VALID;
 
@@ -1049,7 +1049,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          return 0;
 
       if (size)
-         *size                  = (int32_t)stat_buf.st_size;
+         *size                  = (int64_t)stat_buf.st_size;
 
       if (FIO_S_ISDIR(stat_buf.st_mode))
          ret              |= RETRO_VFS_STAT_IS_DIRECTORY;
@@ -1061,7 +1061,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          return 0;
 
       if (size)
-         *size = (int32_t)stat_buf.st_size;
+         *size = (int64_t)stat_buf.st_size;
 
       if ((stat_buf.st_mode & S_IFMT) == S_IFDIR)
          ret  |= RETRO_VFS_STAT_IS_DIRECTORY;
@@ -1069,7 +1069,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
       /* Windows
        * Older MSVC _stat may fail on directory paths 
        * with a trailing backslash */
-      struct _stat stat_buf;
+      struct _stat64 stat_buf;
       char path_buf[PATH_MAX_LENGTH];
       const char *stat_path = path;
       size_t _len = strlcpy(path_buf, path, sizeof(path_buf));
@@ -1118,7 +1118,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
       file_info                 = GetFileAttributesW(path_wide);
 
       if (file_info == INVALID_FILE_ATTRIBUTES
-            || _wstat(path_wide, &stat_buf) != 0)
+            || _wstat64(path_wide, &stat_buf) != 0)
       {
          free(path_wide);
          return 0;
@@ -1128,7 +1128,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
 #endif
 
       if (size)
-         *size = (int32_t)stat_buf.st_size;
+         *size = (int64_t)stat_buf.st_size;
 
       if (file_info & FILE_ATTRIBUTE_DIRECTORY)
          ret  |= RETRO_VFS_STAT_IS_DIRECTORY;
@@ -1148,7 +1148,7 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          return 0;
 
       if (size)
-         *size = (int32_t)stat_buf.st_size;
+         *size = (int64_t)stat_buf.st_size;
 
       if (S_ISDIR(stat_buf.st_mode))
          ret |= RETRO_VFS_STAT_IS_DIRECTORY;
@@ -1156,13 +1156,19 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          ret |= RETRO_VFS_STAT_IS_CHARACTER_SPECIAL;
 #else
       /* Every other platform */
+#if defined(_LARGEFILE64_SOURCE)
+      struct stat64 stat_buf;
+      if (stat64(path, &stat_buf) < 0)
+         return 0;
+#else
       struct stat stat_buf;
 
       if (stat(path, &stat_buf) < 0)
          return 0;
+#endif
 
       if (size)
-         *size = (int32_t)stat_buf.st_size;
+         *size = (int64_t)stat_buf.st_size;
 
       if (S_ISDIR(stat_buf.st_mode))
          ret |= RETRO_VFS_STAT_IS_DIRECTORY;
@@ -1170,6 +1176,21 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
          ret |= RETRO_VFS_STAT_IS_CHARACTER_SPECIAL;
 #endif
    }
+   return ret;
+}
+
+int retro_vfs_stat_impl(const char *path, int32_t *size)
+{
+   int64_t size64 = 0;
+   int ret = retro_vfs_stat_64_impl(path, size ? &size64 : NULL);
+
+   /* if a file is larger than 2 GB, size64 will hold the correct value
+    * but the cast to int32_t will truncate it.
+    * new code should migrate to retro_vfs_stat_64_t
+   */
+   if (size)
+      *size = (int32_t)size64;
+
    return ret;
 }
 
@@ -1499,7 +1520,7 @@ bool retro_vfs_dirent_is_dir_impl(libretro_vfs_implementation_dir *rdir)
    {
       char full[PATH_MAX_LENGTH];
       const char *name = retro_vfs_dirent_get_name_impl(rdir);
-      int32_t sz = 0;
+      int64_t sz = 0;
       int st = 0;
 
       if (!name)

--- a/libretro-common/vfs/vfs_implementation_saf.c
+++ b/libretro-common/vfs/vfs_implementation_saf.c
@@ -620,7 +620,7 @@ int retro_vfs_file_rename_saf(const char *old_tree, const char *old_path, const 
    return -1;
 }
 
-int retro_vfs_stat_saf(const char *tree, const char *path, int32_t *size)
+int retro_vfs_stat_saf(const char *tree, const char *path, int64_t *size)
 {
    JNIEnv *env;
    jstring tree_object;
@@ -677,7 +677,7 @@ int retro_vfs_stat_saf(const char *tree, const char *path, int32_t *size)
    if ((*env)->ExceptionOccurred(env)) goto error;
 
    if (size != NULL)
-      *size = saf_stat_size > INT32_MAX ? INT32_MAX : (int32_t)saf_stat_size;
+      *size = saf_stat_size > INT64_MAX ? INT64_MAX : (int64_t)saf_stat_size;
 
    (*env)->PopLocalFrame(env, NULL);
    return saf_stat_is_directory ? RETRO_VFS_STAT_IS_VALID | RETRO_VFS_STAT_IS_DIRECTORY : RETRO_VFS_STAT_IS_VALID;

--- a/libretro-common/vfs/vfs_implementation_smb.c
+++ b/libretro-common/vfs/vfs_implementation_smb.c
@@ -544,7 +544,7 @@ int retro_vfs_closedir_smb(smb_dir_handle* dh)
    return 0;
 }
 
-int retro_vfs_stat_smb(const char *path, int32_t *size)
+int retro_vfs_stat_smb(const char *path, int64_t *size)
 {
    char rel_path[PATH_MAX_LENGTH];
    struct smb2_stat_64 st;
@@ -572,7 +572,7 @@ int retro_vfs_stat_smb(const char *path, int32_t *size)
       return 0;
 
    if (size)
-      *size = (int32_t)st.smb2_size;
+      *size = (int64_t)st.smb2_size;
 
    return RETRO_VFS_STAT_IS_VALID |
          (st.smb2_type == SMB2_TYPE_DIRECTORY ? RETRO_VFS_STAT_IS_DIRECTORY : 0);

--- a/libretro-common/vfs/vfs_implementation_smb.h
+++ b/libretro-common/vfs/vfs_implementation_smb.h
@@ -60,7 +60,7 @@ struct smbc_dirent* retro_vfs_readdir_smb(smb_dir_handle* dh);
 int                 retro_vfs_closedir_smb(smb_dir_handle* dh);
 
 /* Stat */
-int retro_vfs_stat_smb(const char *path, int32_t *size);
+int retro_vfs_stat_smb(const char *path, int64_t *size);
 
 /* Errors */
 int retro_vfs_file_error_smb(libretro_vfs_implementation_file *stream);

--- a/runloop.c
+++ b/runloop.c
@@ -3012,7 +3012,7 @@ bool runloop_environment_cb(unsigned cmd, void *data)
 
       case RETRO_ENVIRONMENT_GET_VFS_INTERFACE:
       {
-         const uint32_t supported_vfs_version = 3;
+         const uint32_t supported_vfs_version = 4;
          static struct retro_vfs_interface vfs_iface =
          {
             /* VFS API v1 */
@@ -3036,7 +3036,9 @@ bool runloop_environment_cb(unsigned cmd, void *data)
             retro_vfs_readdir_impl,
             retro_vfs_dirent_get_name_impl,
             retro_vfs_dirent_is_dir_impl,
-            retro_vfs_closedir_impl
+            retro_vfs_closedir_impl,
+             /* VFS API v4 */
+            retro_vfs_stat_64_impl,
          };
 
          struct retro_vfs_interface_info *vfs_iface_info = (struct retro_vfs_interface_info *) data;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

The current stat implementation uses a 32-bit integer pointer which means files bigger than 2 GB are not supported. There is about 4 or 5 cores that use the 32-bit stat method that I could find however changing the existing function to 64-bit would break the ABI (requiring these cores to be updated):
https://github.com/search?q=org%3Alibretro+-%3Estat%28&type=code

So we add a new 64-bit version (alternative is to update those cores, which I actually prefer but..)

64-bit is needed dolphin which some ISOs are > 2 GB.

Tested with Dolphin (WIP) using VFS using new stat64 function
Tested with pre-built Quake loading over SMB
Tested with pre-build Visual Boy Advance (M) over SMB which uses old stat function

I have tested local files and SMB, but not SAF.
Tested on linux and android

## Related Issues


## Related Pull Requests


## Reviewers

