### PR TITLE
(cheevos) fix font width calculations

### DIFF
--- a/gfx/widgets/gfx_widget_achievement_popup.c
+++ b/gfx/widgets/gfx_widget_achievement_popup.c
@@ -572,10 +572,10 @@ static void gfx_widget_achievement_popup_start(
    state->width = MAX(
       font_driver_get_message_width(
          p_dispwidget->gfx_widget_fonts.regular.font,
-         state->queue[state->queue_read_index].title, 0, 1.0f),
+         state->queue[state->queue_read_index].title, strlen(state->queue[state->queue_read_index].title), 1.0f),
       font_driver_get_message_width(
          p_dispwidget->gfx_widget_fonts.regular.font,
-         state->queue[state->queue_read_index].subtitle, 0, 1.0f)
+         state->queue[state->queue_read_index].subtitle, strlen(state->queue[state->queue_read_index].subtitle), 1.0f)
    );
    state->width += p_dispwidget->simple_widget_padding * 2;
    state->unfold = 0.0f;

--- a/gfx/widgets/gfx_widget_leaderboard_display.c
+++ b/gfx/widgets/gfx_widget_leaderboard_display.c
@@ -391,7 +391,7 @@ static void gfx_widget_leaderboard_display_frame(void* data, void* userdata)
          const char *disconnected_text = state->disconnected ? "! RA !" : loading_buffer;
          const unsigned disconnect_widget_width = font_driver_get_message_width(
             state->dispwidget_ptr->gfx_widget_fonts.msg_queue.font,
-            disconnected_text, 0, 1) + CHEEVO_LBOARD_DISPLAY_PADDING * 2;
+            disconnected_text, strlen(disconnected_text), 1) + CHEEVO_LBOARD_DISPLAY_PADDING * 2;
          const unsigned disconnect_widget_height =
             p_dispwidget->gfx_widget_fonts.msg_queue.line_height + (CHEEVO_LBOARD_DISPLAY_PADDING - 1) * 2;
          x  = video_width - disconnect_widget_width - spacing;
@@ -489,7 +489,7 @@ void gfx_widgets_set_leaderboard_display(unsigned id, const char* value)
                buffer[0] = (char)(j + CHEEVO_LBOARD_FIRST_FIXED_CHAR);
                state->char_width[j] = (uint16_t)font_driver_get_message_width(
                      state->dispwidget_ptr->gfx_widget_fonts.regular.font,
-                     buffer, 0, 1);
+                     buffer, 1, 1);
                if (state->char_width[j] > state->fixed_char_width)
                   state->fixed_char_width = state->char_width[j];
             }
@@ -631,7 +631,7 @@ void gfx_widget_set_achievement_progress(const char* badge, const char* progress
       snprintf(state->progress_tracker.display, sizeof(state->progress_tracker.display), "%s", progress);
       state->progress_tracker.width = (uint16_t)font_driver_get_message_width(
             state->dispwidget_ptr->gfx_widget_fonts.regular.font,
-            progress, 0, 1);
+            progress, strlen(progress), 1);
    }
 
    if (old_badge_id)


### PR DESCRIPTION
## Description

https://github.com/libretro/RetroArch/commit/8865e0c300e3719e60ff70284bfe3592dc4f499f#diff-c1bcc061bcfe4c0abc36c2659d5e14cdef23e34db934c8f7636f5ba4d9b7e6d7L818-L819 removed code that calculates the string length in `font_driver_get_message_width` if a length is not provided. The achievement widgets were not providing lengths. I've added lengths to the calls for the achievement widgets. 

I did not look to see if any of the other calls were affected.

## Related Issues

https://discord.com/channels/184109094070779904/469974542299955210/1492891810593378476

## Related Pull Requests

n/a

## Reviewers

@LibretroAdmin 
