### PR TITLE
Throttle framerate when V-sync is enabled but window is not focused.

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -7402,7 +7402,7 @@ int runloop_iterate(void)
          /* Rely on vsync throttling unless VRR is enabled and menu throttle is disabled. */
          if (vrr_runloop_enable && !settings->bools.menu_throttle_framerate)
             return 0;
-         else if (settings->bools.video_vsync)
+         else if (settings->bools.video_vsync && (runloop_st->flags & RUNLOOP_FLAG_FOCUSED))
             goto end;
 
          /* Otherwise run menu in video refresh rate speed. */
@@ -7542,7 +7542,8 @@ end:
               || (runloop_st->flags & RUNLOOP_FLAG_FASTMOTION)
 #ifdef HAVE_MENU
               || (menu_state_get_ptr()->flags & MENU_ST_FLAG_ALIVE
-                  && !(settings->bools.video_vsync))
+                  && (!(settings->bools.video_vsync)
+                      || !(runloop_st->flags & RUNLOOP_FLAG_FOCUSED)))
 #endif
               || (runloop_st->flags & RUNLOOP_FLAG_PAUSED)))
       {


### PR DESCRIPTION
RetroArch hogs an entire CPU core when running in the background with V-sync enabled. It seems that when the window is fully obscured by other windows, V-sync ceases to work, allowing RetroArch to run at an unlimited framerate, thrashing the CPU (and making my laptop very loud and hot).

As a workaround, the framerate is now throttled when the window is not in focus. I would rather have it throttle when the window is not visible, but there does not seem to be a way of detecting that.

Note that this is only known to be the case on Windows: I do not know what the situation is for Linux and other operating systems, though macOS does apparently suffer from this exact same problem, according to [this SDL issue](https://github.com/libsdl-org/SDL/issues/4521).

For the unlimited framerate issue to occur, the video driver must be Direct3D11, OpenGL, or Vulkan, 'pause on focus loss' needs to be disabled, V-sync needs to be enabled, and VRR needs to be disabled. If this is not enough to reproduce it, I can try to provide more information.

If anybody knows a better way to mitigate this issue, please let me know.