### PR TITLE
Fix 'Sort Remaps by Gamepad' from CLI

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -4947,9 +4947,8 @@ bool config_load_remap(const char *directory_input_remapping,
    const char *rarch_path_basename        = path_get(RARCH_PATH_BASENAME);
    enum msg_hash_enums msg_remap_loaded   = MSG_GAME_REMAP_FILE_LOADED;
    settings_t *settings                   = config_st;
-   bool notification_show_remap_load      = settings->bools.notification_show_remap_load;
    unsigned joypad_port                   = settings->uints.input_joypad_index[0];
-   const char *inp_dev_name               = input_config_get_device_display_name(joypad_port);
+   bool notification_show_remap_load      = settings->bools.notification_show_remap_load;
    bool sort_remaps_by_controller         = settings->bools.input_remap_sort_by_controller_enable;
 
    /* > Cannot load remaps if we have no core
@@ -4958,28 +4957,24 @@ bool config_load_remap(const char *directory_input_remapping,
        || string_is_empty(directory_input_remapping))
       return false;
 
-   game_path[0]        = '\0';
-   content_path[0]     = '\0';
+   core_path[0]    = '\0';
+   game_path[0]    = '\0';
+   content_path[0] = '\0';
 
-   if (   sort_remaps_by_controller
-       && !string_is_empty(inp_dev_name)
-       )
+   strlcpy(remap_path, core_name, sizeof(remap_path));
+
+   if (sort_remaps_by_controller)
    {
-      /* Ensure directory does not contain special chars */
-      const char *inp_dev_dir = sanitize_path_part(
-            inp_dev_name, strlen(inp_dev_name));
-      /*  Build the new path with the controller name */
-      size_t _len = strlcpy(remap_path, core_name, sizeof(remap_path));
-      _len += strlcpy(remap_path + _len, PATH_DEFAULT_SLASH(),
-            sizeof(remap_path) - _len);
-      strlcpy(remap_path + _len, inp_dev_dir,
-            sizeof(remap_path) - _len);
-      /* Deallocate as we no longer need this */
-      free((char*)inp_dev_dir);
-      inp_dev_dir = NULL;
+      const char *input_device_name = input_config_get_device_display_name(joypad_port);
+
+      if (!string_is_empty(input_device_name))
+      {
+         /* Ensure directory does not contain special chars */
+         const char *input_device_dir = sanitize_path_part(input_device_name, strlen(input_device_name));
+
+         fill_pathname_join_special(remap_path, core_name, input_device_dir, sizeof(remap_path));
+      }
    }
-   else /* We're not using controller path, just use core name */
-      strlcpy(remap_path, core_name, sizeof(remap_path));
 
    if (!string_is_empty(rarch_path_basename))
    {

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3771,39 +3771,31 @@ static int generic_action_ok_remap_file_operation(const char *path,
    const char *rarch_path_basename        = path_get(RARCH_PATH_BASENAME);
    bool has_content                       = !string_is_empty(rarch_path_basename);
    settings_t *settings                   = config_get_ptr();
-   const char *directory_input_remapping  = settings->paths.directory_input_remapping;
    unsigned joypad_port                   = settings->uints.input_joypad_index[0];
-   const char *input_device_name          = input_config_get_device_display_name(joypad_port);
-   const char *input_device_dir           = NULL;
    bool sort_remaps_by_controller         = settings->bools.input_remap_sort_by_controller_enable;
-   size_t _len                            = 0;
+   const char *directory_input_remapping  = settings->paths.directory_input_remapping;
 
-   remap_file_path[0]  = '\0';
+   remap_file_path[0] = '\0';
 
    /* Cannot perform remap file operation if we
     * have no core */
    if (string_is_empty(core_name))
       return -1;
 
-   if (   sort_remaps_by_controller
-       && (input_device_name != NULL)
-       && !string_is_empty(input_device_name))
+   strlcpy(remap_path, core_name, sizeof(remap_path));
+
+   if (sort_remaps_by_controller)
    {
-      /* Ensure directory does not contain special chars */
-      input_device_dir = sanitize_path_part(input_device_name, strlen(input_device_name));
+      const char *input_device_name = input_config_get_device_display_name(joypad_port);
 
-      /* Allocate memory for the new path */
-      /* Build the new path with the controller name */
-      _len  = strlcpy(remap_path, core_name, sizeof(remap_path));
-      _len += strlcpy(remap_path + _len, PATH_DEFAULT_SLASH(), sizeof(remap_path) - _len);
-      strlcpy(remap_path + _len, input_device_dir,     sizeof(remap_path) - _len);
+      if (!string_is_empty(input_device_name))
+      {
+         /* Ensure directory does not contain special chars */
+         const char *input_device_dir = sanitize_path_part(input_device_name, strlen(input_device_name));
 
-      /* Deallocate as we no longer this */
-      free((char*)input_device_dir);
-      input_device_dir = NULL;
+         fill_pathname_join_special(remap_path, core_name, input_device_dir, sizeof(remap_path));
+      }
    }
-   else /* We're not using controller path, just use core name */
-      strlcpy(remap_path, core_name, sizeof(remap_path));
 
    switch (action_type)
    {

--- a/retroarch.c
+++ b/retroarch.c
@@ -8272,10 +8272,12 @@ bool retroarch_main_init(int argc, char *argv[])
             settings->uints.input_max_users);
 #endif
    input_mapper_reset(&input_st->mapper);
+   command_event(CMD_EVENT_CONTROLLER_INIT, NULL);
+
 #ifdef HAVE_REWIND
    command_event(CMD_EVENT_REWIND_INIT, NULL);
 #endif
-   command_event(CMD_EVENT_CONTROLLER_INIT, NULL);
+
    if (!string_is_empty(rec_st->path))
       command_event(CMD_EVENT_RECORD_INIT, NULL);
 

--- a/tasks/task_autodetect.c
+++ b/tasks/task_autodetect.c
@@ -662,6 +662,24 @@ static void cb_input_autoconfigure_connect(
       input_config_set_autoconfig_binds(port,
             autoconfig_handle->autoconfig_file);
 
+#ifdef HAVE_CONFIGFILE
+   /* 'Sort Remaps by Gamepad' must reload remaps after
+    * controller detection, because controller name
+    * does not exist yet at core init when launched from CLI */
+   if (!retroarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
+   {
+      settings_t *settings = config_get_ptr();
+
+      if (     settings->bools.auto_remaps_enable
+            && settings->bools.input_remap_sort_by_controller_enable)
+      {
+         runloop_state_t *runloop_st = runloop_state_get_ptr();
+
+         config_load_remap(settings->paths.directory_input_remapping, &runloop_st->system);
+      }
+   }
+#endif
+
    reallocate_port_if_needed(port,autoconfig_handle->device_info.vid,
          autoconfig_handle->device_info.pid,
          autoconfig_handle->device_info.name,


### PR DESCRIPTION
## Description

- Add remap config load also after autoconf profile load when sort by gamepad is enabled
- Simplified and unified path creation to load and save
- Cleanups

## Related Issues

Closes #17321
Closes #17476
