### PR TITLE
(cheevos) update to rcheevos 12.3

### DIFF
--- a/cheevos/cheevos_client.c
+++ b/cheevos/cheevos_client.c
@@ -327,7 +327,7 @@ void rcheevos_client_server_call(const rc_api_request_t* request,
       rcheevos_log_post_url(request->url, request->post_data);
 
 #ifdef CHEEVOS_JSON_OVERRIDE
-      if (strstr(request->post_data, "r=patch"))
+      if (strstr(request->post_data, "r=patch") || strstr(request->post_data, "r=achievementsets"))
       {
          rcheevos_client_http_load_response(request, callback, callback_data);
          return;
@@ -335,7 +335,7 @@ void rcheevos_client_server_call(const rc_api_request_t* request,
 #endif
 
 #ifdef CHEEVOS_SAVE_JSON
-      if (strstr(request->post_data, "r=patch"))
+      if (strstr(request->post_data, "r=patch") || strstr(request->post_data, "r=achievementsets"))
       {
          task_push_http_post_transfer_with_user_agent(request->url,
             request->post_data, true, "POST", rcheevos_locals->user_agent_core,

--- a/deps/rcheevos/CHANGELOG.md
+++ b/deps/rcheevos/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v12.3.0
+* add rc_client_get_next_achievement_info
+* rc_client image functions will now return RC_INSUFFICENT_BUFFER instead of truncating if buffer is not large enough
+* fix race condition where rich presence from previous game may get associated to current game
+* fix rc_client_has_leaderboards returning true if the game only has hidden leaderboards
+* fix memory leak parsing large achievements
+* fix incomplete rich presence display condition affecting later display conditions
+
 # v12.2.1
 * fix parsing of leaderboards with comparisons in legacy-formatted values
 * fix validation warning on long AddSource chains

--- a/deps/rcheevos/include/rc_client.h
+++ b/deps/rcheevos/include/rc_client.h
@@ -524,6 +524,11 @@ typedef struct rc_client_achievement_t {
 RC_EXPORT const rc_client_achievement_t* RC_CCONV rc_client_get_achievement_info(rc_client_t* client, uint32_t id);
 
 /**
+ * Gets the next achievement after a provided achievement that fits in the specified bucket. Returns NULL if none found.
+ */
+RC_EXPORT const rc_client_achievement_t * RC_CCONV rc_client_get_next_achievement_info(rc_client_t * client, const rc_client_achievement_t * achievement, int bucket);
+
+/**
  * Gets the URL for the achievement image.
  * Returns RC_OK on success.
  */

--- a/deps/rcheevos/src/rc_client_external.c
+++ b/deps/rcheevos/src/rc_client_external.c
@@ -5,6 +5,8 @@
 
 #include "rc_api_runtime.h"
 
+#ifdef RC_CLIENT_SUPPORTS_EXTERNAL
+
 #define RC_CONVERSION_FILL(obj, obj_type, src_type) memset((uint8_t*)obj + sizeof(src_type), 0, sizeof(obj_type) - sizeof(src_type))
 
 /* https://media.retroachievements.org/Badge/123456_lock.png is 58 with null terminator */
@@ -275,3 +277,5 @@ rc_client_achievement_list_t* rc_client_external_convert_v1_achievement_list(con
 
   return (rc_client_achievement_list_t*)new_list;
 }
+
+#endif /* RC_CLIENT_SUPPORTS_EXTERNAL */

--- a/deps/rcheevos/src/rc_client_external.h
+++ b/deps/rcheevos/src/rc_client_external.h
@@ -46,6 +46,7 @@ typedef void (RC_CCONV* rc_client_external_add_game_hash_func_t)(const char* has
 struct rc_client_achievement_list_info_t;
 typedef struct rc_client_achievement_list_info_t* (RC_CCONV *rc_client_external_create_achievement_list_func_t)(int category, int grouping);
 typedef const rc_client_achievement_t* (RC_CCONV *rc_client_external_get_achievement_info_func_t)(uint32_t id);
+typedef const rc_client_achievement_t* (RC_CCONV* rc_client_external_get_next_achievement_info_func_t)(uint32_t id, int grouping);
 
 /* NOTE: rc_client_external_create_leaderboard_list_func_t returns an internal wrapper structure which contains the public list
  * and a destructor function. */
@@ -152,9 +153,12 @@ typedef struct rc_client_external_t
   /* VERSION 6 */
   rc_client_external_create_subset_list_func_t create_subset_list;
 
+  /* VERSION 7 */
+  rc_client_external_get_next_achievement_info_func_t get_next_achievement_info;
+
 } rc_client_external_t;
 
-#define RC_CLIENT_EXTERNAL_VERSION 5
+#define RC_CLIENT_EXTERNAL_VERSION 7
 
 void rc_client_add_game_hash(rc_client_t* client, const char* hash, uint32_t game_id);
 void rc_client_load_unknown_game(rc_client_t* client, const char* hash);

--- a/deps/rcheevos/src/rcheevos/condset.c
+++ b/deps/rcheevos/src/rcheevos/condset.c
@@ -134,10 +134,12 @@ static int rc_find_next_classification(const char* memaddr) {
         break;
 
       default:
+        rc_destroy_parse_state(&parse);
         return classification;
     }
   } while (*memaddr++ == '_');
 
+  rc_destroy_parse_state(&parse);
   return RC_CONDITION_CLASSIFICATION_OTHER;
 }
 
@@ -260,6 +262,11 @@ rc_condset_t* rc_parse_condset(const char** memaddr, rc_parse_state_t* parse) {
   }
 
   next = &self->conditions;
+
+  /* prevent bleedthrough of incomplete conditions from other groups */
+  parse->addsource_oper = RC_OPERATOR_NONE;
+  parse->addsource_parent.type = RC_OPERAND_NONE;
+  parse->indirect_parent.type = RC_OPERAND_NONE;
 
   /* each condition set has a functionally new recall accumulator */
   parse->remember.type = RC_OPERAND_NONE;

--- a/deps/rcheevos/src/rcheevos/runtime_progress.c
+++ b/deps/rcheevos/src/rcheevos/runtime_progress.c
@@ -913,7 +913,7 @@ uint32_t rc_runtime_progress_size(const rc_runtime_t* runtime, void* unused_L)
 
   result = rc_runtime_progress_serialize_internal(&progress);
   if (result != RC_OK)
-    return result;
+    return 0;
 
   return progress.offset;
 }


### PR DESCRIPTION
## Description

There's a couple minor bugfixes being pulled in, but the primary driver for this change is a new function that returns the next most likely achievement to be unlocked. This can be used to mitigate some of the [feedback](https://github.com/libretro/RetroArch/pull/18639#issuecomment-3849187446) from #18639. Instead of loading all badges on demand (new behavior) or all badges up front (old behavior), this allows the next most likely to unlock badge to be downloaded. Then, any time an achievement is unlocked, the next most likely to unlock badge is downloaded. This keeps the cache small, and the eliminates the initial stutter, which minimizing the amount of time when the placeholder badge is shown.

The full list can still be predownloaded by opening the achievements menu.

There was also a [suggestion](https://discord.com/channels/184109094070779904/469974542299955210/1468677602288865491) to delay the popup until the badge is available, which I'm still considering, but that's a bit more complicated and I think it deserves a separate PR.

## Related Issues

https://github.com/libretro/RetroArch/pull/18639#issuecomment-3849187446

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
