### PR TITLE
Dynamic side loading of cores

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -14,6 +14,12 @@ import android.os.Looper;
 import android.os.Message;
 import com.retroarch.browser.preferences.util.ConfigFile;
 import com.retroarch.browser.preferences.util.UserPreferences;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -58,12 +64,77 @@ public final class RetroActivityFuture extends RetroActivityCamera {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    
+
     isRunning = true;
     mDecorView = getWindow().getDecorView();
 
+    // Copy external core .so to internal cores directory if needed
+    copyExternalCoreIfNeeded();
+
     // If QUITFOCUS parameter is provided then enable that Retroarch quits when focus is lost
     quitfocus = getIntent().hasExtra("QUITFOCUS");
+  }
+
+  private void copyExternalCoreIfNeeded() {
+    String libretroPath = getIntent().getStringExtra("LIBRETRO");
+    if (libretroPath == null || !libretroPath.endsWith(".so"))
+      return;
+
+    String dataDir = getApplicationInfo().dataDir;
+
+    // Normalize /data/data/ symlink to real dataDir path (/data/user/0/...)
+    String datadataPrefix = "/data/data/" + getPackageName();
+    if (libretroPath.startsWith(datadataPrefix)) {
+      libretroPath = dataDir + libretroPath.substring(datadataPrefix.length());
+      getIntent().putExtra("LIBRETRO", libretroPath);
+      return;
+    }
+
+    // Already using the real dataDir path
+    if (libretroPath.startsWith(dataDir))
+      return;
+
+    // External core — copy to internal cores directory
+    File srcFile = new File(libretroPath);
+    if (!srcFile.isFile())
+      return;
+
+    File coresDir = new File(dataDir, "cores");
+    if (!coresDir.exists())
+      coresDir.mkdirs();
+
+    File destFile = new File(coresDir, srcFile.getName());
+
+    // Avoid self-copy if source and destination resolve to the same file
+    try {
+      if (srcFile.getCanonicalPath().equals(destFile.getCanonicalPath())) {
+        getIntent().putExtra("LIBRETRO", destFile.getAbsolutePath());
+        return;
+      }
+    } catch (IOException e) {
+      // If we can't resolve, proceed with copy
+    }
+
+    try {
+      InputStream in = new FileInputStream(srcFile);
+      try {
+        OutputStream out = new FileOutputStream(destFile);
+        try {
+          byte[] buf = new byte[8192];
+          int len;
+          while ((len = in.read(buf)) > 0)
+            out.write(buf, 0, len);
+        } finally {
+          out.close();
+        }
+      } finally {
+        in.close();
+      }
+      getIntent().putExtra("LIBRETRO", destFile.getAbsolutePath());
+      Log.i("RetroActivityFuture", "Copied external core to: " + destFile.getAbsolutePath());
+    } catch (IOException e) {
+      Log.e("RetroActivityFuture", "Failed to copy external core: " + e.getMessage());
+    }
   }
 
   @Override


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This PR allows RetroArch Android to sideload cores using the LIBRETRO argument, you can pass a path in that argument and the code will copy that core to /data/user/0 if it's not there already.

Launch command example:

```
am start
  -n com.retroarch/com.retroarch.browser.retroactivity.RetroActivityFuture
  -e ROM {file.path}
  -e LIBRETRO /storage/emulated/0/RetroArch/cores/gambatte_libretro_android.so
  -e CONFIGFILE /storage/emulated/0/Android/data/com.retroarch/files/retroarch.cfg
  -e IME com.android.inputmethod.latin/.LatinIME
  -e DATADIR /data/data/com.retroarch
  -e APK /data/app/com.retroarch-1/base.apk
  -e SDCARD /storage/emulated/0
  -e EXTERNAL /storage/emulated/0/Android/data/com.retroarch/files
```

That command will copy /storage/emulated/0/RetroArch/cores/gambatte_libretro_android.so to /data/data/com.retroarch/cores/mgba_libretro_android.so and use it to launch the provided {file.path}

This has been tested with launchers like ESDE that uses the current LIBRETO argument and has been proved to work too if the user has manually downloaded the core.

```-e LIBRETRO /data/data/com.retroarch/cores/mgba_libretro_android.so```

In a nutshell, you can use the data/data path or a custom path, the code takes care of it.

## Related Issues

None

## Related Pull Requests

None

## Reviewers

[If possible @mention all the people that should review your pull request]
