### PR TITLE
Autoconf profile loading and saving rework

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4203,14 +4203,16 @@ size_t input_config_get_bind_string_joykey(
             && input_descriptor_label_show)
          return fill_pathname_join_delim(s,
                bind->joykey_label, suffix, ' ', len);
+
       /* TODO/FIXME - localize */
       _len  = strlcpy(s, "Button ", len);
       _len += snprintf(s + _len, len - _len, "%u",
             (unsigned)bind->joykey);
-
-      if (!string_is_empty(suffix))
-         _len += snprintf(s + _len, len - _len, " %s", suffix);
    }
+
+   if (!string_is_empty(suffix))
+      _len += snprintf(s + _len, len - _len, " %s", suffix);
+
    return _len;
 }
 
@@ -4225,14 +4227,20 @@ size_t input_config_get_bind_string_joyaxis(
          && input_descriptor_label_show)
       return fill_pathname_join_delim(s,
             bind->joyaxis_label, suffix, ' ', len);
+
    /* TODO/FIXME - localize */
    _len = strlcpy(s, "Axis ", len);
+
    if (AXIS_NEG_GET(bind->joyaxis) != AXIS_DIR_NONE)
       _len += snprintf(s + _len, len - _len, "-%u",
             (unsigned)AXIS_NEG_GET(bind->joyaxis));
    else if (AXIS_POS_GET(bind->joyaxis) != AXIS_DIR_NONE)
       _len += snprintf(s + _len, len - _len, "+%u",
             (unsigned)AXIS_POS_GET(bind->joyaxis));
+
+   if (!string_is_empty(suffix))
+      _len += snprintf(s + _len, len - _len, " %s", suffix);
+
    return _len;
 }
 

--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -14141,7 +14141,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MSG_AUTOCONFIG_FILE_SAVED_SUCCESSFULLY_NAMED,
-   "Controller profile saved in Controller Profiles directory as\n\"%s\""
+   "Controller profile saved as \"%s\"."
    )
 MSG_HASH(
    MSG_AUTOSAVE_FAILED,


### PR DESCRIPTION
## Description

A few changes for helping the creation, updating and management of autoconf profiles:
- Profiles are saved to the base directory instead of active driver subdir
- Profiles are searched from the base directory first and driver subdir only if there is no match

This is because:
- The user most likely wants to prioritize the manually saved profile
- There are lots of duplicate vid/pid/name profiles in the various driver directories, which would be read in order instead, resulting in false matches without manually deleting the wrong profiles

Also:
- Saving checks that at least RetroPad B and D-Pad directions or Left Analog have binds
- Saving pre-fills existing autoconf binds for saving if those already exist without having to bind each bind every time if changing only one bind
- Saving copies existing autoconf labels and display name
- Saving clears controller binds so that manual bind reset is not required in order to not make a mess of the config and to not nuke non-default keyboard binds
- Saving loads and activates the fresh saved profile without replugging
- `(Auto)` suffix is also shown in axis labels without having the label elements defined in the profile
- Minor cleanups