### PR TITLE
set input_block_timeout default value to 1

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1637,6 +1637,11 @@
  * resuming content */
 #define DEFAULT_INPUT_AUTO_GAME_FOCUS AUTO_GAME_FOCUS_OFF
 
+/* Make simultaneous buttons easier to hit on Android */
+#if defined(ANDROID)
+#define DEFAULT_INPUT_BLOCK_TIMEOUT 1
+#endif
+
 /* Show the input descriptors set by the core instead
  * of the default ones. */
 #define DEFAULT_INPUT_DESCRIPTOR_LABEL_SHOW true

--- a/configuration.c
+++ b/configuration.c
@@ -2582,7 +2582,7 @@ static struct config_uint_setting *populate_settings_uint(
    SETTING_UINT("input_rumble_gain",             &settings->uints.input_rumble_gain, true, DEFAULT_RUMBLE_GAIN, false);
    SETTING_UINT("input_auto_game_focus",         &settings->uints.input_auto_game_focus, true, DEFAULT_INPUT_AUTO_GAME_FOCUS, false);
 #ifdef ANDROID
-   SETTING_UINT("input_block_timeout",           &settings->uints.input_block_timeout, true, 0, false);
+   SETTING_UINT("input_block_timeout",           &settings->uints.input_block_timeout, true, DEFAULT_INPUT_BLOCK_TIMEOUT, false);
 #endif
    SETTING_UINT("keyboard_gamepad_mapping_type", &settings->uints.input_keyboard_gamepad_mapping_type, true, 1, false);
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16903,7 +16903,7 @@ static bool setting_append_list(
             &settings->uints.input_block_timeout,
             MENU_ENUM_LABEL_INPUT_BLOCK_TIMEOUT,
             MENU_ENUM_LABEL_VALUE_INPUT_BLOCK_TIMEOUT,
-            0,
+            DEFAULT_INPUT_BLOCK_TIMEOUT,
             &group_info,
             &subgroup_info,
             parent_group,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Hitting >= 2 buttons simultaneously on Android can be difficult, so we added the input_block_timeout setting, but we left the default value to 0. Setting it to 1 greatly improves the situation and only adds a single millisecond of latency, so I think it's worth bumping the default value to 1.

## Related Issues

I don't know of any open tickets, but it's something that comes up often on the subreddit, like this one: https://www.reddit.com/r/RetroArch/comments/1qqifcj/captain_america_the_avengers_projectile_special/

## Related Pull Requests

none

## Reviewers

[If possible @mention all the people that should review your pull request]
