### PR TITLE
Expect same controler GUID format for SDL2 on Windows as Linux

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -135,13 +135,8 @@ static void sdl_pad_connect(unsigned id)
 #ifdef HAVE_SDL2
    guid       = SDL_JoystickGetGUID(pad->joypad);
    guid_ptr   = (uint16_t*)guid.data;
-#ifdef __linux
    vendor     = guid_ptr[2];
    product    = guid_ptr[4];
-#elif _WIN32
-   vendor     = guid_ptr[0];
-   product    = guid_ptr[1];
-#endif
 #ifdef WEBOS
    if (vendor == 0x9999 && product == 0x9999)
    {


### PR DESCRIPTION
## Description

RA [parses the SDL joystick GUID](https://github.com/libretro/RetroArch/blob/3516ce5b6f6776c513741b39a22d7ad57ea3c6ca/input/drivers_joypad/sdl_joypad.c#L142-L143) differently for Windows than it does for Linux. However, SDL has used the same GUID format on all platforms for quite some time ([since 2.0.5](https://github.com/mdqinc/SDL_GameControllerDB/issues/110), and RA's currently bundling 2.0.14.0 with its Windows builds).

Since we currently parse the GUID wrong on Windows, without this change, using the SDL2 driver on Windows results in bogus `input_vendor_id` and `input_product_id` values:

<img width="2560" height="1440" alt="wrong-vid-pid" src="https://github.com/user-attachments/assets/064c35aa-ae24-4fb4-b42b-a5ffe7396ba6" />

After this change, the values are correct:

<img width="2560" height="1440" alt="right-vid-pid" src="https://github.com/user-attachments/assets/4182f3e0-19c4-4acf-be36-590dff78ead6" />

(Notice the fixed `sdl2` driver values now match the [correct ones reported by the `xinput` driver](https://github.com/libretro/retroarch-joypad-autoconfig/pull/1289).)

## Related Issues

Fixes #18634.

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]
