### PR TITLE
udev: set default for wiimote resolution

### DIFF
--- a/input/drivers_joypad/udev_joypad.c
+++ b/input/drivers_joypad/udev_joypad.c
@@ -244,6 +244,13 @@ static void udev_open_sensor_node(struct udev_joypad *pad,
             memset(&pad->sensor_absinfo[1], 0, sizeof(pad->sensor_absinfo[1]));
          if (ioctl(fd, EVIOCGABS(ABS_RZ), &pad->sensor_absinfo[2]) < 0)
             memset(&pad->sensor_absinfo[2], 0, sizeof(pad->sensor_absinfo[2]));
+
+         if (pad->sensor_absinfo[0].resolution == 0)
+            pad->sensor_absinfo[0].resolution = 88;
+         if (pad->sensor_absinfo[1].resolution == 0)
+            pad->sensor_absinfo[1].resolution = 88;
+         if (pad->sensor_absinfo[2].resolution == 0)
+            pad->sensor_absinfo[2].resolution = 88;
       }
       else
       {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

wiimote/udev:
In retropad, vertically it showed detection of sensors, but without setting a resolution the bar didn't actually move.

## Related Issues

## Related Pull Requests

## Reviewers

