### PR TITLE
Vulkan: Fix HDR pipeline blend factor for correct text rendering

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -2668,7 +2668,7 @@ static void vulkan_init_pipelines(vk_t *vk)
       /* HDR pipeline. */
       blend_attachment.blendEnable = VK_TRUE;
 
-      blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+      blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
       blend_attachment.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
 
       /* HDR pipeline. */


### PR DESCRIPTION
## Summary

- **Fix text/UI alpha blending:** Changes `srcColorBlendFactor` from `VK_BLEND_FACTOR_ONE` to `VK_BLEND_FACTOR_SRC_ALPHA` in the HDR pipeline blend attachment, enabling proper alpha blending for text and UI elements rendered over HDR content