### PR TITLE
Fix "Save Main Configuration" saving to wrong file after "Load Configuration"

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -3557,7 +3557,7 @@ static bool check_menu_driver_compatibility(settings_t *settings)
  *
  * Returns: handle to config file if found, otherwise NULL.
  **/
-config_file_t *open_default_config_file(void)
+static config_file_t *open_default_config_file(void)
 {
    char conf_path[PATH_MAX_LENGTH];
    config_file_t *conf                    = NULL;

--- a/configuration.h
+++ b/configuration.h
@@ -1377,8 +1377,6 @@ int8_t config_save_overrides(enum override_type type,
  * another one. Will load a dummy core to flush state
  * properly. */
 bool config_replace(bool config_save_on_exit, char *path);
-
-config_file_t *open_default_config_file(void);
 #endif
 
 bool config_overlay_enable_default(void);

--- a/paths.h
+++ b/paths.h
@@ -56,7 +56,8 @@ enum rarch_path_type
    RARCH_PATH_CONFIG_OVERRIDE,
    RARCH_PATH_DEFAULT_SHADER_PRESET,
    RARCH_PATH_BASENAME,
-   RARCH_PATH_SUBSYSTEM
+   RARCH_PATH_SUBSYSTEM,
+   RARCH_PATH_CONFIG_DEFAULT
 };
 
 void dir_clear(enum rarch_dir_type type);


### PR DESCRIPTION
## Description

After using "Load Configuration" to switch to a different `.cfg` file,
"Save Main Configuration" writes to the loaded file instead of the
original startup config. This is because `config_replace()` updates
`RARCH_PATH_CONFIG` to point at the newly loaded file.

The previous `CMD_EVENT_MENU_SAVE_MAIN_CONFIG` handler called
`open_default_config_file()` as a side effect to reset the path, but
discarded the returned `config_file_t*`, leaking it on every save.

Fix:
- Record the startup config path into a new `RARCH_PATH_CONFIG_DEFAULT`
  slot right after `config_load()` in `retroarch_parse_input_and_config()`
- In the save handler, temporarily swap `RARCH_PATH_CONFIG` to the
  default path before saving, then restore the previous value
- Make `open_default_config_file()` static (no longer called outside
  `configuration.c`) and remove its declaration from `configuration.h`

## Steps to reproduce

1. Launch RetroArch
2. Main Menu > Configuration File > Load Configuration > pick a different `.cfg`
3. Main Menu > Configuration File > Save Main Configuration
4. Save goes to the loaded file, not the default config

## Testing

Android (aarch64, Pixel) and macOS (Metal).

- After "Load Configuration", "Save Main" now writes to the startup config (not the loaded file)
- "Save Main" without prior "Load Configuration" still works
- `config_save_on_exit` still writes to the loaded file after `config_replace()`
- Config overrides unaffected

Relates to #16491
