### PR TITLE
Fix `filestream_tell_cb` guard in `file_stream.c`.

### DIFF
--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -393,7 +393,7 @@ int64_t filestream_tell(RFILE *stream)
 {
    int64_t output;
 
-   if (filestream_size_cb)
+   if (filestream_tell_cb)
       output = filestream_tell_cb(stream->hfile);
    else
       output = retro_vfs_file_tell_impl(


### PR DESCRIPTION
Was checking the wrong variable, likely as the result of a copy-paste error. Would theoretically allow for null-pointer dereferences.