### PR TITLE
intl: Add Thai language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 - LIBRETRO: RETRO_ENVIRONMENT_SET_SAVE_STATE_DISABLE_UNDO allows cores to disable frontend's save state undo feature to decrease memory usage
 - LIBRETRO: Performance improvements for nbio and archive handling in libretro-common
 - LIBRETRO: Performance improvements for utf encoding in libretro-common
+- LOCALIZATION: Add Thai language
 - MACOS: Fix OpenGL color on wide gamut displays
 - MENU: Do hard reset when pushing RetroPad Start on Restart menu item
 - MENU: Remove "Missing firmware check" option

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -485,6 +485,7 @@ enum retro_language
    RETRO_LANGUAGE_GALICIAN            = 33,
    RETRO_LANGUAGE_NORWEGIAN           = 34,
    RETRO_LANGUAGE_IRISH               = 35,
+   RETRO_LANGUAGE_THAI                = 36,
    RETRO_LANGUAGE_LAST,
 
    /** Defined to ensure that <tt>sizeof(retro_language) == sizeof(int)</tt>. Do not use. */

--- a/libretro-common/samples/core_options/example_default/libretro_core_options.h
+++ b/libretro-common/samples/core_options/example_default/libretro_core_options.h
@@ -132,6 +132,7 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    NULL,           /* RETRO_LANGUAGE_BELARUSIAN */
    NULL,           /* RETRO_LANGUAGE_GALICIAN */
    NULL,           /* RETRO_LANGUAGE_NORWEGIAN */
+   NULL,           /* RETRO_LANGUAGE_THAI */
 };
 #endif
 

--- a/libretro-common/samples/core_options/example_default/libretro_core_options_intl.h
+++ b/libretro-common/samples/core_options/example_default/libretro_core_options_intl.h
@@ -83,6 +83,8 @@ extern "C" {
 
 /* RETRO_LANGUAGE_FINNISH */
 
+/* RETRO_LANGUAGE_THAI */
+
 #ifdef __cplusplus
 }
 #endif

--- a/libretro-common/samples/core_options/example_hide_option/libretro_core_options.h
+++ b/libretro-common/samples/core_options/example_hide_option/libretro_core_options.h
@@ -147,6 +147,7 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    NULL,           /* RETRO_LANGUAGE_BELARUSIAN */
    NULL,           /* RETRO_LANGUAGE_GALICIAN */
    NULL,           /* RETRO_LANGUAGE_NORWEGIAN */
+   NULL,           /* RETRO_LANGUAGE_THAI */
 };
 #endif
 

--- a/libretro-common/samples/core_options/example_hide_option/libretro_core_options_intl.h
+++ b/libretro-common/samples/core_options/example_hide_option/libretro_core_options_intl.h
@@ -83,6 +83,8 @@ extern "C" {
 
 /* RETRO_LANGUAGE_FINNISH */
 
+/* RETRO_LANGUAGE_THAI */
+
 #ifdef __cplusplus
 }
 #endif

--- a/libretro-common/samples/core_options/example_translation/libretro_core_options.h
+++ b/libretro-common/samples/core_options/example_translation/libretro_core_options.h
@@ -174,6 +174,7 @@ struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
    &options_be,      /* RETRO_LANGUAGE_BELARUSIAN */
    &options_gl,      /* RETRO_LANGUAGE_GALICIAN */
    &options_no,      /* RETRO_LANGUAGE_NORWEGIAN */
+   &options_th,      /* RETRO_LANGUAGE_THAI */
 };
 #endif
 

--- a/libretro-common/samples/core_options/example_translation/libretro_core_options_intl.h
+++ b/libretro-common/samples/core_options/example_translation/libretro_core_options_intl.h
@@ -150,6 +150,8 @@ struct retro_core_options_v2 options_fr = {
 
 /* RETRO_LANGUAGE_FINNISH */
 
+/* RETRO_LANGUAGE_THAI */
+
 #ifdef __cplusplus
 }
 #endif

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -7284,6 +7284,7 @@ static size_t setting_get_string_representation_uint_user_language(
    LANG_DATA(GALICIAN)
    LANG_DATA(NORWEGIAN)
    LANG_DATA(IRISH)
+   LANG_DATA(THAI)
 
    if (*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE) == RETRO_LANGUAGE_ENGLISH)
       return strlcpy(s, modes[*msg_hash_get_uint(MSG_HASH_USER_LANGUAGE)], len);

--- a/msg_hash.c
+++ b/msg_hash.c
@@ -140,6 +140,8 @@ const char *get_user_language_iso639_1(bool limit)
           return "no";
       case RETRO_LANGUAGE_IRISH:
           return "ga";
+      case RETRO_LANGUAGE_THAI:
+          return "th";
    }
    return "en";
 }
@@ -564,6 +566,18 @@ static const char *msg_hash_to_str_ga(enum msg_hash_enums msg)
 
    return "null";
 }
+
+static const char *msg_hash_to_str_th(enum msg_hash_enums msg)
+{
+   switch (msg)
+   {
+#include "intl/msg_hash_th.h"
+      default:
+         break;
+   }
+
+   return "null";
+}
 #endif
 
 const char *msg_hash_to_str(enum msg_hash_enums msg)
@@ -677,6 +691,9 @@ const char *msg_hash_to_str(enum msg_hash_enums msg)
          break;
       case RETRO_LANGUAGE_IRISH:
          ret = msg_hash_to_str_ga(msg);
+         break;
+      case RETRO_LANGUAGE_THAI:
+         ret = msg_hash_to_str_th(msg);
          break;
       default:
          break;

--- a/retroarch.c
+++ b/retroarch.c
@@ -8941,6 +8941,7 @@ enum retro_language retroarch_get_language_from_iso(const char *iso639)
       {"gl", RETRO_LANGUAGE_GALICIAN},
       {"no", RETRO_LANGUAGE_NORWEGIAN},
       {"ga", RETRO_LANGUAGE_IRISH},
+      {"th", RETRO_LANGUAGE_THAI},
    };
 
    if (string_is_empty(iso639))


### PR DESCRIPTION
# Description

Add Thai language and it has been added to [Crowdin](https://github.com/libretro/RetroArch/commit/a61d6af49cf0aec450cead586f1b3ebc7fbca5af).

## Related Issues

Fix #18861


## Result

Test for "Information" ข้อมูล using [NotoSansThai-Regular.ttf](https://fonts.google.com/noto/specimen/Noto+Sans+Thai?preview.script=Thai)

<img width="1161" height="1065" alt="image" src="https://github.com/user-attachments/assets/d07c78d1-a7cf-4027-bf8e-85d561782871" />
