### PR TITLE
android: Default to Vulkan video driver on Android

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -450,6 +450,8 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_D3D11;
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL1;
 #elif defined(HAVE_VITA2D)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_VITA2D;
+#elif defined(ANDROID) && defined(HAVE_VULKAN)
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_VULKAN;
 #elif defined(HAVE_OPENGL) || defined(HAVE_OPENGLES) || defined(HAVE_PSGL)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_GL;
 #elif defined(HAVE_OPENGL_CORE) && !defined(__HAIKU__)

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -4016,6 +4016,9 @@ static void *vulkan_init(const video_info_t *video,
 
 error:
    vulkan_free(vk);
+#if defined(HAVE_OPENGL) || defined(HAVE_OPENGLES)
+   video_driver_force_fallback("gl");
+#endif
    return NULL;
 }
 


### PR DESCRIPTION
## Description

Android defaults to GL due to preprocessor ordering in configuration.c.
Vulkan enables modern slang shader support and other benefits. Vulkan is widely supported on Android 10+.
Switching video modes is unintuitive, especially to first time users.

Added GL fallback on Vulkan init failure for devices without Vulkan support.