### PR TITLE
fix processing of MODE1_RAW/MODE2_RAW CHD tracks

### DIFF
--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -249,16 +249,21 @@ chdstream_t *chdstream_open(const char *path, int32_t track)
    switch (meta.type[0])
    {
       case 'M':
-         if (meta.type[4] == '_')
-            stream->frame_size = SECTOR_RAW_SIZE;
-         else
+         if (meta.type[5] == '_')
+         {
+            if (meta.type[6] == 'R') /* MODE1_RAW or MODE2_RAW */
+               stream->frame_size = SECTOR_RAW_SIZE;
+            else /* MODE2_FORM... (unhandled, treat like default)*/
+               stream->frame_size = hd->unitbytes;
+         }
+         else /* MODE1 */
             stream->frame_size = SECTOR_SIZE;
          break;
-      case 'A':
+      case 'A': /* AUDIO */
          stream->frame_size   = SECTOR_RAW_SIZE;
          stream->swab         = true;
          break;
-      case 'D':
+      case 'D': /* DVD */
          stream->frame_size   = hd->unitbytes;
          meta.frames          = hd->totalhunks;
          break;


### PR DESCRIPTION
## Description

Fixes a regression introduced in https://github.com/libretro/RetroArch/commit/1e081f9430ae69fa63e6d231a8a84f0359e8fcfc#diff-8350da4f3bf4ff394c17e9d98ef082543aa9715abceeaf7bf315798f7c006859R252.

The underscore in `MODEn_RAW` is at index 5, not index 4:
https://github.com/libretro/RetroArch/blob/1e081f9430ae69fa63e6d231a8a84f0359e8fcfc/libretro-common/streams/chd_stream.c#L249-L256

And while I would like to argue that matching strings by assuming a heuristic uniqueness is dangerous, this solution is better than leaving things broken, and there must be some reason the original change was made.

## Related Issues

Fixes #18883 

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
