### PR TITLE
Revert mipmap generation on render targets from 66a7657

### DIFF
--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -406,8 +406,8 @@ static void d3d10_init_texture(D3D10Device device, d3d10_texture_t* texture)
       unsigned width, height;
 
       texture->desc.BindFlags |= D3D10_BIND_RENDER_TARGET;
-      width                    = texture->desc.Width;
-      height                   = texture->desc.Height;
+      width                    = texture->desc.Width  >> 5;
+      height                   = texture->desc.Height >> 5;
 
       while ((width > 1) || (height > 1))
       {
@@ -2378,7 +2378,6 @@ static void d3d10_init_render_targets(d3d10_video_t* d3d10,
          d3d10->pass[i].rt.desc.BindFlags = D3D10_BIND_RENDER_TARGET;
          d3d10->pass[i].rt.desc.Format    = glslang_format_to_dxgi(
                d3d10->pass[i].semantics.format);
-         d3d10->pass[i].rt.desc.MiscFlags = D3D10_RESOURCE_MISC_GENERATE_MIPS;
          d3d10_release_texture(&d3d10->pass[i].rt);
          d3d10_init_texture(d3d10->device, &d3d10->pass[i].rt);
 
@@ -2721,11 +2720,6 @@ static bool d3d10_gfx_frame(
 #endif /* D3D10_ROLLING_SCANLINE_SIMULATION */
 
             context->lpVtbl->Draw(context, 4, 0);
-
-            /* Generate mipmaps for render target if needed */
-            if (d3d10->pass[i].rt.desc.MiscFlags & D3D10_RESOURCE_MISC_GENERATE_MIPS)
-               context->lpVtbl->GenerateMips(context, d3d10->pass[i].rt.view);
-               
             texture = &d3d10->pass[i].rt;
          }
          else

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -579,9 +579,8 @@ static void d3d11_init_texture(D3D11Device device, d3d11_texture_t* texture)
       unsigned width, height;
 
       texture->desc.BindFlags |= D3D11_BIND_RENDER_TARGET;
-      width                    = texture->desc.Width;
-      height                   = texture->desc.Height;
-      texture->desc.MipLevels  = 1;
+      width                    = texture->desc.Width  >> 5;
+      height                   = texture->desc.Height >> 5;
 
       while ((width > 1) || (height > 1))
       {
@@ -3226,13 +3225,10 @@ static void d3d11_init_render_targets(d3d11_video_t* d3d11, unsigned width, unsi
          d3d11->pass[i].viewport.Width    = width;
          d3d11->pass[i].viewport.Height   = height;
          d3d11->pass[i].viewport.MaxDepth = 1.0;
-         
          d3d11->pass[i].rt.desc.Width     = width;
          d3d11->pass[i].rt.desc.Height    = height;
          d3d11->pass[i].rt.desc.BindFlags = D3D11_BIND_RENDER_TARGET;
          d3d11->pass[i].rt.desc.Format    = glslang_format_to_dxgi(d3d11->pass[i].semantics.format);
-         d3d11->pass[i].rt.desc.MiscFlags = D3D11_RESOURCE_MISC_GENERATE_MIPS;
-
          d3d11_release_texture(&d3d11->pass[i].rt);
          d3d11_init_texture(d3d11->device, &d3d11->pass[i].rt);
 
@@ -3727,10 +3723,6 @@ static bool d3d11_gfx_frame(
             context->lpVtbl->Draw(context, 4, 0);
          else
             context->lpVtbl->Draw(context, 4, 4);
-
-         /* Generate mipmaps for render target if needed */
-         if (d3d11->pass[i].rt.desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS)
-            context->lpVtbl->GenerateMips(context, d3d11->pass[i].rt.view);
 
          texture = &d3d11->pass[i].rt;
       }

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -726,11 +726,11 @@ static void d3d12_init_texture(D3D12Device device, d3d12_texture_t* texture)
    if (!texture->desc.MipLevels)
       texture->desc.MipLevels          = 1;
 
-   /* Calculate mipmap count */
-   if (texture->desc.Width > 1 || texture->desc.Height > 1)
+   if (   !(texture->desc.Width  >> (texture->desc.MipLevels - 1))
+       && !(texture->desc.Height >> (texture->desc.MipLevels - 1)))
    {
-      unsigned width                   = texture->desc.Width;
-      unsigned height                  = texture->desc.Height;
+      unsigned width                   = texture->desc.Width  >> 5;
+      unsigned height                  = texture->desc.Height >> 5;
       texture->desc.MipLevels          = 1;
       while ((width > 1) || (height > 1))
       {
@@ -846,11 +846,33 @@ static void d3d12_init_texture(D3D12Device device, d3d12_texture_t* texture)
    texture->size_data.w = 1.0f / texture->desc.Height;
 }
 
-static void d3d12_generate_mipmaps(
-      D3D12GraphicsCommandList cmd,
-      d3d12_texture_t* texture,
-      void *userdata)
+static void d3d12_upload_texture(D3D12GraphicsCommandList cmd,
+      d3d12_texture_t* texture, void *userdata)
 {
+   D3D12_TEXTURE_COPY_LOCATION src, dst;
+
+   src.pResource        = texture->upload_buffer;
+   src.Type             = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+   src.PlacedFootprint  = texture->layout;
+
+   dst.pResource        = texture->handle;
+   dst.Type             = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+   dst.SubresourceIndex = 0;
+
+   D3D12_RESOURCE_TRANSITION(
+         cmd,
+         texture->handle,
+         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+         D3D12_RESOURCE_STATE_COPY_DEST);
+
+   cmd->lpVtbl->CopyTextureRegion(cmd, &dst, 0, 0, 0, &src, NULL);
+
+   D3D12_RESOURCE_TRANSITION(
+         cmd,
+         texture->handle,
+         D3D12_RESOURCE_STATE_COPY_DEST,
+         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+
    if (texture->desc.MipLevels > 1)
    {
       unsigned       i;
@@ -906,36 +928,6 @@ static void d3d12_generate_mipmaps(
          }
       }
    }
-}
-
-static void d3d12_upload_texture(D3D12GraphicsCommandList cmd,
-      d3d12_texture_t* texture, void *userdata)
-{
-   D3D12_TEXTURE_COPY_LOCATION src, dst;
-
-   src.pResource        = texture->upload_buffer;
-   src.Type             = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
-   src.PlacedFootprint  = texture->layout;
-
-   dst.pResource        = texture->handle;
-   dst.Type             = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
-   dst.SubresourceIndex = 0;
-
-   D3D12_RESOURCE_TRANSITION(
-         cmd,
-         texture->handle,
-         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-         D3D12_RESOURCE_STATE_COPY_DEST);
-
-   cmd->lpVtbl->CopyTextureRegion(cmd, &dst, 0, 0, 0, &src, NULL);
-
-   D3D12_RESOURCE_TRANSITION(
-         cmd,
-         texture->handle,
-         D3D12_RESOURCE_STATE_COPY_DEST,
-         D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-
-   d3d12_generate_mipmaps(cmd, texture, userdata);
 
    texture->dirty = false;
 }
@@ -3776,8 +3768,6 @@ static void d3d12_init_render_targets(d3d12_video_t* d3d12, unsigned width, unsi
          d3d12->pass[i].rt.desc.Flags      = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
          d3d12->pass[i].rt.srv_heap        = &d3d12->desc.srv_heap;
          d3d12->pass[i].rt.desc.Format = glslang_format_to_dxgi(d3d12->pass[i].semantics.format);
-         /* Initialize MipLevels so mipmaps are created for render target */
-         d3d12->pass[i].rt.desc.MipLevels = 0;
          d3d12_release_texture(&d3d12->pass[i].rt);
          d3d12_init_texture(d3d12->device, &d3d12->pass[i].rt);
 
@@ -4423,9 +4413,6 @@ static bool d3d12_gfx_frame(
                   d3d12->pass[i].rt.handle,
                   D3D12_RESOURCE_STATE_RENDER_TARGET,
                   D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-
-            /* Generate mipmaps for framebuffer if it has multiple mipmap levels */
-            d3d12_generate_mipmaps(cmd, &d3d12->pass[i].rt, d3d12);
 
             D3D12_RESOURCE_TRANSITION(
                   cmd,


### PR DESCRIPTION
## Summary
- Reverts the render target mipmap generation feature from 66a7657 (`fix mipmaps on generated textures`) across D3D10, D3D11, and D3D12
- Removes `GENERATE_MIPS` / `MipLevels = 0` on shader pass render targets and the associated `GenerateMips` / `d3d12_generate_mipmaps` calls after render passes
- Preserves the non-square texture mipmap count fix (`||` vs `&&` loop condition) which is a valid standalone bugfix
- Preserves all D3D12 HDR pipeline fixes from 7df941e (blend pipelines, resource state management, overlay support, etc.)

## Context
The mipmap changes from 66a7657 were previously reverted in 226d7b1 (D3D12 only) and then partially re-merged in 7df941e alongside HDR pipeline fixes. This PR cleanly separates the two, reverting only the mipmap render target feature while keeping the HDR fixes intact.