### PR TITLE
GNOME X11: Fix title bar showing in fullscreen

### DIFF
--- a/gfx/common/x11_common.c
+++ b/gfx/common/x11_common.c
@@ -141,6 +141,22 @@ void x11_set_net_wm_fullscreen(Display *dpy, Window win)
          &xev);
 }
 
+/* Set the fullscreen state on the window before it is shown.
+ * On GNOME + X11 (Mutter), fullscreen works properly when the
+ * window carries the fullscreen hint as it is being mapped */
+void x11_set_net_wm_fullscreen_hint(Display *dpy, Window win)
+{
+   Atom states[1]             = {0};
+
+   XA_NET_WM_STATE            = XInternAtom(dpy, "_NET_WM_STATE", False);
+   XA_NET_WM_STATE_FULLSCREEN = XInternAtom(dpy, "_NET_WM_STATE_FULLSCREEN", False);
+   states[0]                  = XA_NET_WM_STATE_FULLSCREEN;
+
+   XChangeProperty(dpy, win, XA_NET_WM_STATE, XA_ATOM, 32,
+         PropModeReplace, (const unsigned char*)states,
+         sizeof(states) / sizeof(*states));
+}
+
 /* Try to be nice to tiling WMs if possible. */
 
 void x11_move_window(Display *dpy, Window win, int x, int y,

--- a/gfx/common/x11_common.h
+++ b/gfx/common/x11_common.h
@@ -30,6 +30,7 @@ extern unsigned g_x11_screen;
 
 void x11_show_mouse(void *data, bool state);
 void x11_set_net_wm_fullscreen(Display *dpy, Window win);
+void x11_set_net_wm_fullscreen_hint(Display *dpy, Window win);
 bool x11_suspend_screensaver(void *data, bool enable);
 
 void x11_move_window(Display *dpy, Window win,

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -603,6 +603,7 @@ static void *xv_init(const video_info_t *video,
 {
    unsigned i;
    int ret;
+   XEvent event;
    XWindowAttributes target;
    char title[128]                        = {0};
    XSetWindowAttributes attributes        = {0};
@@ -741,6 +742,13 @@ static void *xv_init(const video_info_t *video,
    XFree(visualinfo);
    XSetWindowBackground(g_x11_dpy, g_x11_win, 0);
 
+   if (video->fullscreen)
+   {
+      /* Give the window a fullscreen hint before it is shown.
+       * This helps GNOME + X11 enter fullscreen properly */
+      x11_set_net_wm_fullscreen_hint(g_x11_dpy, g_x11_win);
+   }
+
    if (video->fullscreen && video_disable_composition)
    {
       uint32_t value = 1;
@@ -765,7 +773,12 @@ static void *xv_init(const video_info_t *video,
 
    if (video->fullscreen)
    {
+      /* Ask for fullscreen again after the window is visible. Some
+       * GNOME + X11 setups ignore the first request if it happens too
+       * early, which causes RetroArch to only maximise the window */
+      x11_event_queue_check(&event);
       x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      XFlush(g_x11_dpy);
       x11_show_mouse(xv, false);
    }
 

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -623,6 +623,13 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    x11_update_title(NULL);
 
    if (fullscreen)
+   {
+      /* Give the window a fullscreen hint before it is shown.
+       * This helps GNOME + X11 enter fullscreen properly */
+      x11_set_net_wm_fullscreen_hint(g_x11_dpy, g_x11_win);
+   }
+
+   if (fullscreen)
       x11_show_mouse(data, false);
 
 #ifdef HAVE_XF86VM
@@ -661,6 +668,15 @@ static bool gfx_ctx_x_set_video_mode(void *data,
    }
 
    x11_event_queue_check(&event);
+
+   if (fullscreen)
+   {
+      /* Ask for fullscreen again after the window is visible. Some
+       * GNOME + X11 setups ignore the first request if it happens too
+       * early, which causes RetroArch to only maximise the window */
+      x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      XFlush(g_x11_dpy);
+   }
 
    switch (x_api)
    {

--- a/gfx/drivers_context/x_vk_ctx.c
+++ b/gfx/drivers_context/x_vk_ctx.c
@@ -390,6 +390,13 @@ static bool gfx_ctx_x_vk_set_video_mode(void *data,
    x11_update_title(NULL);
 
    if (fullscreen)
+   {
+      /* Give the window a fullscreen hint before it is shown.
+       * This helps GNOME + X11 enter fullscreen properly */
+      x11_set_net_wm_fullscreen_hint(g_x11_dpy, g_x11_win);
+   }
+
+   if (fullscreen)
       x11_show_mouse(data, false);
 
 #ifdef HAVE_XF86VM
@@ -428,6 +435,15 @@ static bool gfx_ctx_x_vk_set_video_mode(void *data,
    }
 
    x11_event_queue_check(&event);
+
+   if (fullscreen)
+   {
+      /* Ask for fullscreen again after the window is visible. Some
+       * GNOME + X11 setups ignore the first request if it happens too
+       * early, which causes RetroArch to only maximise the window */
+      x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      XFlush(g_x11_dpy);
+   }
 
    {
       bool quit, resize;

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -398,6 +398,13 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    x11_update_title(NULL);
 
    if (fullscreen)
+   {
+      /* Give the window a fullscreen hint before it is shown.
+       * This helps GNOME + X11 enter fullscreen properly */
+      x11_set_net_wm_fullscreen_hint(g_x11_dpy, g_x11_win);
+   }
+
+   if (fullscreen)
       x11_show_mouse(data, false);
 
 #ifdef HAVE_XF86VM
@@ -438,6 +445,15 @@ static bool gfx_ctx_xegl_set_video_mode(void *data,
    }
 
    x11_event_queue_check(&event);
+
+   if (fullscreen)
+   {
+      /* Ask for fullscreen again after the window is visible. Some
+       * GNOME + X11 setups ignore the first request if it happens too
+       * early, which causes RetroArch to only maximise the window */
+      x11_set_net_wm_fullscreen(g_x11_dpy, g_x11_win);
+      XFlush(g_x11_dpy);
+   }
    x11_install_quit_atom();
 
 #ifdef HAVE_EGL


### PR DESCRIPTION
This fixes #15259 where the window title bar will appear in fullscreen, which is due to the window basically just maximising instead of entering fullscreen correctly. Over 20 Linux distros were tested and the issue solely seemed to affect GNOME/Mutter + X11.

Changes:

- Set the fullscreen state on the X11 window before it is shown, so the window already carries the fullscreen hint as it is being mapped.
- Request fullscreen again after the window is visible, which fixes cases where the first request happens too early and is not handled correctly.
- Flushed the X11 connection after the second fullscreen request.

