### PR TITLE
Separate sensitive credentials into credentials.cfg

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -27,6 +27,13 @@
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
+      || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) \
+      || defined(__HAIKU__)
+#include <sys/stat.h>
+#define CONFIG_CREDENTIALS_RESTRICT_PERMS 1
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -936,6 +943,11 @@ struct config_path_setting
 #ifdef HAVE_CONFIGFILE
 static void config_parse_file(global_t *global);
 static size_t config_get_credentials_path(char *s, size_t len);
+static bool config_save_credentials(
+      const struct config_array_setting *array_settings,
+      int array_settings_size,
+      const struct config_path_setting *path_settings,
+      int path_settings_size);
 #endif
 
 struct defaults g_defaults;
@@ -6405,6 +6417,29 @@ static bool config_load_file(global_t *global,
          RARCH_LOG("[Config] Loading config: \"%s\".\n", path);
    }
 
+   /* Merge credentials from separate file.
+    * Credentials are stored in retroarch-keychain.cfg alongside
+    * the main config to keep sensitive data (passwords,
+    * tokens, keys) out of retroarch.cfg.
+    * Merged before any --appendconfig files so that an
+    * explicit override on the command line still wins. */
+   {
+      char credentials_path[PATH_MAX_LENGTH];
+      credentials_path[0] = '\0';
+      config_get_credentials_path(credentials_path,
+            sizeof(credentials_path));
+      if (!string_is_empty(credentials_path)
+            && path_is_valid(credentials_path))
+      {
+         bool result = config_append_file(conf, credentials_path);
+         RARCH_LOG("[Config] Merging credentials from \"%s\".\n",
+               credentials_path);
+         if (!result)
+            RARCH_ERR("[Config] Failed to merge credentials from \"%s\".\n",
+                  credentials_path);
+      }
+   }
+
    if (!path_is_empty(RARCH_PATH_CONFIG_APPEND))
    {
       char tmp_append_path[PATH_MAX_LENGTH];
@@ -6488,27 +6523,6 @@ static bool config_load_file(global_t *global,
       if (!string_is_equal(old_overlay_path, new_overlay_path))
          retroarch_override_setting_set(RARCH_OVERRIDE_SETTING_OVERLAY_PRESET, NULL);
 #endif
-   }
-
-   /* Merge credentials from separate file.
-    * Credentials are stored in credentials.cfg alongside
-    * the main config to keep sensitive data (passwords,
-    * tokens, keys) out of retroarch.cfg. */
-   {
-      char credentials_path[PATH_MAX_LENGTH];
-      credentials_path[0] = '\0';
-      config_get_credentials_path(credentials_path,
-            sizeof(credentials_path));
-      if (!string_is_empty(credentials_path)
-            && path_is_valid(credentials_path))
-      {
-         bool result = config_append_file(conf, credentials_path);
-         RARCH_LOG("[Config] Merging credentials from \"%s\".\n",
-               credentials_path);
-         if (!result)
-            RARCH_ERR("[Config] Failed to merge credentials from \"%s\".\n",
-                  credentials_path);
-      }
    }
 
    /* Special case for perfcnt_enable */
@@ -8462,27 +8476,32 @@ static size_t config_get_credentials_path(char *s, size_t len)
          sizeof(config_directory));
 
    return fill_pathname_join_special(s, config_directory,
-         "credentials.cfg", len);
+         "retroarch-keychain.cfg", len);
 }
 
 /**
  * config_save_credentials:
+ * @array_settings      : string settings table (from populate_settings_array)
+ * @array_settings_size : number of entries in @array_settings
+ * @path_settings       : path settings table (from populate_settings_path)
+ * @path_settings_size  : number of entries in @path_settings
  *
  * Writes only sensitive settings (passwords, tokens, keys)
- * to a separate credentials.cfg file.
+ * to a separate retroarch-keychain.cfg file. The tables are the ones
+ * config_save_file() has already built, so nothing is
+ * re-populated here.
  *
  * Returns: true (1) on success, otherwise returns false (0).
  **/
-bool config_save_credentials(void)
+static bool config_save_credentials(
+      const struct config_array_setting *array_settings,
+      int array_settings_size,
+      const struct config_path_setting *path_settings,
+      int path_settings_size)
 {
    unsigned i;
    bool ret                                          = false;
    char credentials_path[PATH_MAX_LENGTH];
-   struct config_array_setting     *array_settings   = NULL;
-   struct config_path_setting      *path_settings    = NULL;
-   settings_t                      *settings         = config_st;
-   int array_settings_size                           = sizeof(settings->arrays) / sizeof(settings->arrays.placeholder);
-   int path_settings_size                            = sizeof(settings->paths)  / sizeof(settings->paths.placeholder);
    config_file_t                   *conf             = NULL;
 
    credentials_path[0] = '\0';
@@ -8497,9 +8516,6 @@ bool config_save_credentials(void)
    if (!conf)
       return false;
 
-   array_settings = populate_settings_array(settings, &array_settings_size);
-   path_settings  = populate_settings_path(settings, &path_settings_size);
-
    if (array_settings && (array_settings_size > 0))
    {
       for (i = 0; i < (unsigned)array_settings_size; i++)
@@ -8510,8 +8526,6 @@ bool config_save_credentials(void)
                array_settings[i].ident,
                array_settings[i].ptr);
       }
-      free(array_settings);
-      array_settings = NULL;
    }
 
    if (path_settings && (path_settings_size > 0))
@@ -8524,15 +8538,24 @@ bool config_save_credentials(void)
                path_settings[i].ident,
                path_settings[i].ptr);
       }
-      free(path_settings);
-      path_settings = NULL;
    }
 
    ret = config_file_write(conf, credentials_path, true);
    config_file_free(conf);
 
    if (ret)
+   {
+#ifdef CONFIG_CREDENTIALS_RESTRICT_PERMS
+      /* The file holds plaintext secrets: make it owner-only.
+       * config_file_write() creates it with the process umask,
+       * which is usually world-readable. Not fatal on failure
+       * (e.g. FAT/exFAT media), the write itself succeeded. */
+      if (chmod(credentials_path, S_IRUSR | S_IWUSR) != 0)
+         RARCH_WARN("[Config] Could not restrict permissions on \"%s\".\n",
+               credentials_path);
+#endif
       RARCH_LOG("[Config] Saved credentials to \"%s\".\n", credentials_path);
+   }
    else
       RARCH_ERR("[Config] Failed to save credentials to \"%s\".\n", credentials_path);
 
@@ -8719,8 +8742,10 @@ bool config_save_file(const char *path)
 
    /* Save credentials to a separate file.
     * Only strip sensitive fields from retroarch.cfg
-    * when credentials.cfg was written successfully. */
-   credentials_saved = config_save_credentials();
+    * when retroarch-keychain.cfg was written successfully. */
+   credentials_saved = config_save_credentials(
+         array_settings, array_settings_size,
+         path_settings,  path_settings_size);
    if (!credentials_saved)
       RARCH_WARN("[Config] Credentials save failed, "
             "keeping sensitive fields in main config.\n");
@@ -8735,9 +8760,9 @@ bool config_save_file(const char *path)
          const char *value         = path_settings[i].ptr;
          const char *default_value = path_defaults ? path_defaults[i].ptr : NULL;
 
-         /* Sensitive settings are stored in credentials.cfg.
+         /* Sensitive settings are stored in retroarch-keychain.cfg.
           * Unset removes stale values from existing configs.
-          * Only strip when credentials.cfg was written OK. */
+          * Only strip when retroarch-keychain.cfg was written OK. */
          if (   credentials_saved
              && (path_settings[i].flags & CFG_BOOL_FLG_SENSITIVE))
          {
@@ -8830,9 +8855,9 @@ bool config_save_file(const char *path)
    {
       for (i = 0; i < (unsigned)array_settings_size; i++)
       {
-         /* Sensitive settings are stored in credentials.cfg.
+         /* Sensitive settings are stored in retroarch-keychain.cfg.
           * Unset removes stale values from existing configs.
-          * Only strip when credentials.cfg was written OK. */
+          * Only strip when retroarch-keychain.cfg was written OK. */
          if (   credentials_saved
              && (array_settings[i].flags & CFG_BOOL_FLG_SENSITIVE))
          {
@@ -9502,7 +9527,7 @@ int8_t config_save_overrides(enum override_type type,
              * config, forcing users to reauthenticate per override.
              * Originally applied to cheevos credentials, now
              * generalized to all sensitive settings via
-             * credentials.cfg. */
+             * retroarch-keychain.cfg. */
             if (array_settings[i].flags & CFG_BOOL_FLG_SENSITIVE)
                continue;
             config_set_string(conf, array_overrides[i].ident,
@@ -9518,7 +9543,7 @@ int8_t config_save_overrides(enum override_type type,
          const char *base = path_settings[i].ptr;
          char        cur_buf[PATH_MAX_LENGTH];
 
-         /* Sensitive settings are managed via credentials.cfg */
+         /* Sensitive settings are managed via retroarch-keychain.cfg */
          if (path_settings[i].flags & CFG_BOOL_FLG_SENSITIVE)
             continue;
 

--- a/configuration.c
+++ b/configuration.c
@@ -817,7 +817,8 @@ static const enum menu_driver_enum MENU_DEFAULT_DRIVER = MENU_NULL;
 enum config_bool_flags
 {
    CFG_BOOL_FLG_DEF_ENABLE = (1 << 0),
-   CFG_BOOL_FLG_HANDLE     = (1 << 1)
+   CFG_BOOL_FLG_HANDLE     = (1 << 1),
+   CFG_BOOL_FLG_SENSITIVE  = (1 << 2)
 };
 
 struct config_bool_setting
@@ -920,9 +921,21 @@ struct config_path_setting
 #define SETTING_OVERRIDE(override_setting) \
    tmp[count-1].override = override_setting
 
+#define SETTING_SENSITIVE() \
+   tmp[count-1].flags |= CFG_BOOL_FLG_SENSITIVE
+
+#define SETTING_ARRAY_SENSITIVE(key, configval, default_enable, default_setting, handle_setting) \
+   SETTING_ARRAY(key, configval, default_enable, default_setting, handle_setting) \
+   SETTING_SENSITIVE()
+
+#define SETTING_PATH_SENSITIVE(key, configval, default_enable, default_setting, handle_setting) \
+   SETTING_PATH(key, configval, default_enable, default_setting, handle_setting) \
+   SETTING_SENSITIVE()
+
 /* Forward declarations */
 #ifdef HAVE_CONFIGFILE
 static void config_parse_file(global_t *global);
+static size_t config_get_credentials_path(char *s, size_t len);
 #endif
 
 struct defaults g_defaults;
@@ -1654,41 +1667,41 @@ static struct config_array_setting *populate_settings_array(
    SETTING_ARRAY("cloud_sync_driver",            settings->arrays.cloud_sync_driver, false, NULL, true);
 
 #ifdef HAVE_CHEEVOS
-   SETTING_ARRAY("cheevos_custom_host",          settings->arrays.cheevos_custom_host, false, NULL, true);
-   SETTING_ARRAY("cheevos_username",             settings->arrays.cheevos_username, false, NULL, true);
-   SETTING_ARRAY("cheevos_password",             settings->arrays.cheevos_password, false, NULL, true);
-   SETTING_ARRAY("cheevos_token",                settings->arrays.cheevos_token, false, NULL, true);
-   SETTING_ARRAY("cheevos_leaderboards_enable",  settings->arrays.cheevos_leaderboards_enable, true, "", true); /* deprecated */
+   SETTING_ARRAY("cheevos_custom_host",                   settings->arrays.cheevos_custom_host, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("cheevos_username",            settings->arrays.cheevos_username, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("cheevos_password",            settings->arrays.cheevos_password, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("cheevos_token",               settings->arrays.cheevos_token, false, NULL, true);
+   SETTING_ARRAY("cheevos_leaderboards_enable",           settings->arrays.cheevos_leaderboards_enable, true, "", true); /* deprecated */
 #endif
 
 #ifdef HAVE_NETWORKING
-   SETTING_ARRAY("netplay_mitm_server",          settings->arrays.netplay_mitm_server, false, NULL, true);
+   SETTING_ARRAY("netplay_mitm_server",                   settings->arrays.netplay_mitm_server, false, NULL, true);
 #ifdef HAVE_CLOUDSYNC
-   SETTING_ARRAY("webdav_url",                   settings->arrays.webdav_url, false, NULL, true);
-   SETTING_ARRAY("webdav_username",              settings->arrays.webdav_username, false, NULL, true);
-   SETTING_ARRAY("webdav_password",              settings->arrays.webdav_password, false, NULL, true);
-   SETTING_ARRAY("google_drive_refresh_token",   settings->arrays.google_drive_refresh_token, false, NULL, true);
+   SETTING_ARRAY("webdav_url",                            settings->arrays.webdav_url, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("webdav_username",             settings->arrays.webdav_username, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("webdav_password",             settings->arrays.webdav_password, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("google_drive_refresh_token",  settings->arrays.google_drive_refresh_token, false, NULL, true);
 #ifdef HAVE_S3
-   SETTING_ARRAY("s3_url",                       settings->arrays.s3_url, false, NULL, true);
-   SETTING_ARRAY("access_key_id",                settings->arrays.access_key_id, false, NULL, true);
-   SETTING_ARRAY("secret_access_key",            settings->arrays.secret_access_key, false, NULL, true);
+   SETTING_ARRAY("s3_url",                                settings->arrays.s3_url, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("access_key_id",               settings->arrays.access_key_id, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("secret_access_key",           settings->arrays.secret_access_key, false, NULL, true);
 #endif
 #endif
-   SETTING_ARRAY("youtube_stream_key",           settings->arrays.youtube_stream_key, true, NULL, true);
-   SETTING_ARRAY("twitch_stream_key",            settings->arrays.twitch_stream_key, true, NULL, true);
-   SETTING_ARRAY("facebook_stream_key",          settings->arrays.facebook_stream_key, true, NULL, true);
-   SETTING_ARRAY("kick_stream_key",              settings->arrays.kick_stream_key, true, NULL, true);
-   SETTING_ARRAY("discord_app_id",               settings->arrays.discord_app_id, true, DEFAULT_DISCORD_APP_ID, true);
-   SETTING_ARRAY("ai_service_url",               settings->arrays.ai_service_url, true, DEFAULT_AI_SERVICE_URL, true);
+   SETTING_ARRAY_SENSITIVE("youtube_stream_key",          settings->arrays.youtube_stream_key, true, NULL, true);
+   SETTING_ARRAY_SENSITIVE("twitch_stream_key",           settings->arrays.twitch_stream_key, true, NULL, true);
+   SETTING_ARRAY_SENSITIVE("facebook_stream_key",         settings->arrays.facebook_stream_key, true, NULL, true);
+   SETTING_ARRAY_SENSITIVE("kick_stream_key",             settings->arrays.kick_stream_key, true, NULL, true);
+   SETTING_ARRAY("discord_app_id",                        settings->arrays.discord_app_id, true, DEFAULT_DISCORD_APP_ID, true);
+   SETTING_ARRAY("ai_service_url",                        settings->arrays.ai_service_url, true, DEFAULT_AI_SERVICE_URL, true);
 #endif
 
 #ifdef HAVE_SMBCLIENT
-   SETTING_ARRAY("smb_client_server_address", settings->arrays.smb_client_server_address, false, NULL, true);
-   SETTING_ARRAY("smb_client_share", settings->arrays.smb_client_share, false, NULL, true);
-   SETTING_ARRAY("smb_client_subdir", settings->arrays.smb_client_subdir, false, NULL, true);
-   SETTING_ARRAY("smb_client_username", settings->arrays.smb_client_username, false, NULL, true);
-   SETTING_ARRAY("smb_client_password", settings->arrays.smb_client_password, false, NULL, true);
-   SETTING_ARRAY("smb_client_workgroup", settings->arrays.smb_client_workgroup, false, NULL, true);
+   SETTING_ARRAY("smb_client_server_address",             settings->arrays.smb_client_server_address, false, NULL, true);
+   SETTING_ARRAY("smb_client_share",                      settings->arrays.smb_client_share, false, NULL, true);
+   SETTING_ARRAY("smb_client_subdir",                     settings->arrays.smb_client_subdir, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("smb_client_username",         settings->arrays.smb_client_username, false, NULL, true);
+   SETTING_ARRAY_SENSITIVE("smb_client_password",         settings->arrays.smb_client_password, false, NULL, true);
+   SETTING_ARRAY("smb_client_workgroup",                  settings->arrays.smb_client_workgroup, false, NULL, true);
 #endif
 
 #ifdef HAVE_LAKKA
@@ -1790,11 +1803,11 @@ static struct config_path_setting *populate_settings_path(
 #endif
 
 #ifdef HAVE_NETWORKING
-   SETTING_PATH("netplay_ip_address",            settings->paths.netplay_server, false, NULL, true);
-   SETTING_PATH("netplay_custom_mitm_server",    settings->paths.netplay_custom_mitm_server, false, NULL, true);
-   SETTING_PATH("netplay_nickname",              settings->paths.username, false, NULL, true);
-   SETTING_PATH("netplay_password",              settings->paths.netplay_password, false, NULL, true);
-   SETTING_PATH("netplay_spectate_password",     settings->paths.netplay_spectate_password, false, NULL, true);
+   SETTING_PATH("netplay_ip_address",                     settings->paths.netplay_server, false, NULL, true);
+   SETTING_PATH("netplay_custom_mitm_server",             settings->paths.netplay_custom_mitm_server, false, NULL, true);
+   SETTING_PATH("netplay_nickname",                       settings->paths.username, false, NULL, true);
+   SETTING_PATH_SENSITIVE("netplay_password",             settings->paths.netplay_password, false, NULL, true);
+   SETTING_PATH_SENSITIVE("netplay_spectate_password",    settings->paths.netplay_spectate_password, false, NULL, true);
 #endif
 
 #ifdef _3DS
@@ -6477,6 +6490,27 @@ static bool config_load_file(global_t *global,
 #endif
    }
 
+   /* Merge credentials from separate file.
+    * Credentials are stored in credentials.cfg alongside
+    * the main config to keep sensitive data (passwords,
+    * tokens, keys) out of retroarch.cfg. */
+   {
+      char credentials_path[PATH_MAX_LENGTH];
+      credentials_path[0] = '\0';
+      config_get_credentials_path(credentials_path,
+            sizeof(credentials_path));
+      if (!string_is_empty(credentials_path)
+            && path_is_valid(credentials_path))
+      {
+         bool result = config_append_file(conf, credentials_path);
+         RARCH_LOG("[Config] Merging credentials from \"%s\".\n",
+               credentials_path);
+         if (!result)
+            RARCH_ERR("[Config] Failed to merge credentials from \"%s\".\n",
+                  credentials_path);
+      }
+   }
+
    /* Special case for perfcnt_enable */
    {
       bool tmp = false;
@@ -8405,6 +8439,107 @@ static void config_path_strip_trailing_slash(char *s)
 }
 
 /**
+ * config_get_credentials_path:
+ *
+ * Builds the path to the credentials config file.
+ * Uses the same directory as the main config file.
+ *
+ * Returns: length of the string written to @s.
+ **/
+static size_t config_get_credentials_path(char *s, size_t len)
+{
+   char config_directory[DIR_MAX_LENGTH];
+   config_directory[0] = '\0';
+
+   if (path_is_empty(RARCH_PATH_CONFIG))
+   {
+      s[0] = '\0';
+      return 0;
+   }
+
+   fill_pathname_basedir(config_directory,
+         path_get(RARCH_PATH_CONFIG),
+         sizeof(config_directory));
+
+   return fill_pathname_join_special(s, config_directory,
+         "credentials.cfg", len);
+}
+
+/**
+ * config_save_credentials:
+ *
+ * Writes only sensitive settings (passwords, tokens, keys)
+ * to a separate credentials.cfg file.
+ *
+ * Returns: true (1) on success, otherwise returns false (0).
+ **/
+bool config_save_credentials(void)
+{
+   unsigned i;
+   bool ret                                          = false;
+   char credentials_path[PATH_MAX_LENGTH];
+   struct config_array_setting     *array_settings   = NULL;
+   struct config_path_setting      *path_settings    = NULL;
+   settings_t                      *settings         = config_st;
+   int array_settings_size                           = sizeof(settings->arrays) / sizeof(settings->arrays.placeholder);
+   int path_settings_size                            = sizeof(settings->paths)  / sizeof(settings->paths.placeholder);
+   config_file_t                   *conf             = NULL;
+
+   credentials_path[0] = '\0';
+   config_get_credentials_path(credentials_path, sizeof(credentials_path));
+
+   if (string_is_empty(credentials_path))
+      return false;
+
+   conf = config_file_new_from_path_to_string(credentials_path);
+   if (!conf)
+      conf = config_file_new_alloc();
+   if (!conf)
+      return false;
+
+   array_settings = populate_settings_array(settings, &array_settings_size);
+   path_settings  = populate_settings_path(settings, &path_settings_size);
+
+   if (array_settings && (array_settings_size > 0))
+   {
+      for (i = 0; i < (unsigned)array_settings_size; i++)
+      {
+         if (!(array_settings[i].flags & CFG_BOOL_FLG_SENSITIVE))
+            continue;
+         config_set_string(conf,
+               array_settings[i].ident,
+               array_settings[i].ptr);
+      }
+      free(array_settings);
+      array_settings = NULL;
+   }
+
+   if (path_settings && (path_settings_size > 0))
+   {
+      for (i = 0; i < (unsigned)path_settings_size; i++)
+      {
+         if (!(path_settings[i].flags & CFG_BOOL_FLG_SENSITIVE))
+            continue;
+         config_set_path(conf,
+               path_settings[i].ident,
+               path_settings[i].ptr);
+      }
+      free(path_settings);
+      path_settings = NULL;
+   }
+
+   ret = config_file_write(conf, credentials_path, true);
+   config_file_free(conf);
+
+   if (ret)
+      RARCH_LOG("[Config] Saved credentials to \"%s\".\n", credentials_path);
+   else
+      RARCH_ERR("[Config] Failed to save credentials to \"%s\".\n", credentials_path);
+
+   return ret;
+}
+
+/**
  * config_save_file:
  * @path            : Path that shall be written to.
  *
@@ -8418,6 +8553,7 @@ bool config_save_file(const char *path)
    unsigned i                                        = 0;
    bool ret                                          = false;
    bool minimal                                      = false;
+   bool credentials_saved                            = false;
    settings_t                     *defaults          = NULL;
    retro_keybind_set              *defaults_binds    = NULL;
    struct config_bool_setting     *bool_settings     = NULL;
@@ -8581,6 +8717,14 @@ bool config_save_file(const char *path)
       }
    }
 
+   /* Save credentials to a separate file.
+    * Only strip sensitive fields from retroarch.cfg
+    * when credentials.cfg was written successfully. */
+   credentials_saved = config_save_credentials();
+   if (!credentials_saved)
+      RARCH_WARN("[Config] Credentials save failed, "
+            "keeping sensitive fields in main config.\n");
+
    /* Path settings */
    if (path_settings && (path_settings_size > 0))
    {
@@ -8590,6 +8734,16 @@ bool config_save_file(const char *path)
          char default_buf[PATH_MAX_LENGTH];
          const char *value         = path_settings[i].ptr;
          const char *default_value = path_defaults ? path_defaults[i].ptr : NULL;
+
+         /* Sensitive settings are stored in credentials.cfg.
+          * Unset removes stale values from existing configs.
+          * Only strip when credentials.cfg was written OK. */
+         if (   credentials_saved
+             && (path_settings[i].flags & CFG_BOOL_FLG_SENSITIVE))
+         {
+            config_unset(conf, path_settings[i].ident);
+            continue;
+         }
 
          if (path_settings[i].flags & CFG_BOOL_FLG_DEF_ENABLE)
          {
@@ -8676,6 +8830,15 @@ bool config_save_file(const char *path)
    {
       for (i = 0; i < (unsigned)array_settings_size; i++)
       {
+         /* Sensitive settings are stored in credentials.cfg.
+          * Unset removes stale values from existing configs.
+          * Only strip when credentials.cfg was written OK. */
+         if (   credentials_saved
+             && (array_settings[i].flags & CFG_BOOL_FLG_SENSITIVE))
+         {
+            config_unset(conf, array_settings[i].ident);
+            continue;
+         }
          if (   !array_settings[i].override
              || !retroarch_override_setting_is_set(array_settings[i].override, NULL))
          {
@@ -9334,22 +9497,14 @@ int8_t config_save_overrides(enum override_type type,
       {
          if (!string_is_equal(array_settings[i].ptr, array_overrides[i].ptr))
          {
-#ifdef HAVE_CHEEVOS
-            /* As authentication doesn't occur until after content is loaded,
-             * the achievement authentication token might only exist in the
-             * override set, and therefore differ from the master config set.
-             * Storing the achievement authentication token in an override
-             * is a recipe for disaster. If it expires and the user generates
-             * a new token, then the override will be out of date and the
-             * user will have to reauthenticate for each override (and also
-             * remember to update each override). Also exclude the username
-             * as it's directly tied to the token and password.
-             */
-            if (   string_is_equal(array_settings[i].ident, "cheevos_token")
-                || string_is_equal(array_settings[i].ident, "cheevos_password")
-                || string_is_equal(array_settings[i].ident, "cheevos_username"))
+            /* Authentication tokens stored in overrides become stale
+             * when they expire and get regenerated in the master
+             * config, forcing users to reauthenticate per override.
+             * Originally applied to cheevos credentials, now
+             * generalized to all sensitive settings via
+             * credentials.cfg. */
+            if (array_settings[i].flags & CFG_BOOL_FLG_SENSITIVE)
                continue;
-#endif
             config_set_string(conf, array_overrides[i].ident,
                   array_overrides[i].ptr);
             RARCH_DBG("[Override] %s = \"%s\"\n",
@@ -9362,6 +9517,10 @@ int8_t config_save_overrides(enum override_type type,
          const char *cur  = path_overrides[i].ptr;
          const char *base = path_settings[i].ptr;
          char        cur_buf[PATH_MAX_LENGTH];
+
+         /* Sensitive settings are managed via credentials.cfg */
+         if (path_settings[i].flags & CFG_BOOL_FLG_SENSITIVE)
+            continue;
 
          /* savefile_directory / savestate_directory alias a global
           * buffer, so path_settings[] and path_overrides[] point at the

--- a/configuration.c
+++ b/configuration.c
@@ -27,13 +27,6 @@
 #include <string/stdstring.h>
 #include <streams/file_stream.h>
 
-#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) \
-      || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) \
-      || defined(__HAIKU__)
-#include <sys/stat.h>
-#define CONFIG_CREDENTIALS_RESTRICT_PERMS 1
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -8545,15 +8538,12 @@ static bool config_save_credentials(
 
    if (ret)
    {
-#ifdef CONFIG_CREDENTIALS_RESTRICT_PERMS
       /* The file holds plaintext secrets: make it owner-only.
-       * config_file_write() creates it with the process umask,
-       * which is usually world-readable. Not fatal on failure
-       * (e.g. FAT/exFAT media), the write itself succeeded. */
-      if (chmod(credentials_path, S_IRUSR | S_IWUSR) != 0)
+       * Not fatal on failure (e.g. FAT/exFAT media), the write
+       * itself succeeded. */
+      if (!path_set_private(credentials_path))
          RARCH_WARN("[Config] Could not restrict permissions on \"%s\".\n",
                credentials_path);
-#endif
       RARCH_LOG("[Config] Saved credentials to \"%s\".\n", credentials_path);
    }
    else

--- a/configuration.h
+++ b/configuration.h
@@ -1484,16 +1484,6 @@ bool config_save_autoconf_profile(const char *device_name, unsigned user);
 bool config_save_file(const char *path);
 
 /**
- * config_save_credentials:
- *
- * Writes only sensitive settings (passwords, tokens, keys)
- * to a separate credentials.cfg file.
- *
- * Returns: true (1) on success, otherwise returns false (0).
- **/
-bool config_save_credentials(void);
-
-/**
  * config_save_overrides:
  * @path            : Path that shall be written to.
  *

--- a/configuration.h
+++ b/configuration.h
@@ -1484,6 +1484,16 @@ bool config_save_autoconf_profile(const char *device_name, unsigned user);
 bool config_save_file(const char *path);
 
 /**
+ * config_save_credentials:
+ *
+ * Writes only sensitive settings (passwords, tokens, keys)
+ * to a separate credentials.cfg file.
+ *
+ * Returns: true (1) on success, otherwise returns false (0).
+ **/
+bool config_save_credentials(void);
+
+/**
  * config_save_overrides:
  * @path            : Path that shall be written to.
  *

--- a/libretro-common/file/file_path_io.c
+++ b/libretro-common/file/file_path_io.c
@@ -128,6 +128,11 @@ bool path_is_valid(const char *path)
    return (path_stat32_cb(path, NULL) & RETRO_VFS_STAT_IS_VALID) != 0;
 }
 
+bool path_set_private(const char *path)
+{
+   return retro_vfs_restrict_permissions_impl(path) == 0;
+}
+
 int64_t path_get_size(const char *path)
 {
    int64_t filesize = 0;

--- a/libretro-common/include/file/file_path.h
+++ b/libretro-common/include/file/file_path.h
@@ -683,6 +683,19 @@ int path_stat(const char *path);
 
 bool path_is_valid(const char *path);
 
+/**
+ * path_set_private:
+ * @path               : file
+ *
+ * Restricts @path to the owning user (0600 on POSIX). Use for files
+ * that hold secrets. A no-op that returns true on platforms where
+ * the location is already private or has no permission model.
+ *
+ * @return true if the permissions are restricted (or nothing needed
+ * doing), false if the platform supports it and it failed.
+ **/
+bool path_set_private(const char *path);
+
 int64_t path_get_size(const char *path);
 
 bool is_path_accessible_using_standard_io(const char *path);

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -91,6 +91,19 @@ int retro_vfs_stat_64_impl(const char *path, int64_t *size);
 
 int retro_vfs_mkdir_impl(const char *dir);
 
+/**
+ * retro_vfs_restrict_permissions_impl:
+ * @path : file to restrict
+ *
+ * Makes @path readable and writable by the owning user only, for
+ * files that hold secrets. On platforms without per-user file
+ * permissions (Windows profile directories, single-user consoles,
+ * Android SAF) there is nothing to do and the call succeeds.
+ *
+ * Returns: 0 on success, -1 on failure.
+ **/
+int retro_vfs_restrict_permissions_impl(const char *path);
+
 libretro_vfs_implementation_dir *retro_vfs_opendir_impl(const char *dir, bool include_hidden);
 
 bool retro_vfs_readdir_impl(libretro_vfs_implementation_dir *dirstream);

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -2564,6 +2564,23 @@ static bool dirent_check_err(libretro_vfs_implementation_dir *rdir)
 #endif
 }
 
+int retro_vfs_restrict_permissions_impl(const char *path)
+{
+#if defined(_WIN32) || defined(VITA) || defined(PSP) || defined(PS2) \
+      || defined(__PS3__) || defined(GEKKO) || defined(WIIU) \
+      || defined(_3DS) || defined(HAVE_LIBNX) || defined(__CELLOS_LV2__) \
+      || defined(ORBIS) || defined(DJGPP) || defined(EMSCRIPTEN) \
+      || defined(ANDROID) || TARGET_OS_IPHONE || TARGET_OS_TV
+   /* No per-user permission model the frontend controls: Windows
+    * profile directories and mobile app sandboxes are already
+    * private, consoles are single-user. */
+   (void)path;
+   return 0;
+#else
+   return chmod(path, S_IRUSR | S_IWUSR) == 0 ? 0 : -1;
+#endif
+}
+
 libretro_vfs_implementation_dir *retro_vfs_opendir_impl(
       const char *name, bool include_hidden)
 {

--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -488,6 +488,14 @@ int retro_vfs_mkdir_impl(const char* dir)
     return uwp_mkdir_impl(std::filesystem::path(dir));
 }
 
+int retro_vfs_restrict_permissions_impl(const char* path)
+{
+    /* UWP app data is already private to the package; there is no
+     * per-user permission model to tighten. Nothing to do. */
+    (void)path;
+    return 0;
+}
+
 /* The first run parameter is used to avoid error checking
  * when doing recursion.
  * Unlike the initial implementation, this can move folders


### PR DESCRIPTION
## Description

Separates sensitive settings (passwords, tokens, stream keys) into a dedicated `credentials.cfg` file so they are not exposed when sharing or backing up `retroarch.cfg`.

- Adds `CFG_BOOL_FLG_SENSITIVE` flag with `SETTING_ARRAY_SENSITIVE` and `SETTING_PATH_SENSITIVE` wrapper macros to tag 13 sensitive settings (cheevos, webdav, smb, netplay, streaming)
- On save, sensitive fields are written to `credentials.cfg` and stripped from the main config via `config_unset`
- On load, `credentials.cfg` is merged back via `config_append_file`
- If `credentials.cfg` write fails, sensitive fields stay in `retroarch.cfg` as a safety net
- Migration is JIT: first config save after updating creates `credentials.cfg` and cleans the main config
- Generalizes the cheevos-specific override exclusion (`#ifdef HAVE_CHEEVOS` + 3x `string_is_equal`) into a single flag check covering all sensitive settings

Testing:
- macOS (M4 Pro)
- Verified credentials.cfg created on quit, retroarch.cfg clean
- Verified "Save New Configuration" produces no sensitive fields
- Verified deletion of credentials.cfg + relaunch recreates it