### PR TITLE
Fix MSVC build: C89 compliance in wgl_ctx.c

### DIFF
--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -184,11 +184,14 @@ static bool wgl_has_extension(const char *ext, const char *exts)
    if (!exts || !ext || *ext == '\0' || strchr(ext, ' '))
       return false;
    _len = strlen(ext);
-   for (const char *start = exts; (start = strstr(start, ext)); start += _len)
    {
-      if (   (start       == exts || start[-1]   == ' ')
-          && (start[_len] == ' '  || start[_len] == '\0'))
-         return true;
+      const char *start;
+      for (start = exts; (start = strstr(start, ext)); start += _len)
+      {
+         if (   (start       == exts || start[-1]   == ' ')
+             && (start[_len] == ' '  || start[_len] == '\0'))
+            return true;
+      }
    }
    return false;
 }


### PR DESCRIPTION
## Summary
- Fixes Windows build failure caused by C99 for-loop variable declaration in `wgl_has_extension()`
- Moves the `const char *start` declaration to block scope for C89/MSVC compatibility

## Test plan
- [x] Verify Windows MSVC build succeeds in CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)