### PR TITLE
Makefile.miyoo: use generic call for SYSROOT path

### DIFF
--- a/Makefile.miyoo
+++ b/Makefile.miyoo
@@ -26,11 +26,13 @@ else
 STRIP                 = $(TOOLCHAIN_DIR)/usr/bin/arm-linux-strip
 endif
 
-GCW0_SDL_CONFIG      ?= $(TOOLCHAIN_DIR)/usr/arm-miyoo-linux-uclibcgnueabi/sysroot/usr/bin/sdl-config
-GCW0_FREETYPE_CONFIG ?= $(TOOLCHAIN_DIR)/usr/arm-miyoo-linux-uclibcgnueabi/sysroot/usr/bin/freetype-config
+SYSROOT              ?= $(shell $(CC) --print-sysroot)
 
-GCW0_INC_DIR         ?= $(TOOLCHAIN_DIR)/usr/arm-miyoo-linux-uclibcgnueabi/sysroot/usr/include
-GCW0_LIB_DIR         ?= $(TOOLCHAIN_DIR)/usr/arm-miyoo-linux-uclibcgnueabi/sysroot/usr/lib
+GCW0_SDL_CONFIG      ?= $(SYSROOT)/usr/bin/sdl-config
+GCW0_FREETYPE_CONFIG ?= $(SYSROOT)/usr/bin/freetype-config
+
+GCW0_INC_DIR         ?= $(SYSROOT)/usr/include
+GCW0_LIB_DIR         ?= $(SYSROOT)/usr/lib
 
 #########################
 #########################


### PR DESCRIPTION
## PR Description

Allows easy building with other libC implementations (e.g musl), not necessary uclibc.

## Off-Topic (question)
We're slowly switching to musl based system on Miyoo arm32, mostly for performance reasons (might be less stable), but allowing for uClibc in separate CFW image with better backward compatibility (our old toolchain, the one in libretro buildbot is using uclibc). 

**Question**: For future and for ppl to be using `musl` based OS, would it be possible to add another template in libretro infrastucture? Probably dup of [dingux-arm32.yml](https://git.libretro.com/libretro-infrastructure/ci-templates/-/blob/master/dingux-arm32.yml?ref_type=heads) with image `libretro-build-dingux:musl` by adding Dockerfile.musl (mirror of [Dockerfile](https://git.libretro.com/libretro-infrastructure/libretro-build-dingux/-/blob/master/Dockerfile) with latest musl dynamic toolchain) and another [SDK](https://git.libretro.com/libretro-infrastructure/libretro-build-dingux/-/tree/master/toolchain). Writing it down, cuz I'm not sure if anybody "outside" is allowed to make any PR in self-hosted gitlab.