### PR TITLE
(Windows) strip trailing backslash before calling `_stat`

### DIFF
--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -1076,7 +1076,8 @@ int retro_vfs_stat_impl(const char *path, int32_t *size)
 
       if (_len > 0 && _len < sizeof(path_buf))
       {
-         while (_len > 0 && path_buf[_len - 1] == '\\')
+         while (_len > 0 && 
+               (path_buf[_len - 1] == '\\' || path_buf[_len - 1] == '/'))
          {
             /* Keep drive roots like "C:\" intact */
             if (_len == 3 &&


### PR DESCRIPTION
## Description

Fix directory detection by removing the trailing slash before calling `_stat`. Older `_stat` implementations may reject directory paths with a trailing separator, which causes `path_is_directory` to return false unexpectedly,improving compatibility with older Win32/MSVC-compatible runtimes and making directory detection more robust.

