### PR TITLE
Widget default size adjustment

### DIFF
--- a/gfx/gfx_widgets.h
+++ b/gfx/gfx_widgets.h
@@ -235,7 +235,6 @@ typedef struct dispgfx_widget
    unsigned msg_queue_icon_size_y;
    unsigned msg_queue_icon_offset_y;
    unsigned msg_queue_scissor_start_x;
-   unsigned msg_queue_default_rect_width_menu_alive;
    unsigned msg_queue_default_rect_width;
    unsigned msg_queue_regular_padding_x;
    unsigned msg_queue_regular_text_start;


### PR DESCRIPTION
## Description

- Use small widget size always by default and big size with word wrapped messages
- Use consistent max message wrap width regardless of menu state
- Rename duplicate variable name `msg` for clarity