### PR TITLE
DXGI: fix HDR metadata array comparisons

### DIFF
--- a/gfx/common/dxgi_common.c
+++ b/gfx/common/dxgi_common.c
@@ -762,10 +762,10 @@ void dxgi_set_hdr_metadata(
    hdr10_meta_data.MaxFrameAverageLightLevel    =
       (UINT16)(max_fall);
 
-   if (g_hdr10_meta_data.RedPrimary                 != hdr10_meta_data.RedPrimary            ||
-       g_hdr10_meta_data.GreenPrimary               != hdr10_meta_data.GreenPrimary          ||
-       g_hdr10_meta_data.BluePrimary                != hdr10_meta_data.BluePrimary           ||
-       g_hdr10_meta_data.WhitePoint                 != hdr10_meta_data.WhitePoint            ||
+   if (memcmp(g_hdr10_meta_data.RedPrimary,   hdr10_meta_data.RedPrimary,   sizeof(hdr10_meta_data.RedPrimary))   ||
+       memcmp(g_hdr10_meta_data.GreenPrimary, hdr10_meta_data.GreenPrimary, sizeof(hdr10_meta_data.GreenPrimary)) ||
+       memcmp(g_hdr10_meta_data.BluePrimary,  hdr10_meta_data.BluePrimary,  sizeof(hdr10_meta_data.BluePrimary))  ||
+       memcmp(g_hdr10_meta_data.WhitePoint,   hdr10_meta_data.WhitePoint,   sizeof(hdr10_meta_data.WhitePoint))   ||
        g_hdr10_meta_data.MaxContentLightLevel       != hdr10_meta_data.MaxContentLightLevel  ||
        g_hdr10_meta_data.MaxMasteringLuminance      != hdr10_meta_data.MaxMasteringLuminance ||
        g_hdr10_meta_data.MinMasteringLuminance      != hdr10_meta_data.MinMasteringLuminance ||


### PR DESCRIPTION
## Summary
- `RedPrimary`, `GreenPrimary`, `BluePrimary`, and `WhitePoint` in `DXGI_HDR_METADATA_HDR10` are `UINT16[2]` arrays. Using `!=` compared pointer addresses (always different), not the actual values, causing `SetHDRMetaData` to be called every frame unnecessarily.
- Replace with `memcmp` for correct element-wise comparison.