### PR TITLE
image_core: Rename to "Image Viewer"

### DIFF
--- a/cores/libretro-imageviewer/image_core.c
+++ b/cores/libretro-imageviewer/image_core.c
@@ -101,8 +101,8 @@ static const char* IMAGE_CORE_PREFIX(valid_extensions) = image_formats + 1;
 
 void IMAGE_CORE_PREFIX(retro_get_system_info)(struct retro_system_info *info)
 {
-   info->library_name     = "image display";
-   info->library_version  = "v0.1";
+   info->library_name     = "Image Viewer";
+   info->library_version  = "";
    info->need_fullpath    = true;
    info->block_extract    = false;
    info->valid_extensions = IMAGE_CORE_PREFIX(valid_extensions);

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8707,7 +8707,7 @@ static enum menu_action ozone_parse_menu_entry_action(
                && (ozone->show_thumbnail_bar))
          {
             /* Allow launch if already using "imageviewer" core */
-            if (string_is_equal(runloop_state_get_ptr()->system.info.library_name, "image display"))
+            if (string_is_equal(runloop_state_get_ptr()->system.info.library_name, "Image Viewer"))
                break;
 
             if (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -5953,7 +5953,7 @@ static enum menu_action xmb_parse_menu_entry_action(
                && xmb_get_system_tab(xmb, (unsigned)xmb->categories_selection_ptr) == XMB_SYSTEM_TAB_MAIN)
          {
             /* Allow launch if already using "imageviewer" core */
-            if (string_is_equal(runloop_state_get_ptr()->system.info.library_name, "image display"))
+            if (string_is_equal(runloop_state_get_ptr()->system.info.library_name, "Image Viewer"))
                break;
 
             if (xmb->show_fullscreen_thumbnails)


### PR DESCRIPTION
When you run the image viewer core, it's labeled as "image display", which while makes sense, isn't really a human-friendly core name. This small change updates the display name to "Image Viewer" so it looks a bit nicer in the display.

### Before

<img width="323" height="45" alt="Screenshot from 2026-02-03 18-57-18" src="https://github.com/user-attachments/assets/560117d1-f8e3-4bfe-809b-e7481ba52327" />


### After
<img width="245" height="51" alt="Screenshot from 2026-02-03 18-56-40" src="https://github.com/user-attachments/assets/6e7951f1-8e07-4200-83e7-bbe829254ccb" />

