### PR TITLE
github actions: include current macOS / iOS builders

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Compile RA
       run: |
         set -o pipefail
-        xcodebuild -workspace pkg/apple/RetroArch.xcworkspace -scheme RetroArch -config Release -xcconfig pkg/apple/GitHubCI.xcconfig -derivedDataPath build | xcpretty --color
+        xcodebuild -workspace pkg/apple/RetroArch.xcworkspace -scheme RetroArch -config Release -xcconfig pkg/apple/GitHubCI.xcconfig -derivedDataPath build
 
     - name: Get short SHA
       id: slug
       run: echo "sha8=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: RetroArch-${{ steps.slug.outputs.sha8 }}
         path: |

--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -1,0 +1,26 @@
+name: CI iOS (13)
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Compile RA
+      run: |
+        set -o pipefail
+        xcodebuild -workspace pkg/apple/RetroArch.xcworkspace -destination generic/platform=iOS -config Release \
+        -scheme "RetroArch iOS Release" -xcconfig pkg/apple/GitHubCI.xcconfig \
+        CODE_SIGNING_ALLOWED=NO \ CODE_SIGNING_REQUIRED=NO \ CODE_SIGN_IDENTITY="" \ PROVISIONING_PROFILE_SPECIFIER="" \
+        -derivedDataPath build


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Adds Apple builders for the current metal and IOS project
Removes xpretty because that hides the debug information I actually need
Note: iOS does not produce a artifact due to no credentials in github

This is useful for me as I do not own a macbook to compile with so I can see failures and correct them.

## Related Issues

## Related Pull Requests

## Reviewers
