### PR TITLE
Add shared savestate thumbnail path getter function

### DIFF
--- a/gfx/gfx_thumbnail_path.c
+++ b/gfx/gfx_thumbnail_path.c
@@ -767,3 +767,26 @@ size_t gfx_thumbnail_get_content_dir(gfx_thumbnail_path_data_t *path_data,
    strlcpy(tmp_buf, path_data->content_path, _len * sizeof(char));
    return strlcpy(s, path_basename_nocompression(tmp_buf), len);
 }
+
+/* Gets the common savestate thumbnail path. */
+void gfx_savestate_thumbnail_get_path(
+      char *s, size_t len,
+      const char *state_name,
+      int state_slot)
+{
+   size_t _len;
+
+   s[0] = '\0';
+
+   if (string_is_empty(state_name))
+      return;
+
+   _len = strlcpy(s, state_name, len);
+
+   if (state_slot > 0)
+      _len += snprintf(s + _len, len - _len, "%d", state_slot);
+   else if (state_slot < 0)
+      _len  = fill_pathname_join_delim(s, state_name, "auto", '.', len);
+
+   strlcpy(s + _len, FILE_PATH_PNG_EXTENSION, len - _len);
+}

--- a/gfx/gfx_thumbnail_path.h
+++ b/gfx/gfx_thumbnail_path.h
@@ -143,6 +143,9 @@ bool gfx_thumbnail_update_path(gfx_thumbnail_path_data_t *path_data, enum gfx_th
  * Returns true if content directory is valid. */
 size_t gfx_thumbnail_get_content_dir(gfx_thumbnail_path_data_t *path_data, char *s, size_t len);
 
+/* Gets the common savestate thumbnail path. */
+void gfx_savestate_thumbnail_get_path(char *s, size_t len, const char *state_name, int state_slot);
+
 RETRO_END_DECLS
 
 #endif

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -707,16 +707,12 @@ typedef struct materialui_handle
          last_landscape_layout_optimization;
    enum materialui_list_view_type list_view_type;
 
-   /* These have to be huge, because runloop_st->name.savestate
-    * has a hard-coded size of (PATH_MAX_LENGTH * 2)... */
-   char savestate_thumbnail_file_path[(PATH_MAX_LENGTH * 2)];
-   char prev_savestate_thumbnail_file_path[(PATH_MAX_LENGTH * 2)];
-
    char msgbox[1024];
    char menu_title[NAME_MAX_LENGTH];
    char fullscreen_thumbnail_label[NAME_MAX_LENGTH];
    char sysicons_path[PATH_MAX_LENGTH];
    char icons_path[PATH_MAX_LENGTH];
+   char savestate_thumbnail_file_path[PATH_MAX_LENGTH];
 } materialui_handle_t;
 
 static void hex32_to_rgba_normalized(uint32_t hex, float* rgba, float alpha)
@@ -2482,17 +2478,11 @@ static void materialui_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    settings_t *settings     = config_get_ptr();
    materialui_handle_t *mui = (materialui_handle_t*)data;
-   int state_slot           = settings->ints.state_slot;
    bool savestate_thumbnail = settings->bools.savestate_thumbnail_enable;
+   const char *current_path = strdup(mui->savestate_thumbnail_file_path);
 
    if (!mui)
       return;
-
-   /* Cache previous savestate thumbnail path */
-   strlcpy(
-         mui->prev_savestate_thumbnail_file_path,
-         mui->savestate_thumbnail_file_path,
-         sizeof(mui->prev_savestate_thumbnail_file_path));
 
    mui->savestate_thumbnail_file_path[0] = '\0';
 
@@ -2511,35 +2501,25 @@ static void materialui_update_savestate_thumbnail_path(void *data, unsigned i)
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_STATE))
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_SAVE_STATE)))
          {
-            size_t _len;
-            char path[PATH_MAX_LENGTH * 2];
+            char path[PATH_MAX_LENGTH];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
+            int state_slot              = settings->ints.state_slot;
 
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
                state_slot    = i - 1;
 
-            if (state_slot < 0)
-            {
-               path[0]       = '\0';
-               _len          = fill_pathname_join_delim(path,
-                     runloop_st->name.savestate, "auto", '.', sizeof(path));
-            }
-            else
-            {
-               _len          = strlcpy(path, runloop_st->name.savestate, sizeof(path));
-               if (state_slot > 0)
-                  _len      += snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
-            }
-
-            strlcpy(path + _len, FILE_PATH_PNG_EXTENSION, sizeof(path) - _len);
+            gfx_savestate_thumbnail_get_path(path, sizeof(path),
+                  runloop_st->name.savestate, state_slot);
 
             /* Must let invalid be empty here as opposed to other drivers
              * in order to see the missing image placeholder in normal list */
             if (path_is_valid(path))
-               strlcpy(
-                     mui->savestate_thumbnail_file_path, path,
+               strlcpy(mui->savestate_thumbnail_file_path, path,
                      sizeof(mui->savestate_thumbnail_file_path));
+
+            if (!string_is_equal(current_path, mui->savestate_thumbnail_file_path))
+               gfx_thumbnail_reset(&mui->thumbnails.savestate);
 
             materialui_update_fullscreen_thumbnail_label(mui);
          }
@@ -2562,22 +2542,11 @@ static void materialui_update_savestate_thumbnail_image(void *data)
       mui->thumbnails.savestate.status = GFX_THUMBNAIL_STATUS_MISSING;
       mui->thumbnails.savestate.alpha  = 1.0f;
    }
-   else
-   {
-      /* Only request thumbnail if:
-       * > Thumbnail has never been loaded *OR*
-       * > Thumbnail path has changed */
-      if (     (mui->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
-            || (mui->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_PENDING)
-            || !string_is_equal(mui->savestate_thumbnail_file_path,
-                     mui->prev_savestate_thumbnail_file_path))
-      {
-         gfx_thumbnail_request_file(
-               mui->savestate_thumbnail_file_path,
-               &mui->thumbnails.savestate,
-               config_get_ptr()->uints.gfx_thumbnail_upscale_threshold);
-      }
-   }
+   else if (mui->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
+      gfx_thumbnail_request_file(
+            mui->savestate_thumbnail_file_path,
+            &mui->thumbnails.savestate,
+            config_get_ptr()->uints.gfx_thumbnail_upscale_threshold);
 
    mui->thumbnails.savestate.flags |= GFX_THUMB_FLAG_CORE_ASPECT;
 }
@@ -9141,14 +9110,13 @@ static void *materialui_init(void **userdata, bool video_is_threaded)
    /* Enable fade in animation for missing thumbnails */
    gfx_thumbnail_set_fade_missing(true);
 
-   /* Savestate thumbnail empty */
-   mui->savestate_thumbnail_file_path[0]      = '\0';
-   mui->prev_savestate_thumbnail_file_path[0] = '\0';
-
    /* Ensure that fullscreen thumbnails are inactive */
    mui->fullscreen_thumbnail_selection         = 0;
    mui->fullscreen_thumbnail_alpha             = 0.0f;
    mui->fullscreen_thumbnail_label[0]          = '\0';
+
+   /* Savestate thumbnail empty */
+   mui->savestate_thumbnail_file_path[0]       = '\0';
 
    /* Ensure status bar has sane initial values */
    mui->status_bar.height                      = 0;

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -642,11 +642,7 @@ struct ozone_handle
    char icons_path[PATH_MAX_LENGTH];
    char icons_path_default[PATH_MAX_LENGTH];
    char tab_path[PATH_MAX_LENGTH];
-
-   /* These have to be huge, because runloop_st->name.savestate
-    * has a hard-coded size of (PATH_MAX_LENGTH * 2)... */
-   char savestate_thumbnail_file_path[(PATH_MAX_LENGTH * 2)];
-   char prev_savestate_thumbnail_file_path[(PATH_MAX_LENGTH * 2)];
+   char savestate_thumbnail_file_path[PATH_MAX_LENGTH];
 
    char thumbnails_left_status_prev;
    char thumbnails_right_status_prev;
@@ -3855,17 +3851,11 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    settings_t *settings     = config_get_ptr();
    ozone_handle_t *ozone    = (ozone_handle_t*)data;
-   int state_slot           = settings->ints.state_slot;
    bool savestate_thumbnail = settings->bools.savestate_thumbnail_enable;
+   const char *current_path = strdup(ozone->savestate_thumbnail_file_path);
 
    if (!ozone)
       return;
-
-   /* Cache previous savestate thumbnail path */
-   strlcpy(
-         ozone->prev_savestate_thumbnail_file_path,
-         ozone->savestate_thumbnail_file_path,
-         sizeof(ozone->prev_savestate_thumbnail_file_path));
 
    if (ozone->flags2 & OZONE_FLAG2_SELECTION_CORE_IS_VIEWER_REAL)
       ozone->flags2 |=  OZONE_FLAG2_SELECTION_CORE_IS_VIEWER;
@@ -3901,9 +3891,9 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_STATE))
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_SAVE_STATE)))
          {
-            size_t _len;
-            char path[PATH_MAX_LENGTH * 2];
+            char path[PATH_MAX_LENGTH];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
+            int state_slot              = settings->ints.state_slot;
 
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
@@ -3912,24 +3902,14 @@ static void ozone_update_savestate_thumbnail_path(void *data, unsigned i)
                ozone->flags |= OZONE_FLAG_IS_STATE_SLOT;
             }
 
-            if (state_slot < 0)
-            {
-               path[0] = '\0';
-               _len    = fill_pathname_join_delim(path,
-                     runloop_st->name.savestate, "auto", '.', sizeof(path));
-            }
-            else
-            {
-               _len    = strlcpy(path, runloop_st->name.savestate, sizeof(path));
-               if (state_slot > 0)
-                  _len += snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
-            }
+            gfx_savestate_thumbnail_get_path(path, sizeof(path),
+                  runloop_st->name.savestate, state_slot);
 
-            strlcpy(path + _len, FILE_PATH_PNG_EXTENSION, sizeof(path) - _len);
-
-            strlcpy(
-                  ozone->savestate_thumbnail_file_path, path,
+            strlcpy(ozone->savestate_thumbnail_file_path, path,
                   sizeof(ozone->savestate_thumbnail_file_path));
+
+            if (!string_is_equal(current_path, ozone->savestate_thumbnail_file_path))
+               gfx_thumbnail_reset(&ozone->thumbnails.savestate);
 
             ozone->flags |= OZONE_FLAG_WANT_THUMBNAIL_BAR
                           | OZONE_FLAG_FULLSCREEN_THUMBNAILS_AVAILABLE;
@@ -3960,21 +3940,11 @@ static void ozone_update_savestate_thumbnail_image(void *data)
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(ozone->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&ozone->thumbnails.savestate);
-   else
-   {
-      /* Only request thumbnail if:
-       * > Thumbnail has never been loaded *OR*
-       * > Thumbnail path has changed */
-      if (     (ozone->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
-            || !string_is_equal(ozone->savestate_thumbnail_file_path,
-                     ozone->prev_savestate_thumbnail_file_path))
-      {
-         gfx_thumbnail_request_file(
-               ozone->savestate_thumbnail_file_path,
-               &ozone->thumbnails.savestate,
-               thumbnail_upscale_threshold);
-      }
-   }
+   else if (ozone->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
+      gfx_thumbnail_request_file(
+            ozone->savestate_thumbnail_file_path,
+            &ozone->thumbnails.savestate,
+            thumbnail_upscale_threshold);
 
    ozone->thumbnails.savestate.flags |= GFX_THUMB_FLAG_CORE_ASPECT;
 }
@@ -9231,6 +9201,7 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
 
    ozone->flags                                |= OZONE_FLAG_FIRST_FRAME;
 
+   ozone->animations.left_thumbnail_alpha       = 1.0f;
    ozone->animations.sidebar_text_alpha         = 1.0f;
    ozone->animations.thumbnail_bar_position     = 0.0f;
    ozone->dimensions_sidebar_width              = 0.0f;
@@ -9243,14 +9214,10 @@ static void *ozone_init(void **userdata, bool video_is_threaded)
    if (!(ozone->screensaver = menu_screensaver_init()))
       goto error;
 
-   ozone->savestate_thumbnail_file_path[0]      = '\0';
-   ozone->prev_savestate_thumbnail_file_path[0] = '\0';
-
    ozone->animations.fullscreen_thumbnail_alpha = 0.0f;
    ozone->fullscreen_thumbnail_selection        = 0;
    ozone->fullscreen_thumbnail_label[0]         = '\0';
-
-   ozone->animations.left_thumbnail_alpha       = 1.0f;
+   ozone->savestate_thumbnail_file_path[0]      = '\0';
 
    ozone->thumbnails.pending                    = OZONE_PENDING_THUMBNAIL_NONE;
    ozone->thumbnails.stream_delay               = OZONE_THUMBNAIL_STREAM_DELAY;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -350,13 +350,9 @@ typedef struct
    struct scaler_ctx image_scaler;
    menu_input_pointer_t pointer;
 
-   /* These have to be huge, because runloop_st->name.savestate
-    * has a hard-coded size of (PATH_MAX_LENGTH * 2)... */
-   char savestate_thumbnail_file_path[PATH_MAX_LENGTH * 2];
-   char prev_savestate_thumbnail_file_path[PATH_MAX_LENGTH * 2];
-
    char menu_title[NAME_MAX_LENGTH];              /* Must be a fixed length array... */
    char msgbox[1024];
+   char savestate_thumbnail_file_path[PATH_MAX_LENGTH];
    char theme_preset_path[PATH_MAX_LENGTH];       /* Must be a fixed length array... */
    char theme_dynamic_path[PATH_MAX_LENGTH];      /* Must be a fixed length array... */
    char last_theme_dynamic_path[PATH_MAX_LENGTH]; /* Must be a fixed length array... */
@@ -2842,6 +2838,16 @@ static void rgui_render_fs_thumbnail(
    }
 }
 
+/* Forward declaration */
+static void (*rgui_blit_line)(
+      rgui_t *rgui,
+      unsigned fb_width,
+      int x,
+      int y,
+      const char *message,
+      uint16_t color,
+      uint16_t shadow_color);
+
 static INLINE unsigned rgui_get_mini_thumbnail_fullwidth(rgui_t *rgui)
 {
    unsigned width      = rgui->mini_thumbnail.is_valid ? rgui->mini_thumbnail.width : 0;
@@ -2858,7 +2864,8 @@ static void rgui_render_mini_thumbnail(
       unsigned fb_height,
       size_t fb_pitch,
       bool swap_thumbnails,
-      bool thumbnail_background)
+      bool thumbnail_background,
+      bool savestate)
 {
    if (thumbnail->is_valid && frame_buf_data && thumbnail->data)
    {
@@ -2918,6 +2925,41 @@ static void rgui_render_mini_thumbnail(
                fb_x_offset + 1, fb_y_offset + thumbnail->height,
                thumbnail->width, 1, rgui->colors.shadow_color);
       }
+   }
+   /* Draw "not available" placeholder for unused save state thumbnails */
+   else if (savestate && frame_buf_data)
+   {
+      int text_x, text_y;
+      unsigned fb_x_offset, fb_y_offset;
+      unsigned term_width  = rgui->term_layout.width * rgui->font_width_stride;
+      unsigned term_height = rgui->term_layout.height * rgui->font_height_stride;
+      const char *msg      = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE);
+
+      fb_x_offset    = (rgui->term_layout.start_x + term_width) - thumbnail->max_width;
+
+      if (     ((thumbnail_id == GFX_THUMBNAIL_RIGHT) && !swap_thumbnails)
+            || ((thumbnail_id == GFX_THUMBNAIL_LEFT)  &&  swap_thumbnails))
+         fb_y_offset = rgui->term_layout.start_y;
+      else
+         fb_y_offset = (rgui->term_layout.start_y + term_height) - thumbnail->max_height;
+
+      text_x         = (thumbnail->max_width  / 2) + fb_x_offset - (strlen(msg) * (rgui->font_width_stride / 2));
+      text_y         = (thumbnail->max_height / 2) + fb_y_offset - (rgui->font_height_stride / 3);
+
+      /* Draw background */
+      rgui_fill_rect(frame_buf_data, fb_width, fb_height,
+            rgui->term_layout.start_x + term_width - thumbnail->max_width,
+            fb_y_offset,
+            thumbnail->max_width, thumbnail->max_height,
+            rgui->colors.shadow_color,
+            rgui->colors.shadow_color,
+            false);
+
+      /* Draw "N/A" label */
+      rgui_blit_line(rgui, fb_width, text_x, text_y,
+            msg,
+            rgui->colors.normal_color,
+            rgui->colors.shadow_color);
    }
 }
 
@@ -5769,7 +5811,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
                   rgui->frame_buf.data,
                   (rgui_swap_thumbnails) ? GFX_THUMBNAIL_RIGHT : GFX_THUMBNAIL_LEFT,
                   fb_width, fb_height, fb_pitch,
-                  rgui_swap_thumbnails, thumbnail_background);
+                  rgui_swap_thumbnails, thumbnail_background, true);
       }
       else if (show_mini_thumbnails)
       {
@@ -5780,13 +5822,13 @@ static void rgui_render(void *data, unsigned width, unsigned height,
                   rgui->frame_buf.data,
                   GFX_THUMBNAIL_RIGHT,
                   fb_width, fb_height, fb_pitch,
-                  rgui_swap_thumbnails, thumbnail_background);
+                  rgui_swap_thumbnails, thumbnail_background, false);
          if (show_left_thumbnail && thumbnail2)
             rgui_render_mini_thumbnail(rgui, thumbnail2,
                   rgui->frame_buf.data,
                   GFX_THUMBNAIL_LEFT,
                   fb_width, fb_height, fb_pitch,
-                  rgui_swap_thumbnails, thumbnail_background);
+                  rgui_swap_thumbnails, thumbnail_background, false);
       }
 
       /* Print menu sublabel/core name (if required) */
@@ -6643,7 +6685,6 @@ static void *rgui_init(void **userdata, bool video_is_threaded)
    memset(rgui->playlist_selection, 0, sizeof(rgui->playlist_selection));
 
    rgui->savestate_thumbnail_file_path[0]      = '\0';
-   rgui->prev_savestate_thumbnail_file_path[0] = '\0';
 
    /* Ensure that pointer device starts with well defined
     * values (should not be necessary, but some platforms may
@@ -6923,19 +6964,12 @@ static void rgui_load_current_thumbnails(rgui_t *rgui, struct menu_state *menu_s
 
 static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
 {
-   settings_t *settings = config_get_ptr();
-   rgui_t *rgui         = (rgui_t*)data;
-   int state_slot       = settings->ints.state_slot;
-   bool savestate_thumbnail_enable
-                        = settings->bools.savestate_thumbnail_enable;
+   settings_t *settings     = config_get_ptr();
+   rgui_t *rgui             = (rgui_t*)data;
+   bool savestate_thumbnail = settings->bools.savestate_thumbnail_enable;
+
    if (!rgui)
       return;
-
-   /* Cache previous savestate thumbnail path */
-   strlcpy(
-         rgui->prev_savestate_thumbnail_file_path,
-         rgui->savestate_thumbnail_file_path,
-         sizeof(rgui->prev_savestate_thumbnail_file_path));
 
    rgui->savestate_thumbnail_file_path[0] = '\0';
 
@@ -6945,7 +6979,7 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
          || (rgui->flags & RGUI_FLAG_IS_STATE_SLOT)))
       return;
 
-   if (savestate_thumbnail_enable)
+   if (savestate_thumbnail)
    {
       menu_entry_t entry;
 
@@ -6960,9 +6994,9 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_STATE))
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_SAVE_STATE)))
          {
-            size_t _len;
-            char path[PATH_MAX_LENGTH * 2];
+            char path[PATH_MAX_LENGTH];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
+            int state_slot              = settings->ints.state_slot;
 
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
@@ -6971,22 +7005,8 @@ static void rgui_update_savestate_thumbnail_path(void *data, unsigned i)
                rgui->flags        |= RGUI_FLAG_IS_STATE_SLOT;
             }
 
-            if (state_slot < 0)
-            {
-               path[0] = '\0';
-               _len    = fill_pathname_join_delim(path,
-                     runloop_st->name.savestate, "auto", '.', sizeof(path));
-            }
-            else
-            {
-               _len = strlcpy(path,
-                     runloop_st->name.savestate, sizeof(path));
-               if (state_slot > 0)
-                  _len += snprintf(path + _len, sizeof(path) - _len, "%d",
-                        state_slot);
-            }
-
-            strlcpy(path + _len, FILE_PATH_PNG_EXTENSION, sizeof(path) - _len);
+            gfx_savestate_thumbnail_get_path(path, sizeof(path),
+                  runloop_st->name.savestate, state_slot);
 
             strlcpy(rgui->savestate_thumbnail_file_path,
                   path,

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -452,10 +452,7 @@ typedef struct xmb_handle
    char entry_index_str[32];
    char entry_index_offset;
 
-   /* These have to be huge, because runloop_st->name.savestate
-    * has a hard-coded size of (PATH_MAX_LENGTH * 2)... */
-   char savestate_thumbnail_file_path[PATH_MAX_LENGTH * 2];
-   char prev_savestate_thumbnail_file_path[PATH_MAX_LENGTH * 2];
+   char savestate_thumbnail_file_path[PATH_MAX_LENGTH];
    char fullscreen_thumbnail_label[NAME_MAX_LENGTH];
 
    char thumbnails_left_status_prev;
@@ -1287,17 +1284,11 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
 {
    xmb_handle_t *xmb        = (xmb_handle_t*)data;
    settings_t *settings     = config_get_ptr();
-   int state_slot           = settings->ints.state_slot;
    bool savestate_thumbnail = settings->bools.savestate_thumbnail_enable;
+   const char *current_path = strdup(xmb->savestate_thumbnail_file_path);
 
    if (!xmb)
       return;
-
-   /* Cache previous savestate thumbnail path */
-   strlcpy(
-         xmb->prev_savestate_thumbnail_file_path,
-         xmb->savestate_thumbnail_file_path,
-         sizeof(xmb->prev_savestate_thumbnail_file_path));
 
    if (xmb->skip_thumbnail_reset)
       return;
@@ -1326,9 +1317,9 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_LOAD_STATE))
                || string_is_equal(entry.label, msg_hash_to_str(MENU_ENUM_LABEL_SAVE_STATE)))
          {
-            size_t _len;
-            char path[PATH_MAX_LENGTH * 2];
+            char path[PATH_MAX_LENGTH];
             runloop_state_t *runloop_st = runloop_state_get_ptr();
+            int state_slot              = settings->ints.state_slot;
 
             /* State slot dropdown */
             if (string_to_unsigned(entry.label) == MENU_ENUM_LABEL_STATE_SLOT)
@@ -1337,23 +1328,14 @@ static void xmb_update_savestate_thumbnail_path(void *data, unsigned i)
                xmb->is_state_slot = true;
             }
 
-            if (state_slot < 0)
-            {
-               path[0] = '\0';
-               _len    = fill_pathname_join_delim(path,
-                     runloop_st->name.savestate, "auto", '.', sizeof(path));
-            }
-            else
-            {
-               _len    = strlcpy(path, runloop_st->name.savestate, sizeof(path));
-               if (state_slot > 0)
-                  _len += snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
-            }
-
-            strlcpy(path + _len, FILE_PATH_PNG_EXTENSION, sizeof(path) - _len);
+            gfx_savestate_thumbnail_get_path(path, sizeof(path),
+                  runloop_st->name.savestate, state_slot);
 
             strlcpy(xmb->savestate_thumbnail_file_path, path,
                   sizeof(xmb->savestate_thumbnail_file_path));
+
+            if (!string_is_equal(current_path, xmb->savestate_thumbnail_file_path))
+               gfx_thumbnail_reset(&xmb->thumbnails.savestate);
 
             xmb->fullscreen_thumbnails_available = true;
 
@@ -1788,19 +1770,11 @@ static void xmb_update_savestate_thumbnail_image(void *data)
    /* If path is empty, just reset thumbnail */
    if (string_is_empty(xmb->savestate_thumbnail_file_path))
       gfx_thumbnail_reset(&xmb->thumbnails.savestate);
-   else
-   {
-      /* Only request thumbnail if:
-       * > Thumbnail has never been loaded *OR*
-       * > Thumbnail path has changed */
-      if (     (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
-            || !string_is_equal(xmb->savestate_thumbnail_file_path,
-                xmb->prev_savestate_thumbnail_file_path))
-         gfx_thumbnail_request_file(
-               xmb->savestate_thumbnail_file_path,
-               &xmb->thumbnails.savestate,
-               upscale_threshold);
-   }
+   else if (xmb->thumbnails.savestate.status == GFX_THUMBNAIL_STATUS_UNKNOWN)
+      gfx_thumbnail_request_file(
+            xmb->savestate_thumbnail_file_path,
+            &xmb->thumbnails.savestate,
+            upscale_threshold);
 
    xmb->thumbnails.savestate.flags |= GFX_THUMB_FLAG_CORE_ASPECT;
 }
@@ -9164,9 +9138,6 @@ static void *xmb_init(void **userdata, bool video_is_threaded)
    if (!(xmb->screensaver = menu_screensaver_init()))
       goto error;
 
-   xmb->savestate_thumbnail_file_path[0]      = '\0';
-   xmb->prev_savestate_thumbnail_file_path[0] = '\0';
-
    xmb->fullscreen_thumbnails_available       = false;
    xmb->show_fullscreen_thumbnails            = false;
    xmb->skip_thumbnail_reset                  = false;
@@ -9174,6 +9145,7 @@ static void *xmb_init(void **userdata, bool video_is_threaded)
    xmb->fullscreen_thumbnail_alpha            = 0.0f;
    xmb->fullscreen_thumbnail_selection        = 0;
    xmb->fullscreen_thumbnail_label[0]         = '\0';
+   xmb->savestate_thumbnail_file_path[0]      = '\0';
 
    xmb->thumbnails.pending                    = XMB_PENDING_THUMBNAIL_NONE;
    gfx_thumbnail_set_stream_delay(-1.0f);

--- a/runloop.c
+++ b/runloop.c
@@ -6954,18 +6954,10 @@ static enum runloop_state_enum runloop_check_state(
 #ifdef HAVE_SCREENSHOTS
          if (dispwidget_get_ptr()->active && settings->bools.savestate_thumbnail_enable)
          {
-            char path[PATH_MAX_LENGTH * 2];
-            size_t _len;
+            char path[PATH_MAX_LENGTH];
 
-            _len = strlcpy(path, runloop_st->name.savestate, sizeof(path));
-
-            if (state_slot > 0)
-               _len += snprintf(path + _len, sizeof(path) - _len, "%d", state_slot);
-            else if (state_slot < 0)
-               _len  = fill_pathname_join_delim(path,
-                     runloop_st->name.savestate, "auto", '.', sizeof(path));
-
-            strlcpy(path + _len, FILE_PATH_PNG_EXTENSION, sizeof(path) - _len);
+            gfx_savestate_thumbnail_get_path(path, sizeof(path),
+                  runloop_st->name.savestate, state_slot);
 
             if (state_slot < 0)
                snprintf(msg, sizeof(msg), "%s", "Auto");

--- a/runloop.h
+++ b/runloop.h
@@ -288,16 +288,17 @@ struct runloop
 
    struct
    {
+      /* TODO/FIXME: Same type for all */
       char *remapfile;
-      char savefile [PATH_MAX_LENGTH*2];
-      char savestate[PATH_MAX_LENGTH*2];
-      char replay   [PATH_MAX_LENGTH*2];
-      char cheatfile[PATH_MAX_LENGTH*2];
-      char ups      [PATH_MAX_LENGTH*2];
-      char bps      [PATH_MAX_LENGTH*2];
-      char ips      [PATH_MAX_LENGTH*2];
-      char xdelta   [PATH_MAX_LENGTH*2];
-      char label    [PATH_MAX_LENGTH*2];
+      char label    [PATH_MAX_LENGTH];
+      char savefile [PATH_MAX_LENGTH];
+      char savestate[PATH_MAX_LENGTH];
+      char replay   [PATH_MAX_LENGTH];
+      char cheatfile[PATH_MAX_LENGTH];
+      char ups      [PATH_MAX_LENGTH];
+      char bps      [PATH_MAX_LENGTH];
+      char ips      [PATH_MAX_LENGTH];
+      char xdelta   [PATH_MAX_LENGTH];
    } name;
 
    bool perfcnt_enable;


### PR DESCRIPTION
## Description

- Add a shared function for generating the savestate thumbnail path

Also got rid of the clunky double prev path comparison for resetting the image, and set a more sensible size for the paths, and added the missing empty savestate thumbnail placeholder for RGUI.


