### PR TITLE
UWP/MSVC: Small Tweaks

### DIFF
--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -68,12 +68,6 @@ static size_t frontend_uwp_get_os(char *s, size_t len, int *major, int *minor)
       case PROCESSOR_ARCHITECTURE_AMD64:
          arch = "x64";
          break;
-      case PROCESSOR_ARCHITECTURE_INTEL:
-         arch = "x86";
-         break;
-      case PROCESSOR_ARCHITECTURE_ARM:
-         arch = "ARM";
-         break;
       case PROCESSOR_ARCHITECTURE_ARM64:
          arch = "ARM64";
          break;
@@ -98,8 +92,10 @@ static size_t frontend_uwp_get_os(char *s, size_t len, int *major, int *minor)
                _len = strlcpy(s, "Windows Server 2016", len);
             else if ((vi.dwBuildNumber >= 17763) && (vi.dwBuildNumber < 20348))
                _len = strlcpy(s, "Windows Server 2019", len);
-            else if (vi.dwBuildNumber >= 20348)
+            else if ((vi.dwBuildNumber >= 20348) && (vi.dwBuildNumber < 26100))
                _len = strlcpy(s, "Windows Server 2022", len);
+		    else if (vi.dwBuildNumber >= 26100)
+				_len = strlcpy(s, "Windows Server 2025", len);
          }
          else
          {
@@ -181,10 +177,6 @@ enum frontend_architecture frontend_uwp_get_arch(void)
    {
       case PROCESSOR_ARCHITECTURE_AMD64:
          return FRONTEND_ARCH_X86_64;
-      case PROCESSOR_ARCHITECTURE_INTEL:
-         return FRONTEND_ARCH_X86;
-      case PROCESSOR_ARCHITECTURE_ARM:
-         return FRONTEND_ARCH_ARM;
       case PROCESSOR_ARCHITECTURE_ARM64:
          return FRONTEND_ARCH_ARMV8;
       default:

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -4471,8 +4471,10 @@ static const char * msvc_vercode_to_str(const unsigned vercode)
             return " msvc2017";
          else if (vercode >= 1920 && vercode < 1930)
             return " msvc2019";
-         else if (vercode >= 1930)
+         else if (vercode >= 1930 && vercode < 1950)
             return " msvc2022";
+         else if (vercode >= 1950)
+            return " msvc2026";
          break;
    }
 


### PR DESCRIPTION
## Description

- Detect if the OS is Windows Server 2025
- Identify if the compiler was msvc2026 on the menu

This is a follow up to an old commit of mine, figured it was better if the OS/MSVC identifiers were up to date

## Related Issues

N/A

## Related Pull Requests

N/A

## Reviewers

N/A
