### PR TITLE
XMB: Support all possible image formats for dynamic wallpapers

### DIFF
--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1222,11 +1222,34 @@ static void xmb_path_dynamic_wallpaper(xmb_handle_t *xmb, char *s, size_t len)
     * then comes 'menu_wallpaper', and then iconset 'bg.png' */
    if (menu_dynamic_wallpaper_enable)
    {
+      const char* const SUPPORTED_DYNAMIC_WALLPAPER_EXTENSIONS[] = {
+   #ifdef HAVE_RPNG
+         ".png",
+   #endif
+   #ifdef HAVE_RJPEG
+         ".jpg", ".jpeg",
+   #endif
+   #ifdef HAVE_RBMP
+         ".bmp",
+   #endif
+   #ifdef HAVE_RTGA
+         ".tga",
+   #endif
+         0
+      };
+      int i = 0;
       size_t _len = fill_pathname_join_special(s,
                dir_dynamic_wallpapers,
                xmb->title_name,
                len);
-      strlcpy(s + _len, ".png", len - _len);
+      while (SUPPORTED_DYNAMIC_WALLPAPER_EXTENSIONS[i] != 0) {
+         const char *extension = SUPPORTED_DYNAMIC_WALLPAPER_EXTENSIONS[i];
+         strlcpy(s + _len, extension, len - _len);
+         if (!string_is_empty(s) && path_is_valid(s)) {
+            break;
+         }
+         i++;
+      }
    }
 
    if (!string_is_empty(s) && path_is_valid(s))


### PR DESCRIPTION
## Motivation

Before this PR, only PNG wallpapers were supported. This was pretty inefficient for two reasons:
1. Wallpapers can be photos that do not work well with PNG compression. It is frequent to have a PNG that are 10x larger than an equivalent JPEG.
2. Because of their larger size, PNGs are much slower to load. This is not necessarily visible on a high-end device, but even medium-range devices will lag behind. For example, it is very noticeable on a Nintento Switch, where a 1920x1080 PNG wallpaper will take _several seconds_ to load and show up.

In other words, PNGs waste both time and storage.

## Description

This pull requests tries to load wallpapers according to the image formats that RetroArch supports. Before this PR, XMB would always try to look up `.png` files, even if `HAVE_RPNG` was not set.

The behavior is similar to what RetroArch already does for thumbnails, and uses the same priority order: it will first try PNG, then JPEG, then BMP, and finally TGA, and will use whichever image it finds first, if any.