### PR TITLE
uwp: log to retroarch.log in production, log to debug console when in debug mode

### DIFF
--- a/verbosity.c
+++ b/verbosity.c
@@ -231,7 +231,14 @@ void RARCH_LOG_V(const char *tag, const char *fmt, va_list ap)
       wvsprintf(buffer + _len, fmt, ap);
 #endif
    }
+#ifdef _DEBUG
    OutputDebugStringA(buffer);
+#endif
+   if (main_verbosity_st.initialized && main_verbosity_st.fp)
+   {
+      fputs(buffer, main_verbosity_st.fp);
+      fflush(main_verbosity_st.fp);
+   }
 
 #elif defined(ANDROID)
    {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

The UWP build (Xbox) etc. does not log to retroarch.log. This fixes that and also changes the behavior to use OutputDebugStringA as it did before only if building a debug build.

This fixes no logs from Xbox users.

## Related Issues

## Related Pull Requests

## Reviewers
