### PR TITLE
vulkan: minor hdr fix

### DIFF
--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -238,7 +238,8 @@ enum vk_flags
    VK_FLAG_READBACK_PENDING    = (1 << 12),
    VK_FLAG_READBACK_STREAMED   = (1 << 13),
    VK_FLAG_OVERLAY_ENABLE      = (1 << 14),
-   VK_FLAG_OVERLAY_FULLSCREEN  = (1 << 15)
+   VK_FLAG_OVERLAY_FULLSCREEN  = (1 << 15),
+   VK_FLAG_SDR_OFFSCREEN       = (1 << 16)  /* Rendering to SDR offscreen buffer */
 };
 
 


### PR DESCRIPTION
The vulkan validation layers were warning that there were still format mismatches between pipelines and render passes.

1. Display/overlay pipelines created with SDR render pass were being used when rendering to HDR framebuffers
2. When rendering to the SDR offscreen buffer (for menu/overlay compositing), HDR pipelines were incorrectly being selected

cc @MajorPainTheCactus 