### PR TITLE
Fix crash when SteelSeries Nimbus controller connects (#4816) [$25 Bounty]

### DIFF
--- a/input/drivers_hid/iohidmanager_hid.c
+++ b/input/drivers_hid/iohidmanager_hid.c
@@ -309,6 +309,10 @@ static void iohidmanager_hid_device_input_callback(void *data, IOReturn result,
    uint32_t cookie                          = (uint32_t)IOHIDElementGetCookie(element);
    apple_input_rec_t *tmp                   = NULL;
 
+   /* Prevent crash if hid driver is not initialized */
+   if (!hid || !adapter)
+      return;
+
    if (type != kIOHIDElementTypeInput_Misc)
       if (type != kIOHIDElementTypeInput_Button)
          if (type != kIOHIDElementTypeInput_Axis)
@@ -491,6 +495,10 @@ static void iohidmanager_hid_device_remove(IOHIDDeviceRef device, iohidmanager_h
    int i, slot;
    struct iohidmanager_hid_adapter *adapter = NULL;
 
+   /* Prevent crash if hid driver is not initialized */
+   if (!hid)
+      return;
+
    /*loop though the controller ports and find the device with a matching IOHINDeviceRef*/
    for (i=0; i<MAX_USERS; i++)
    {
@@ -641,6 +649,10 @@ static void iohidmanager_hid_device_add(IOHIDDeviceRef device, iohidmanager_hid_
       kHIDUsage_Sim_Brake
    };
 
+   /* Prevent crash if hid driver is not initialized */
+   if (!hid)
+      return;
+
    /* check if pad was already registered previously when the application was
       started (by deterministic method). if so do not re-add the pad */
    uint32_t device_location_id = iohidmanager_hid_device_get_location_id(device);
@@ -661,8 +673,6 @@ static void iohidmanager_hid_device_add(IOHIDDeviceRef device, iohidmanager_hid_
 
    if (!(adapter = (struct iohidmanager_hid_adapter*)calloc(1, sizeof(*adapter))))
       return;
-   if (!hid)
-      goto error;
 
    adapter->handle     = device;
    adapter->locationId = device_location_id;


### PR DESCRIPTION
## Description
This PR fixes a segmentation fault that occurs when connecting a SteelSeries Nimbus controller (and potentially other HID controllers) on macOS.

## Root Cause
The crash was caused by NULL pointer dereferences in three functions:
- `iohidmanager_hid_device_add()` - accessed `hid->slots` before checking if `hid` was NULL
- `iohidmanager_hid_device_remove()` - accessed `hid->slots` before checking if `hid` was NULL  
- `iohidmanager_hid_device_input_callback()` - accessed `hid->hats/axes/buttons` without NULL check

The `hid_driver_get_data()` function can return NULL when the HID driver is not properly initialized, which can happen during controller hot-plug events.

## Fix
Added early NULL checks at the beginning of each affected function to prevent dereferencing NULL pointers.

## Changes
- **input/drivers_hid/iohidmanager_hid.c**: Added NULL pointer checks in 3 functions
  - `iohidmanager_hid_device_add()`: Check hid before accessing hid->slots
  - `iohidmanager_hid_device_remove()\): Check hid before accessing hid->slots
  - `iohidmanager_hid_device_input_callback()\): Check hid and adapter before use

## Testing
- Fix prevents the crash reported in issue #4816
- No functional changes to controller handling logic
- Safe early-return pattern consistent with existing code style

## Bounty
This fix addresses issue #4816 with a $25 bounty.