### PR TITLE
added ROM Memory Type

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -519,6 +519,9 @@ enum retro_language
 /* Video ram lets a frontend peek into a game systems video RAM (VRAM). */
 #define RETRO_MEMORY_VIDEO_RAM   3
 
+/* ROM lets a frontend peek into a game systems ROM. */
+#define RETRO_MEMORY_ROM   4
+
 /** @} */
 
 /* Keysyms used for ID in input state callback when polling RETRO_KEYBOARD. */


### PR DESCRIPTION
This adds a ROM memory type constant, useful for scripting.

Example usages:

 - [frontend side](https://github.com/eadmaster/RetroArch/blob/lua_scripting/lua_manager.c#L504)
 - [inside a core](https://github.com/libretro/snes9x2010/blob/master/libretro/libretro.c#L563).

As alternative, `content_state_get_ptr()->content_list->entries[0].data` currently provides a read-only buffer that remains separate from the one used by most cores.
