### PR TITLE
replace ifdef from "LAKKA" to "HAVE_LAKKA" in command.h

### DIFF
--- a/command.h
+++ b/command.h
@@ -351,7 +351,7 @@ bool command_network_send(const char *cmd_);
 #ifdef HAVE_STDIN_CMD
 command_t* command_stdin_new(void);
 #endif
-#ifdef LAKKA
+#ifdef HAVE_LAKKA
 command_t* command_uds_new(void);
 #endif
 #ifdef EMSCRIPTEN


### PR DESCRIPTION
## Description
In Lakka devel branch - retroarch building, the following compilation error was occurred.
```
input/input_driver.c: In function 'input_driver_init_command':
input/input_driver.c:5154:33: error: implicit declaration of function 'command_uds_new'; did you mean 'command_stdin_new'? [-Wimplicit-function-declaration]
 5154 |    if (!(input_st->command[2] = command_uds_new()))
      |                                 ^~~~~~~~~~~~~~~
      |                                 command_stdin_new
input/input_driver.c:5154:31: error: assignment to 'command_t *' {aka 'struct command_handler *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
 5154 |    if (!(input_st->command[2] = command_uds_new()))
      |                               ^
```

https://github.com/libretro/RetroArch/blob/3516ce5b6f6776c513741b39a22d7ad57ea3c6ca/command.h#L354
### In command.h, it uses `#ifdef LAKKA`, but Lakka build expects `#ifdef HAVE_LAKKA`.

## Related Issues
None

## Related Pull Requests
[retroarch: fix miss ifdef from LAKKA to HAVE_LAKKA #2166](https://github.com/libretro/Lakka-LibreELEC/pull/2166)


Thanks
ASAI, Shigeaki