### PR TITLE
Detect and correctly report all Windows x86/x64 versions in System Information

### DIFF
--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -467,7 +467,8 @@ static size_t frontend_win32_get_os(char *s, size_t len, int *major, int *minor)
             /* Detect Windows 11 starting from an early leaked preview build */
             if (vi.dwBuildNumber >= 21996)
                _len = strlcpy(s, "Windows 11", len);
-            else if (vi.dwBuildNumber >= 10240)
+            /* Detect Windows 10 from the first NT 10.0-based preview build */
+            else if (vi.dwBuildNumber >= 9888)
                _len = strlcpy(s, "Windows 10", len);
             else
                _len = snprintf(s, len, "Windows NT kernel %lu.%lu",


### PR DESCRIPTION
This fixes the incorrect Windows OS being reported in `System Information → Frontend OS`. 

This issue has existed for a very long time, possibly since Windows 8.1, and has been mentioned in #4768, #17712 and #13110, which are now closed. But the problem was never fixed (see latest posts [here](https://github.com/libretro/RetroArch/issues/13110#issuecomment-2844672043)). The latest stable and nightly builds are still affected.

<br/>Windows OSes affected by this issue:

- Windows 11 - All editions
- Windows 10 - All editions
- Windows 8.1 - All editions
- Windows Server 2025, 2022, 2019, 2016, and 2012 R2

<br/>Basically, it is **all** Windows OSes from 8.1 onwards. The problem is partly because of the compiler/manifest.

Here's some examples of OS misreporting with the latest buildbot builds:

| OS | RetroArch |
|----|-------------|
| **Windows 11** | <img width="240" height="41" alt="Image" src="https://github.com/user-attachments/assets/d37d1b84-081a-4dfe-b01f-54f86ae4d024" /> |
| **Windows 10** | <img width="440" height="49" alt="Image" src="https://github.com/user-attachments/assets/e6832390-3fc6-45d8-9de5-ea978ee1c897" /> |
| **Windows 8.1** | <img width="440" height="46" alt="Image" src="https://github.com/user-attachments/assets/e9b8c71b-95a7-456b-9e35-f78e5aa8fe0e" /> |
| **Windows Server 2025** | <img width="240" height="42" alt="Image" src="https://github.com/user-attachments/assets/22b0d244-bf52-4808-8779-73ffc2443c45" /> |

<br/>Changes in this PR:

- Correctly report all Windows OSes from 8.1 onwards. Previously, the deprecated `GetVersionEx` was used, so OS reporting accuracy depended on manifest compatibility entries that can vary by toolchain and compiler. Windows 8.1+ will intentionally report an older OS when the manifest does not declare support for the OS. This is why Windows 10 shows Windows 8 with buildbot/MinGW 10.2.0 above, but newer MinGW versions will work. `RtlGetVersion` is now used for OS detection starting from NT 5.0 (Windows 2000), which always reports the actual Windows version regardless of the manifest.
- Report the Windows feature version when available (e.g. `25H2`). This is increasingly important given the long lifespan of modern Windows versions (10/11) and how often these feature updates now break/change/add components. Future releases should also be reported correctly without requiring any changes, as the feature version is read from the Windows registry.
- Added detection for Windows Server 2019/2022/2025.
- Correctly report Windows XP Professional x64 Edition and Windows Server 2003/2003 R2/2008/2008 R2. These share the same NT version + build number, which was causing detection to fail.
- Detect Windows 98 Second Edition separately from Windows 98, which is a distinct OS revision with meaningful system and driver differences.
- Change Windows Me being reported as `Windows ME` to `Windows Me` (official documentation always uses a lower-case `e`. So i've been typing it wrong for 25+ years...).
- Improve readability of the reported OS by inserting a `-`. For example: `Windows 11 (25H2) x64 - Build 26200`
- Made fallbacks more robust and improved clarity. They will now show either: `Windows NT kernel x.x` or `Windows 9x version x.x`. Previously it would show `Windows x.x`, which could be mistaken for the OS name.
- Added many code comments to help maintainability.

<br/>Accurately reporting the Windows OS involves many edge cases and historical inconsistencies, so all Windows versions listed below were tested using x86/x64 builds from many different MSVC and MinGW compiler versions (yeah it took ages!).
<br>

| OS (by release date) | RetroArch |
|----|------------|
| **Windows 11 Insider Preview<br/>(latest Dev channel build)** | <img width="500" height="76" alt="win11_26H1_Dev" src="https://github.com/user-attachments/assets/da199e30-2eab-48c9-8cab-594e9a42141f" /><br/>Now reported correctly.  |
| **Windows 11 Insider Preview<br/>(older Dev channel build)** | <img width="500" height="70" alt="win11_Dev" src="https://github.com/user-attachments/assets/12022ea7-1555-4a00-b484-f276d35a66bd" /><br/>Note: Windows Insider builds may report channel names (e.g. “Dev”), as this is <br/>_sometimes_ stored in the registry, instead of the feature version name. |
| **Windows 11 (25H2)** | <img width="500" height="75" alt="win11_25H2" src="https://github.com/user-attachments/assets/cc405119-6146-48e0-9cd8-457ca5f5e58d" /><br/>Now reported correctly. |
| **Windows Server 2025 (24H2)** | <img width="500" height="79" alt="win_server_2025" src="https://github.com/user-attachments/assets/a827595b-017d-49c7-a89a-82b933593433" /><br/>Newly added. |
| **Windows 11 IoT Enterprise <br>(24H2)** | <img width="500" height="78" alt="win11_IoT_Ent" src="https://github.com/user-attachments/assets/f5c5b468-a878-464a-9d2d-657b2a68fcf8" /><br/>An example of a more obscure Windows edition. Different editions make no <br>difference to OS detection accuracy. |
| **Windows 10 (22H2)** | <img width="500" height="73" alt="win10_22H2" src="https://github.com/user-attachments/assets/e51c3547-2ccf-489a-ad78-b299bdca55f4" /><br/>Now reported correctly. |
| **Windows Server 2022 (21H2)** | <img width="500" height="76" alt="win_server_2022" src="https://github.com/user-attachments/assets/1a2ce5d5-55f6-4a87-826d-71aa59edf40c" /><br/>Newly added. |
| **Windows Server 2019 (1809)** | <img width="500" height="82" alt="win_server_2019" src="https://github.com/user-attachments/assets/c4a90e2b-585a-4639-87dd-072280df384a" /><br/>Newly added. |
| **Windows Server 2016 (1607)** | <img width="500" height="85" alt="win_server_2016" src="https://github.com/user-attachments/assets/cda14ae1-6edf-4814-86eb-4b0a3c73022f" /><br/>Now reported correctly. |
| **Windows 10 (1507)<br>(first released version)** | <img width="500" height="86" alt="win10_RTM" src="https://github.com/user-attachments/assets/bba2765f-d3d8-4144-88a5-a864e366e02a" /><br/>Note: Earlier Win10/Server releases used a different feature version format, e.g. <br>1507 (year/month) instead of the current year/half-year format. |
| **Windows Server 2012 R2** | <img width="500" height="73" alt="win_server_2012_R2" src="https://github.com/user-attachments/assets/26ce9fd2-4054-47cf-9220-08bf9d138986" /><br/>Now reported correctly. |
| **Windows 8.1** | <img width="500" height="72" alt="win8 1" src="https://github.com/user-attachments/assets/f4e67adf-0f49-47dc-ae0c-a3144aa0df7e" /><br/>Now reported correctly. |
| **Windows 8** | <img width="500" height="81" alt="win8" src="https://github.com/user-attachments/assets/2f8599fe-cdda-40be-8428-65f0e616b8ec" /><br/> |
| **Windows Server 2012** | <img width="500" height="86" alt="win_server_2012" src="https://github.com/user-attachments/assets/049c2a12-3b0c-4f30-b8bc-c9e9790b79f8" /><br/> |
| **Windows 7** | <img width="500" height="75" alt="win7" src="https://github.com/user-attachments/assets/14af2516-c12a-463d-b416-acb8c8ef40cf" /><br/> |
| **Windows Server 2008 R2** | <img width="500" height="74" alt="win_server_2008_R2" src="https://github.com/user-attachments/assets/58a6413d-73e9-45ab-8705-26e7bc016fb4" /><br/>Now reported correctly. |
| **Windows Server 2008** | <img width="500" height="76" alt="win_server_2008" src="https://github.com/user-attachments/assets/a060cadb-169e-43c9-bf6a-b1d128b068c3" /><br/>Now reported correctly. |
| **Windows Vista** | <img width="500" height="89" alt="winVista" src="https://github.com/user-attachments/assets/cc3999e5-5ad8-4802-8027-cdd4f1ded320" /><br/>Note: Pre-Vista Oses (below) lack reliable API support for x86/x64 detection. |
| **Windows Server 2003 R2** | <img width="500" height="67" alt="win_server_2003_R2" src="https://github.com/user-attachments/assets/067e611e-3fb8-4ada-b3ae-d6681af58a69" /><br/>Now reported correctly. |
| **Windows XP x64** | <img width="500" height="68" alt="winXP_x64" src="https://github.com/user-attachments/assets/fffe7a39-8e00-421d-8d90-398523b34533" /><br/>Now reported correctly. Note: XP x64 only had a single edition released, making <br/>it safe/easy to use the full product name here. |
| **Windows Server 2003** | <img width="500" height="69" alt="win_server_2003" src="https://github.com/user-attachments/assets/9dfd2b68-8a8c-4190-9011-15f0ffdc3d60" /><br>Now reported correctly. |
| **Windows XP** | <img width="500" height="76" alt="winXP" src="https://github.com/user-attachments/assets/218ee3ac-456f-4f09-850d-9d10ac6bccfe" /> |
| **Windows Me** | <img width="500" height="71" alt="winMe" src="https://github.com/user-attachments/assets/cd4e5d5d-b008-4bd0-b1c0-78c6974c4392" /><br/>Now displays `Me` instead of `ME`. |
| **Windows 2000** | <img width="500" height="74" alt="win2k" src="https://github.com/user-attachments/assets/a32be9e8-4a40-42d1-902f-ee0684e5e1db" /><br/> |
| **Windows 98 Second Edition** | <img width="500" height="69" alt="win98SE" src="https://github.com/user-attachments/assets/10ab4a70-68b9-4192-924b-f68dc6585498" /><br/>Newly added. |
| **Windows 98** | <img width="500" height="70" alt="win98" src="https://github.com/user-attachments/assets/4427143a-4ccf-462b-b64c-e776970f9583" /><br/> |
| **Windows 95 and NT 4.0** | Were not tested. RA hasn't worked on these OSes for a long time, but they <br/>should be reported correctly if builds were made to work on them. |

