### PR TITLE
Fix for XMB menu freeze when scan button pushed twice in file explorer

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1991,13 +1991,6 @@ static bool menu_content_find_first_core(
    return true;
 }
 
-#ifdef HAVE_LIBRETRODB
-void handle_dbscan_finished(retro_task_t *task,
-      void *task_data, void *user_data, const char *err);
-#endif
-
-
-
 static int file_load_with_detect_core_wrapper(
       enum msg_hash_enums enum_label_idx,
       size_t idx, size_t entry_idx,
@@ -8456,7 +8449,7 @@ static int action_ok_manual_content_scan_start(const char *path,
          settings->bools.playlist_portable_paths ?
                settings->paths.directory_menu_content : NULL);
 
-   task_push_manual_content_scan(&playlist_config, directory_playlist);
+   task_push_manual_content_scan(true);
    return 0;
 }
 
@@ -9031,8 +9024,7 @@ static int action_ok_playlist_refresh(const char *path,
             settings->bools.playlist_portable_paths ?
             settings->paths.directory_menu_content : NULL);
 
-      task_push_manual_content_scan(playlist_config,
-            settings->paths.directory_playlist);
+      task_push_manual_content_scan(true);
    }
    return 0;
 }

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -191,7 +191,8 @@ enum db_flags_enum
    DB_HANDLE_FLAG_SCAN_STARTED            = (1 << 1),
    DB_HANDLE_FLAG_SCAN_WITHOUT_CORE_MATCH = (1 << 2),
    DB_HANDLE_FLAG_SHOW_HIDDEN_FILES       = (1 << 3),
-   DB_HANDLE_FLAG_USE_FIRST_MATCH_ONLY    = (1 << 4)
+   DB_HANDLE_FLAG_USE_FIRST_MATCH_ONLY    = (1 << 4),
+   DB_HANDLE_FLAG_DO_MENU_REFRESH         = (1 << 5)
 };
 
 enum manual_scan_status
@@ -1651,7 +1652,7 @@ bool task_push_dbscan(
 {
    manual_content_scan_set_menu_content_dir(fullpath);
    /*manual_content_scan_set_menu_scan_method(MANUAL_CONTENT_SCAN_METHOD_AUTOMATIC);*/
-   return task_push_manual_content_scan(NULL,NULL);
+   return task_push_manual_content_scan(false);
 }
 
 #endif
@@ -1783,7 +1784,12 @@ static void cb_task_manual_content_scan(
 end:
    /* When creating playlists, the playlist tabs of
     * any active menu driver must be refreshed */
-   if (menu_st->driver_ctx->environ_cb)
+   if (   
+#ifdef HAVE_LIBRETRODB
+         (!manual_scan || 
+         (manual_scan->flags & DB_HANDLE_FLAG_DO_MENU_REFRESH)) && 
+#endif
+       menu_st->driver_ctx->environ_cb)
       menu_st->driver_ctx->environ_cb(MENU_ENVIRON_RESET_HORIZONTAL_LIST,
             NULL, menu_st->userdata);
 #endif
@@ -2441,8 +2447,7 @@ static bool task_manual_content_scan_finder(retro_task_t *task, void *user_data)
 }
 
 bool task_push_manual_content_scan(
-      const playlist_config_t *playlist_config,
-      const char *playlist_directory)
+      bool do_menu_refresh)
 {
    size_t _len;
    task_finder_data_t find_data;
@@ -2489,6 +2494,9 @@ bool task_push_manual_content_scan(
 
    if (settings->bools.show_hidden_files)
       manual_scan->flags |= DB_HANDLE_FLAG_SHOW_HIDDEN_FILES;
+
+   if (do_menu_refresh)
+      manual_scan->flags |= DB_HANDLE_FLAG_DO_MENU_REFRESH;
 
    manual_scan->content_database_path               = strdup(settings->paths.path_content_database);
 #endif

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -193,8 +193,7 @@ bool task_push_dbscan(
 #endif
 
 bool task_push_manual_content_scan(
-      const playlist_config_t *playlist_config,
-      const char *playlist_directory);
+      bool do_menu_refresh);
 
 #ifdef HAVE_OVERLAY
 bool task_push_overlay_load_default(


### PR DESCRIPTION
## Description

Scanning needs to follow up potentially added playlists by an extra menu refresh. When scanning was invoked from file browser under XMB, by pushing retropad-y, second scanning followup would get lost as the logic is brittle, resulting in an unresponsive menu.

The extra menu refresh is now combined with the regular scan task.

This also allows a better workflow for cherry picking content file-by-file into a playlist: set up scanning as needed, scan a single file, then instead of always selecting content - going back to scan menu - starting scan - selecting content again, single-button scan can be triggered from the file browser. (This was also possible earlier, just not very much known.)

## Related Issues

This was one of the postponed issues in #18641 .

## Reviewers

@sonninnos 
