### PR TITLE
Fix GPU recording performance on Vulkan & GL2/3

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -7513,8 +7513,7 @@ static bool retroarch_parse_input_and_config(
 
             case 'r':
                strlcpy(rec_st->path, optarg, sizeof(rec_st->path));
-               if (rec_st->enable)
-                  rec_st->enable = true;
+               rec_st->enable = true;
                break;
 
             case RA_OPT_SET_SHADER:


### PR DESCRIPTION
## Fix GPU recording performance with Vulkan & GL2/3

GPU recording falls back to synchronous readback, causing poor performance. Async readback is never initialized because video driver init runs before recording is set up.

CLI -r handler had no-op bug (if (enable) enable = true) that prevented rec_st->enable from being set.

Adds lazy init of async readback for Vulkan and GL2/3. Readback is set up on first frame where recording is active, and torn down when recording stops.

Adds padding for odd viewport dimensions up to even in FFmpeg recording driver. Subsampled formats (420/422) need even sizes.