### PR TITLE
Small fixes for DOS

### DIFF
--- a/core_info.c
+++ b/core_info.c
@@ -2118,7 +2118,7 @@ static core_info_list_t *core_info_list_new(const char *path,
       info->core_file_id.str  = strdup(core_file_id);
       info->core_file_id.hash = core_info_hash_string(core_file_id);
 
-      strlcpy(core_file_id + _len, ".info", sizeof(core_file_id) - _len);
+      strlcpy(core_file_id + _len, FILE_PATH_CORE_INFO_EXTENSION, sizeof(core_file_id) - _len);
 
       /* Parse core info file */
       if ((conf = core_info_get_config_file(core_file_id, info_dir)))

--- a/file_path_special.h
+++ b/file_path_special.h
@@ -39,7 +39,11 @@ RETRO_BEGIN_DECLS
 #define FILE_PATH_AUTO_EXTENSION ".auto"
 #define FILE_PATH_BSV_EXTENSION ".replay"
 #define FILE_PATH_OPT_EXTENSION ".opt"
+#ifdef DJGPP
+#define FILE_PATH_CORE_INFO_EXTENSION ".inf"
+#else
 #define FILE_PATH_CORE_INFO_EXTENSION ".info"
+#endif
 #define FILE_PATH_CONFIG_EXTENSION ".cfg"
 #define FILE_PATH_REMAP_EXTENSION ".rmp"
 #define FILE_PATH_RTC_EXTENSION ".rtc"
@@ -91,8 +95,13 @@ RETRO_BEGIN_DECLS
 #define FILE_PATH_CONTENT_MUSIC_HISTORY "content_music_history.lpl"
 #define FILE_PATH_CONTENT_VIDEO_HISTORY "content_video_history.lpl"
 #define FILE_PATH_CORE_OPTIONS_CONFIG "retroarch-core-options.cfg"
+#ifdef DJGPP
+#define FILE_PATH_MAIN_CONFIG "retrodos.cfg"
+#define FILE_PATH_SALAMANDER_CONFIG "retrosal.cfg"
+#else
 #define FILE_PATH_MAIN_CONFIG "retroarch.cfg"
 #define FILE_PATH_SALAMANDER_CONFIG "retroarch-salamander.cfg"
+#endif
 #define FILE_PATH_BACKGROUND_IMAGE "bg.png"
 #define FILE_PATH_TTF_FONT "font.ttf"
 #define FILE_PATH_RUNTIME_EXTENSION ".lrtl"

--- a/frontend/drivers/platform_dos.c
+++ b/frontend/drivers/platform_dos.c
@@ -58,7 +58,7 @@ static void frontend_dos_get_env_settings(int *argc, char *argv[],
    if ((slash = strrchr(base_path, '/')))
       *slash = '\0';
    slash = strrchr(base_path, '/');
-   if (slash && strcasecmp(slash, "/cores"))
+   if (slash && strcasecmp(slash, "/cores") == 0)
       *slash = '\0';
 
    fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CORE], base_path,


### PR DESCRIPTION
Adjusting a few definitions to help the DOS version. It is still not really operational, but these changes cause no harm elsewhere.

At least config saving/loading is not working as it should, logging to console kind of works, but it needs an external utility to capture because command.com has no provisions to direct stderr to file. Duh.

## Related Issues

Inspired by #18584 (but it does not solve it)
