### PR TITLE
netplay: add RARCH_NETPLAY_CTL_GET_SELF_CLIENT_NUM

### DIFF
--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -2590,6 +2590,18 @@ enum retro_mod
 */
 #define RETRO_ENVIRONMENT_GET_TARGET_SAMPLE_RATE (81 | RETRO_ENVIRONMENT_EXPERIMENTAL)
 
+/**
+ * Returns the local player's netplay client index when using frontend-managed
+ * multiplayer/rollback netplay.
+ *
+ * @param[out] data <tt>unsigned *</tt>.
+ * Pointer to an unsigned integer where the frontend stores the local client index.
+ * 0 indicates host. Values > 0 indicate connected clients.
+ * @return \\c true if the environment call is available and value was written,
+ * \\c false otherwise.
+*/
+#define RETRO_ENVIRONMENT_GET_NETPLAY_CLIENT_INDEX (82 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
 /**@}*/
 
 /**

--- a/network/netplay/netplay_defines.h
+++ b/network/netplay/netplay_defines.h
@@ -58,6 +58,7 @@ enum rarch_netplay_ctl_state
 #endif
    RARCH_NETPLAY_CTL_REFRESH_CLIENT_INFO,
    RARCH_NETPLAY_CTL_IS_ENABLED,
+   RARCH_NETPLAY_CTL_GET_SELF_CLIENT_NUM,
    RARCH_NETPLAY_CTL_IS_REPLAYING,
    RARCH_NETPLAY_CTL_IS_SERVER,
    RARCH_NETPLAY_CTL_IS_CONNECTED,
@@ -85,7 +86,7 @@ enum rarch_netplay_connection_mode
 {
    NETPLAY_CONNECTION_NONE = 0,
 
-   NETPLAY_CONNECTION_DELAYED_DISCONNECT, 
+   NETPLAY_CONNECTION_DELAYED_DISCONNECT,
    /* The connection is dead, but data
       is still waiting to be forwarded */
 

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -9567,6 +9567,16 @@ bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data)
          ret = ((net_st->flags & NET_DRIVER_ST_FLAG_NETPLAY_ENABLED) > 0);
          break;
 
+      case RARCH_NETPLAY_CTL_GET_SELF_CLIENT_NUM:
+         if (data && netplay)
+         {
+            *(uint32_t*)data = netplay->self_client_num;
+            ret = true;
+         }
+         else
+            ret = false;
+         break;
+
       case RARCH_NETPLAY_CTL_IS_DATA_INITED:
          ret = (netplay != NULL);
          break;

--- a/runloop.c
+++ b/runloop.c
@@ -3175,6 +3175,22 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          break;
       }
 
+      case RETRO_ENVIRONMENT_GET_NETPLAY_CLIENT_INDEX:
+      {
+#ifdef HAVE_NETWORKING
+         if (data)
+         {
+            uint32_t self_client_num = 0;
+            if (netplay_driver_ctl(RARCH_NETPLAY_CTL_GET_SELF_CLIENT_NUM, &self_client_num))
+            {
+               *(unsigned*)data = self_client_num;
+               break;
+            }
+         }
+#endif
+         return false;
+      }
+
       case RETRO_ENVIRONMENT_GET_MIDI_INTERFACE:
       {
          struct retro_midi_interface *midi_interface =


### PR DESCRIPTION
This option is for obtaining player index in rollback netplay.
It's for cases where a core has split-screen multiplayer but each player wants to only see their own screen.
Specifically for what I'm working on with mgba-libretro.
I couldn't find a way to do this without adding this flag or implementing rollback multiplayer within the core. 