### PR TITLE
Add pkg/android/phoenix-legacy/.project to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ wiiu/wut/elf2rpl/elf2rpl
 /pkg/android/phoenix/.gradle
 /pkg/android/phoenix/.externalNativeBuild
 /pkg/android/phoenix/build
+/pkg/android/phoenix-legacy/.project
 
 # Cloned by libretro-fetch.sh
 /media/assets/


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

I use VSCode and it keeps creating pkg/android/phoenix-legacy/.project, so I've added it to .gitignore as its quite annoying.

## Related Issues

## Related Pull Requests


## Reviewers

