### PR TITLE
Win32: Add mmdevice notification callback

### DIFF
--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -459,6 +459,17 @@ static void audio_driver_flush(audio_driver_state_t *audio_st,
                ? 0.0f
                : audio_st->volume_gain;
 
+   if (audio_st->reinit_request)
+   {
+      audio_st->reinit_request = false;
+      RARCH_LOG("[Audio] Driver reinit requested...\n");
+      command_event(CMD_EVENT_AUDIO_REINIT, NULL);
+#ifdef HAVE_MICROPHONE
+      command_event(CMD_EVENT_MICROPHONE_REINIT, NULL);
+#endif
+      return;
+   }
+
    /* Fast path: if driver handles resampling and no DSP/mixer is active,
     * bypass software resampling entirely. */
    if (audio->write_raw

--- a/audio/audio_driver.h
+++ b/audio/audio_driver.h
@@ -262,6 +262,7 @@ typedef struct
 
    char resampler_ident[64];
 
+   bool reinit_request;
    bool mute_enable;
 #ifdef HAVE_AUDIOMIXER
    bool mixer_mute_enable;

--- a/audio/common/mmdevice_common.c
+++ b/audio/common/mmdevice_common.c
@@ -22,7 +22,182 @@
 #include "mmdevice_common.h"
 #include "mmdevice_common_inline.h"
 
+#include "../audio_driver.h"
+
 #include "../../verbosity.h"
+
+DWORD IMMNotificationThreadId = 0;
+
+/* IUnknown methods */
+HRESULT STDMETHODCALLTYPE IMM_QueryInterface(IMMNotificationClient *This,
+      REFIID riid, void **ppvObject)
+{
+#ifdef __cplusplus
+   if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_IMMNotificationClient))
+#else
+   if (IsEqualIID(riid, &IID_IUnknown) || IsEqualIID(riid, &IID_IMMNotificationClient))
+#endif
+   {
+      *ppvObject = This;
+      InterlockedIncrement(&((MyNotificationClient*)This)->refCount);
+      return S_OK;
+   }
+   *ppvObject = NULL;
+   return E_NOINTERFACE;
+}
+
+ULONG STDMETHODCALLTYPE IMM_AddRef(IMMNotificationClient *This)
+{
+   return InterlockedIncrement(&((MyNotificationClient*)This)->refCount);
+}
+
+ULONG STDMETHODCALLTYPE IMM_Release(IMMNotificationClient *This)
+{
+   LONG ref = InterlockedDecrement(&((MyNotificationClient*)This)->refCount);
+   if (ref == 0)
+      free(This);
+   return ref;
+}
+
+/* IMMNotificationClient methods */
+HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(IMMNotificationClient *This,
+      EDataFlow flow, ERole role, LPCWSTR pwstrDefaultDeviceId)
+{
+   BOOL result = PostThreadMessage(IMMNotificationThreadId,
+         WM_AUDIO_DEFAULT_CHANGED, 0, 0);
+
+   if (!result)
+      RARCH_ERR("[MMDevice] PostThreadMessage failed: %lu, threadId: %lu\n",
+            GetLastError(), IMMNotificationThreadId);
+
+   return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OnDeviceAdded(IMMNotificationClient *This,
+      LPCWSTR pwstrDeviceId)
+{
+   return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OnDeviceRemoved(IMMNotificationClient *This,
+      LPCWSTR pwstrDeviceId)
+{
+   return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OnDeviceStateChanged(IMMNotificationClient *This,
+      LPCWSTR pwstrDeviceId, DWORD dwNewState)
+{
+   BOOL result = PostThreadMessage(IMMNotificationThreadId,
+         WM_AUDIO_DEVICE_STATE_CHANGED, 0, 0);
+
+   if (!result)
+      RARCH_ERR("[MMDevice] PostThreadMessage failed: %lu, threadId: %lu\n",
+            GetLastError(), IMMNotificationThreadId);
+
+   return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(IMMNotificationClient *This,
+      LPCWSTR pwstrDeviceId, const PROPERTYKEY key)
+{
+   return S_OK;
+}
+
+/* IMMNotificationClient VTable */
+IMMNotificationClientVtbl notificationVtbl = {
+   IMM_QueryInterface,
+   IMM_AddRef,
+   IMM_Release,
+   OnDeviceStateChanged,
+   OnDeviceAdded,
+   OnDeviceRemoved,
+   OnDefaultDeviceChanged,
+   OnPropertyValueChanged
+};
+
+#ifdef HAVE_THREADS
+void mmdevice_thread(void *data)
+#else
+DWORD CALLBACK mmdevice_thread(PVOID data)
+#endif
+{
+#if !defined(_XBOX) && !defined(__WINRT__)
+   HRESULT hr;
+   IMMDeviceEnumerator *enumerator = NULL;
+   MyNotificationClient *client    = NULL;
+   audio_driver_state_t *audio_st  = audio_state_get_ptr();
+
+   hr = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+   if (FAILED(hr))
+      return;
+
+#ifdef __cplusplus
+   hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+         IID_IMMDeviceEnumerator, (void **)&enumerator);
+#else
+   hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+         &IID_IMMDeviceEnumerator, (void **)&enumerator);
+#endif
+   if (FAILED(hr))
+   {
+      RARCH_ERR("[MMDevice] Failed to create device enumerator: %s.\n", mmdevice_hresult_name(hr));
+      goto cleanup;
+   }
+
+   client = (MyNotificationClient*)malloc(sizeof(MyNotificationClient));
+   if (!client)
+      goto cleanup;
+
+   client->lpVtbl   = &notificationVtbl;
+   client->refCount = 1;
+
+   _IMMDeviceEnumerator_RegisterEndpointNotificationCallback(enumerator,
+         (IMMNotificationClient*)client);
+   if (FAILED(hr))
+   {
+      RARCH_ERR("[MMDevice] RegisterEndpointNotificationCallback failed: 0x%lx.\n", hr);
+      goto cleanup;
+   }
+
+   IMMNotificationThreadId = GetCurrentThreadId();
+
+   while (IMMNotificationThreadId)
+   {
+      DWORD result = MsgWaitForMultipleObjects(0, NULL, FALSE, 5000, QS_ALLPOSTMESSAGE);
+      if (result == WAIT_OBJECT_0)
+      {
+         MSG msg;
+         while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+         {
+            switch (msg.message)
+            {
+               case WM_AUDIO_DEVICE_STATE_CHANGED:
+               case WM_AUDIO_DEFAULT_CHANGED:
+                  audio_st->reinit_request = true;
+                  goto done;
+               case WM_QUIT:
+                  goto done;
+            }
+         }
+      }
+   }
+
+done:
+   _IMMDeviceEnumerator_UnregisterEndpointNotificationCallback(enumerator,
+         (IMMNotificationClient*)client);
+
+cleanup:
+   free(client);
+   client = NULL;
+
+   RELEASE(enumerator);
+
+   IMMNotificationThreadId = 0;
+   CoUninitialize();
+   ExitThread(0);
+#endif
+}
 
 static const char *mmdevice_data_flow_name(unsigned data_flow)
 {
@@ -136,15 +311,7 @@ size_t mmdevice_samplerate(void *data)
    }
 
    PropVariantClear(&prop_var);
-   if (prop_store)
-   {
-#ifdef __cplusplus
-      prop_store->Release();
-#else
-      prop_store->lpVtbl->Release(prop_store);
-#endif
-      prop_store = NULL;
-   }
+   RELEASE(prop_store);
    return (size_t)result;
 }
 
@@ -172,15 +339,7 @@ char *mmdevice_name(void *data)
       result = utf16_to_utf8_string_alloc(prop_var.pwszVal);
 
    PropVariantClear(&prop_var);
-   if (prop_store)
-   {
-#ifdef __cplusplus
-      prop_store->Release();
-#else
-      prop_store->lpVtbl->Release(prop_store);
-#endif
-      prop_store = NULL;
-   }
+   RELEASE(prop_store);
    return result;
 }
 
@@ -190,6 +349,7 @@ void *mmdevice_handle(int id, unsigned data_flow)
    IMMDeviceEnumerator *enumerator = NULL;
    IMMDevice *device               = NULL;
    IMMDeviceCollection *collection = NULL;
+
 #ifdef __cplusplus
    hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
          IID_IMMDeviceEnumerator, (void **)&enumerator);
@@ -199,8 +359,9 @@ void *mmdevice_handle(int id, unsigned data_flow)
 #endif
    if (FAILED(hr))
       return NULL;
+
    hr = _IMMDeviceEnumerator_EnumAudioEndpoints(enumerator,
-         data_flow, DEVICE_STATE_ACTIVE, &collection);
+         (EDataFlow)data_flow, DEVICE_STATE_ACTIVE, &collection);
    if (FAILED(hr))
    {
       RARCH_ERR("[MMDevice] Failed to enumerate audio endpoints: %s.\n", mmdevice_hresult_name(hr));
@@ -217,21 +378,8 @@ void *mmdevice_handle(int id, unsigned data_flow)
    return device;
 
 error:
-   if (collection)
-#ifdef __cplusplus
-      collection->Release();
-#else
-      collection->lpVtbl->Release(collection);
-#endif
-   if (enumerator)
-#ifdef __cplusplus
-      enumerator->Release();
-#else
-      enumerator->lpVtbl->Release(enumerator);
-#endif
-   collection = NULL;
-   enumerator = NULL;
-
+   RELEASE(collection);
+   RELEASE(enumerator);
    return NULL;
 }
 
@@ -241,11 +389,7 @@ size_t mmdevice_get_samplerate(int id)
    if (device)
    {
       size_t _len = mmdevice_samplerate(device);
-#ifdef __cplusplus
-      device->Release();
-#else
-      device->lpVtbl->Release(device);
-#endif
+      RELEASE(device);
       return _len;
    }
    return 0;
@@ -261,9 +405,9 @@ void *mmdevice_init_device(const char *id, unsigned data_flow)
    const char *data_flow_name      = mmdevice_data_flow_name(data_flow);
 
    if (id)
-      RARCH_DBG("[MMDevice] Initializing %s device \"%s\"...\n", data_flow_name, id);
+      RARCH_LOG("[MMDevice] Initializing %s device \"%s\"...\n", data_flow_name, id);
    else
-      RARCH_DBG("[MMDevice] Initializing default %s device...\n", data_flow_name);
+      RARCH_LOG("[MMDevice] Initializing default %s device...\n", data_flow_name);
 
 #ifdef __cplusplus
    hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
@@ -298,7 +442,7 @@ void *mmdevice_init_device(const char *id, unsigned data_flow)
          {
             if (string_is_equal(id, list->elems[d].data))
             {
-               RARCH_DBG("[MMDevice] Found device #%d: \"%s\".\n", d,
+               RARCH_LOG("[MMDevice] Found device #%d: \"%s\".\n", d,
                      list->elems[d].data);
                idx_found = d;
                break;
@@ -320,7 +464,7 @@ void *mmdevice_init_device(const char *id, unsigned data_flow)
          idx_found = 0;
 
       hr = _IMMDeviceEnumerator_EnumAudioEndpoints(enumerator,
-            data_flow, DEVICE_STATE_ACTIVE, &collection);
+            (EDataFlow)data_flow, DEVICE_STATE_ACTIVE, &collection);
       if (FAILED(hr))
       {
          RARCH_ERR("[MMDevice] Failed to enumerate audio endpoints: %s.\n", mmdevice_hresult_name(hr));
@@ -346,19 +490,13 @@ void *mmdevice_init_device(const char *id, unsigned data_flow)
          if (i == (UINT32)idx_found)
             break;
 
-         if (device)
-#ifdef __cplusplus
-            device->Release();
-#else
-            device->lpVtbl->Release(device);
-#endif
-          device = NULL;
+         RELEASE(device);
       }
    }
    else
    {
       hr = _IMMDeviceEnumerator_GetDefaultAudioEndpoint(
-            enumerator, data_flow, eConsole, &device);
+            enumerator, (EDataFlow)data_flow, eConsole, &device);
       if (FAILED(hr))
       {
          RARCH_ERR("[MMDevice] Failed to get default audio endpoint: %s.\n", mmdevice_hresult_name(hr));
@@ -369,41 +507,16 @@ void *mmdevice_init_device(const char *id, unsigned data_flow)
    if (!device)
       goto error;
 
-   if (collection)
-#ifdef __cplusplus
-      collection->Release();
-#else
-      collection->lpVtbl->Release(collection);
-#endif
-   if (enumerator)
-#ifdef __cplusplus
-      enumerator->Release();
-#else
-      enumerator->lpVtbl->Release(enumerator);
-#endif
-   collection = NULL;
-   enumerator = NULL;
-
+   RELEASE(collection);
+   RELEASE(enumerator);
    return device;
 
 error:
-   if (collection)
-#ifdef __cplusplus
-      collection->Release();
-#else
-      collection->lpVtbl->Release(collection);
-#endif
-   if (enumerator)
-#ifdef __cplusplus
-      enumerator->Release();
-#else
-      enumerator->lpVtbl->Release(enumerator);
-#endif
-   collection = NULL;
-   enumerator = NULL;
+   RELEASE(collection);
+   RELEASE(enumerator);
 
    if (id)
-      RARCH_WARN("[MMDevice] Failed to initialize %s device \"%s\".\n", data_flow_name, id);
+      RARCH_ERR("[MMDevice] Failed to initialize %s device \"%s\".\n", data_flow_name, id);
    else
       RARCH_ERR("[MMDevice] Failed to initialize default %s device.\n", data_flow_name);
 
@@ -440,7 +553,7 @@ void *mmdevice_list_new(const void *u, unsigned data_flow)
       goto error;
 
    hr = _IMMDeviceEnumerator_EnumAudioEndpoints(enumerator,
-         data_flow, DEVICE_STATE_ACTIVE, &collection);
+         (EDataFlow)data_flow, DEVICE_STATE_ACTIVE, &collection);
    if (FAILED(hr))
       goto error;
 
@@ -472,79 +585,36 @@ void *mmdevice_list_new(const void *u, unsigned data_flow)
 
       if (dev_id_wstr)
          CoTaskMemFree(dev_id_wstr);
+      dev_id_wstr  = NULL;
+
       if (dev_name_str)
          free(dev_name_str);
       dev_name_str = NULL;
-      dev_id_wstr  = NULL;
-      if (device)
-      {
-#ifdef __cplusplus
-         device->Release();
-#else
-         device->lpVtbl->Release(device);
-#endif
-         device = NULL;
-      }
+
+      RELEASE(device);
    }
 
-   if (collection)
-   {
-#ifdef __cplusplus
-      collection->Release();
-#else
-      collection->lpVtbl->Release(collection);
-#endif
-      collection = NULL;
-   }
-   if (enumerator)
-   {
-#ifdef __cplusplus
-      enumerator->Release();
-#else
-      enumerator->lpVtbl->Release(enumerator);
-#endif
-      enumerator = NULL;
-   }
-
+   RELEASE(collection);
+   RELEASE(enumerator);
    return sl;
 
 error:
    if (dev_id_str)
       free(dev_id_str);
+   dev_id_str   = NULL;
+
    if (dev_name_str)
       free(dev_name_str);
-   dev_id_str   = NULL;
    dev_name_str = NULL;
+
    if (dev_id_wstr)
       CoTaskMemFree(dev_id_wstr);
    dev_id_wstr = NULL;
-   if (device)
-   {
-#ifdef __cplusplus
-      device->Release();
-#else
-      device->lpVtbl->Release(device);
-#endif
-      device = NULL;
-   }
-   if (collection)
-   {
-#ifdef __cplusplus
-      collection->Release();
-#else
-      collection->lpVtbl->Release(collection);
-#endif
-      collection = NULL;
-   }
-   if (enumerator)
-   {
-#ifdef __cplusplus
-      enumerator->Release();
-#else
-      enumerator->lpVtbl->Release(enumerator);
-#endif
-      enumerator = NULL;
-   }
+
+   RELEASE(device);
+   RELEASE(collection);
+   RELEASE(enumerator);
+
    if (sl)
       string_list_free(sl);
 

--- a/audio/common/mmdevice_common.h
+++ b/audio/common/mmdevice_common.h
@@ -44,8 +44,13 @@ size_t mmdevice_get_samplerate(int id);
 
 const char *mmdevice_hresult_name(int hr);
 
-
 void *mmdevice_init_device(const char *id, unsigned data_flow);
+
+#ifdef HAVE_THREADS
+void mmdevice_thread(void *data);
+#else
+DWORD CALLBACK mmdevice_thread(PVOID data);
+#endif
 
 RETRO_END_DECLS
 

--- a/audio/common/mmdevice_common_inline.h
+++ b/audio/common/mmdevice_common_inline.h
@@ -33,10 +33,80 @@
 
 #include <retro_common_api.h>
 
+#ifdef __cplusplus
+#define RELEASE(x) \
+   if (x) \
+      x->Release(); \
+   x = NULL;
+#else
+#define RELEASE(x) \
+   if (x) \
+      x->lpVtbl->Release(x); \
+   x = NULL;
+#endif
+
+#define WM_AUDIO_DEVICE_STATE_CHANGED (WM_USER + 1)
+#define WM_AUDIO_DEFAULT_CHANGED      (WM_USER + 2)
+
+extern DWORD IMMNotificationThreadId;
+
+#ifdef __cplusplus
+typedef struct IMMNotificationClientVtbl {
+    BEGIN_INTERFACE
+
+    /*** IUnknown methods ***/
+    HRESULT (STDMETHODCALLTYPE *IMM_QueryInterface)(
+        IMMNotificationClient *This,
+        REFIID riid,
+        void **ppvObject);
+
+    ULONG (STDMETHODCALLTYPE *IMM_AddRef)(
+        IMMNotificationClient *This);
+
+    ULONG (STDMETHODCALLTYPE *IMM_Release)(
+        IMMNotificationClient *This);
+
+    /*** IMMNotificationClient methods ***/
+    HRESULT (STDMETHODCALLTYPE *OnDeviceStateChanged)(
+        IMMNotificationClient *This,
+        LPCWSTR pwstrDeviceId,
+        DWORD dwNewState);
+
+    HRESULT (STDMETHODCALLTYPE *OnDeviceAdded)(
+        IMMNotificationClient *This,
+        LPCWSTR pwstrDeviceId);
+
+    HRESULT (STDMETHODCALLTYPE *OnDeviceRemoved)(
+        IMMNotificationClient *This,
+        LPCWSTR pwstrDeviceId);
+
+    HRESULT (STDMETHODCALLTYPE *OnDefaultDeviceChanged)(
+        IMMNotificationClient *This,
+        EDataFlow flow,
+        ERole role,
+        LPCWSTR pwstrDeviceId);
+
+    HRESULT (STDMETHODCALLTYPE *OnPropertyValueChanged)(
+        IMMNotificationClient *This,
+        LPCWSTR pwstrDeviceId,
+        const PROPERTYKEY key);
+
+    END_INTERFACE
+} IMMNotificationClientVtbl;
+#endif
+
+#if !defined(_XBOX) && !defined(__WINRT__)
+typedef struct MyNotificationClient {
+    IMMNotificationClientVtbl *lpVtbl;
+    LONG refCount;
+} MyNotificationClient;
+#endif
+
 #ifdef _MSC_VER
 DEFINE_GUID(IID_IAudioClient, 0x1CB9AD4C, 0xDBFA, 0x4C32, 0xB1, 0x78, 0xC2, 0xF5, 0x68, 0xA7, 0x03, 0xB2);
 DEFINE_GUID(IID_IAudioRenderClient, 0xF294ACFC, 0x3146, 0x4483, 0xA7, 0xBF, 0xAD, 0xDC, 0xA7, 0xC2, 0x60, 0xE2);
 DEFINE_GUID(IID_IAudioCaptureClient, 0xC8ADBD64, 0xE71E, 0x48A0, 0xA4, 0xDE, 0x18, 0x5C, 0x39, 0x5C, 0xD3, 0x17);
+DEFINE_GUID(IID_IMMNotificationClient, 0x7991EEC9, 0x7E89, 0x4D85, 0x83, 0x90, 0x6C, 0x70, 0x3C, 0xEC, 0x60, 0xC0);
 DEFINE_GUID(IID_IMMDeviceEnumerator, 0xA95664D2, 0x9614, 0x4F35, 0xA7, 0x46, 0xDE, 0x8D, 0xB6, 0x36, 0x17, 0xE6);
 DEFINE_GUID(CLSID_MMDeviceEnumerator, 0xBCDE0395, 0xE52F, 0x467C, 0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E);
 #undef KSDATAFORMAT_SUBTYPE_IEEE_FLOAT
@@ -67,6 +137,8 @@ DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0
 #define _IMMDevice_Activate(This,iid,dwClsCtx,pActivationParams,ppv) ((This)->Activate(iid,(dwClsCtx),pActivationParams,ppv))
 #define _IMMDeviceEnumerator_EnumAudioEndpoints(This,dataFlow,dwStateMask,ppDevices) (This)->EnumAudioEndpoints(dataFlow,dwStateMask,ppDevices)
 #define _IMMDeviceEnumerator_GetDefaultAudioEndpoint(This,dataFlow,role,ppEndpoint) (This)->GetDefaultAudioEndpoint(dataFlow,role,ppEndpoint)
+#define _IMMDeviceEnumerator_RegisterEndpointNotificationCallback(This,client) (This)->RegisterEndpointNotificationCallback(client)
+#define _IMMDeviceEnumerator_UnregisterEndpointNotificationCallback(This,client) (This)->UnregisterEndpointNotificationCallback(client)
 #define _IMMDevice_OpenPropertyStore(This,stgmAccess,ppProperties) (This)->OpenPropertyStore(stgmAccess,ppProperties)
 #define _IMMDevice_GetId(This,ppstrId) ((This)->GetId(ppstrId))
 #define _IPropertyStore_GetValue(This,key,pv) ( (This)->GetValue(key,pv) )
@@ -99,6 +171,8 @@ DEFINE_PROPERTYKEY(PKEY_Device_FriendlyName, 0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0
 #define _IMMDevice_Activate(This,iid,dwClsCtx,pActivationParams,ppv) ((This)->lpVtbl->Activate(This,&(iid),dwClsCtx,pActivationParams,ppv))
 #define _IMMDeviceEnumerator_EnumAudioEndpoints(This,dataFlow,dwStateMask,ppDevices) (This)->lpVtbl->EnumAudioEndpoints(This,dataFlow,dwStateMask,ppDevices)
 #define _IMMDeviceEnumerator_GetDefaultAudioEndpoint(This,dataFlow,role,ppEndpoint) (This)->lpVtbl->GetDefaultAudioEndpoint(This,dataFlow,role,ppEndpoint)
+#define _IMMDeviceEnumerator_RegisterEndpointNotificationCallback(This,client) (This)->lpVtbl->RegisterEndpointNotificationCallback(This,client)
+#define _IMMDeviceEnumerator_UnregisterEndpointNotificationCallback(This,client) (This)->lpVtbl->UnregisterEndpointNotificationCallback(This,client)
 #define _IMMDevice_OpenPropertyStore(This,stgmAccess,ppProperties) (This)->lpVtbl->OpenPropertyStore(This,stgmAccess,ppProperties)
 #define _IMMDevice_GetId(This,ppstrId) (This)->lpVtbl->GetId(This,ppstrId)
 #define _IPropertyStore_GetValue(This,key,pv) ( (This)->lpVtbl -> GetValue(This,&(key),pv) )

--- a/audio/drivers/dsound.c
+++ b/audio/drivers/dsound.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
+#include <boolean.h>
 
 #ifndef _XBOX
 #include <windows.h>
@@ -26,8 +27,6 @@
 #endif
 
 #include <dsound.h>
-
-#include <boolean.h>
 
 #include <retro_inline.h>
 #include <retro_miscellaneous.h>
@@ -38,6 +37,17 @@
 #include <lists/string_list.h>
 #include <queues/fifo_queue.h>
 #include <string/stdstring.h>
+
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0600 /*_WIN32_WINNT_VISTA */)
+#ifndef HAVE_MMDEVICE
+#define HAVE_MMDEVICE
+#endif
+#endif
+
+#ifdef HAVE_MMDEVICE
+#include "../common/mmdevice_common.h"
+#include "../common/mmdevice_common_inline.h"
+#endif
 
 #include "../audio_driver.h"
 #include "../../verbosity.h"
@@ -54,6 +64,7 @@
 #endif
 
 #define CHUNK_SIZE 256
+#define DSOUND_TIMEOUT 256
 
 typedef struct dsound
 {
@@ -68,6 +79,13 @@ typedef struct dsound
    sthread_t *thread;
 #else
    HANDLE thread;
+#endif
+#ifdef HAVE_MMDEVICE
+#ifdef HAVE_THREADS
+   sthread_t *imm_thread;
+#else
+   HANDLE imm_thread;
+#endif
 #endif
    size_t fifo_bufsize;
    unsigned buffer_size;
@@ -84,6 +102,41 @@ struct audio_lock
    DWORD size1;
    DWORD size2;
 };
+
+#ifdef HAVE_MMDEVICE
+static void dsound_imm_stop_thread(dsound_t *ds)
+{
+   if (!ds->imm_thread)
+      return;
+
+   PostThreadMessage(IMMNotificationThreadId, WM_QUIT, 0, 0);
+
+#ifdef HAVE_THREADS
+   sthread_join(ds->imm_thread);
+#else
+   WaitForSingleObject(ds->imm_thread, DSOUND_TIMEOUT);
+   CloseHandle(ds->imm_thread);
+#endif
+
+   IMMNotificationThreadId = 0;
+   ds->imm_thread = NULL;
+}
+
+static bool dsound_imm_start_thread(dsound_t *ds)
+{
+   if (!ds->imm_thread)
+   {
+#ifdef HAVE_THREADS
+      ds->imm_thread = sthread_create(mmdevice_thread, ds);
+#else
+      ds->imm_thread = CreateThread(NULL, 0, mmdevice_thread, ds, 0, NULL);
+#endif
+      if (!ds->imm_thread)
+         return false;
+   }
+   return true;
+}
+#endif
 
 static BOOL CALLBACK dsound_enumerate_cb(LPGUID guid,
       LPCSTR desc, LPCSTR module, LPVOID context)
@@ -116,7 +169,7 @@ static BOOL CALLBACK dsound_enumerate_cb(LPGUID guid,
    return TRUE;
 }
 
-static void *dsound_list_new(void *u)
+static void *dsound_device_list_new(void *u)
 {
    struct string_list *sl = string_list_new();
 
@@ -133,7 +186,6 @@ static void *dsound_list_new(void *u)
 
    return sl;
 }
-
 
 static INLINE unsigned _dsound_write_avail(unsigned read_ptr,
       unsigned write_ptr, unsigned buffer_size)
@@ -270,7 +322,7 @@ static void dsound_stop_thread(dsound_t *ds)
 #ifdef HAVE_THREADS
    sthread_join(ds->thread);
 #else
-   WaitForSingleObject(ds->thread, INFINITE);
+   WaitForSingleObject(ds->thread, DSOUND_TIMEOUT);
    CloseHandle(ds->thread);
 #endif
 
@@ -316,17 +368,10 @@ static void dsound_free(void *data)
    if (!ds)
       return;
 
-   if (ds->thread)
-   {
-      ds->thread_alive = false;
-#ifdef HAVE_THREADS
-      sthread_join(ds->thread);
-#else
-      WaitForSingleObject(ds->thread, INFINITE);
-      CloseHandle(ds->thread);
+#ifdef HAVE_MMDEVICE
+   dsound_imm_stop_thread(ds);
 #endif
-   }
-
+   dsound_stop_thread(ds);
    DeleteCriticalSection(&ds->crit);
 
    if (ds->dsb)
@@ -398,7 +443,7 @@ static void *dsound_init(const char *dev, unsigned rate, unsigned latency,
 
    if (dev)
    {
-      struct string_list *list = (struct string_list*)dsound_list_new(NULL);
+      struct string_list *list = (struct string_list*)dsound_device_list_new(NULL);
 
        /* Search for device name first */
       if (list && list->elems)
@@ -462,8 +507,8 @@ static void *dsound_init(const char *dev, unsigned rate, unsigned latency,
    if (ds->buffer_size < 4 * CHUNK_SIZE)
       ds->buffer_size    = 4 * CHUNK_SIZE;
 
-   RARCH_LOG("[DirectSound] Setting buffer size of %u bytes.\n", ds->buffer_size);
-   RARCH_LOG("[DirectSound] Latency = %u ms.\n", (unsigned)((1000 * ds->buffer_size) / wf.nAvgBytesPerSec));
+   RARCH_LOG("[DirectSound] Setting buffer size of %u bytes, latency %u ms.\n",
+         ds->buffer_size, (unsigned)((1000 * ds->buffer_size) / wf.nAvgBytesPerSec));
 
    bufdesc.dwSize        = sizeof(DSBUFFERDESC);
    bufdesc.dwFlags       = 0;
@@ -489,6 +534,10 @@ static void *dsound_init(const char *dev, unsigned rate, unsigned latency,
    IDirectSoundBuffer_SetCurrentPosition(ds->dsb, 0);
 
    dsound_clear_buffer(ds);
+
+#ifdef HAVE_MMDEVICE
+   dsound_imm_start_thread(ds);
+#endif
 
    if (IDirectSoundBuffer_Play(ds->dsb, 0, 0, DSBPLAY_LOOPING) == DS_OK)
       if (dsound_start_thread(ds))
@@ -582,7 +631,7 @@ static ssize_t dsound_write(void *data, const void *buf_, size_t len)
          if (!ds->thread_alive)
             break;
 
-         if (avail == 0 && !(WaitForSingleObject(ds->event, 50) == WAIT_OBJECT_0))
+         if (avail == 0 && !(WaitForSingleObject(ds->event, DSOUND_TIMEOUT) == WAIT_OBJECT_0))
             return -1;
       }
    }
@@ -628,7 +677,7 @@ audio_driver_t audio_dsound = {
    dsound_free,
    dsound_use_float,
    "dsound",
-   dsound_list_new,
+   dsound_device_list_new,
    dsound_device_list_free,
    dsound_write_avail,
    dsound_buffer_size,

--- a/audio/drivers/wasapi.c
+++ b/audio/drivers/wasapi.c
@@ -20,6 +20,10 @@
 #include <queues/fifo_queue.h>
 #include <string/stdstring.h>
 
+#ifdef HAVE_THREADS
+#include <rthreads/rthreads.h>
+#endif
+
 #include "../common/mmdevice_common.h"
 #include "../common/mmdevice_common_inline.h"
 #include "../common/wasapi.h"
@@ -31,7 +35,6 @@
 #include "../../verbosity.h"
 #include "../../configuration.h"
 
-/* Max time to wait before continuing */
 #define WASAPI_TIMEOUT 256
 
 enum wasapi_flags
@@ -44,6 +47,11 @@ enum wasapi_flags
 typedef struct
 {
    HANDLE write_event;
+#ifdef HAVE_THREADS
+   sthread_t *imm_thread;
+#else
+   HANDLE imm_thread;
+#endif
    IMMDevice          *device;
    IAudioClient       *client;
    IAudioRenderClient *renderer;
@@ -52,6 +60,39 @@ typedef struct
    unsigned char frame_size;          /* 4 or 8 only */
    uint8_t flags;
 } wasapi_t;
+
+static void wasapi_imm_stop_thread(wasapi_t *w)
+{
+   if (!w->imm_thread)
+      return;
+
+   PostThreadMessage(IMMNotificationThreadId, WM_QUIT, 0, 0);
+
+#ifdef HAVE_THREADS
+   sthread_join(w->imm_thread);
+#else
+   WaitForSingleObject(w->imm_thread, WASAPI_TIMEOUT);
+   CloseHandle(w->imm_thread);
+#endif
+
+   IMMNotificationThreadId = 0;
+   w->imm_thread = NULL;
+}
+
+static bool wasapi_imm_start_thread(wasapi_t *w)
+{
+   if (!w->imm_thread)
+   {
+#ifdef HAVE_THREADS
+      w->imm_thread = sthread_create(mmdevice_thread, w);
+#else
+      w->imm_thread = CreateThread(NULL, 0, mmdevice_thread, w, 0, NULL);
+#endif
+      if (!w->imm_thread)
+         return false;
+   }
+   return true;
+}
 
 static const char *wasapi_wave_subtype_name(const GUID *guid)
 {
@@ -71,7 +112,6 @@ static const char *wasapi_wave_format_name(const WAVEFORMATEXTENSIBLE *format)
       default:
          break;
    }
-
    return "<unknown>";
 }
 
@@ -161,7 +201,6 @@ static bool wasapi_is_format_suitable(const WAVEFORMATEXTENSIBLE *format)
          /* Other formats are unsupported */
          return false;
    }
-
    return true;
 }
 
@@ -181,11 +220,11 @@ static bool wasapi_select_device_format(WAVEFORMATEXTENSIBLE *format, IAudioClie
    /* Try the requested sample format first, then try the other one. */
    WAVEFORMATEXTENSIBLE *suggested_format  = NULL;
    /* IAudioClient::IsFormatSupported allocates a format object. */
+   /* The Windows docs say that casting these arguments to WAVEFORMATEX* is okay. */
    HRESULT hr                              = _IAudioClient_IsFormatSupported(
          client, mode,
          (const WAVEFORMATEX *)format,
          (WAVEFORMATEX **)&suggested_format);
-   /* The Windows docs say that casting these arguments to WAVEFORMATEX* is okay. */
 
    switch (hr)
    {
@@ -274,11 +313,8 @@ static IAudioClient *wasapi_init_client_ex(IMMDevice *device,
 
    hr = _IAudioClient_GetDevicePeriod(client, NULL, &minimum_period);
    if (FAILED(hr))
-   {
       RARCH_ERR("[WASAPI] Failed to get minimum device period of exclusive client: %s.\n",
             mmdevice_hresult_name(hr));
-      goto error;
-   }
 
    /* Buffer_duration is in 100ns units. */
    buffer_duration = latency * 10000.0;
@@ -316,13 +352,8 @@ static IAudioClient *wasapi_init_client_ex(IMMDevice *device,
          goto error;
       }
 
-      if (client)
-#ifdef __cplusplus
-         client->Release();
-#else
-         client->lpVtbl->Release(client);
-#endif
-      client = NULL;
+      RELEASE(client);
+
       hr     = _IMMDevice_Activate(device,
             IID_IAudioClient,
             CLSCTX_ALL, NULL, (void**)&client);
@@ -340,13 +371,8 @@ static IAudioClient *wasapi_init_client_ex(IMMDevice *device,
    }
    if (hr == AUDCLNT_E_ALREADY_INITIALIZED)
    {
-      if (client)
-#ifdef __cplusplus
-         client->Release();
-#else
-         client->lpVtbl->Release(client);
-#endif
-      client = NULL;
+      RELEASE(client);
+
       hr     = _IMMDevice_Activate(device,
             IID_IAudioClient,
             CLSCTX_ALL, NULL, (void**)&client);
@@ -361,8 +387,8 @@ static IAudioClient *wasapi_init_client_ex(IMMDevice *device,
             AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_NOPERSIST,
             buffer_duration, buffer_duration, (WAVEFORMATEX*)&wf, NULL);
    }
-   if (hr == AUDCLNT_E_DEVICE_IN_USE          ||
-       hr == AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED)
+   if (     hr == AUDCLNT_E_DEVICE_IN_USE
+         || hr == AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED)
       goto error;
 
    if (FAILED(hr))
@@ -374,18 +400,10 @@ static IAudioClient *wasapi_init_client_ex(IMMDevice *device,
 
    *float_fmt = wf.Format.wFormatTag != WAVE_FORMAT_PCM;
    *rate      = wf.Format.nSamplesPerSec;
-
    return client;
 
 error:
-   if (client)
-#ifdef __cplusplus
-      client->Release();
-#else
-      client->lpVtbl->Release(client);
-#endif
-   client = NULL;
-
+   RELEASE(client);
    return NULL;
 }
 
@@ -410,11 +428,8 @@ static IAudioClient *wasapi_init_client_sh(IMMDevice *device,
 
    hr = _IAudioClient_GetDevicePeriod(client, &default_period, NULL);
    if (FAILED(hr))
-   {
       RARCH_ERR("[WASAPI] Failed to get default device period of shared client: %s.\n",
             mmdevice_hresult_name(hr));
-      goto error;
-   }
 
    /* Use audio latency setting for buffer size if allowed */
    if (     (sh_buffer_length < WASAPI_SH_BUFFER_DEVICE_PERIOD)
@@ -446,13 +461,8 @@ static IAudioClient *wasapi_init_client_sh(IMMDevice *device,
 
    if (hr == AUDCLNT_E_ALREADY_INITIALIZED)
    {
-      if (client)
-#ifdef __cplusplus
-         client->Release();
-#else
-         client->lpVtbl->Release(client);
-#endif
-      client = NULL;
+      RELEASE(client);
+
       hr     = _IMMDevice_Activate(device,
             IID_IAudioClient,
             CLSCTX_ALL, NULL, (void**)&client);
@@ -477,18 +487,10 @@ static IAudioClient *wasapi_init_client_sh(IMMDevice *device,
 
    *float_fmt = wf.Format.wFormatTag != WAVE_FORMAT_PCM;
    *rate      = wf.Format.nSamplesPerSec;
-
    return client;
 
 error:
-   if (client)
-#ifdef __cplusplus
-      client->Release();
-#else
-      client->lpVtbl->Release(client);
-#endif
-   client = NULL;
-
+   RELEASE(client);
    return NULL;
 }
 
@@ -590,7 +592,6 @@ static IAudioClient *wasapi_init_client(IMMDevice *device, bool *exclusive,
          *exclusive ? "exclusive" : "shared",
          *float_fmt ? "FLOAT" : "PCM",
          *rate, latency_res);
-
    return client;
 }
 
@@ -637,39 +638,20 @@ static void wasapi_microphone_close_mic(void *driver_context, void *mic_context)
 
    write_event = mic->read_event;
 
-   if (mic->capture)
-#ifdef __cplusplus
-      mic->capture->Release();
-#else
-      mic->capture->lpVtbl->Release(mic->capture);
-#endif
-   mic->capture = NULL;
    if (mic->client)
-   {
       _IAudioClient_Stop(mic->client);
-#ifdef __cplusplus
-      mic->client->Release();
-#else
-      mic->client->lpVtbl->Release(mic->client);
-#endif
-   }
-   if (mic->device)
-   {
-#ifdef __cplusplus
-      mic->device->Release();
-#else
-      mic->device->lpVtbl->Release(mic->device);
-#endif
-   }
-   mic->client = NULL;
-   mic->device = NULL;
+
+   RELEASE(mic->capture);
+   RELEASE(mic->client);
+   RELEASE(mic->device);
+
    if (mic->buffer)
       fifo_free(mic->buffer);
    if (mic->device_name)
       free(mic->device_name);
    free(mic);
 
-   ir = WaitForSingleObject(write_event, 20);
+   ir = WaitForSingleObject(write_event, WASAPI_TIMEOUT);
    if (ir == WAIT_FAILED)
    {
       RARCH_ERR("[WASAPI mic] WaitForSingleObject failed: %s.\n",
@@ -690,7 +672,6 @@ static void *wasapi_microphone_init(void)
       return NULL;
    }
    wasapi->nonblock = !config_get_ptr()->bools.audio_sync;
-   RARCH_DBG("[WASAPI mic] Initialized microphone driver context.\n");
    return wasapi;
 }
 
@@ -771,7 +752,6 @@ static int wasapi_microphone_fetch_fifo(wasapi_microphone_handle_t *mic)
          next_packet_size = 0;
    }
    while (next_packet_size != 0);
-
    return FIFO_READ_AVAIL(mic->buffer);
 }
 
@@ -840,7 +820,6 @@ static int wasapi_microphone_read_buffered(
    }
 
    /* Now that we have samples available, let's give them to the core */
-
    bytes_read = MIN((int)len, bytes_available);
    fifo_read(mic->buffer, s, bytes_read);
    /* Read data from the sample queue and store it in the provided buffer */
@@ -872,7 +851,6 @@ static int wasapi_microphone_read(void *driver_context, void *mic_context, void 
       if (read == -1)
          return -1;
    }
-
    return bytes_read;
 }
 
@@ -1024,31 +1002,10 @@ static void *wasapi_microphone_open_mic(void *driver_context, const char *device
    return mic;
 
 error:
-   if (mic->capture)
-#ifdef __cplusplus
-      mic->capture->Release();
-#else
-      mic->capture->lpVtbl->Release(mic->capture);
-#endif
-   mic->capture = NULL;
-   if (mic->client)
-   {
-#ifdef __cplusplus
-      mic->client->Release();
-#else
-      mic->client->lpVtbl->Release(mic->client);
-#endif
-   }
-   if (mic->device)
-   {
-#ifdef __cplusplus
-      mic->device->Release();
-#else
-      mic->device->lpVtbl->Release(mic->device);
-#endif
-   }
-   mic->client = NULL;
-   mic->device = NULL;
+   RELEASE(mic->capture);
+   RELEASE(mic->client);
+   RELEASE(mic->device);
+
    if (mic->read_event)
       CloseHandle(mic->read_event);
    if (mic->buffer)
@@ -1157,7 +1114,7 @@ static void *wasapi_init(const char *dev_id, unsigned rate, unsigned latency,
 
    w->device                 = (IMMDevice*)mmdevice_init_device(dev_id, 0 /* eRender */);
    if (!w->device && dev_id)
-      w->device = (IMMDevice*)mmdevice_init_device(NULL, 0 /* eRender */);
+      w->device              = (IMMDevice*)mmdevice_init_device(NULL, 0 /* eRender */);
    if (!w->device)
       goto error;
 
@@ -1238,40 +1195,21 @@ static void *wasapi_init(const char *dev_id, unsigned rate, unsigned latency,
    if (new_rate)
       *new_rate = rate;
 
+   if (!wasapi_imm_start_thread(w))
+      goto error;
+
    return w;
 
 error:
-   if (w->renderer)
-#ifdef __cplusplus
-      w->renderer->Release();
-#else
-      w->renderer->lpVtbl->Release(w->renderer);
-#endif
-   w->renderer = NULL;
-   if (w->client)
-   {
-#ifdef __cplusplus
-      w->client->Release();
-#else
-      w->client->lpVtbl->Release(w->client);
-#endif
-   }
-   if (w->device)
-   {
-#ifdef __cplusplus
-      w->device->Release();
-#else
-      w->device->lpVtbl->Release(w->device);
-#endif
-   }
-   w->client = NULL;
-   w->device = NULL;
+   RELEASE(w->renderer);
+   RELEASE(w->client);
+   RELEASE(w->device);
+
    if (w->write_event)
       CloseHandle(w->write_event);
    if (w->buffer)
       fifo_free(w->buffer);
    free(w);
-
    return NULL;
 }
 
@@ -1293,7 +1231,7 @@ static ssize_t wasapi_write(void *wh, const void *data, size_t len)
          {
             UINT32 frame_count;
             BYTE *dest         = NULL;
-            if (WaitForSingleObject(w->write_event, 0) != WAIT_OBJECT_0)
+            if (WaitForSingleObject(w->write_event, WASAPI_TIMEOUT) != WAIT_OBJECT_0)
                return 0;
             frame_count        = w->engine_buffer_size / w->frame_size;
             if (FAILED(_IAudioRenderClient_GetBuffer(
@@ -1467,7 +1405,6 @@ static ssize_t wasapi_write(void *wh, const void *data, size_t len)
          }
       }
    }
-
    return _len;
 }
 
@@ -1479,7 +1416,6 @@ static bool wasapi_stop(void *wh)
       return (!(w->flags & WASAPI_FLG_RUNNING));
 
    w->flags &= ~WASAPI_FLG_RUNNING;
-
    return true;
 }
 
@@ -1518,37 +1454,21 @@ static void wasapi_free(void *wh)
    wasapi_t *w        = (wasapi_t*)wh;
    HANDLE write_event = w->write_event;
 
-   if (w->renderer)
-#ifdef __cplusplus
-      w->renderer->Release();
-#else
-      w->renderer->lpVtbl->Release(w->renderer);
-#endif
-   w->renderer = NULL;
+   if (w)
+      wasapi_imm_stop_thread(w);
+
    if (w->client)
-   {
       _IAudioClient_Stop(w->client);
-#ifdef __cplusplus
-      w->client->Release();
-#else
-      w->client->lpVtbl->Release(w->client);
-#endif
-      w->client = NULL;
-   }
-   if (w->device)
-   {
-#ifdef __cplusplus
-      w->device->Release();
-#else
-      w->device->lpVtbl->Release(w->device);
-#endif
-      w->device = NULL;
-   }
+
+   RELEASE(w->renderer);
+   RELEASE(w->client);
+   RELEASE(w->device);
+
    if (w->buffer)
       fifo_free(w->buffer);
    free(w);
 
-   ir = WaitForSingleObject(write_event, 20);
+   ir = WaitForSingleObject(write_event, WASAPI_TIMEOUT);
    if (ir == WAIT_FAILED)
       RARCH_ERR("[WASAPI] WaitForSingleObject failed with error %d.\n", GetLastError());
 
@@ -1560,6 +1480,11 @@ static bool wasapi_use_float(void *wh)
 {
    wasapi_t *w = (wasapi_t*)wh;
    return (w->frame_size == 8);
+}
+
+static void *wasapi_device_list_new(void *u)
+{
+   return mmdevice_list_new(u, 0 /* eRender */);
 }
 
 static void wasapi_device_list_free(void *u, void *slp)
@@ -1590,13 +1515,7 @@ static size_t wasapi_buffer_size(void *wh)
 
    if (w->buffer)
       return w->buffer->size;
-
    return w->engine_buffer_size;
-}
-
-static void *wasapi_device_list_new(void *u)
-{
-   return mmdevice_list_new(u, 0 /* eRender */);
 }
 
 audio_driver_t audio_wasapi = {

--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -43,6 +43,9 @@
 #ifdef HAVE_MMDEVICE
 #include "../common/mmdevice_common.h"
 #include "../common/mmdevice_common_inline.h"
+#ifdef HAVE_THREADS
+#include <rthreads/rthreads.h>
+#endif
 #endif
 
 #include "../audio_driver.h"
@@ -51,14 +54,9 @@
 typedef struct xaudio2 xaudio2_t;
 
 #define MAX_BUFFERS      16
-
 #define MAX_BUFFERS_MASK (MAX_BUFFERS - 1)
-
-#ifndef COINIT_MULTITHREADED
-#define COINIT_MULTITHREADED 0x00
-#endif
-
 #define XAUDIO2_WRITE_AVAILABLE(handle) ((handle)->bufsize * (MAX_BUFFERS - (handle)->buffers - 1))
+#define XAUDIO_TIMEOUT   256
 
 enum xa_flags
 {
@@ -68,10 +66,56 @@ enum xa_flags
 
 typedef struct
 {
+#ifdef HAVE_MMDEVICE
+#ifdef HAVE_THREADS
+   sthread_t *imm_thread;
+#else
+   HANDLE imm_thread;
+#endif
+#endif
    xaudio2_t *xa;
    size_t bufsize;
    uint8_t flags;
 } xa_t;
+
+#ifdef HAVE_MMDEVICE
+static void xaudio_imm_stop_thread(xa_t *xa)
+{
+#if !defined(_XBOX) && !defined(__WINRT__)
+   if (!xa->imm_thread)
+      return;
+
+   PostThreadMessage(IMMNotificationThreadId, WM_QUIT, 0, 0);
+
+#ifdef HAVE_THREADS
+   sthread_join(xa->imm_thread);
+#else
+   WaitForSingleObject(xa->imm_thread, XAUDIO_TIMEOUT);
+   CloseHandle(xa->imm_thread);
+#endif
+
+   IMMNotificationThreadId = 0;
+   xa->imm_thread = NULL;
+#endif
+}
+
+static bool xaudio_imm_start_thread(xa_t *xa)
+{
+#if !defined(_XBOX) && !defined(__WINRT__)
+   if (!xa->imm_thread)
+   {
+#ifdef HAVE_THREADS
+      xa->imm_thread = sthread_create(mmdevice_thread, xa);
+#else
+      xa->imm_thread = CreateThread(NULL, 0, mmdevice_thread, xa, 0, NULL);
+#endif
+      if (!xa->imm_thread)
+         return false;
+   }
+#endif
+   return true;
+}
+#endif
 
 #if defined(__cplusplus) && !defined(CINTERFACE)
 struct xaudio2 : public IXAudio2VoiceCallback
@@ -236,7 +280,7 @@ static size_t xa_device_get_samplerate(int id)
 #endif
 }
 
-static void *xa_list_new(void *u)
+static void *xa_device_list_new(void *u)
 {
 #if defined(_XBOX) || !defined(HAVE_MMDEVICE)
    unsigned i;
@@ -280,7 +324,6 @@ static void *xa_list_new(void *u)
 #endif
 }
 
-
 static xaudio2_t *xaudio2_new(unsigned *rate, unsigned channels,
       unsigned latency, size_t len, const char *dev_id)
 {
@@ -290,7 +333,7 @@ static xaudio2_t *xaudio2_new(unsigned *rate, unsigned channels,
    xaudio2_t *handle        = NULL;
 
 #if !defined(_XBOX) && !defined(__WINRT__)
-   if (FAILED(CoInitialize(NULL)))
+   if (FAILED(CoInitializeEx(NULL, COINIT_APARTMENTTHREADED)))
       return NULL;
 #endif
 
@@ -308,7 +351,7 @@ static xaudio2_t *xaudio2_new(unsigned *rate, unsigned channels,
       return NULL;
    }
 
-   list = (struct string_list*)xa_list_new(NULL);
+   list = (struct string_list*)xa_device_list_new(NULL);
 
 #if !defined(__cplusplus) || defined(CINTERFACE)
    handle->lpVtbl = &xa_voice_vtable;
@@ -338,7 +381,7 @@ static xaudio2_t *xaudio2_new(unsigned *rate, unsigned channels,
             if (string_is_equal(dev_id, list->elems[i].data))
             {
                size_t new_rate = 0;
-               RARCH_DBG("[XAudio2] Found device #%d: \"%s\".\n", i,
+               RARCH_LOG("[XAudio2] Found device #%d: \"%s\".\n", i,
                      list->elems[i].data);
                idx_found = i;
                new_rate  = xa_device_get_samplerate(i);
@@ -382,6 +425,8 @@ static xaudio2_t *xaudio2_new(unsigned *rate, unsigned channels,
          free(temp);
    }
 #else
+   /* FIXME 2.7: idx_found order depends on OS default device,
+    * therefore index can be correct only by accident */
    if (FAILED(IXAudio2_CreateMasteringVoice(handle->pXAudio2,
                &handle->pMasterVoice, channels, *rate, 0, idx_found, NULL)))
       goto error;
@@ -445,6 +490,10 @@ static void *xa_init(const char *dev_id, unsigned rate, unsigned latency,
    RARCH_LOG("[XAudio2] Requesting %u ms latency, using %d ms latency.\n",
          latency, (int)bufsize * 1000 / rate);
 
+#ifdef HAVE_MMDEVICE
+   xaudio_imm_start_thread(xa);
+#endif
+
    return xa;
 }
 
@@ -486,7 +535,7 @@ static ssize_t xa_write(void *data, const void *s, size_t len)
          XAUDIO2_BUFFER xa2buffer;
 
          while (handle->buffers == MAX_BUFFERS - 1)
-            if (!(WaitForSingleObject(handle->hEvent, 50) == WAIT_OBJECT_0))
+            if (!(WaitForSingleObject(handle->hEvent, XAUDIO_TIMEOUT) == WAIT_OBJECT_0))
                return -1;
 
          xa2buffer.Flags      = 0;
@@ -566,6 +615,10 @@ static void xa_free(void *data)
    if (!xa)
       return;
 
+#ifdef HAVE_MMDEVICE
+   xaudio_imm_stop_thread(xa);
+#endif
+
    if (xa->xa)
       xaudio2_free(xa->xa);
    free(xa);
@@ -603,7 +656,7 @@ audio_driver_t audio_xa = {
    xa_free,
    xa_use_float,
    "xaudio",
-   xa_list_new,
+   xa_device_list_new,
    xa_device_list_free,
    xa_write_avail,
    xa_buffer_size,

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -5328,13 +5328,11 @@ static int menu_displaylist_parse_audio_device_list(file_list_t *info_list,
    if (!audio_driver_get_devices_list((void**)&ptr))
       return 0;
 
-   if (!ptr)
-      return 0;
-
    /* Get index in the string list */
-   audio_device_index = string_list_find_elem(ptr, setting->value.target.string) - 1;
+   if (ptr)
+      audio_device_index = string_list_find_elem(ptr, setting->value.target.string) - 1;
 
-   /* Add "Default" */
+   /* Add "Default" even if driver fails and device list is empty */
    if (i == -1)
    {
       bool add = false;
@@ -5364,7 +5362,7 @@ static int menu_displaylist_parse_audio_device_list(file_list_t *info_list,
       }
    }
 
-   for (i = 0; i < (int)ptr->size; i++)
+   for (i = 0; ptr && i < (int)ptr->size; i++)
    {
       bool add = false;
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -8381,26 +8381,6 @@ static size_t get_string_representation_input_mouse_index(
    return _len;
 }
 
-static void read_handler_audio_rate_control_delta(rarch_setting_t *setting)
-{
-   settings_t      *settings = config_get_ptr();
-
-   if (!setting || setting->enum_idx == MSG_UNKNOWN)
-      return;
-
-   *setting->value.target.fraction = *(audio_get_float_ptr(AUDIO_ACTION_RATE_CONTROL_DELTA));
-   if (*setting->value.target.fraction < 0.0005)
-   {
-      configuration_set_bool(settings, settings->bools.audio_rate_control, false);
-      audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, 0.0f);
-   }
-   else
-   {
-      configuration_set_bool(settings, settings->bools.audio_rate_control, true);
-      audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, *setting->value.target.fraction);
-   }
-}
-
 static void general_read_handler(rarch_setting_t *setting)
 {
    settings_t      *settings = config_get_ptr();
@@ -8412,6 +8392,19 @@ static void general_read_handler(rarch_setting_t *setting)
    {
       case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
          *setting->value.target.fraction = settings->floats.audio_max_timing_skew;
+         break;
+      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
+         *setting->value.target.fraction = *(audio_get_float_ptr(AUDIO_ACTION_RATE_CONTROL_DELTA));
+         if (*setting->value.target.fraction < 0.0005)
+         {
+            configuration_set_bool(settings, settings->bools.audio_rate_control, false);
+            audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, 0.0f);
+         }
+         else
+         {
+            configuration_set_bool(settings, settings->bools.audio_rate_control, true);
+            audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, *setting->value.target.fraction);
+         }
          break;
       case MENU_ENUM_LABEL_VIDEO_REFRESH_RATE_AUTO:
          *setting->value.target.fraction = settings->floats.video_refresh_rate;
@@ -8440,31 +8433,6 @@ static enum event_command write_handler_get_cmd(rarch_setting_t *setting)
          return setting->cmd_trigger_idx;
    }
    return CMD_EVENT_NONE;
-}
-
-static void write_handler_audio_rate_control_delta(rarch_setting_t *setting)
-{
-   settings_t *settings         = config_get_ptr();
-   enum event_command rarch_cmd = CMD_EVENT_NONE;
-
-   if (!setting)
-      return;
-
-   rarch_cmd                    = write_handler_get_cmd(setting);
-
-   if (*setting->value.target.fraction < 0.0005)
-   {
-      configuration_set_bool(settings, settings->bools.audio_rate_control, false);
-      audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, 0.0f);
-   }
-   else
-   {
-      configuration_set_bool(settings, settings->bools.audio_rate_control, true);
-      audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, *setting->value.target.fraction);
-   }
-
-   if (rarch_cmd || (setting->flags & SD_FLAG_CMD_TRIGGER_EVENT_TRIGGERED))
-      command_event(rarch_cmd, NULL);
 }
 
 static void write_handler_logging_verbosity(rarch_setting_t *setting)
@@ -8610,11 +8578,6 @@ static void general_write_handler(rarch_setting_t *setting)
             if (setting->change_handler)
                setting->change_handler(setting);
          }
-         break;
-      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
-         configuration_set_float(settings,
-               settings->floats.audio_max_timing_skew,
-               *setting->value.target.fraction);
          break;
       case MENU_ENUM_LABEL_VIDEO_BLACK_FRAME_INSERTION:
          /* If enabling BFI, auto disable other sync settings
@@ -8963,8 +8926,12 @@ static void general_write_handler(rarch_setting_t *setting)
          audio_set_float(AUDIO_ACTION_MIXER_VOLUME_GAIN, *setting->value.target.fraction);
 #endif
          break;
+      case MENU_ENUM_LABEL_AUDIO_ENABLE:
+      case MENU_ENUM_LABEL_AUDIO_SYNC:
       case MENU_ENUM_LABEL_AUDIO_LATENCY:
       case MENU_ENUM_LABEL_AUDIO_OUTPUT_RATE:
+      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_DRIVER:
+      case MENU_ENUM_LABEL_AUDIO_RESAMPLER_QUALITY:
 #ifdef HAVE_WASAPI
       case MENU_ENUM_LABEL_AUDIO_WASAPI_EXCLUSIVE_MODE:
       case MENU_ENUM_LABEL_AUDIO_WASAPI_FLOAT_FORMAT:
@@ -8972,9 +8939,30 @@ static void general_write_handler(rarch_setting_t *setting)
 #endif
          rarch_cmd = CMD_EVENT_AUDIO_REINIT;
          break;
+      case MENU_ENUM_LABEL_AUDIO_MAX_TIMING_SKEW:
+         configuration_set_float(settings,
+               settings->floats.audio_max_timing_skew,
+               *setting->value.target.fraction);
+         rarch_cmd = CMD_EVENT_AUDIO_REINIT;
+         break;
+      case MENU_ENUM_LABEL_AUDIO_RATE_CONTROL_DELTA:
+         if (*setting->value.target.fraction < 0.0005)
+         {
+            configuration_set_bool(settings, settings->bools.audio_rate_control, false);
+            audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, 0.0f);
+         }
+         else
+         {
+            configuration_set_bool(settings, settings->bools.audio_rate_control, true);
+            audio_set_float(AUDIO_ACTION_RATE_CONTROL_DELTA, *setting->value.target.fraction);
+         }
+         rarch_cmd = CMD_EVENT_AUDIO_REINIT;
+         break;
 #ifdef HAVE_MICROPHONE
       case MENU_ENUM_LABEL_MICROPHONE_LATENCY:
       case MENU_ENUM_LABEL_MICROPHONE_INPUT_RATE:
+      case MENU_ENUM_LABEL_MICROPHONE_RESAMPLER_DRIVER:
+      case MENU_ENUM_LABEL_MICROPHONE_RESAMPLER_QUALITY:
          rarch_cmd = CMD_EVENT_MICROPHONE_REINIT;
          break;
 #endif
@@ -13444,14 +13432,7 @@ static bool setting_append_list(
                   list,
                   list_info,
                   CMD_EVENT_VIDEO_SET_ASPECT_RATIO);
-            menu_settings_list_current_add_range(
-                  list,
-                  list_info,
-                  0,
-                  LAST_ASPECT_RATIO,
-                  1,
-                  true,
-                  true);
+            menu_settings_list_current_add_range(list, list_info, 0, LAST_ASPECT_RATIO, 1, true, true);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_CMD_APPLY_AUTO);
             (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
             (*list)[list_info->index - 1].get_string_representation =
@@ -14890,7 +14871,6 @@ static bool setting_append_list(
                general_read_handler,
                SD_FLAG_NONE
                );
-         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
 
          CONFIG_BOOL(
                list, list_info,
@@ -15053,7 +15033,6 @@ static bool setting_append_list(
                general_read_handler,
                SD_FLAG_NONE
                );
-         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
          SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
          CONFIG_UINT(
@@ -15117,18 +15096,10 @@ static bool setting_append_list(
                &group_info,
                &subgroup_info,
                parent_group,
-               write_handler_audio_rate_control_delta,
-               read_handler_audio_rate_control_delta);
+               general_write_handler,
+               general_read_handler);
          (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-         menu_settings_list_current_add_range(
-               list,
-               list_info,
-               0.0,
-               0.020,
-               0.001,
-               true,
-               true);
-         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
+         menu_settings_list_current_add_range(list, list_info, 0.0, 0.020, 0.001, true, true);
          SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
          CONFIG_FLOAT(
@@ -15144,15 +15115,7 @@ static bool setting_append_list(
                general_write_handler,
                general_read_handler);
          (*list)[list_info->index - 1].action_ok = &setting_action_ok_uint;
-         menu_settings_list_current_add_range(
-               list,
-               list_info,
-               0.0,
-               0.5,
-               0.01,
-               true,
-               true);
-         MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_AUDIO_REINIT);
+         menu_settings_list_current_add_range(list, list_info, 0.0, 0.5, 0.01, true, true);
          SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_ADVANCED);
 
 #ifdef RARCH_MOBILE

--- a/retroarch.c
+++ b/retroarch.c
@@ -4477,6 +4477,7 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_AUDIO_REINIT:
          driver_uninit(DRIVER_AUDIO_MASK, DRIVER_LIFETIME_RESET);
          drivers_init(settings, DRIVER_AUDIO_MASK, DRIVER_LIFETIME_RESET, verbosity_is_enabled());
+         menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
 #if defined(HAVE_AUDIOMIXER)
          audio_driver_load_system_sounds();
 #endif
@@ -4485,6 +4486,7 @@ bool command_event(enum event_command cmd, void *data)
       case CMD_EVENT_MICROPHONE_REINIT:
          driver_uninit(DRIVER_MICROPHONE_MASK, DRIVER_LIFETIME_RESET);
          drivers_init(settings, DRIVER_MICROPHONE_MASK, DRIVER_LIFETIME_RESET, verbosity_is_enabled());
+         menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
          break;
 #endif
       case CMD_EVENT_SHUTDOWN:


### PR DESCRIPTION
## Description

- Reinit audio on device state change. Happens in `audio_driver_flush()` if requested by the callback
- Reinit audio when changing all related audio + resampler options
- Refresh menu items on reinit in case menu navigation is inside the device dropdown
- Move `audio_rate_control_delta` specific write and read handler functions to generic handlers
- Show "Default" device in audio device list even if audio init fails
- Simplifications and cleanups

Wasapi, xaudio and dsound drivers recover gracefully when either there is a change in the device list or when the default device changes. I left sdl driver alone for now since it is not Windows-only, but the same mmdevice code probably could be added there too. Or put all mmdevice thread start/stop code to win32 platform code instead of audio drivers..

Old xaudio 2.7 non-default device selection is still wrong since it does not follow the mmdevice list order, but uses its own index order instead which depends on current OS default device, making it correct only when a specific device is the default.


## Related Issues

Closes #3392
Closes #6018
Closes #15724
Closes #18737
