### PR TITLE
sensors: protect frontend sensor state from core set state

### DIFF
--- a/gfx/drivers_shader/shader_gl3.cpp
+++ b/gfx/drivers_shader/shader_gl3.cpp
@@ -1117,6 +1117,16 @@ bool Pass::init_pipeline()
    reflect_parameter("Accelerometer", reflection.semantics[SLANG_SEMANTIC_ACCELEROMETER]);
    reflect_parameter("AccelerometerRest", reflection.semantics[SLANG_SEMANTIC_ACCELEROMETER_REST]);
 
+   {
+      auto &g = reflection.semantics[SLANG_SEMANTIC_GYROSCOPE];
+      auto &a = reflection.semantics[SLANG_SEMANTIC_ACCELEROMETER];
+      auto &r = reflection.semantics[SLANG_SEMANTIC_ACCELEROMETER_REST];
+      if (g.uniform || g.push_constant ||
+          a.uniform || a.push_constant ||
+          r.uniform || r.push_constant)
+         input_state_get_ptr()->shader_uses_sensors = true;
+   }
+
    reflect_parameter("OriginalSize", reflection.semantic_textures[SLANG_TEXTURE_SEMANTIC_ORIGINAL][0]);
    reflect_parameter("SourceSize", reflection.semantic_textures[SLANG_TEXTURE_SEMANTIC_SOURCE][0]);
    reflect_parameter_array("OriginalHistorySize", reflection.semantic_textures[SLANG_TEXTURE_SEMANTIC_ORIGINAL_HISTORY]);
@@ -2804,7 +2814,11 @@ gl3_filter_chain_t *gl3_filter_chain_create_from_preset(
 
 struct video_shader *gl3_filter_chain_get_preset(
       gl3_filter_chain_t *chain) { return chain->get_shader_preset(); }
-void gl3_filter_chain_free(gl3_filter_chain_t *chain) { delete chain; }
+void gl3_filter_chain_free(gl3_filter_chain_t *chain)
+{
+   delete chain;
+   input_state_get_ptr()->shader_uses_sensors = false;
+}
 
 void gl3_filter_chain_set_shader(
       gl3_filter_chain_t *chain,

--- a/gfx/drivers_shader/shader_glsl.c
+++ b/gfx/drivers_shader/shader_glsl.c
@@ -765,6 +765,11 @@ static void gl_glsl_find_uniforms(glsl_shader_data_t *glsl,
    uni->accelerometer         = gl_glsl_get_uniform(glsl, prog, "Accelerometer");
    uni->accelerometer_rest    = gl_glsl_get_uniform(glsl, prog, "AccelerometerRest");
 
+   if (  uni->gyroscope >= 0
+      || uni->accelerometer >= 0
+      || uni->accelerometer_rest >= 0)
+      input_state_get_ptr()->shader_uses_sensors = true;
+
    for (i = 0; i < glsl->shader->luts; i++)
       uni->lut_texture[i] = glGetUniformLocation(prog, glsl->shader->lut[i].id);
 
@@ -874,6 +879,7 @@ static void gl_glsl_deinit(void *data)
       return;
 
    gl_glsl_destroy_resources(glsl);
+   input_state_get_ptr()->shader_uses_sensors = false;
 
    free(glsl);
 }

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -2309,6 +2309,16 @@ bool Pass::build()
    if (!slang_reflect_spirv(vertex_shader, fragment_shader, &reflection))
       return false;
 
+   {
+      auto &g = reflection.semantics[SLANG_SEMANTIC_GYROSCOPE];
+      auto &a = reflection.semantics[SLANG_SEMANTIC_ACCELEROMETER];
+      auto &r = reflection.semantics[SLANG_SEMANTIC_ACCELEROMETER_REST];
+      if (g.uniform || g.push_constant ||
+          a.uniform || a.push_constant ||
+          r.uniform || r.push_constant)
+         input_state_get_ptr()->shader_uses_sensors = true;
+   }
+
    /* Filter out parameters which we will never use anyways. */
    filtered_parameters.clear();
 
@@ -3356,6 +3366,7 @@ void vulkan_filter_chain_free(
       vulkan_filter_chain_t *chain)
 {
    delete chain;
+   input_state_get_ptr()->shader_uses_sensors = false;
 }
 
 void vulkan_filter_chain_set_shader(

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -4717,6 +4717,62 @@ bool input_set_sensor_state(unsigned port,
       joy_idx, input_sensors_enable, action, rate);
 }
 
+/* Core-facing wrappers that track which sensors the core has enabled.
+ * Used as the retro_sensor_interface callbacks so the frontend knows
+ * what the core requested independently of shader/platform enables. */
+bool input_core_set_sensor_state(unsigned port,
+      enum retro_sensor_action action, unsigned rate)
+{
+   input_driver_state_t *input_st = &input_driver_st;
+
+   switch (action)
+   {
+      case RETRO_SENSOR_ACCELEROMETER_ENABLE:
+         input_st->core_accel_rate = rate;
+         break;
+      case RETRO_SENSOR_ACCELEROMETER_DISABLE:
+         input_st->core_accel_rate = 0;
+         break;
+      case RETRO_SENSOR_GYROSCOPE_ENABLE:
+         input_st->core_gyro_rate = rate;
+         break;
+      case RETRO_SENSOR_GYROSCOPE_DISABLE:
+         input_st->core_gyro_rate = 0;
+         break;
+      default:
+         break;
+   }
+
+   /* For accel/gyro, the poll loop reconciles core/shader/frontend
+    * state and manages driver enable/disable. For other sensor types,
+    * pass through to the driver directly. */
+   switch (action)
+   {
+      case RETRO_SENSOR_ACCELEROMETER_ENABLE:
+      case RETRO_SENSOR_ACCELEROMETER_DISABLE:
+      case RETRO_SENSOR_GYROSCOPE_ENABLE:
+      case RETRO_SENSOR_GYROSCOPE_DISABLE:
+         return true;
+      default:
+         return input_set_sensor_state(port, action, rate);
+   }
+}
+
+float input_core_get_sensor_state(unsigned port, unsigned id)
+{
+   input_driver_state_t *input_st = &input_driver_st;
+
+   /* Only return data for sensor types the core has enabled */
+   if (id <= RETRO_SENSOR_ACCELEROMETER_Z && !input_st->core_accel_rate)
+      return 0.0f;
+   if (  id >= RETRO_SENSOR_GYROSCOPE_X
+      && id <= RETRO_SENSOR_GYROSCOPE_Z
+      && !input_st->core_gyro_rate)
+      return 0.0f;
+
+   return input_get_sensor_state(port, id);
+}
+
 const char *joypad_driver_name(unsigned i)
 {
    if (!input_driver_st.primary_joypad || !input_driver_st.primary_joypad->name)
@@ -6455,6 +6511,37 @@ void input_driver_poll(void)
       sec_joypad->poll();
    if (input && input->poll)
       input->poll(input_st->current_data);
+
+   /* Enable/disable sensors at the driver level based on demand
+    * from shaders and/or core. Setting gates everything. */
+   if (settings->bools.input_sensors_enable)
+   {
+      bool want = input_st->shader_uses_sensors
+         || input_st->core_accel_rate
+         || input_st->core_gyro_rate;
+
+      if (want && !input_st->frontend_sensors_enabled)
+      {
+         input_set_sensor_state(0, RETRO_SENSOR_ACCELEROMETER_ENABLE,
+               input_st->core_accel_rate ? input_st->core_accel_rate : 60);
+         input_set_sensor_state(0, RETRO_SENSOR_GYROSCOPE_ENABLE,
+               input_st->core_gyro_rate ? input_st->core_gyro_rate : 60);
+         input_st->frontend_sensors_enabled = true;
+         input_sensor_start_rest_capture();
+      }
+      else if (!want && input_st->frontend_sensors_enabled)
+      {
+         input_set_sensor_state(0, RETRO_SENSOR_ACCELEROMETER_DISABLE, 0);
+         input_set_sensor_state(0, RETRO_SENSOR_GYROSCOPE_DISABLE, 0);
+         input_st->frontend_sensors_enabled = false;
+      }
+   }
+   else if (input_st->frontend_sensors_enabled)
+   {
+      input_set_sensor_state(0, RETRO_SENSOR_ACCELEROMETER_DISABLE, 0);
+      input_set_sensor_state(0, RETRO_SENSOR_GYROSCOPE_DISABLE, 0);
+      input_st->frontend_sensors_enabled = false;
+   }
 
    /* Update accelerometer rest position capture (runs for ~30 frames
     * after focus gain, then stops) */

--- a/input/input_driver.h
+++ b/input/input_driver.h
@@ -677,6 +677,10 @@ typedef struct
    float rest_accum[3];
    unsigned rest_sample_count;
    bool rest_capturing;
+   bool shader_uses_sensors;
+   bool frontend_sensors_enabled;
+   unsigned core_accel_rate; /* >0 means core wants accel at this rate */
+   unsigned core_gyro_rate;  /* >0 means core wants gyro at this rate */
 } input_driver_state_t;
 
 
@@ -1107,6 +1111,11 @@ void input_sensor_start_rest_capture(void);
 
 bool input_set_sensor_state(unsigned port,
       enum retro_sensor_action action, unsigned rate);
+
+/* Core-facing sensor callbacks that track core enable/disable state */
+bool input_core_set_sensor_state(unsigned port,
+      enum retro_sensor_action action, unsigned rate);
+float input_core_get_sensor_state(unsigned port, unsigned id);
 
 void *input_driver_init_wrap(input_driver_t *input, const char *name);
 

--- a/runloop.c
+++ b/runloop.c
@@ -2533,8 +2533,8 @@ bool runloop_environment_cb(unsigned cmd, void *data)
          if (!input_sensors_enable)
             return false;
 
-         iface->set_sensor_state = input_set_sensor_state;
-         iface->get_sensor_input = input_get_sensor_state;
+         iface->set_sensor_state = input_core_set_sensor_state;
+         iface->get_sensor_input = input_core_get_sensor_state;
          break;
       }
       case RETRO_ENVIRONMENT_GET_CAMERA_INTERFACE:
@@ -4094,6 +4094,13 @@ void runloop_event_deinit_core(void)
    settings_t        *settings = config_get_ptr();
 
    core_unload_game();
+
+   /* Reset core sensor tracking — the core is going away */
+   {
+      input_driver_state_t *input_st = input_state_get_ptr();
+      input_st->core_accel_rate      = 0;
+      input_st->core_gyro_rate       = 0;
+   }
 
    video_st->frame_cache_data  = NULL;
 


### PR DESCRIPTION
If frontend wants sensors (like for shaders) on then the core shouldn't be able to turn it off.