### PR TITLE
sdl2: enable hidapi sensor input for wiimote

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -29,6 +29,7 @@
 
 #define SDL_SUPPORTS_RUMBLE  SDL_VERSION_ATLEAST(2, 0, 9)
 #define SDL_SUPPORTS_SENSORS SDL_VERSION_ATLEAST(2, 0, 14)
+#define SDL_SUPPORTS_HIDAPI_WII SDL_VERSION_ATLEAST(2, 26, 0)
 
 typedef struct _sdl_joypad
 {
@@ -300,6 +301,10 @@ static void *sdl_joypad_init(void *data)
 #if SDL_SUPPORTS_RUMBLE
    /* enable extended hid reports to support ps4/ps5 rumble over bluetooth */
    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
+#endif
+#if SDL_SUPPORTS_HIDAPI_WII
+   /* enable HIDAPI Wii driver for accelerometer/gyro support */
+   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
 #endif
 #endif
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Enabled SDL2 sensors for the wiimote.

Note: you need to set permissions to the correct device. For me it was:

```
for i in /dev/hidraw*; do echo -n "$i: "; cat /sys/class/hidraw/$(basename $i)/device/uevent 2>/dev/null | grep "HID_ID=0005:0000057E:00000306" && break; done

sudo chmod 666 /dev/hidraw9 (your device)
``` 

but that will vary depending on your setup as other devices are present (keyboard, mouse etc).

or

```
echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0306", MODE="0666"' | sudo tee /etc/udev/rules.d/99-wiimote-hidraw.rules
sudo udevadm control --reload-rules
```

## Related Issues

## Related Pull Requests

## Reviewers

