### PR TITLE
lakka: reconsideration for samba service enable disable

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3072,7 +3072,7 @@ void config_set_defaults(void *data)
    configuration_set_bool(settings,
          settings->bools.ssh_enable, filestream_exists(LAKKA_SSH_PATH));
    configuration_set_bool(settings,
-         settings->bools.samba_enable, filestream_exists(LAKKA_SAMBA_PATH));
+         settings->bools.samba_enable, !filestream_exists(LAKKA_SAMBA_DISABLED_FILE_PATH));
    configuration_set_bool(settings,
          settings->bools.bluetooth_enable, filestream_exists(LAKKA_BLUETOOTH_PATH));
    configuration_set_bool(settings, settings->bools.localap_enable, false);
@@ -4442,7 +4442,7 @@ static bool config_load_file(global_t *global,
    configuration_set_bool(settings,
          settings->bools.ssh_enable, filestream_exists(LAKKA_SSH_PATH));
    configuration_set_bool(settings,
-         settings->bools.samba_enable, filestream_exists(LAKKA_SAMBA_PATH));
+         settings->bools.samba_enable, !filestream_exists(LAKKA_SAMBA_DISABLED_FILE_PATH));
    configuration_set_bool(settings,
          settings->bools.bluetooth_enable, filestream_exists(LAKKA_BLUETOOTH_PATH));
 #ifdef HAVE_RETROFLAG
@@ -5700,11 +5700,11 @@ bool config_save_file(const char *path)
    else
       filestream_delete(LAKKA_SSH_PATH);
    if (settings->bools.samba_enable)
-      filestream_close(filestream_open(LAKKA_SAMBA_PATH,
+      filestream_delete(LAKKA_SAMBA_DISABLED_FILE_PATH);
+   else
+      filestream_close(filestream_open(LAKKA_SAMBA_DISABLED_FILE_PATH,
                RETRO_VFS_FILE_ACCESS_WRITE,
                RETRO_VFS_FILE_ACCESS_HINT_NONE));
-   else
-      filestream_delete(LAKKA_SAMBA_PATH);
    if (settings->bools.bluetooth_enable)
       filestream_close(filestream_open(LAKKA_BLUETOOTH_PATH,
                RETRO_VFS_FILE_ACCESS_WRITE,

--- a/lakka.h
+++ b/lakka.h
@@ -18,16 +18,17 @@
 #ifndef __RARCH_LAKKA_H
 #define __RARCH_LAKKA_H
 
-#define LAKKA_SSH_PATH          "/storage/.cache/services/sshd.conf"
-#define LAKKA_SAMBA_PATH        "/storage/.cache/services/samba.conf"
-#define LAKKA_BLUETOOTH_PATH    "/storage/.cache/services/bluez.conf"
+#define LAKKA_SSH_PATH                 "/storage/.cache/services/sshd.conf"
+#define LAKKA_SAMBA_PATH               "/storage/.cache/services/samba.conf"
+#define LAKKA_SAMBA_DISABLED_FILE_PATH "/storage/.cache/services/samba.disabled"
+#define LAKKA_BLUETOOTH_PATH           "/storage/.cache/services/bluez.conf"
 #ifdef HAVE_RETROFLAG
-#define LAKKA_SAFESHUTDOWN_PATH "/storage/.cache/services/safeshutdown.conf"
+#define LAKKA_SAFESHUTDOWN_PATH        "/storage/.cache/services/safeshutdown.conf"
 #endif
-#define LAKKA_UPDATE_DIR        "/storage/.update/"
-#define LAKKA_CONNMAN_DIR       "/storage/.cache/connman/"
-#define LAKKA_LOCALAP_PATH      "/storage/.cache/services/localap.conf"
-#define LAKKA_TIMEZONE_PATH     "/storage/.cache/timezone"
+#define LAKKA_UPDATE_DIR               "/storage/.update/"
+#define LAKKA_CONNMAN_DIR              "/storage/.cache/connman/"
+#define LAKKA_LOCALAP_PATH             "/storage/.cache/services/localap.conf"
+#define LAKKA_TIMEZONE_PATH            "/storage/.cache/timezone"
 
 #define DEFAULT_TIMEZONE "UTC"
 #define TIMEZONE_LENGTH 255

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -9465,6 +9465,33 @@ static void systemd_service_toggle(const char *path, char *unit, bool enable)
    }
 }
 
+static void systemd_samba_service_toggle(const char *path, char *unit, bool enable)
+{
+   /* There is difference between samba and ssh/bluetooth.
+    * - samba.service is disabled if "/storage/.cache/services/samba.disabled" file is exist.
+    * - ssh.service is enabled if "/storage/.cache/services/sshd.conf" file is exist.
+    * - bluetooth.service is enabled if "/storage/.cache/services/bluez.conf" file is exist.
+    * So it separates the systemd_service_toggle for samba.service. */
+
+   pid_t pid    = fork();
+   char* args[] = {(char*)"systemctl",
+                   enable ? (char*)"start" : (char*)"stop",
+                   unit,
+                   NULL};
+
+   if (pid == 0)
+   {
+      if (enable)
+         filestream_delete(path);
+      else
+         filestream_close(filestream_open(path,
+                  RETRO_VFS_FILE_ACCESS_WRITE,
+                  RETRO_VFS_FILE_ACCESS_HINT_NONE));
+
+      execvp(args[0], args);
+   }
+}
+
 #ifdef HAVE_LAKKA_SWITCH
 static void switch_oc_enable_toggle_change_handler(rarch_setting_t *setting)
 {
@@ -9513,7 +9540,7 @@ static void ssh_enable_toggle_change_handler(rarch_setting_t *setting)
 
 static void samba_enable_toggle_change_handler(rarch_setting_t *setting)
 {
-   systemd_service_toggle(LAKKA_SAMBA_PATH, (char*)"smbd.service",
+   systemd_samba_service_toggle(LAKKA_SAMBA_DISABLED_FILE_PATH, (char*)"smbd.service",
          *setting->value.target.boolean);
 }
 


### PR DESCRIPTION
## Description
This Pull requests is from Lakka.
This Pull requests fixes samba.service lost enable/disable setting after reboot on Lakka.

### [Cause]
> Lakka merged the commit https://github.com/libretro/Lakka-LibreELEC/commit/061bb5d39b8076c4f00489bc8006dbd9193a0046.
> 
> "/storage/.cache/services/samba.disabled" file is added for samba enable/disable by this commit.
> The smbd.service uses this file for enable/disable service itself. 
> 
> But retroarch is not chatched up for this commit yet.
> So retroarch uses/removes "/storage/.cache/services/samba.conf" file that was used at before this commit.
> The smbd.service can't find "/storage/.cache/services/samba.disabled" file if samba is disabled in retroarch, so samba is enabled after reboot.

### [Fix]
> 1. retroarch does catch up [061bb5d39b8076c4f00489bc8006dbd9193a0046](https://github.com/libretro/Lakka-LibreELEC/commit/061bb5d39b8076c4f00489bc8006dbd9193a0046)
> Use "/storage/.cache/services/samba.disabled" for enable/disable samba.

## Related Issues
https://github.com/libretro/Lakka-LibreELEC/issues/2098

## Related Pull Requests
https://github.com/libretro/Lakka-LibreELEC/pull/2101

## Reviewers
@ToKe79 

Thanks
ASAI, Shigeaki