### PR TITLE
lakka: notify initialize complete to systemd when 

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -815,6 +815,7 @@ endif
 ifeq ($(HAVE_LAKKA), 1)
    OBJ += network/drivers_wifi/connmanctl.o
    OBJ += misc/cpufreq/cpufreq.o
+   LIBS += -lsystemd
 endif
 
 ifeq ($(HAVE_WIFI), 1)

--- a/retroarch.c
+++ b/retroarch.c
@@ -226,6 +226,7 @@
 
 #ifdef HAVE_LAKKA
 #include "lakka.h"
+#include <systemd/sd-daemon.h>
 #endif
 
 #define _PSUPP(var, name, desc) printf("  %s:\n\t\t%s: %s\n", name, desc, var ? "yes" : "no")
@@ -6143,6 +6144,9 @@ int rarch_main(int argc, char *argv[], void *data)
 #ifdef HAVE_CLOUDSYNC
    if (settings->uints.cloud_sync_sync_mode == CLOUD_SYNC_MODE_AUTOMATIC)
       task_push_cloud_sync();
+#endif
+#ifdef HAVE_LAKKA
+   sd_notify(0, "READY=1");
 #endif
 #if !defined(HAVE_MAIN) || defined(HAVE_QT)
    for (;;)


### PR DESCRIPTION
## Description
This Pull requests is from Lakka.
This Pull requests adds "initialize complete" notify to systemd when retroarch intialize complete on Lakka.

By this Pull requests, cec-mini-kb.service was able to know that retroarch(retroarch.service) finished initialize.
After that, cec-mini-kb.service is able to start itself service.

## Related Issues
https://github.com/libretro/Lakka-LibreELEC/issues/1981

## Related Pull Requests
https://github.com/libretro/Lakka-LibreELEC/pull/1984

## Reviewers
@toke79

Thanks,
ASAI, Shigeaki