### PR TITLE
Initial step at deferred shader loading (per-frame)

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -503,7 +503,11 @@
 /* When enabled, shaders compile one pass per frame instead of
  * stalling for the entire preset.  Disable to force the legacy
  * synchronous (blocking) shader load path. */
+#if defined(ANDROID)
+#define DEFAULT_SHADER_DEFERRED_LOADING false
+#else
 #define DEFAULT_SHADER_DEFERRED_LOADING true
+#endif
 
 /* HDR output mode: 0 = off, 1 = HDR10, 2 = scRGB */
 #define DEFAULT_VIDEO_HDR_MODE 0

--- a/config.def.h
+++ b/config.def.h
@@ -500,6 +500,11 @@
 /* Enable use of shaders */
 #define DEFAULT_SHADER_ENABLE true
 
+/* When enabled, shaders compile one pass per frame instead of
+ * stalling for the entire preset.  Disable to force the legacy
+ * synchronous (blocking) shader load path. */
+#define DEFAULT_SHADER_DEFERRED_LOADING true
+
 /* HDR output mode: 0 = off, 1 = HDR10, 2 = scRGB */
 #define DEFAULT_VIDEO_HDR_MODE 0
 

--- a/configuration.c
+++ b/configuration.c
@@ -1932,6 +1932,7 @@ static struct config_bool_setting *populate_settings_bool(
    SETTING_BOOL("crt_switch_resolution_use_custom_refresh_rate", &settings->bools.crt_switch_custom_refresh_enable, true, false, false);
    SETTING_BOOL("crt_switch_hires_menu",         &settings->bools.crt_switch_hires_menu, true, false, true);
    SETTING_BOOL("video_shader_enable",           &settings->bools.video_shader_enable, true, DEFAULT_SHADER_ENABLE, false);
+   SETTING_BOOL("video_shader_deferred_loading", &settings->bools.video_shader_deferred_loading, true, DEFAULT_SHADER_DEFERRED_LOADING, false);
    SETTING_BOOL("video_shader_watch_files",      &settings->bools.video_shader_watch_files, true, DEFAULT_VIDEO_SHADER_WATCH_FILES, false);
    SETTING_BOOL("video_shader_remember_last_dir", &settings->bools.video_shader_remember_last_dir, true, DEFAULT_VIDEO_SHADER_REMEMBER_LAST_DIR, false);
    SETTING_BOOL("video_shader_preset_save_reference_enable", &settings->bools.video_shader_preset_save_reference_enable, true, DEFAULT_VIDEO_SHADER_PRESET_SAVE_REFERENCE_ENABLE, false);

--- a/configuration.h
+++ b/configuration.h
@@ -678,6 +678,7 @@ typedef struct settings
       bool video_dingux_ipu_keep_aspect;
       bool video_scale_integer;
       bool video_shader_enable;
+      bool video_shader_deferred_loading;
       bool video_shader_watch_files;
       bool video_shader_remember_last_dir;
       bool video_shader_preset_save_reference_enable;

--- a/gfx/drivers/caca_gfx.c
+++ b/gfx/drivers/caca_gfx.c
@@ -449,6 +449,8 @@ video_driver_t video_caca = {
 #endif
    caca_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/ctr_gfx.c
+++ b/gfx/drivers/ctr_gfx.c
@@ -3051,6 +3051,8 @@ video_driver_t video_ctr =
 #endif
    ctr_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    ctr_widgets_enabled
 #endif

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -1619,6 +1619,366 @@ static void d3d10_free_shader_preset(d3d10_video_t* d3d10)
                                   | D3D10_ST_FLAG_RESIZE_RTS);
 }
 
+/* ---- Deferred (per-frame) shader loading for D3D10 ---- */
+
+typedef struct d3d10_deferred_pass
+{
+   d3d10_shader_t    shader;
+   pass_semantics_t  semantics;
+   D3D10Buffer       buffers[SLANG_CBUFFER_MAX];
+} d3d10_deferred_pass_t;
+
+typedef struct d3d10_deferred_state
+{
+   struct video_shader      *shader_preset;
+   d3d10_deferred_pass_t     passes[GFX_MAX_SHADERS];
+   d3d10_texture_t           luts[GFX_MAX_TEXTURES];
+   bool                      luts_loaded;
+} d3d10_deferred_state_t;
+
+static bool d3d10_shader_load_begin(void *data,
+      shader_load_deferred_t *deferred)
+{
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   d3d10_video_t *d3d10 = (d3d10_video_t*)data;
+   d3d10_deferred_state_t *ds;
+
+   if (!d3d10)
+      return false;
+
+   if (deferred->type != RARCH_SHADER_SLANG)
+      return false;
+
+   ds = (d3d10_deferred_state_t*)calloc(1, sizeof(*ds));
+   if (!ds)
+      return false;
+
+   ds->shader_preset = (struct video_shader*)calloc(
+         1, sizeof(*ds->shader_preset));
+   if (!ds->shader_preset)
+   {
+      free(ds);
+      return false;
+   }
+
+   if (!video_shader_load_preset_into_shader(
+            deferred->preset_path, ds->shader_preset))
+   {
+      free(ds->shader_preset);
+      free(ds);
+      return false;
+   }
+
+   deferred->total_passes = ds->shader_preset->passes;
+
+   /* Load LUTs synchronously */
+   {
+      unsigned i;
+      for (i = 0; i < ds->shader_preset->luts; i++)
+      {
+         struct texture_image image;
+         image.pixels        = NULL;
+         image.width         = 0;
+         image.height        = 0;
+         image.supports_rgba = true;
+
+         if (!image_texture_load(&image,
+                  ds->shader_preset->lut[i].path))
+         {
+            RARCH_ERR("[D3D10] Deferred: failed to load LUT: \"%s\".\n",
+                  ds->shader_preset->lut[i].path);
+            goto error;
+         }
+
+         ds->luts[i].desc.Width  = image.width;
+         ds->luts[i].desc.Height = image.height;
+         ds->luts[i].desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+         if (ds->shader_preset->lut[i].mipmap)
+            ds->luts[i].desc.MiscFlags = D3D10_RESOURCE_MISC_GENERATE_MIPS;
+
+         d3d10_init_texture(d3d10->device, &ds->luts[i]);
+
+         if (ds->luts[i].staging)
+            d3d10_update_texture(
+                  d3d10->device,
+                  image.width, image.height, 0,
+                  DXGI_FORMAT_R8G8B8A8_UNORM, image.pixels,
+                  &ds->luts[i]);
+
+         image_texture_free(&image);
+      }
+      ds->luts_loaded = true;
+   }
+
+   RARCH_LOG("[D3D10] Deferred: prepared %u passes for \"%s\".\n",
+         deferred->total_passes, deferred->preset_path);
+
+   deferred->driver_data = ds;
+   return true;
+
+error:
+   {
+      unsigned j;
+      for (j = 0; j < ds->shader_preset->luts; j++)
+         d3d10_release_texture(&ds->luts[j]);
+   }
+   free(ds->shader_preset);
+   free(ds);
+   return false;
+#else
+   return false;
+#endif
+}
+
+static void d3d10_deferred_state_free(
+      d3d10_deferred_state_t *ds,
+      unsigned passes_built)
+{
+   unsigned i;
+
+   if (!ds)
+      return;
+
+   for (i = 0; i < passes_built; i++)
+   {
+      unsigned j;
+      d3d10_release_shader(&ds->passes[i].shader);
+      free(ds->passes[i].semantics.textures);
+      ds->passes[i].semantics.textures = NULL;
+      for (j = 0; j < SLANG_CBUFFER_MAX; j++)
+      {
+         free(ds->passes[i].semantics.cbuffers[j].uniforms);
+         ds->passes[i].semantics.cbuffers[j].uniforms = NULL;
+         Release(ds->passes[i].buffers[j]);
+      }
+   }
+
+   if (ds->luts_loaded && ds->shader_preset)
+   {
+      for (i = 0; i < ds->shader_preset->luts; i++)
+         d3d10_release_texture(&ds->luts[i]);
+   }
+
+   if (ds->shader_preset)
+   {
+      for (i = 0; i < ds->shader_preset->passes; i++)
+      {
+         free(ds->shader_preset->pass[i].source.string.vertex);
+         free(ds->shader_preset->pass[i].source.string.fragment);
+      }
+      free(ds->shader_preset);
+   }
+
+   free(ds);
+}
+
+static bool d3d10_shader_load_step(void *data,
+      shader_load_deferred_t *deferred)
+{
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   d3d10_video_t *d3d10          = (d3d10_video_t*)data;
+   d3d10_deferred_state_t *ds    =
+      (d3d10_deferred_state_t*)deferred->driver_data;
+   unsigned pass                 = deferred->current_pass;
+
+   if (!d3d10 || !ds)
+   {
+      deferred->state = SHADER_LOAD_FAILED;
+      return false;
+   }
+
+   if (pass < deferred->total_passes)
+   {
+      d3d10_texture_t *source;
+      unsigned i = pass;
+
+      RARCH_LOG("[D3D10] Deferred: compiling pass %u/%u...\n",
+            pass + 1, deferred->total_passes);
+
+      source = (i == 0)
+         ? &d3d10->frame.texture[0]
+         : &d3d10->pass[i - 1].rt;
+
+      {
+         unsigned j;
+         semantics_map_t semantics_map = {
+            {
+               { &d3d10->frame.texture[0].view, 0,
+                  &d3d10->frame.texture[0].size_data, 0 },
+               { &source->view, 0,
+                  &source->size_data, 0 },
+               { &d3d10->frame.texture[0].view,
+                  sizeof(*d3d10->frame.texture),
+                  &d3d10->frame.texture[0].size_data,
+                  sizeof(*d3d10->frame.texture) },
+               { &d3d10->pass[0].rt.view, sizeof(*d3d10->pass),
+                  &d3d10->pass[0].rt.size_data,
+                  sizeof(*d3d10->pass) },
+               { &d3d10->pass[0].feedback.view, sizeof(*d3d10->pass),
+                  &d3d10->pass[0].feedback.size_data,
+                  sizeof(*d3d10->pass) },
+               /* Point at d3d10->luts, not ds->luts */
+               { &d3d10->luts[0].view, sizeof(*d3d10->luts),
+                  &d3d10->luts[0].size_data, sizeof(*d3d10->luts) },
+            },
+            {
+               &d3d10->mvp,
+               &d3d10->pass[i].rt.size_data,
+               &d3d10->frame.output_size,
+               &d3d10->pass[i].frame_count,
+               &d3d10->pass[i].frame_direction,
+               &d3d10->pass[i].frame_time_delta,
+               &d3d10->pass[i].original_fps,
+               &d3d10->pass[i].rotation,
+               &d3d10->pass[i].core_aspect,
+               &d3d10->pass[i].core_aspect_rot,
+               &d3d10->pass[i].total_subframes,
+               &d3d10->pass[i].current_subframe,
+            }
+         };
+
+         if (!slang_process(
+                  ds->shader_preset, i, RARCH_SHADER_HLSL,
+                  40, &semantics_map,
+                  &ds->passes[i].semantics))
+         {
+            RARCH_ERR("[D3D10] Deferred: failed to process pass %u.\n", i);
+            d3d10_deferred_state_free(ds, pass);
+            deferred->state       = SHADER_LOAD_FAILED;
+            deferred->driver_data = NULL;
+            return false;
+         }
+
+         /* Compile HLSL and create shader objects */
+         {
+            static const D3D10_INPUT_ELEMENT_DESC desc[] = {
+               { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0,
+                  offsetof(d3d10_vertex_t, position),
+                  D3D10_INPUT_PER_VERTEX_DATA, 0 },
+               { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0,
+                  offsetof(d3d10_vertex_t, texcoord),
+                  D3D10_INPUT_PER_VERTEX_DATA, 0 },
+            };
+            char _path[PATH_MAX_LENGTH];
+            const char *slang_path =
+               ds->shader_preset->pass[i].source.path;
+            const char *vs_src =
+               ds->shader_preset->pass[i].source.string.vertex;
+            const char *ps_src =
+               ds->shader_preset->pass[i].source.string.fragment;
+            size_t _len = strlcpy(_path, slang_path, sizeof(_path));
+
+            strlcpy(_path + _len, ".vs.hlsl", sizeof(_path) - _len);
+            d3d10_init_shader(d3d10->device, vs_src, 0,
+                  _path, "main", NULL, NULL, desc, countof(desc),
+                  &ds->passes[i].shader);
+
+            strlcpy(_path + _len, ".ps.hlsl", sizeof(_path) - _len);
+            d3d10_init_shader(d3d10->device, ps_src, 0, _path,
+                  NULL, "main", NULL, NULL, 0,
+                  &ds->passes[i].shader);
+
+            free(ds->shader_preset->pass[i].source.string.vertex);
+            free(ds->shader_preset->pass[i].source.string.fragment);
+            ds->shader_preset->pass[i].source.string.vertex   = NULL;
+            ds->shader_preset->pass[i].source.string.fragment = NULL;
+
+            if (!ds->passes[i].shader.vs || !ds->passes[i].shader.ps)
+            {
+               RARCH_ERR("[D3D10] Deferred: failed to compile shader"
+                     " for pass %u.\n", i);
+               d3d10_deferred_state_free(ds, pass + 1);
+               deferred->state       = SHADER_LOAD_FAILED;
+               deferred->driver_data = NULL;
+               return false;
+            }
+         }
+
+         /* Create cbuffers */
+         for (j = 0; j < SLANG_CBUFFER_MAX; j++)
+         {
+            D3D10_BUFFER_DESC buf_desc;
+            buf_desc.ByteWidth      =
+               ds->passes[i].semantics.cbuffers[j].size;
+            buf_desc.Usage          = D3D10_USAGE_DYNAMIC;
+            buf_desc.BindFlags      = D3D10_BIND_CONSTANT_BUFFER;
+            buf_desc.CPUAccessFlags = D3D10_CPU_ACCESS_WRITE;
+            buf_desc.MiscFlags      = 0;
+
+            if (!buf_desc.ByteWidth)
+               continue;
+
+            d3d10->device->lpVtbl->CreateBuffer(
+                  d3d10->device, &buf_desc, NULL,
+                  &ds->passes[i].buffers[j]);
+         }
+      }
+
+      deferred->current_pass++;
+      return true;
+   }
+
+   /* Cancellation check */
+   if (deferred->state != SHADER_LOAD_COMPILING)
+   {
+      RARCH_LOG("[D3D10] Deferred: cancelled, cleaning up.\n");
+      d3d10_deferred_state_free(ds, pass);
+      deferred->state       = SHADER_LOAD_FAILED;
+      deferred->driver_data = NULL;
+      return false;
+   }
+
+   /* All passes compiled — install */
+   RARCH_LOG("[D3D10] Deferred: finalizing...\n");
+
+   d3d10->device->lpVtbl->Flush(d3d10->device);
+   d3d10_free_shader_preset(d3d10);
+
+   /* Install preset */
+   d3d10->shader_preset = ds->shader_preset;
+   ds->shader_preset    = NULL;
+
+   /* Install LUTs */
+   memcpy(d3d10->luts, ds->luts, sizeof(ds->luts));
+   memset(ds->luts, 0, sizeof(ds->luts));
+   ds->luts_loaded = false;
+
+   /* Install per-pass state */
+   {
+      unsigned i;
+      for (i = 0; i < deferred->total_passes; i++)
+      {
+         d3d10->pass[i].shader = ds->passes[i].shader;
+         memset(&ds->passes[i].shader, 0,
+               sizeof(ds->passes[i].shader));
+
+         d3d10->pass[i].semantics = ds->passes[i].semantics;
+         memset(&ds->passes[i].semantics, 0,
+               sizeof(ds->passes[i].semantics));
+
+         memcpy(d3d10->pass[i].buffers,
+               ds->passes[i].buffers,
+               sizeof(ds->passes[i].buffers));
+         memset(ds->passes[i].buffers, 0,
+               sizeof(ds->passes[i].buffers));
+      }
+   }
+
+   d3d10->flags |= D3D10_ST_FLAG_INIT_HISTORY | D3D10_ST_FLAG_RESIZE_RTS;
+
+   deferred->state = SHADER_LOAD_DONE;
+   RARCH_LOG("[D3D10] Deferred: shader loaded successfully.\n");
+
+   free(ds);
+   deferred->driver_data = NULL;
+   return false;
+#else
+   deferred->state = SHADER_LOAD_FAILED;
+   return false;
+#endif
+}
+
 static bool d3d10_gfx_set_shader(void* data,
       enum rarch_shader_type type, const char* path)
 {
@@ -3418,8 +3778,8 @@ video_driver_t video_d3d10 = {
 #endif
    d3d10_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
-   NULL, /* shader_load_begin */
-   NULL, /* shader_load_step */
+   d3d10_shader_load_begin,
+   d3d10_shader_load_step,
 #if defined(HAVE_GFX_WIDGETS)
    d3d10_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d10.c
+++ b/gfx/drivers/d3d10.c
@@ -3418,6 +3418,8 @@ video_driver_t video_d3d10 = {
 #endif
    d3d10_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #if defined(HAVE_GFX_WIDGETS)
    d3d10_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -4899,6 +4899,8 @@ video_driver_t video_d3d11 = {
 #endif
    d3d11_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #if defined(HAVE_GFX_WIDGETS)
    d3d11_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d11.c
+++ b/gfx/drivers/d3d11.c
@@ -1986,6 +1986,464 @@ static void d3d11_free_shader_preset(d3d11_video_t* d3d11)
                                    );
 }
 
+/* ---- Deferred (per-frame) shader loading for D3D11 ---- */
+
+typedef struct d3d11_deferred_pass
+{
+   d3d11_shader_t    shader;
+   pass_semantics_t  semantics;
+   D3D11Buffer       buffers[SLANG_CBUFFER_MAX];
+} d3d11_deferred_pass_t;
+
+typedef struct d3d11_deferred_state
+{
+   struct video_shader      *shader_preset;
+   d3d11_deferred_pass_t     passes[GFX_MAX_SHADERS];
+   d3d11_texture_t           luts[GFX_MAX_TEXTURES];
+   bool                      luts_loaded;
+   unsigned                  shader_model;
+   enum d3d11_feature_level_hint feat_level_hint;
+} d3d11_deferred_state_t;
+
+static bool d3d11_shader_load_begin(void *data,
+      shader_load_deferred_t *deferred)
+{
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   d3d11_video_t *d3d11 = (d3d11_video_t*)data;
+   d3d11_deferred_state_t *ds;
+
+   if (!d3d11)
+      return false;
+
+   if (deferred->type != RARCH_SHADER_SLANG)
+      return false;
+
+   ds = (d3d11_deferred_state_t*)calloc(1, sizeof(*ds));
+   if (!ds)
+      return false;
+
+   ds->shader_preset = (struct video_shader*)calloc(
+         1, sizeof(*ds->shader_preset));
+   if (!ds->shader_preset)
+   {
+      free(ds);
+      return false;
+   }
+
+   if (!video_shader_load_preset_into_shader(
+            deferred->preset_path, ds->shader_preset))
+   {
+      free(ds->shader_preset);
+      free(ds);
+      return false;
+   }
+
+   /* Determine shader model from feature level */
+   ds->shader_model    = 40;
+   ds->feat_level_hint = D3D11_FEATURE_LEVEL_HINT_DONTCARE;
+
+   switch (d3d11->supportedFeatureLevel)
+   {
+      case D3D_FEATURE_LEVEL_11_0:
+         ds->shader_model    = 50;
+         ds->feat_level_hint = D3D11_FEATURE_LEVEL_HINT_11_0;
+         break;
+      case D3D_FEATURE_LEVEL_11_1:
+         ds->shader_model    = 50;
+         ds->feat_level_hint = D3D11_FEATURE_LEVEL_HINT_11_1;
+         break;
+      case D3D_FEATURE_LEVEL_12_0:
+         ds->shader_model    = 50;
+         ds->feat_level_hint = D3D11_FEATURE_LEVEL_HINT_12_0;
+         break;
+      case D3D_FEATURE_LEVEL_12_1:
+         ds->shader_model    = 50;
+         ds->feat_level_hint = D3D11_FEATURE_LEVEL_HINT_12_1;
+         break;
+      default:
+         break;
+   }
+
+   deferred->total_passes = ds->shader_preset->passes;
+
+   /* Load LUTs synchronously */
+   {
+      unsigned i;
+      for (i = 0; i < ds->shader_preset->luts; i++)
+      {
+         struct texture_image image;
+         image.pixels        = NULL;
+         image.width         = 0;
+         image.height        = 0;
+         image.supports_rgba = true;
+
+         if (!image_texture_load(&image,
+                  ds->shader_preset->lut[i].path))
+         {
+            RARCH_ERR("[D3D11] Deferred: failed to load LUT: \"%s\".\n",
+                  ds->shader_preset->lut[i].path);
+            goto error;
+         }
+
+         ds->luts[i].desc.Width  = image.width;
+         ds->luts[i].desc.Height = image.height;
+         ds->luts[i].desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+         if (ds->shader_preset->lut[i].mipmap)
+            ds->luts[i].desc.MiscFlags = D3D11_RESOURCE_MISC_GENERATE_MIPS;
+
+         d3d11_init_texture(d3d11->device, &ds->luts[i]);
+
+         if (ds->luts[i].staging)
+            d3d11_update_texture(
+                  d3d11->context,
+                  image.width, image.height, 0,
+                  DXGI_FORMAT_R8G8B8A8_UNORM, image.pixels,
+                  &ds->luts[i]);
+
+         image_texture_free(&image);
+      }
+      ds->luts_loaded = true;
+   }
+
+   RARCH_LOG("[D3D11] Deferred: prepared %u passes for \"%s\".\n",
+         deferred->total_passes, deferred->preset_path);
+
+   deferred->driver_data = ds;
+   return true;
+
+error:
+   {
+      unsigned j;
+      for (j = 0; j < ds->shader_preset->luts; j++)
+         d3d11_release_texture(&ds->luts[j]);
+   }
+   free(ds->shader_preset);
+   free(ds);
+   return false;
+#else
+   return false;
+#endif
+}
+
+static void d3d11_deferred_state_free(
+      d3d11_deferred_state_t *ds,
+      unsigned passes_built)
+{
+   unsigned i;
+
+   if (!ds)
+      return;
+
+   for (i = 0; i < passes_built; i++)
+   {
+      unsigned j;
+      d3d11_release_shader(&ds->passes[i].shader);
+      free(ds->passes[i].semantics.textures);
+      ds->passes[i].semantics.textures = NULL;
+      for (j = 0; j < SLANG_CBUFFER_MAX; j++)
+      {
+         free(ds->passes[i].semantics.cbuffers[j].uniforms);
+         ds->passes[i].semantics.cbuffers[j].uniforms = NULL;
+         Release(ds->passes[i].buffers[j]);
+      }
+   }
+
+   if (ds->luts_loaded && ds->shader_preset)
+   {
+      for (i = 0; i < ds->shader_preset->luts; i++)
+         d3d11_release_texture(&ds->luts[i]);
+   }
+
+   if (ds->shader_preset)
+   {
+      for (i = 0; i < ds->shader_preset->passes; i++)
+      {
+         free(ds->shader_preset->pass[i].source.string.vertex);
+         free(ds->shader_preset->pass[i].source.string.fragment);
+      }
+      free(ds->shader_preset);
+   }
+
+   free(ds);
+}
+
+static bool d3d11_shader_load_step(void *data,
+      shader_load_deferred_t *deferred)
+{
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   d3d11_video_t *d3d11          = (d3d11_video_t*)data;
+   d3d11_deferred_state_t *ds    =
+      (d3d11_deferred_state_t*)deferred->driver_data;
+   unsigned pass                 = deferred->current_pass;
+
+   if (!d3d11 || !ds)
+   {
+      deferred->state = SHADER_LOAD_FAILED;
+      return false;
+   }
+
+   if (pass < deferred->total_passes)
+   {
+      d3d11_texture_t *source;
+      unsigned i = pass;
+
+      RARCH_LOG("[D3D11] Deferred: compiling pass %u/%u...\n",
+            pass + 1, deferred->total_passes);
+
+      source = (i == 0)
+         ? &d3d11->frame.texture[0]
+         : &d3d11->pass[i - 1].rt;
+
+      {
+         unsigned j;
+         semantics_map_t semantics_map = {
+            {
+               { &d3d11->frame.texture[0].view, 0,
+                  &d3d11->frame.texture[0].size_data, 0 },
+               { &source->view, 0,
+                  &source->size_data, 0 },
+               { &d3d11->frame.texture[0].view,
+                  sizeof(*d3d11->frame.texture),
+                  &d3d11->frame.texture[0].size_data,
+                  sizeof(*d3d11->frame.texture) },
+               { &d3d11->pass[0].rt.view, sizeof(*d3d11->pass),
+                  &d3d11->pass[0].rt.size_data,
+                  sizeof(*d3d11->pass) },
+               { &d3d11->pass[0].feedback.view, sizeof(*d3d11->pass),
+                  &d3d11->pass[0].feedback.size_data,
+                  sizeof(*d3d11->pass) },
+               /* Point at d3d11->luts, not ds->luts — stored
+                * texture_data pointers must remain valid after
+                * ds is freed */
+               { &d3d11->luts[0].view, sizeof(*d3d11->luts),
+                  &d3d11->luts[0].size_data, sizeof(*d3d11->luts) },
+            },
+            {
+               i == ds->shader_preset->passes - 1
+                  ? &d3d11->mvp : &d3d11->identity,
+               &d3d11->pass[i].rt.size_data,
+               &d3d11->frame.output_size,
+               &d3d11->pass[i].frame_count,
+               &d3d11->pass[i].frame_direction,
+               &d3d11->pass[i].frame_time_delta,
+               &d3d11->pass[i].original_fps,
+               &d3d11->pass[i].rotation,
+               &d3d11->pass[i].core_aspect,
+               &d3d11->pass[i].core_aspect_rot,
+               &d3d11->pass[i].total_subframes,
+               &d3d11->pass[i].current_subframe,
+#ifdef HAVE_DXGI_HDR
+               &d3d11->pass[i].hdr_mode,
+               &d3d11->pass[i].paper_white_nits,
+               &d3d11->pass[i].scanlines,
+               &d3d11->pass[i].subpixel_layout,
+               &d3d11->pass[i].expand_gamut,
+               &d3d11->pass[i].inverse_tonemap,
+               &d3d11->pass[i].hdr10
+#endif
+            }
+         };
+
+         if (!slang_process(
+                  ds->shader_preset, i, RARCH_SHADER_HLSL,
+                  ds->shader_model, &semantics_map,
+                  &ds->passes[i].semantics))
+         {
+            RARCH_ERR("[D3D11] Deferred: failed to process pass %u.\n", i);
+            d3d11_deferred_state_free(ds, pass);
+            deferred->state       = SHADER_LOAD_FAILED;
+            deferred->driver_data = NULL;
+            return false;
+         }
+
+         /* Compile HLSL and create shader objects */
+         {
+            static const D3D11_INPUT_ELEMENT_DESC desc[] = {
+               { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0,
+                  offsetof(d3d11_vertex_t, position),
+                  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+               { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0,
+                  offsetof(d3d11_vertex_t, texcoord),
+                  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+            };
+            char _path[PATH_MAX_LENGTH];
+            const char *slang_path =
+               ds->shader_preset->pass[i].source.path;
+            const char *vs_src =
+               ds->shader_preset->pass[i].source.string.vertex;
+            const char *ps_src =
+               ds->shader_preset->pass[i].source.string.fragment;
+            size_t _len = strlcpy(_path, slang_path, sizeof(_path));
+
+            strlcpy(_path + _len, ".vs.hlsl", sizeof(_path) - _len);
+            d3d11_init_shader(d3d11->device, vs_src, 0,
+                  _path, "main", NULL, NULL, desc, countof(desc),
+                  &ds->passes[i].shader, ds->feat_level_hint);
+
+            strlcpy(_path + _len, ".ps.hlsl", sizeof(_path) - _len);
+            d3d11_init_shader(d3d11->device, ps_src, 0, _path,
+                  NULL, "main", NULL, NULL, 0,
+                  &ds->passes[i].shader, ds->feat_level_hint);
+
+            free(ds->shader_preset->pass[i].source.string.vertex);
+            free(ds->shader_preset->pass[i].source.string.fragment);
+            ds->shader_preset->pass[i].source.string.vertex   = NULL;
+            ds->shader_preset->pass[i].source.string.fragment = NULL;
+
+            if (!ds->passes[i].shader.vs || !ds->passes[i].shader.ps)
+            {
+               RARCH_ERR("[D3D11] Deferred: failed to compile shader"
+                     " for pass %u.\n", i);
+               d3d11_deferred_state_free(ds, pass + 1);
+               deferred->state       = SHADER_LOAD_FAILED;
+               deferred->driver_data = NULL;
+               return false;
+            }
+         }
+
+         /* Create cbuffers */
+         for (j = 0; j < SLANG_CBUFFER_MAX; j++)
+         {
+            D3D11_BUFFER_DESC buf_desc;
+            buf_desc.ByteWidth           =
+               ds->passes[i].semantics.cbuffers[j].size;
+            buf_desc.Usage               = D3D11_USAGE_DYNAMIC;
+            buf_desc.BindFlags           = D3D11_BIND_CONSTANT_BUFFER;
+            buf_desc.CPUAccessFlags      = D3D11_CPU_ACCESS_WRITE;
+            buf_desc.MiscFlags           = 0;
+            buf_desc.StructureByteStride = 0;
+
+            if (!buf_desc.ByteWidth)
+               continue;
+
+            d3d11->device->lpVtbl->CreateBuffer(
+                  d3d11->device, &buf_desc, NULL,
+                  &ds->passes[i].buffers[j]);
+         }
+      }
+
+      deferred->current_pass++;
+      return true;
+   }
+
+   /* Cancellation check */
+   if (deferred->state != SHADER_LOAD_COMPILING)
+   {
+      RARCH_LOG("[D3D11] Deferred: cancelled, cleaning up.\n");
+      d3d11_deferred_state_free(ds, pass);
+      deferred->state       = SHADER_LOAD_FAILED;
+      deferred->driver_data = NULL;
+      return false;
+   }
+
+   /* All passes compiled — install */
+   RARCH_LOG("[D3D11] Deferred: finalizing...\n");
+
+   d3d11->context->lpVtbl->Flush(d3d11->context);
+   d3d11_free_shader_preset(d3d11);
+
+   /* Install preset */
+   d3d11->shader_preset = ds->shader_preset;
+   ds->shader_preset    = NULL;
+
+   /* Install LUTs */
+   memcpy(d3d11->luts, ds->luts, sizeof(ds->luts));
+   memset(ds->luts, 0, sizeof(ds->luts));
+   ds->luts_loaded = false;
+
+   /* Install per-pass state */
+   {
+      unsigned i;
+      for (i = 0; i < deferred->total_passes; i++)
+      {
+         d3d11->pass[i].shader = ds->passes[i].shader;
+         memset(&ds->passes[i].shader, 0,
+               sizeof(ds->passes[i].shader));
+
+         d3d11->pass[i].semantics = ds->passes[i].semantics;
+         memset(&ds->passes[i].semantics, 0,
+               sizeof(ds->passes[i].semantics));
+
+         memcpy(d3d11->pass[i].buffers,
+               ds->passes[i].buffers,
+               sizeof(ds->passes[i].buffers));
+         memset(ds->passes[i].buffers, 0,
+               sizeof(ds->passes[i].buffers));
+      }
+   }
+
+#ifdef HAVE_DXGI_HDR
+   if (d3d11->flags & D3D11_ST_FLAG_HDR_ENABLE)
+   {
+      settings_t *settings        = config_get_ptr();
+      unsigned menu_hdr_mode      = settings->uints.video_hdr_mode;
+      enum glslang_format last_fmt =
+         (d3d11->shader_preset && d3d11->shader_preset->passes)
+         ? d3d11->pass[d3d11->shader_preset->passes - 1].semantics.format
+         : SLANG_FORMAT_UNKNOWN;
+
+      if (menu_hdr_mode == 2)
+      {
+         d3d11_set_hdr_inverse_tonemap(d3d11, false);
+         d3d11_set_hdr10(d3d11, false);
+
+         if (last_fmt == SLANG_FORMAT_R16G16B16A16_SFLOAT)
+            d3d11->hdr.ubo_values.hdr_mode = 0;
+         else if (last_fmt == SLANG_FORMAT_A2B10G10R10_UNORM_PACK32)
+            d3d11->hdr.ubo_values.hdr_mode = 3;
+         else
+         {
+            d3d11->hdr.ubo_values.hdr_mode = 2;
+            if (last_fmt == SLANG_FORMAT_R8G8B8A8_UNORM)
+            {
+               d3d11_set_hdr_scanlines(d3d11, false);
+               settings->bools.video_hdr_scanlines = false;
+            }
+         }
+         d3d11->flags |= D3D11_ST_FLAG_RESIZE_CHAIN;
+      }
+      else
+      {
+         if (last_fmt == SLANG_FORMAT_A2B10G10R10_UNORM_PACK32
+               || last_fmt == SLANG_FORMAT_R16G16B16A16_SFLOAT)
+         {
+            d3d11_set_hdr_inverse_tonemap(d3d11, false);
+            d3d11_set_hdr10(d3d11, false);
+            d3d11->flags |= D3D11_ST_FLAG_RESIZE_CHAIN;
+         }
+         else if (last_fmt == SLANG_FORMAT_R8G8B8A8_UNORM)
+         {
+            d3d11_set_hdr_inverse_tonemap(d3d11, true);
+            d3d11_set_hdr10(d3d11, true);
+            d3d11_set_hdr_scanlines(d3d11, false);
+            settings->bools.video_hdr_scanlines = false;
+            d3d11->flags |= D3D11_ST_FLAG_RESIZE_CHAIN;
+         }
+         else
+         {
+            d3d11_set_hdr_inverse_tonemap(d3d11, true);
+            d3d11_set_hdr10(d3d11, true);
+         }
+         d3d11->hdr.ubo_values.hdr_mode = 0;
+      }
+   }
+#endif
+
+   d3d11->flags |= D3D11_ST_FLAG_INIT_HISTORY | D3D11_ST_FLAG_RESIZE_RTS;
+
+   deferred->state = SHADER_LOAD_DONE;
+   RARCH_LOG("[D3D11] Deferred: shader loaded successfully.\n");
+
+   free(ds);
+   deferred->driver_data = NULL;
+   return false;
+#else
+   deferred->state = SHADER_LOAD_FAILED;
+   return false;
+#endif
+}
+
 static bool d3d11_gfx_set_shader(void* data, enum rarch_shader_type type, const char* path)
 {
 #if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
@@ -4899,8 +5357,8 @@ video_driver_t video_d3d11 = {
 #endif
    d3d11_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
-   NULL, /* shader_load_begin */
-   NULL, /* shader_load_step */
+   d3d11_shader_load_begin,
+   d3d11_shader_load_step,
 #if defined(HAVE_GFX_WIDGETS)
    d3d11_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -5801,6 +5801,8 @@ video_driver_t video_d3d12 = {
 #endif
    d3d12_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    d3d12_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -2292,6 +2292,477 @@ static void d3d12_init_pipeline(
    device->lpVtbl->CreateGraphicsPipelineState(device, desc, uuidof(ID3D12PipelineState), (void**)out);
 }
 
+/* ---- Deferred (per-frame) shader loading for D3D12 ---- */
+
+typedef struct d3d12_deferred_pass
+{
+   D3D12PipelineState     pipe;
+   pass_semantics_t       semantics;
+   D3D12Resource          buffers[SLANG_CBUFFER_MAX];
+   D3D12_CONSTANT_BUFFER_VIEW_DESC buffer_view[SLANG_CBUFFER_MAX];
+} d3d12_deferred_pass_t;
+
+typedef struct d3d12_deferred_state
+{
+   struct video_shader   *shader_preset;
+   d3d12_deferred_pass_t  passes[GFX_MAX_SHADERS];
+   d3d12_texture_t        luts[GFX_MAX_TEXTURES];
+   bool                   luts_loaded;
+} d3d12_deferred_state_t;
+
+static bool d3d12_shader_load_begin(void *data,
+      shader_load_deferred_t *deferred)
+{
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   d3d12_video_t *d3d12 = (d3d12_video_t*)data;
+   d3d12_deferred_state_t *ds;
+
+   if (!d3d12)
+      return false;
+
+   if (deferred->type != RARCH_SHADER_SLANG)
+      return false;
+
+   ds = (d3d12_deferred_state_t*)calloc(1, sizeof(*ds));
+   if (!ds)
+      return false;
+
+   ds->shader_preset = (struct video_shader*)calloc(
+         1, sizeof(*ds->shader_preset));
+   if (!ds->shader_preset)
+   {
+      free(ds);
+      return false;
+   }
+
+   if (!video_shader_load_preset_into_shader(
+            deferred->preset_path, ds->shader_preset))
+   {
+      free(ds->shader_preset);
+      free(ds);
+      return false;
+   }
+
+   deferred->total_passes = ds->shader_preset->passes;
+
+   /* Load LUTs synchronously (same as before) */
+   {
+      unsigned i;
+      for (i = 0; i < ds->shader_preset->luts; i++)
+      {
+         struct texture_image image;
+         image.pixels        = NULL;
+         image.width         = 0;
+         image.height        = 0;
+         image.supports_rgba = true;
+
+         if (!image_texture_load(&image,
+                  ds->shader_preset->lut[i].path))
+         {
+            RARCH_ERR("[D3D12] Deferred: failed to load LUT: \"%s\".\n",
+                  ds->shader_preset->lut[i].path);
+            goto error;
+         }
+
+         ds->luts[i].desc.Width  = image.width;
+         ds->luts[i].desc.Height = image.height;
+         ds->luts[i].desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+         ds->luts[i].srv_heap    = &d3d12->desc.srv_heap;
+
+         if (ds->shader_preset->lut[i].mipmap)
+            ds->luts[i].desc.MipLevels = UINT16_MAX;
+
+         d3d12_init_texture(d3d12->device, &ds->luts[i]);
+
+         if (ds->luts[i].upload_buffer)
+            d3d12_update_texture(
+                  image.width, image.height, 0,
+                  DXGI_FORMAT_R8G8B8A8_UNORM, image.pixels,
+                  &ds->luts[i]);
+
+         image_texture_free(&image);
+      }
+      ds->luts_loaded = true;
+   }
+
+   RARCH_LOG("[D3D12] Deferred: prepared %u passes for \"%s\".\n",
+         deferred->total_passes, deferred->preset_path);
+
+   deferred->driver_data = ds;
+   return true;
+
+error:
+   {
+      unsigned j;
+      for (j = 0; j < ds->shader_preset->luts; j++)
+         d3d12_release_texture(&ds->luts[j]);
+   }
+   free(ds->shader_preset);
+   free(ds);
+   return false;
+#else
+   return false;
+#endif
+}
+
+static void d3d12_deferred_state_free(
+      d3d12_video_t *d3d12,
+      d3d12_deferred_state_t *ds,
+      unsigned passes_built)
+{
+   unsigned i;
+
+   if (!ds)
+      return;
+
+   for (i = 0; i < passes_built; i++)
+   {
+      unsigned j;
+      Release(ds->passes[i].pipe);
+      free(ds->passes[i].semantics.textures);
+      ds->passes[i].semantics.textures = NULL;
+      for (j = 0; j < SLANG_CBUFFER_MAX; j++)
+      {
+         free(ds->passes[i].semantics.cbuffers[j].uniforms);
+         ds->passes[i].semantics.cbuffers[j].uniforms = NULL;
+         Release(ds->passes[i].buffers[j]);
+      }
+   }
+
+   if (ds->luts_loaded && ds->shader_preset)
+   {
+      for (i = 0; i < ds->shader_preset->luts; i++)
+         d3d12_release_texture(&ds->luts[i]);
+   }
+
+   if (ds->shader_preset)
+   {
+      for (i = 0; i < ds->shader_preset->passes; i++)
+      {
+         free(ds->shader_preset->pass[i].source.string.vertex);
+         free(ds->shader_preset->pass[i].source.string.fragment);
+      }
+      free(ds->shader_preset);
+   }
+
+   free(ds);
+}
+
+static bool d3d12_shader_load_step(void *data,
+      shader_load_deferred_t *deferred)
+{
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+   d3d12_video_t *d3d12          = (d3d12_video_t*)data;
+   d3d12_deferred_state_t *ds    =
+      (d3d12_deferred_state_t*)deferred->driver_data;
+   unsigned pass                 = deferred->current_pass;
+
+   if (!d3d12 || !ds)
+   {
+      deferred->state = SHADER_LOAD_FAILED;
+      return false;
+   }
+
+   if (pass < deferred->total_passes)
+   {
+      d3d12_texture_t *source;
+      unsigned i = pass;
+
+      RARCH_LOG("[D3D12] Deferred: compiling pass %u/%u...\n",
+            pass + 1, deferred->total_passes);
+
+      /* Build semantics map pointing at real d3d12->pass[].rt
+       * and d3d12->frame.texture[] — the pointers are stored
+       * but only dereferenced at render time after completion. */
+      source = (i == 0)
+         ? &d3d12->frame.texture[0]
+         : &d3d12->pass[i - 1].rt;
+
+      {
+         unsigned j;
+         semantics_map_t semantics_map = {
+            {
+               { &d3d12->frame.texture[0], 0,
+                  &d3d12->frame.texture[0].size_data, 0 },
+               { source, 0,
+                  &source->size_data, 0 },
+               { &d3d12->frame.texture[0],
+                  sizeof(*d3d12->frame.texture),
+                  &d3d12->frame.texture[0].size_data,
+                  sizeof(*d3d12->frame.texture) },
+               { &d3d12->pass[0].rt, sizeof(*d3d12->pass),
+                  &d3d12->pass[0].rt.size_data,
+                  sizeof(*d3d12->pass) },
+               { &d3d12->pass[0].feedback, sizeof(*d3d12->pass),
+                  &d3d12->pass[0].feedback.size_data,
+                  sizeof(*d3d12->pass) },
+               /* Point at d3d12->luts, not ds->luts — the stored
+                * texture_data pointers must remain valid after ds
+                * is freed. LUT contents are memcpy'd here on
+                * completion. */
+               { &d3d12->luts[0], sizeof(*d3d12->luts),
+                  &d3d12->luts[0].size_data, sizeof(*d3d12->luts) },
+            },
+            {
+               i == ds->shader_preset->passes - 1
+                  ? &d3d12->mvp : &d3d12->identity,
+               &d3d12->pass[i].rt.size_data,
+               &d3d12->frame.output_size,
+               &d3d12->pass[i].frame_count,
+               &d3d12->pass[i].frame_direction,
+               &d3d12->pass[i].frame_time_delta,
+               &d3d12->pass[i].original_fps,
+               &d3d12->pass[i].rotation,
+               &d3d12->pass[i].core_aspect,
+               &d3d12->pass[i].core_aspect_rot,
+               &d3d12->pass[i].total_subframes,
+               &d3d12->pass[i].current_subframe,
+#ifdef HAVE_DXGI_HDR
+               &d3d12->pass[i].hdr_mode,
+               &d3d12->pass[i].paper_white_nits,
+               &d3d12->pass[i].scanlines,
+               &d3d12->pass[i].subpixel_layout,
+               &d3d12->pass[i].expand_gamut,
+               &d3d12->pass[i].inverse_tonemap,
+               &d3d12->pass[i].hdr10
+#endif
+            }
+         };
+
+         if (!slang_process(
+                  ds->shader_preset, i, RARCH_SHADER_HLSL, 50,
+                  &semantics_map, &ds->passes[i].semantics))
+         {
+            RARCH_ERR("[D3D12] Deferred: failed to process pass %u.\n", i);
+            d3d12_deferred_state_free(d3d12, ds, pass);
+            deferred->state      = SHADER_LOAD_FAILED;
+            deferred->driver_data = NULL;
+            return false;
+         }
+
+         /* Compile HLSL and create PSO */
+         {
+            D3DBlob vs_code = NULL;
+            D3DBlob ps_code = NULL;
+            D3D12_GRAPHICS_PIPELINE_STATE_DESC desc =
+               { d3d12->desc.sl_rootSignature };
+            static const D3D12_INPUT_ELEMENT_DESC inputElementDesc[] = {
+               { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0,
+                  offsetof(d3d12_vertex_t, position),
+                  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+               { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0,
+                  offsetof(d3d12_vertex_t, texcoord),
+                  D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
+            };
+            char _path[PATH_MAX_LENGTH];
+            const char *slang_path =
+               ds->shader_preset->pass[i].source.path;
+            const char *vs_src =
+               ds->shader_preset->pass[i].source.string.vertex;
+            const char *ps_src =
+               ds->shader_preset->pass[i].source.string.fragment;
+            size_t _len = strlcpy(_path, slang_path, sizeof(_path));
+
+            strlcpy(_path + _len, ".vs.hlsl", sizeof(_path) - _len);
+            d3d_compile(vs_src, 0, _path, "main", "vs_5_0", &vs_code);
+
+            strlcpy(_path + _len, ".ps.hlsl", sizeof(_path) - _len);
+            d3d_compile(ps_src, 0, _path, "main", "ps_5_0", &ps_code);
+
+            desc.BlendState.RenderTarget[0].RenderTargetWriteMask =
+               D3D12_COLOR_WRITE_ENABLE_ALL;
+            desc.RTVFormats[0] = glslang_format_to_dxgi(
+                  ds->passes[i].semantics.format);
+            desc.PrimitiveTopologyType =
+               D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+            desc.InputLayout.pInputElementDescs = inputElementDesc;
+            desc.InputLayout.NumElements = countof(inputElementDesc);
+
+            d3d12_init_pipeline(d3d12->device,
+                  vs_code, ps_code, NULL, &desc,
+                  &ds->passes[i].pipe);
+
+            free(ds->shader_preset->pass[i].source.string.vertex);
+            free(ds->shader_preset->pass[i].source.string.fragment);
+            ds->shader_preset->pass[i].source.string.vertex   = NULL;
+            ds->shader_preset->pass[i].source.string.fragment = NULL;
+
+            Release(vs_code);
+            Release(ps_code);
+
+            if (!ds->passes[i].pipe)
+            {
+               RARCH_ERR("[D3D12] Deferred: failed to create pipeline"
+                     " for pass %u.\n", i);
+               d3d12_deferred_state_free(d3d12, ds, pass + 1);
+               deferred->state       = SHADER_LOAD_FAILED;
+               deferred->driver_data = NULL;
+               return false;
+            }
+         }
+
+         /* Create cbuffers */
+         for (j = 0; j < SLANG_CBUFFER_MAX; j++)
+         {
+            if (!ds->passes[i].semantics.cbuffers[j].size)
+               continue;
+            ds->passes[i].buffer_view[j].SizeInBytes =
+               ds->passes[i].semantics.cbuffers[j].size;
+            ds->passes[i].buffer_view[j].BufferLocation =
+               d3d12_create_buffer(d3d12->device,
+                     ds->passes[i].buffer_view[j].SizeInBytes,
+                     &ds->passes[i].buffers[j]);
+         }
+      }
+
+      deferred->current_pass++;
+      return true;
+   }
+
+   /* Cancellation check */
+   if (deferred->state != SHADER_LOAD_COMPILING)
+   {
+      RARCH_LOG("[D3D12] Deferred: cancelled, cleaning up.\n");
+      d3d12_deferred_state_free(d3d12, ds, pass);
+      deferred->state       = SHADER_LOAD_FAILED;
+      deferred->driver_data = NULL;
+      return false;
+   }
+
+   /* All passes compiled — install */
+   RARCH_LOG("[D3D12] Deferred: finalizing...\n");
+
+   D3D12_GFX_SYNC();
+   d3d12_free_shader_preset(d3d12);
+
+   /* Install preset */
+   d3d12->shader_preset = ds->shader_preset;
+   ds->shader_preset    = NULL; /* ownership transferred */
+
+   /* Install LUTs */
+   memcpy(d3d12->luts, ds->luts, sizeof(ds->luts));
+   memset(ds->luts, 0, sizeof(ds->luts));
+   ds->luts_loaded = false;
+
+   /* Install per-pass state */
+   {
+      unsigned i;
+      for (i = 0; i < deferred->total_passes; i++)
+      {
+         d3d12->pass[i].pipe = ds->passes[i].pipe;
+         ds->passes[i].pipe  = NULL; /* ownership transferred */
+
+         d3d12->pass[i].semantics = ds->passes[i].semantics;
+         memset(&ds->passes[i].semantics, 0,
+               sizeof(ds->passes[i].semantics));
+
+         memcpy(d3d12->pass[i].buffers,
+               ds->passes[i].buffers,
+               sizeof(ds->passes[i].buffers));
+         memset(ds->passes[i].buffers, 0,
+               sizeof(ds->passes[i].buffers));
+
+         memcpy(d3d12->pass[i].buffer_view,
+               ds->passes[i].buffer_view,
+               sizeof(ds->passes[i].buffer_view));
+
+         /* Set up descriptor heap pointers */
+#ifdef HAVE_DXGI_HDR
+         d3d12->pass[i].rt.rt_view.ptr =
+            d3d12->desc.rtv_heap.cpu.ptr +
+            (countof(d3d12->chain.renderTargets) + 1 + (2 * i))
+            * d3d12->desc.rtv_heap.stride;
+#else
+         d3d12->pass[i].rt.rt_view.ptr =
+            d3d12->desc.rtv_heap.cpu.ptr +
+            (countof(d3d12->chain.renderTargets) + (2 * i))
+            * d3d12->desc.rtv_heap.stride;
+#endif
+         d3d12->pass[i].feedback.rt_view.ptr =
+            d3d12->pass[i].rt.rt_view.ptr +
+            d3d12->desc.rtv_heap.stride;
+
+         d3d12->pass[i].textures.ptr =
+            d3d12->desc.srv_heap.gpu.ptr +
+            i * SLANG_NUM_SEMANTICS * d3d12->desc.srv_heap.stride;
+         d3d12->pass[i].samplers.ptr =
+            d3d12->desc.sampler_heap.gpu.ptr +
+            i * SLANG_NUM_SEMANTICS *
+            d3d12->desc.sampler_heap.stride;
+      }
+   }
+
+#ifdef HAVE_DXGI_HDR
+   if (d3d12->flags & D3D12_ST_FLAG_HDR_ENABLE)
+   {
+      settings_t *settings        = config_get_ptr();
+      unsigned menu_hdr_mode      = settings->uints.video_hdr_mode;
+      enum glslang_format last_fmt =
+         (d3d12->shader_preset && d3d12->shader_preset->passes)
+         ? d3d12->pass[d3d12->shader_preset->passes - 1].semantics.format
+         : SLANG_FORMAT_UNKNOWN;
+
+      if (menu_hdr_mode == 2)
+      {
+         d3d12_set_hdr_inverse_tonemap(d3d12, false);
+         d3d12_set_hdr10(d3d12, false);
+
+         if (last_fmt == SLANG_FORMAT_R16G16B16A16_SFLOAT)
+            d3d12->hdr.ubo_values.hdr_mode = 0;
+         else if (last_fmt == SLANG_FORMAT_A2B10G10R10_UNORM_PACK32)
+            d3d12->hdr.ubo_values.hdr_mode = 3;
+         else
+         {
+            d3d12->hdr.ubo_values.hdr_mode = 2;
+            if (last_fmt == SLANG_FORMAT_R8G8B8A8_UNORM)
+            {
+               d3d12_set_hdr_scanlines(d3d12, false);
+               settings->bools.video_hdr_scanlines = false;
+            }
+         }
+         d3d12->flags |= D3D12_ST_FLAG_RESIZE_CHAIN;
+      }
+      else
+      {
+         if (last_fmt == SLANG_FORMAT_A2B10G10R10_UNORM_PACK32
+               || last_fmt == SLANG_FORMAT_R16G16B16A16_SFLOAT)
+         {
+            d3d12_set_hdr_inverse_tonemap(d3d12, false);
+            d3d12_set_hdr10(d3d12, false);
+            d3d12->flags |= D3D12_ST_FLAG_RESIZE_CHAIN;
+         }
+         else if (last_fmt == SLANG_FORMAT_R8G8B8A8_UNORM)
+         {
+            d3d12_set_hdr_inverse_tonemap(d3d12, true);
+            d3d12_set_hdr10(d3d12, true);
+            d3d12_set_hdr_scanlines(d3d12, false);
+            settings->bools.video_hdr_scanlines = false;
+            d3d12->flags |= D3D12_ST_FLAG_RESIZE_CHAIN;
+         }
+         else
+         {
+            d3d12_set_hdr_inverse_tonemap(d3d12, true);
+            d3d12_set_hdr10(d3d12, true);
+         }
+         d3d12->hdr.ubo_values.hdr_mode = 0;
+      }
+   }
+#endif
+
+   d3d12->flags |= D3D12_ST_FLAG_INIT_HISTORY | D3D12_ST_FLAG_RESIZE_RTS;
+
+   deferred->state = SHADER_LOAD_DONE;
+   RARCH_LOG("[D3D12] Deferred: shader loaded successfully.\n");
+
+   free(ds);
+   deferred->driver_data = NULL;
+   return false;
+#else
+   deferred->state = SHADER_LOAD_FAILED;
+   return false;
+#endif
+}
+
 static bool d3d12_gfx_set_shader(void* data, enum rarch_shader_type type, const char* path)
 {
 #if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
@@ -5801,8 +6272,8 @@ video_driver_t video_d3d12 = {
 #endif
    d3d12_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
-   NULL, /* shader_load_begin */
-   NULL, /* shader_load_step */
+   d3d12_shader_load_begin,
+   d3d12_shader_load_step,
 #ifdef HAVE_GFX_WIDGETS
    d3d12_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d12.c
+++ b/gfx/drivers/d3d12.c
@@ -1011,7 +1011,9 @@ static void d3d12_update_texture(
 
    read_range.Begin         = 0;
    read_range.End           = 0;
-   resource->lpVtbl->Map(resource, 0, &read_range, (void**)&dst);
+   if (FAILED(resource->lpVtbl->Map(resource, 0, &read_range, (void**)&dst))
+         || !dst)
+      return;
    dxgi_copy(width, height, format, pitch, data, texture->desc.Format,
          texture->layout.Footprint.RowPitch, dst + texture->layout.Offset);
    resource->lpVtbl->Unmap(resource, 0, NULL);
@@ -3511,6 +3513,13 @@ static void d3d12_gfx_free(void* data)
    Release(d3d12->sprites.pipe_font_hdr);
 #endif
 
+   /* Release swapchain render targets BEFORE destroying the command
+    * queue.  The debug layer checks resource lifetimes against the
+    * queue — releasing them after the queue triggers error #921
+    * (OBJECT_DELETED_WHILE_STILL_IN_USE). */
+   Release(d3d12->chain.renderTargets[0]);
+   Release(d3d12->chain.renderTargets[1]);
+
    Release(d3d12->queue.fence);
    Release(d3d12->queue.cmd);
    Release(d3d12->queue.allocator);
@@ -3518,9 +3527,6 @@ static void d3d12_gfx_free(void* data)
 
    if (d3d12->queue.fenceEvent)
       CloseHandle(d3d12->queue.fenceEvent);
-
-   Release(d3d12->chain.renderTargets[0]);
-   Release(d3d12->chain.renderTargets[1]);
 
 #if 0
    /* Releasing this will crash eventually (?!) */
@@ -4648,6 +4654,11 @@ static bool d3d12_gfx_frame(
             true);
 
    D3D12_GFX_SYNC();
+
+   /* If the device was removed (TDR / GPU hang), bail out early.
+    * Continuing would crash on the first Map or Draw call. */
+   if (FAILED(d3d12->device->lpVtbl->GetDeviceRemovedReason(d3d12->device)))
+      return false;
 
 #ifdef HAVE_DXGI_HDR
    d3d12_hdr_enable               = (d3d12->flags & D3D12_ST_FLAG_HDR_ENABLE) ? true : false;
@@ -6135,17 +6146,14 @@ static bool d3d12_get_current_software_framebuffer(
    if (!d3d12 || !fb)
       return false;
 
-   /* Ensure the frame texture is large enough for the requested size */
+   /* Ensure the frame texture is large enough for the requested size.
+    * If it doesn't match, return false so the core uses its own
+    * buffer this frame.  d3d12_gfx_frame will recreate the texture
+    * (after its D3D12_GFX_SYNC) and the core will get the SW
+    * framebuffer on the next call. */
    if (     d3d12->frame.texture[0].desc.Width  != fb->width
          || d3d12->frame.texture[0].desc.Height != fb->height)
-   {
-      d3d12->frame.texture[0].desc.Width  = fb->width;
-      d3d12->frame.texture[0].desc.Height = fb->height;
-      d3d12->frame.texture[0].desc.Format = d3d12->format;
-      d3d12->frame.texture[0].srv_heap    = &d3d12->desc.srv_heap;
-      d3d12_release_texture(&d3d12->frame.texture[0]);
-      d3d12_init_texture(d3d12->device, &d3d12->frame.texture[0]);
-   }
+      return false;
 
    if (!d3d12->frame.texture[0].upload_buffer)
       return false;

--- a/gfx/drivers/d3d8.c
+++ b/gfx/drivers/d3d8.c
@@ -2231,6 +2231,8 @@ video_driver_t video_d3d8 = {
 #endif
    d3d8_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/d3d9cg.c
+++ b/gfx/drivers/d3d9cg.c
@@ -4632,6 +4632,8 @@ video_driver_t video_d3d9_cg = {
 #endif
    d3d9_cg_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    d3d9_cg_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/d3d9hlsl.c
+++ b/gfx/drivers/d3d9hlsl.c
@@ -7968,6 +7968,8 @@ video_driver_t video_d3d9_hlsl = {
 #endif
    d3d9_hlsl_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    d3d9_hlsl_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/dispmanx_gfx.c
+++ b/gfx/drivers/dispmanx_gfx.c
@@ -644,6 +644,8 @@ video_driver_t video_dispmanx = {
 #endif
    dispmanx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/drm_gfx.c
+++ b/gfx/drivers/drm_gfx.c
@@ -992,6 +992,8 @@ video_driver_t video_drm = {
 #endif
    drm_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/exynos_gfx.c
+++ b/gfx/drivers/exynos_gfx.c
@@ -1512,6 +1512,8 @@ video_driver_t video_exynos = {
 #endif
    exynos_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/fpga_gfx.c
+++ b/gfx/drivers/fpga_gfx.c
@@ -412,6 +412,8 @@ video_driver_t video_fpga = {
 #endif
    fpga_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/gdi_gfx.c
+++ b/gfx/drivers/gdi_gfx.c
@@ -1037,6 +1037,8 @@ video_driver_t video_gdi = {
 #endif
    gdi_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -2485,6 +2485,8 @@ video_driver_t video_gl1 = {
 #endif
    gl1_get_poke_interface,
    gl1_wrap_type_to_enum,
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    gl1_widgets_enabled
 #endif

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -5515,6 +5515,8 @@ video_driver_t video_gl2 = {
 #endif
    gl2_get_poke_interface,
    gl2_wrap_type_to_enum,
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    gl2_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/gl3.c
+++ b/gfx/drivers/gl3.c
@@ -3341,6 +3341,144 @@ static bool gl3_suppress_screensaver(void *data, bool enable)
    return false;
 }
 
+#ifdef HAVE_SLANG
+/* ---- Deferred (per-frame) shader loading for GL Core ---- */
+
+typedef struct gl3_deferred_state
+{
+   gl3_filter_chain_t *new_chain;   /* chain being built          */
+   gl3_filter_chain_t *old_chain;   /* previous, kept as fallback */
+   enum glslang_filter_chain_filter filter;
+} gl3_deferred_state_t;
+
+static bool gl3_shader_load_begin(void *data,
+      shader_load_deferred_t *deferred)
+{
+   gl3_t *gl = (gl3_t *)data;
+   gl3_deferred_state_t *ds;
+
+   if (!gl)
+      return false;
+
+   ds = (gl3_deferred_state_t*)calloc(1, sizeof(*ds));
+   if (!ds)
+      return false;
+
+   if (gl->flags & GL3_FLAG_USE_SHARED_CONTEXT)
+      gl->ctx_driver->bind_hw_render(gl->ctx_data, false);
+
+   /* Keep old chain alive — it continues rendering
+    * while the new one is being compiled. */
+   ds->old_chain = gl->filter_chain;
+   ds->filter    = gl->video_info.smooth
+      ? GLSLANG_FILTER_CHAIN_LINEAR
+      : GLSLANG_FILTER_CHAIN_NEAREST;
+
+   ds->new_chain = gl3_filter_chain_create_deferred(
+         deferred->preset_path,
+         ds->filter,
+         &deferred->total_passes);
+
+   if (gl->flags & GL3_FLAG_USE_SHARED_CONTEXT)
+      gl->ctx_driver->bind_hw_render(gl->ctx_data, true);
+
+   if (!ds->new_chain)
+   {
+      RARCH_ERR("[GLCore] Deferred: failed to create chain for \"%s\".\n",
+            deferred->preset_path);
+      free(ds);
+      return false;
+   }
+
+   RARCH_LOG("[GLCore] Deferred: prepared %u passes for \"%s\".\n",
+         deferred->total_passes, deferred->preset_path);
+
+   deferred->driver_data = ds;
+   return true;
+}
+
+static bool gl3_shader_load_step(void *data,
+      shader_load_deferred_t *deferred)
+{
+   gl3_t *gl                = (gl3_t *)data;
+   gl3_deferred_state_t *ds = (gl3_deferred_state_t*)deferred->driver_data;
+   unsigned pass            = deferred->current_pass;
+
+   if (!gl || !ds)
+   {
+      deferred->state = SHADER_LOAD_FAILED;
+      return false;
+   }
+
+   if (gl->flags & GL3_FLAG_USE_SHARED_CONTEXT)
+      gl->ctx_driver->bind_hw_render(gl->ctx_data, false);
+
+   if (pass < deferred->total_passes)
+   {
+      RARCH_LOG("[GLCore] Deferred: compiling pass %u/%u...\n",
+            pass + 1, deferred->total_passes);
+
+      if (!gl3_filter_chain_compile_pass(ds->new_chain, pass, ds->filter))
+      {
+         RARCH_ERR("[GLCore] Deferred: failed to compile pass %u.\n", pass);
+         gl3_filter_chain_free(ds->new_chain);
+         /* Restore old chain */
+         gl->filter_chain = ds->old_chain;
+         deferred->state  = SHADER_LOAD_FAILED;
+         goto cleanup;
+      }
+
+      deferred->current_pass++;
+
+      if (gl->flags & GL3_FLAG_USE_SHARED_CONTEXT)
+         gl->ctx_driver->bind_hw_render(gl->ctx_data, true);
+
+      return true; /* more work remains */
+   }
+
+   /* Check if this is a cancellation (state was changed externally).
+    * Don't try to finalize a partially compiled chain — just clean up. */
+   if (deferred->state != SHADER_LOAD_COMPILING)
+   {
+      RARCH_LOG("[GLCore] Deferred: cancelled, cleaning up.\n");
+      gl3_filter_chain_free(ds->new_chain);
+      gl->filter_chain = ds->old_chain;
+      deferred->state  = SHADER_LOAD_FAILED;
+      goto cleanup;
+   }
+
+   /* All passes compiled — finalize the chain */
+   RARCH_LOG("[GLCore] Deferred: finalizing chain...\n");
+
+   if (gl3_filter_chain_finalize(ds->new_chain))
+   {
+      /* Tear down old chain */
+      if (ds->old_chain)
+         gl3_filter_chain_free(ds->old_chain);
+
+      /* Swap in the new chain */
+      gl->filter_chain = ds->new_chain;
+      deferred->state  = SHADER_LOAD_DONE;
+
+      RARCH_LOG("[GLCore] Deferred: shader loaded successfully.\n");
+   }
+   else
+   {
+      RARCH_ERR("[GLCore] Deferred: finalize failed.\n");
+      gl3_filter_chain_free(ds->new_chain);
+      gl->filter_chain = ds->old_chain;
+      deferred->state  = SHADER_LOAD_FAILED;
+   }
+
+cleanup:
+   if (gl->flags & GL3_FLAG_USE_SHARED_CONTEXT)
+      gl->ctx_driver->bind_hw_render(gl->ctx_data, true);
+   free(ds);
+   deferred->driver_data = NULL;
+   return false; /* no more work */
+}
+#endif /* HAVE_SLANG */
+
 static bool gl3_set_shader(void *data,
       enum rarch_shader_type type, const char *path)
 {
@@ -4737,6 +4875,13 @@ video_driver_t video_gl3 = {
 #endif
    gl3_get_poke_interface,
    gl3_wrap_type_to_enum,
+#ifdef HAVE_SLANG
+   gl3_shader_load_begin,
+   gl3_shader_load_step,
+#else
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
+#endif
 #ifdef HAVE_GFX_WIDGETS
    gl3_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/gx2_gfx.c
+++ b/gfx/drivers/gx2_gfx.c
@@ -2574,6 +2574,8 @@ video_driver_t video_wiiu =
 #endif
    gx2_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    gx2_widgets_enabled
 #endif

--- a/gfx/drivers/gx_gfx.c
+++ b/gfx/drivers/gx_gfx.c
@@ -1732,6 +1732,8 @@ video_driver_t video_gx = {
 #endif
    gx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -2867,6 +2867,8 @@ video_driver_t video_metal = {
 #endif
    metal_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    metal_widgets_enabled
 #endif

--- a/gfx/drivers/network_gfx.c
+++ b/gfx/drivers/network_gfx.c
@@ -498,6 +498,8 @@ video_driver_t video_network = {
 #endif
    network_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/oga_gfx.c
+++ b/gfx/drivers/oga_gfx.c
@@ -794,6 +794,8 @@ video_driver_t video_oga = {
 #endif
    oga_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/omap_gfx.c
+++ b/gfx/drivers/omap_gfx.c
@@ -1139,6 +1139,8 @@ video_driver_t video_omap = {
 #endif
    omap_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/ps2_gfx.c
+++ b/gfx/drivers/ps2_gfx.c
@@ -1179,6 +1179,8 @@ video_driver_t video_ps2 = {
 #endif
    ps2_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/psp1_gfx.c
+++ b/gfx/drivers/psp1_gfx.c
@@ -841,6 +841,8 @@ video_driver_t video_psp1 = {
 #endif
    psp_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/rsx_gfx.c
+++ b/gfx/drivers/rsx_gfx.c
@@ -2481,6 +2481,8 @@ video_driver_t video_gcm =
 #endif
    rsx_get_poke_interface,
    rsx_wrap_type_to_enum,
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    rsx_widgets_enabled
 #endif

--- a/gfx/drivers/sdl2_gfx.c
+++ b/gfx/drivers/sdl2_gfx.c
@@ -693,6 +693,8 @@ video_driver_t video_sdl2 = {
 #endif
    sdl2_gfx_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/sdl_dingux_gfx.c
+++ b/gfx/drivers/sdl_dingux_gfx.c
@@ -1125,6 +1125,8 @@ video_driver_t video_sdl_dingux = {
 #endif
    sdl_dingux_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -584,6 +584,8 @@ video_driver_t video_sdl = {
 #endif
    sdl_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/sdl_rs90_gfx.c
+++ b/gfx/drivers/sdl_rs90_gfx.c
@@ -1449,6 +1449,8 @@ video_driver_t video_sdl_rs90 = {
 #endif
    sdl_rs90_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/sixel_gfx.c
+++ b/gfx/drivers/sixel_gfx.c
@@ -670,6 +670,8 @@ video_driver_t video_sixel = {
 #endif
    sixel_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/sunxi_gfx.c
+++ b/gfx/drivers/sunxi_gfx.c
@@ -958,6 +958,8 @@ video_driver_t video_sunxi = {
 #endif
    sunxi_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/switch_nx_gfx.c
+++ b/gfx/drivers/switch_nx_gfx.c
@@ -991,6 +991,8 @@ video_driver_t video_switch = {
 #endif
    switch_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/vg.c
+++ b/gfx/drivers/vg.c
@@ -498,6 +498,8 @@ video_driver_t video_vg = {
 #endif
    vg_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/vga_gfx.c
+++ b/gfx/drivers/vga_gfx.c
@@ -518,6 +518,8 @@ video_driver_t video_vga = {
 #endif
    vga_gfx_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/vita2d_gfx.c
+++ b/gfx/drivers/vita2d_gfx.c
@@ -1397,6 +1397,8 @@ video_driver_t video_vita2d = {
 #endif
    vita2d_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    vita2d_widgets_enabled
 #endif

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -7717,6 +7717,8 @@ video_driver_t video_vulkan = {
 #endif
    vulkan_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    vulkan_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -5033,6 +5033,231 @@ static bool vulkan_suppress_screensaver(void *data, bool enable)
    return false;
 }
 
+/* ---- Deferred (per-frame) shader loading for Vulkan ---- */
+
+typedef struct vulkan_deferred_state
+{
+   vulkan_filter_chain_t *new_chain;
+   vulkan_filter_chain_t *old_chain;
+   enum glslang_filter_chain_filter filter;
+} vulkan_deferred_state_t;
+
+static bool vulkan_shader_load_begin(void *data,
+      shader_load_deferred_t *deferred)
+{
+   vk_t *vk = (vk_t *)data;
+   vulkan_deferred_state_t *ds;
+   struct vulkan_filter_chain_create_info info;
+
+   if (!vk || !vk->context)
+      return false;
+
+   /* Only Slang supported */
+   if (deferred->type != RARCH_SHADER_SLANG)
+      return false;
+
+   ds = (vulkan_deferred_state_t*)calloc(1, sizeof(*ds));
+   if (!ds)
+      return false;
+
+   ds->old_chain = vk->filter_chain;
+   ds->filter    = vk->video.smooth
+      ? GLSLANG_FILTER_CHAIN_LINEAR
+      : GLSLANG_FILTER_CHAIN_NEAREST;
+
+   {
+      settings_t *settings       = config_get_ptr();
+
+      info.device                = vk->context->device;
+      info.gpu                   = vk->context->gpu;
+      info.memory_properties     = &vk->context->memory_properties;
+      info.pipeline_cache        = vk->pipelines.cache;
+      info.queue                 = vk->context->queue;
+      info.command_pool          = vk->swapchain[
+         vk->context->current_frame_index].cmd_pool;
+      info.num_passes            = 0;
+      info.original_format       = VK_REMAP_TO_TEXFMT(vk->tex_fmt);
+      info.max_input_size.width  = vk->tex_w;
+      info.max_input_size.height = vk->tex_h;
+      info.swapchain.vp          = vk->vk_vp;
+      info.swapchain.format      = vk->context->swapchain_format;
+      info.swapchain.render_pass = vk->render_pass;
+      info.swapchain.num_indices = vk->context->num_swapchain_images;
+#ifdef VULKAN_HDR_SWAPCHAIN
+      info.hdr_enabled           = settings->uints.video_hdr_mode > 0;
+#endif
+   }
+
+   ds->new_chain = vulkan_filter_chain_create_deferred(
+         &info, deferred->preset_path, ds->filter,
+         &deferred->total_passes);
+
+   if (!ds->new_chain)
+   {
+      RARCH_ERR("[Vulkan] Deferred: failed to create chain for \"%s\".\n",
+            deferred->preset_path);
+      free(ds);
+      return false;
+   }
+
+   RARCH_LOG("[Vulkan] Deferred: prepared %u passes for \"%s\".\n",
+         deferred->total_passes, deferred->preset_path);
+
+   deferred->driver_data = ds;
+   return true;
+}
+
+static bool vulkan_shader_load_step(void *data,
+      shader_load_deferred_t *deferred)
+{
+   vk_t *vk                    = (vk_t *)data;
+   vulkan_deferred_state_t *ds =
+      (vulkan_deferred_state_t*)deferred->driver_data;
+   unsigned pass               = deferred->current_pass;
+
+   if (!vk || !ds)
+   {
+      deferred->state = SHADER_LOAD_FAILED;
+      return false;
+   }
+
+   if (pass < deferred->total_passes)
+   {
+      RARCH_LOG("[Vulkan] Deferred: compiling pass %u/%u...\n",
+            pass + 1, deferred->total_passes);
+
+      if (!vulkan_filter_chain_compile_pass(
+               ds->new_chain, pass, ds->filter))
+      {
+         RARCH_ERR("[Vulkan] Deferred: failed to compile pass %u.\n", pass);
+         vulkan_filter_chain_free(ds->new_chain);
+         vk->filter_chain = ds->old_chain;
+         deferred->state  = SHADER_LOAD_FAILED;
+         goto cleanup;
+      }
+
+      deferred->current_pass++;
+      return true; /* more work */
+   }
+
+   /* Check for cancellation */
+   if (deferred->state != SHADER_LOAD_COMPILING)
+   {
+      RARCH_LOG("[Vulkan] Deferred: cancelled, cleaning up.\n");
+      vulkan_filter_chain_free(ds->new_chain);
+      vk->filter_chain = ds->old_chain;
+      deferred->state  = SHADER_LOAD_FAILED;
+      goto cleanup;
+   }
+
+   /* All passes compiled — finalize */
+   RARCH_LOG("[Vulkan] Deferred: finalizing chain...\n");
+
+   if (vulkan_filter_chain_finalize(ds->new_chain))
+   {
+      if (ds->old_chain)
+         vulkan_filter_chain_free(ds->old_chain);
+
+      vk->filter_chain = ds->new_chain;
+      deferred->state  = SHADER_LOAD_DONE;
+
+#ifdef VULKAN_HDR_SWAPCHAIN
+      if (vk->context->flags & VK_CTX_FLAG_HDR_ENABLE)
+      {
+         settings_t *settings = config_get_ptr();
+         struct video_shader *shader_preset =
+            vulkan_filter_chain_get_preset(vk->filter_chain);
+         bool emits_hdr10 = shader_preset && shader_preset->passes
+            && vulkan_filter_chain_emits_hdr10(vk->filter_chain);
+         bool emits_hdr16 = shader_preset && shader_preset->passes
+            && vulkan_filter_chain_emits_hdr16(vk->filter_chain);
+         unsigned hdr_mode = settings->uints.video_hdr_mode;
+
+         vulkan_filter_chain_set_paper_white_nits(
+               vk->filter_chain,
+               settings->floats.video_hdr_paper_white_nits);
+         vulkan_filter_chain_set_expand_gamut(
+               vk->filter_chain,
+               settings->uints.video_hdr_expand_gamut);
+         vulkan_filter_chain_set_scanlines(
+               vk->filter_chain,
+               settings->bools.video_hdr_scanlines ? 1.0f : 0.0f);
+         vulkan_filter_chain_set_subpixel_layout(
+               vk->filter_chain,
+               settings->uints.video_hdr_subpixel_layout);
+
+         if (hdr_mode == 2)
+         {
+            vk->context->flags |= VK_CTX_FLAG_HDR_SCRGB;
+            vulkan_set_hdr_inverse_tonemap(vk, vk->filter_chain, false);
+            vulkan_set_hdr10(vk, vk->filter_chain, false);
+
+            if (!emits_hdr16 && !emits_hdr10)
+            {
+               struct vulkan_filter_chain_swapchain_info sdr_swapchain;
+               sdr_swapchain.vp          = vk->vk_vp;
+               sdr_swapchain.format      = vk->context->swapchain_format;
+               sdr_swapchain.render_pass = vk->sdr_render_pass;
+               sdr_swapchain.num_indices = vk->context->num_swapchain_images;
+               vulkan_filter_chain_update_swapchain_info(
+                     vk->filter_chain, &sdr_swapchain);
+            }
+            else if (emits_hdr10)
+            {
+               struct vulkan_filter_chain_swapchain_info sdr_swapchain;
+               sdr_swapchain.vp          = vk->vk_vp;
+               sdr_swapchain.format      = vk->context->swapchain_format;
+               sdr_swapchain.render_pass = vk->sdr_render_pass;
+               sdr_swapchain.num_indices = vk->context->num_swapchain_images;
+               vulkan_filter_chain_update_swapchain_info(
+                     vk->filter_chain, &sdr_swapchain);
+            }
+            vk->flags |= VK_FLAG_SHOULD_RESIZE;
+         }
+         else /* hdr_mode == 1, HDR10 */
+         {
+            vk->context->flags &= ~VK_CTX_FLAG_HDR_SCRGB;
+
+            if (emits_hdr10 || emits_hdr16)
+            {
+               vulkan_set_hdr_inverse_tonemap(vk, vk->filter_chain, false);
+               vulkan_set_hdr10(vk, vk->filter_chain, false);
+            }
+            else
+            {
+               vulkan_set_hdr_inverse_tonemap(vk, vk->filter_chain, true);
+               vulkan_set_hdr10(vk, vk->filter_chain, true);
+               {
+                  struct vulkan_filter_chain_swapchain_info sdr_swapchain;
+                  sdr_swapchain.vp          = vk->vk_vp;
+                  sdr_swapchain.format      = vk->context->swapchain_format;
+                  sdr_swapchain.render_pass = vk->sdr_render_pass;
+                  sdr_swapchain.num_indices = vk->context->num_swapchain_images;
+                  vulkan_filter_chain_update_swapchain_info(
+                        vk->filter_chain, &sdr_swapchain);
+               }
+            }
+            vk->flags |= VK_FLAG_SHOULD_RESIZE;
+         }
+      }
+#endif /* VULKAN_HDR_SWAPCHAIN */
+
+      RARCH_LOG("[Vulkan] Deferred: shader loaded successfully.\n");
+   }
+   else
+   {
+      RARCH_ERR("[Vulkan] Deferred: finalize failed.\n");
+      vulkan_filter_chain_free(ds->new_chain);
+      vk->filter_chain = ds->old_chain;
+      deferred->state  = SHADER_LOAD_FAILED;
+   }
+
+cleanup:
+   free(ds);
+   deferred->driver_data = NULL;
+   return false; /* no more work */
+}
+
 static bool vulkan_set_shader(void *data,
       enum rarch_shader_type type, const char *path)
 {
@@ -7717,8 +7942,8 @@ video_driver_t video_vulkan = {
 #endif
    vulkan_get_poke_interface,
    NULL, /* wrap_type_to_enum */
-   NULL, /* shader_load_begin */
-   NULL, /* shader_load_step */
+   vulkan_shader_load_begin,
+   vulkan_shader_load_step,
 #ifdef HAVE_GFX_WIDGETS
    vulkan_gfx_widgets_enabled
 #endif

--- a/gfx/drivers/xenon360_gfx.c
+++ b/gfx/drivers/xenon360_gfx.c
@@ -289,6 +289,9 @@ video_driver_t video_xenon360 = {
    NULL, /* get_overlay_interface */
 #endif
    xenon360_get_poke_interface,
+   NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/xshm_gfx.c
+++ b/gfx/drivers/xshm_gfx.c
@@ -244,6 +244,8 @@ video_driver_t video_xshm = {
 #endif
    xshm_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers/xvideo.c
+++ b/gfx/drivers/xvideo.c
@@ -1155,6 +1155,8 @@ video_driver_t video_xvideo = {
 #endif
    xv_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    NULL  /* gfx_widgets_enabled */
 #endif

--- a/gfx/drivers_context/drm_ctx.c
+++ b/gfx/drivers_context/drm_ctx.c
@@ -1087,9 +1087,12 @@ static uint32_t gfx_ctx_drm_get_flags(void *data)
       BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
    }
+   else
+   {
 #ifdef HAVE_GLSL
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 #endif
+   }
 
    BIT32_SET(flags, GFX_CTX_FLAGS_CRT_SWITCHRES);
 

--- a/gfx/drivers_context/drm_go2_ctx.c
+++ b/gfx/drivers_context/drm_go2_ctx.c
@@ -367,9 +367,12 @@ static uint32_t gfx_ctx_go2_drm_get_flags(void *data)
       BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
    }
+   else
+   {
 #ifdef HAVE_GLSL
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 #endif
+   }
 
    return flags;
 }

--- a/gfx/drivers_context/orbis_ctx.c
+++ b/gfx/drivers_context/orbis_ctx.c
@@ -318,9 +318,12 @@ static uint32_t orbis_ctx_get_flags(void *data)
       BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
    }
+   else
+   {
 #ifdef HAVE_GLSL
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 #endif
+   }
 
    return flags;
 }

--- a/gfx/drivers_context/switch_ctx.c
+++ b/gfx/drivers_context/switch_ctx.c
@@ -238,9 +238,12 @@ static uint32_t switch_ctx_get_flags(void *data)
       BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
    }
+   else
+   {
 #ifdef HAVE_GLSL
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 #endif
+   }
 
     return flags;
 }

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -608,14 +608,14 @@ static uint32_t gfx_ctx_wl_get_flags(void *data)
    if (wl->core_hw_context_enable)
       BIT32_SET(flags, GFX_CTX_FLAGS_GL_CORE_CONTEXT);
 
-   if (string_is_equal(video_ident, "glcore") || string_is_equal(video_ident, "gl"))
+   if (string_is_equal(video_ident, "glcore"))
    {
-      if (string_is_equal(video_ident, "glcore"))
-      {
 #if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
-         BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
-      }
+   }
+   else if (string_is_equal(video_ident, "gl"))
+   {
 #ifdef HAVE_GLSL
       BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 #endif

--- a/gfx/drivers_context/wgl_ctx.c
+++ b/gfx/drivers_context/wgl_ctx.c
@@ -775,14 +775,14 @@ static uint32_t gfx_ctx_wgl_get_flags(void *data)
             BIT32_SET(flags, GFX_CTX_FLAGS_GL_CORE_CONTEXT);
 
          if (string_is_equal(video_driver_get_ident(), "gl1")) { }
+         else if (string_is_equal(video_driver_get_ident(), "glcore"))
+         {
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+            BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+#endif
+         }
          else
          {
-            if (string_is_equal(video_driver_get_ident(), "glcore"))
-            {
-#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
-               BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
-#endif
-            }
 #ifdef HAVE_CG
             if (!(wgl_flags & WGL_FLAG_CORE_HW_CTX_ENABLE))
                BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_CG);

--- a/gfx/drivers_context/x_ctx.c
+++ b/gfx/drivers_context/x_ctx.c
@@ -1103,14 +1103,14 @@ static uint32_t gfx_ctx_x_get_flags(void *data)
             BIT32_SET(flags, GFX_CTX_FLAGS_MULTISAMPLING);
 
          if (string_is_equal(video_driver_get_ident(), "gl1")) { }
+         else if (string_is_equal(video_driver_get_ident(), "glcore"))
+         {
+#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
+            BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
+#endif
+         }
          else
          {
-            if (string_is_equal(video_driver_get_ident(), "glcore"))
-            {
-#if defined(HAVE_SLANG) && defined(HAVE_SPIRV_CROSS)
-               BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
-#endif
-            }
 #ifdef HAVE_CG
             if (!(x->core_hw_context_enable || x->core_es))
                BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_CG);

--- a/gfx/drivers_context/xegl_ctx.c
+++ b/gfx/drivers_context/xegl_ctx.c
@@ -588,9 +588,12 @@ static uint32_t gfx_ctx_xegl_get_flags(void *data)
       BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_SLANG);
 #endif
    }
+   else
+   {
 #ifdef HAVE_GLSL
-   BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
+      BIT32_SET(flags, GFX_CTX_FLAGS_SHADERS_GLSL);
 #endif
+   }
 
    return flags;
 }

--- a/gfx/drivers_shader/shader_gl3.cpp
+++ b/gfx/drivers_shader/shader_gl3.cpp
@@ -1884,6 +1884,11 @@ public:
                    const uint32_t *spirv, size_t spirv_words);
 
    bool init();
+   bool init_single_pass(unsigned pass_idx);
+   bool init_alias_early();
+   bool compile_full_pass(unsigned pass_idx,
+         enum glslang_filter_chain_filter default_filter);
+   bool finalize();
 
    void set_input_texture(const gl3_filter_chain_texture &texture);
    void build_offscreen_passes(const gl3_viewport &vp);
@@ -1923,6 +1928,7 @@ private:
    bool init_alias();
    std::vector<std::unique_ptr<gl3_shader::Framebuffer>> original_history;
    bool require_clear = false;
+   bool alias_initialized = false;
    void clear_history_and_feedback();
    void update_feedback_info();
    void update_history_info();
@@ -2276,6 +2282,7 @@ bool gl3_filter_chain::init()
 
    if (!init_alias())
       return false;
+   alias_initialized = true;
 
    for (i = 0; i < passes.size(); i++)
    {
@@ -2287,6 +2294,271 @@ bool gl3_filter_chain::init()
       passes[i]->set_pass_info(pass_info[i]);
       if (!passes[i]->build())
          return false;
+   }
+
+   require_clear = false;
+   if (!init_history())
+      return false;
+   if (!init_feedback())
+      return false;
+   common.pass_outputs.resize(passes.size());
+   return true;
+}
+
+bool gl3_filter_chain::init_single_pass(unsigned pass_idx)
+{
+   if (pass_idx >= passes.size())
+      return false;
+
+   RARCH_LOG("[GLCore] Building pass #%u (%s)\n", pass_idx,
+         passes[pass_idx]->get_name().empty() ?
+         msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE) :
+         passes[pass_idx]->get_name().c_str());
+
+   passes[pass_idx]->set_pass_info(pass_info[pass_idx]);
+   if (!passes[pass_idx]->build())
+      return false;
+
+   return true;
+}
+
+bool gl3_filter_chain::compile_full_pass(unsigned pass_idx,
+      glslang_filter_chain_filter default_filter)
+{
+   video_shader *shader = common.shader_preset.get();
+   if (!shader || pass_idx >= passes.size())
+      return false;
+
+   /* For the extra opaque pass appended when last_pass_is_fbo,
+    * the SPIRV was already set in create_deferred — just build. */
+   if (pass_idx >= shader->passes)
+      return init_single_pass(pass_idx);
+
+   const video_shader_pass *pass      = &shader->pass[pass_idx];
+   const video_shader_pass *next_pass =
+      pass_idx + 1 < shader->passes
+      ? &shader->pass[pass_idx + 1] : nullptr;
+
+   /* ---- SPIRV cross-compile (CPU) ---- */
+   glslang_output output;
+   if (!glslang_compile_shader(pass->source.path, &output))
+   {
+      RARCH_ERR("[GLCore] Failed to compile shader: \"%s\".\n",
+            pass->source.path);
+      return false;
+   }
+
+   /* ---- Extract parameters ---- */
+   for (unsigned j = 0; j < output.meta.parameters.size(); j++)
+   {
+      auto meta_param = output.meta.parameters[j];
+
+      if (shader->num_parameters >= GFX_MAX_PARAMETERS)
+      {
+         RARCH_ERR("[GLCore] Exceeded maximum number of parameters (%u).\n",
+               GFX_MAX_PARAMETERS);
+         return false;
+      }
+
+      video_shader_parameter *itr = NULL;
+      {
+         unsigned k;
+         for (k = 0; k < shader->num_parameters; k++)
+         {
+            if (meta_param.id == shader->parameters[k].id)
+            {
+               itr = &shader->parameters[k];
+               break;
+            }
+         }
+      }
+
+      if (itr)
+      {
+         if (   meta_param.desc    != itr->desc
+             || meta_param.initial != itr->initial
+             || meta_param.minimum != itr->minimum
+             || meta_param.maximum != itr->maximum
+             || meta_param.step    != itr->step)
+         {
+            RARCH_ERR("[GLCore] Duplicate parameters found for \"%s\","
+                  " but arguments do not match.\n", itr->id);
+            return false;
+         }
+         add_parameter(pass_idx,
+               (unsigned)(itr - shader->parameters), meta_param.id);
+      }
+      else
+      {
+         video_shader_parameter *param =
+            &shader->parameters[shader->num_parameters];
+         strlcpy(param->id, meta_param.id.c_str(), sizeof(param->id));
+         strlcpy(param->desc, meta_param.desc.c_str(), sizeof(param->desc));
+         param->initial = meta_param.initial;
+         param->minimum = meta_param.minimum;
+         param->maximum = meta_param.maximum;
+         param->step    = meta_param.step;
+         add_parameter(pass_idx, shader->num_parameters, meta_param.id);
+         shader->num_parameters++;
+      }
+   }
+
+   /* ---- Set SPIRV on the pass ---- */
+   set_shader(pass_idx, GL_VERTEX_SHADER,
+         output.vertex.data(), output.vertex.size());
+   set_shader(pass_idx, GL_FRAGMENT_SHADER,
+         output.fragment.data(), output.fragment.size());
+
+   set_frame_count_period(pass_idx, pass->frame_count_mod);
+
+   /* ---- Pass name (from shader #pragma or preset alias) ---- */
+   if (!output.meta.name.empty())
+      set_pass_name(pass_idx, output.meta.name.c_str());
+   if (*pass->alias)
+      set_pass_name(pass_idx, pass->alias);
+
+   /* Update the alias map so later passes can reference this one.
+    * Re-running init_alias is safe — it clears and repopulates. */
+   if (!passes[pass_idx]->get_name().empty())
+   {
+      alias_initialized = false;
+      if (!init_alias_early())
+         return false;
+   }
+
+   /* ---- Pass info (scale, filter, format) ---- */
+   struct gl3_filter_chain_pass_info p_info;
+   p_info.scale_type_x  = GLSLANG_FILTER_CHAIN_SCALE_ORIGINAL;
+   p_info.scale_type_y  = GLSLANG_FILTER_CHAIN_SCALE_ORIGINAL;
+   p_info.scale_x       = 0.0f;
+   p_info.scale_y       = 0.0f;
+   p_info.rt_format     = 0;
+   p_info.source_filter = GLSLANG_FILTER_CHAIN_LINEAR;
+   p_info.mip_filter    = GLSLANG_FILTER_CHAIN_LINEAR;
+   p_info.address       = GLSLANG_FILTER_CHAIN_ADDRESS_REPEAT;
+   p_info.max_levels    = 0;
+
+   if (pass->filter == RARCH_FILTER_UNSPEC)
+      p_info.source_filter = default_filter;
+   else
+   {
+      p_info.source_filter =
+         pass->filter == RARCH_FILTER_LINEAR
+         ? GLSLANG_FILTER_CHAIN_LINEAR
+         : GLSLANG_FILTER_CHAIN_NEAREST;
+   }
+   p_info.address    = rarch_wrap_to_address(pass->wrap);
+   p_info.max_levels = 1;
+
+   if (next_pass && next_pass->mipmap)
+      p_info.max_levels = ~0u;
+
+   p_info.mip_filter = pass->filter != RARCH_FILTER_NEAREST
+      && p_info.max_levels > 1
+      ? GLSLANG_FILTER_CHAIN_LINEAR
+      : GLSLANG_FILTER_CHAIN_NEAREST;
+
+   bool explicit_format = output.meta.rt_format != SLANG_FORMAT_UNKNOWN;
+
+   if (output.meta.rt_format == SLANG_FORMAT_UNKNOWN)
+      output.meta.rt_format = SLANG_FORMAT_R8G8B8A8_UNORM;
+
+   if (!(pass->fbo.flags & FBO_SCALE_FLAG_VALID))
+   {
+      bool scale_viewport = pass_idx + 1 == shader->passes;
+      if (scale_viewport)
+      {
+         p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+         p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+      }
+      else
+      {
+         p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+         p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+      }
+      p_info.scale_x = 1.0f;
+      p_info.scale_y = 1.0f;
+
+      if (scale_viewport)
+      {
+         p_info.rt_format = 0;
+         if (explicit_format)
+            RARCH_WARN("[GLCore] Using explicit format for last pass in chain,"
+                  " but it is not rendered to framebuffer,"
+                  " using swapchain format instead.\n");
+      }
+      else
+         p_info.rt_format =
+            gl3_shader::convert_glslang_format(output.meta.rt_format);
+   }
+   else
+   {
+      if (pass->fbo.flags & FBO_SCALE_FLAG_SRGB_FBO)
+         output.meta.rt_format = SLANG_FORMAT_R8G8B8A8_SRGB;
+      else if (pass->fbo.flags & FBO_SCALE_FLAG_FP_FBO)
+         output.meta.rt_format = SLANG_FORMAT_R16G16B16A16_SFLOAT;
+
+      p_info.rt_format =
+         gl3_shader::convert_glslang_format(output.meta.rt_format);
+
+      switch (pass->fbo.type_x)
+      {
+         case RARCH_SCALE_INPUT:
+            p_info.scale_x      = pass->fbo.scale_x;
+            p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+            break;
+         case RARCH_SCALE_ABSOLUTE:
+            p_info.scale_x      = (float)(pass->fbo.abs_x);
+            p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_ABSOLUTE;
+            break;
+         case RARCH_SCALE_VIEWPORT:
+            p_info.scale_x      = pass->fbo.scale_x;
+            p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+            break;
+      }
+
+      switch (pass->fbo.type_y)
+      {
+         case RARCH_SCALE_INPUT:
+            p_info.scale_y      = pass->fbo.scale_y;
+            p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+            break;
+         case RARCH_SCALE_ABSOLUTE:
+            p_info.scale_y      = (float)(pass->fbo.abs_y);
+            p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_ABSOLUTE;
+            break;
+         case RARCH_SCALE_VIEWPORT:
+            p_info.scale_y      = pass->fbo.scale_y;
+            p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+            break;
+      }
+   }
+
+   set_pass_info(pass_idx, p_info);
+
+   /* ---- GPU compile/link (the expensive GL part) ---- */
+   return init_single_pass(pass_idx);
+}
+
+bool gl3_filter_chain::init_alias_early()
+{
+   if (alias_initialized)
+      return true;
+   if (!init_alias())
+      return false;
+   alias_initialized = true;
+   return true;
+}
+
+bool gl3_filter_chain::finalize()
+{
+   /* init_alias may have been called early for deferred loading;
+    * skip it if already done. */
+   if (!alias_initialized)
+   {
+      if (!init_alias())
+         return false;
+      alias_initialized = true;
    }
 
    require_clear = false;
@@ -2817,6 +3089,105 @@ gl3_filter_chain_t *gl3_filter_chain_create_from_preset(
       return nullptr;
 
    return chain.release();
+}
+
+/* ---- Deferred (per-frame) filter chain construction ---- */
+
+gl3_filter_chain_t *gl3_filter_chain_create_deferred(
+      const char *path,
+      glslang_filter_chain_filter filter,
+      unsigned *out_num_passes)
+{
+   unsigned i;
+   std::unique_ptr<video_shader> shader{ new video_shader() };
+   if (!shader)
+      return nullptr;
+
+   if (!video_shader_load_preset_into_shader(path, shader.get()))
+      return nullptr;
+
+   bool last_pass_is_fbo = shader->pass[shader->passes - 1].fbo.flags &
+      FBO_SCALE_FLAG_VALID;
+
+   unsigned total_passes = shader->passes + (last_pass_is_fbo ? 1 : 0);
+   std::unique_ptr<gl3_filter_chain> chain{ new gl3_filter_chain(total_passes) };
+   if (!chain)
+      return nullptr;
+
+   if (      shader->luts
+         && !gl3_filter_chain_load_luts(chain.get(), shader.get()))
+      return nullptr;
+
+   shader->num_parameters = 0;
+
+   /* Set pass names from preset aliases only (no SPIRV needed).
+    * Names from #pragma in shader source will be set during
+    * compile_full_pass. */
+   for (i = 0; i < shader->passes; i++)
+   {
+      if (*shader->pass[i].alias)
+         chain->set_pass_name(i, shader->pass[i].alias);
+   }
+
+   if (last_pass_is_fbo)
+   {
+      struct gl3_filter_chain_pass_info pass_info;
+
+      pass_info.scale_type_x  = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+      pass_info.scale_type_y  = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+      pass_info.scale_x       = 1.0f;
+      pass_info.scale_y       = 1.0f;
+      pass_info.rt_format     = 0;
+      pass_info.source_filter = filter;
+      pass_info.mip_filter    = GLSLANG_FILTER_CHAIN_NEAREST;
+      pass_info.address       = GLSLANG_FILTER_CHAIN_ADDRESS_CLAMP_TO_EDGE;
+      pass_info.max_levels    = 0;
+
+      chain->set_pass_info(shader->passes, pass_info);
+
+      chain->set_shader(shader->passes,
+            GL_VERTEX_SHADER,
+            gl3_shader::opaque_vert,
+            sizeof(gl3_shader::opaque_vert) / sizeof(uint32_t));
+
+      chain->set_shader(shader->passes,
+            GL_FRAGMENT_SHADER,
+            gl3_shader::opaque_frag,
+            sizeof(gl3_shader::opaque_frag) / sizeof(uint32_t));
+   }
+
+   chain->set_shader_preset(std::move(shader));
+
+   /* Populate the alias map with preset-defined aliases.
+    * compile_full_pass() will incrementally update the map
+    * when shaders add names via #pragma name. */
+   if (!chain->init_alias_early())
+   {
+      RARCH_ERR("[GLCore] Deferred: failed to initialize alias map.\n");
+      return nullptr;
+   }
+
+   /* NOTE: We do NOT call chain->init() here.
+    * Passes are compiled one per frame via
+    * gl3_filter_chain_compile_pass / gl3_filter_chain_finalize. */
+
+   if (out_num_passes)
+      *out_num_passes = total_passes;
+
+   return chain.release();
+}
+
+bool gl3_filter_chain_compile_pass(
+      gl3_filter_chain_t *chain,
+      unsigned pass_index,
+      glslang_filter_chain_filter filter)
+{
+   return chain->compile_full_pass(pass_index, filter);
+}
+
+bool gl3_filter_chain_finalize(gl3_filter_chain_t *chain)
+{
+   return chain->finalize();
 }
 
 struct video_shader *gl3_filter_chain_get_preset(

--- a/gfx/drivers_shader/shader_gl3.h
+++ b/gfx/drivers_shader/shader_gl3.h
@@ -170,8 +170,50 @@ gl3_filter_chain_t *gl3_filter_chain_create_from_preset(
       const char *path,
       enum glslang_filter_chain_filter filter);
 
+/**
+ * Deferred (per-frame) filter chain creation API.
+ * Splits gl3_filter_chain_create_from_preset into three phases:
+ *   1. create_deferred  - parse preset, load LUTs, allocate pass slots
+ *   2. compile_pass     - compile one shader pass (call once per frame)
+ *   3. finalize         - init history/feedback, mark chain ready
+ **/
 struct video_shader *gl3_filter_chain_get_preset(
       gl3_filter_chain_t *chain);
+
+/* ---- Deferred (per-frame) filter chain construction ---- */
+
+/**
+ * gl3_filter_chain_create_deferred:
+ *
+ * Parse a preset and allocate a chain, load LUT textures, but do NOT
+ * compile any shader passes. Returns NULL on failure.
+ * The returned chain is NOT yet usable for rendering.
+ **/
+gl3_filter_chain_t *gl3_filter_chain_create_deferred(
+      const char *path,
+      enum glslang_filter_chain_filter filter,
+      unsigned *out_num_passes);
+
+/**
+ * gl3_filter_chain_compile_pass:
+ *
+ * SPIRV-cross-compile and GL-compile/link one shader pass.
+ * Call once per frame with incrementing pass_index.
+ * Returns true on success, false on error.
+ **/
+bool gl3_filter_chain_compile_pass(
+      gl3_filter_chain_t *chain,
+      unsigned pass_index,
+      enum glslang_filter_chain_filter filter);
+
+/**
+ * gl3_filter_chain_finalize:
+ *
+ * Finalize the chain after all passes are compiled:
+ * init aliases, build GPU resources, set up history/feedback.
+ * Returns true on success.
+ **/
+bool gl3_filter_chain_finalize(gl3_filter_chain_t *chain);
 
 void gl3_filter_chain_end_frame(gl3_filter_chain_t *chain);
 

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -838,6 +838,7 @@ struct vulkan_filter_chain
       vulkan_filter_chain_texture input_texture;
 
       Size2D max_input_size;
+      Size2D deferred_source;   /* accumulated source size for per-frame builds */
       vulkan_filter_chain_swapchain_info swapchain_info;
       unsigned current_sync_index;
 
@@ -1267,6 +1268,7 @@ vulkan_filter_chain::vulkan_filter_chain(
      original_format(info.original_format)
 {
    max_input_size = { info.max_input_size.width, info.max_input_size.height };
+   deferred_source = max_input_size;
    set_swapchain_info(info.swapchain);
    set_num_passes(info.num_passes);
 }
@@ -1823,13 +1825,11 @@ bool vulkan_filter_chain::init_single_pass(unsigned pass_idx)
    if (pass_idx >= passes.size())
       return false;
 
-   /* Accumulate source size from all prior passes */
-   Size2D source = max_input_size;
-   for (unsigned i = 0; i <= pass_idx; i++)
-   {
-      source = passes[i]->set_pass_info(max_input_size,
-            source, swapchain_info, pass_info[i]);
-   }
+   /* Only call set_pass_info on this pass, using the accumulated
+    * source size. set_pass_info calls clear_vk() which destroys
+    * Vulkan objects — we must NOT re-call it on prior passes. */
+   deferred_source = passes[pass_idx]->set_pass_info(max_input_size,
+         deferred_source, swapchain_info, pass_info[pass_idx]);
 
    RARCH_LOG("[Vulkan] Building pass #%u (%s)\n", pass_idx,
          passes[pass_idx]->get_name().empty()

--- a/gfx/drivers_shader/shader_vulkan.cpp
+++ b/gfx/drivers_shader/shader_vulkan.cpp
@@ -772,6 +772,11 @@ struct vulkan_filter_chain
             const uint32_t *spirv, size_t spirv_words);
 
       bool init();
+      bool init_single_pass(unsigned pass_idx);
+      bool init_alias_early();
+      bool compile_full_pass(unsigned pass_idx,
+            enum glslang_filter_chain_filter default_filter);
+      bool finalize();
       bool update_swapchain_info(
             const vulkan_filter_chain_swapchain_info &info);
 
@@ -839,6 +844,7 @@ struct vulkan_filter_chain
       std::vector<std::unique_ptr<Framebuffer>> original_history;
       unsigned history_ring_index    = 0;
       bool require_clear        = false;
+      bool alias_initialized    = false;
       bool emits_hdr_colorspace = false;
       bool emits_hdr16_output   = false;
 
@@ -1784,6 +1790,7 @@ bool vulkan_filter_chain::init()
 
    if (!init_alias())
       return false;
+   alias_initialized = true;
 
    for (i = 0; i < passes.size(); i++)
    {
@@ -1798,6 +1805,294 @@ bool vulkan_filter_chain::init()
             source, swapchain_info, pass_info[i]);
       if (!passes[i]->build())
          return false;
+   }
+
+   require_clear = false;
+   if (!init_ubo())
+      return false;
+   if (!init_history())
+      return false;
+   if (!init_feedback())
+      return false;
+   common.pass_outputs.resize(passes.size());
+   return true;
+}
+
+bool vulkan_filter_chain::init_single_pass(unsigned pass_idx)
+{
+   if (pass_idx >= passes.size())
+      return false;
+
+   /* Accumulate source size from all prior passes */
+   Size2D source = max_input_size;
+   for (unsigned i = 0; i <= pass_idx; i++)
+   {
+      source = passes[i]->set_pass_info(max_input_size,
+            source, swapchain_info, pass_info[i]);
+   }
+
+   RARCH_LOG("[Vulkan] Building pass #%u (%s)\n", pass_idx,
+         passes[pass_idx]->get_name().empty()
+         ? msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE)
+         : passes[pass_idx]->get_name().c_str());
+
+   if (!passes[pass_idx]->build())
+      return false;
+
+   return true;
+}
+
+bool vulkan_filter_chain::compile_full_pass(unsigned pass_idx,
+      glslang_filter_chain_filter default_filter)
+{
+   video_shader *shader = common.shader_preset.get();
+   if (!shader || pass_idx >= passes.size())
+      return false;
+
+   /* Extra opaque pass (last_pass_is_fbo) — SPIRV already set */
+   if (pass_idx >= shader->passes)
+      return init_single_pass(pass_idx);
+
+   const video_shader_pass *pass      = &shader->pass[pass_idx];
+   const video_shader_pass *next_pass =
+      pass_idx + 1 < shader->passes
+      ? &shader->pass[pass_idx + 1] : nullptr;
+
+   /* ---- SPIRV cross-compile (CPU) ---- */
+   glslang_output output;
+   if (!glslang_compile_shader(pass->source.path, &output))
+   {
+      RARCH_ERR("[Vulkan] Failed to compile shader: \"%s\".\n",
+            pass->source.path);
+      return false;
+   }
+
+   /* ---- Extract parameters ---- */
+   for (unsigned j = 0; j < output.meta.parameters.size(); j++)
+   {
+      auto &meta_param = output.meta.parameters[j];
+
+      if (shader->num_parameters >= GFX_MAX_PARAMETERS)
+      {
+         RARCH_ERR("[Vulkan] Exceeded maximum number of parameters (%u).\n",
+               GFX_MAX_PARAMETERS);
+         return false;
+      }
+
+      video_shader_parameter *itr = NULL;
+      {
+         unsigned k;
+         for (k = 0; k < shader->num_parameters; k++)
+         {
+            if (meta_param.id == shader->parameters[k].id)
+            {
+               itr = &shader->parameters[k];
+               break;
+            }
+         }
+      }
+
+      if (itr)
+      {
+         if (   meta_param.desc    != itr->desc
+             || meta_param.initial != itr->initial
+             || meta_param.minimum != itr->minimum
+             || meta_param.maximum != itr->maximum
+             || meta_param.step    != itr->step)
+         {
+            RARCH_ERR("[Vulkan] Duplicate parameters found for \"%s\","
+                  " but arguments do not match.\n", itr->id);
+            return false;
+         }
+         add_parameter(pass_idx,
+               (unsigned)(itr - shader->parameters), meta_param.id);
+      }
+      else
+      {
+         video_shader_parameter *param =
+            &shader->parameters[shader->num_parameters];
+         strlcpy(param->id, meta_param.id.c_str(), sizeof(param->id));
+         strlcpy(param->desc, meta_param.desc.c_str(), sizeof(param->desc));
+         param->initial = meta_param.initial;
+         param->minimum = meta_param.minimum;
+         param->maximum = meta_param.maximum;
+         param->step    = meta_param.step;
+         add_parameter(pass_idx, shader->num_parameters, meta_param.id);
+         shader->num_parameters++;
+      }
+   }
+
+   /* ---- Set SPIRV on the pass ---- */
+   set_shader(pass_idx, VK_SHADER_STAGE_VERTEX_BIT,
+         output.vertex.data(), output.vertex.size());
+   set_shader(pass_idx, VK_SHADER_STAGE_FRAGMENT_BIT,
+         output.fragment.data(), output.fragment.size());
+
+   set_frame_count_period(pass_idx, pass->frame_count_mod);
+
+   /* ---- Pass name ---- */
+   if (!output.meta.name.empty())
+      set_pass_name(pass_idx, output.meta.name.c_str());
+   if (*pass->alias)
+      set_pass_name(pass_idx, pass->alias);
+
+   /* Update alias map incrementally */
+   if (!passes[pass_idx]->get_name().empty())
+   {
+      alias_initialized = false;
+      if (!init_alias_early())
+         return false;
+   }
+
+   /* ---- Pass info (scale, filter, format) ---- */
+   struct vulkan_filter_chain_pass_info p_info;
+   p_info.scale_type_x  = GLSLANG_FILTER_CHAIN_SCALE_ORIGINAL;
+   p_info.scale_type_y  = GLSLANG_FILTER_CHAIN_SCALE_ORIGINAL;
+   p_info.scale_x       = 0.0f;
+   p_info.scale_y       = 0.0f;
+   p_info.rt_format     = VK_FORMAT_UNDEFINED;
+   p_info.source_filter = GLSLANG_FILTER_CHAIN_LINEAR;
+   p_info.mip_filter    = GLSLANG_FILTER_CHAIN_LINEAR;
+   p_info.address       = GLSLANG_FILTER_CHAIN_ADDRESS_REPEAT;
+   p_info.max_levels    = 0;
+
+   if (pass->filter == RARCH_FILTER_UNSPEC)
+      p_info.source_filter = default_filter;
+   else
+   {
+      p_info.source_filter =
+         pass->filter == RARCH_FILTER_LINEAR
+         ? GLSLANG_FILTER_CHAIN_LINEAR
+         : GLSLANG_FILTER_CHAIN_NEAREST;
+   }
+   p_info.address    = rarch_wrap_to_address(pass->wrap);
+   p_info.max_levels = 1;
+
+   if (next_pass && next_pass->mipmap)
+      p_info.max_levels = ~0u;
+
+   p_info.mip_filter =
+      (pass->filter != RARCH_FILTER_NEAREST && p_info.max_levels > 1)
+      ? GLSLANG_FILTER_CHAIN_LINEAR
+      : GLSLANG_FILTER_CHAIN_NEAREST;
+
+   bool explicit_format = output.meta.rt_format != SLANG_FORMAT_UNKNOWN;
+
+   if (output.meta.rt_format == SLANG_FORMAT_UNKNOWN)
+      output.meta.rt_format = SLANG_FORMAT_R8G8B8A8_UNORM;
+
+   if (!(pass->fbo.flags & FBO_SCALE_FLAG_VALID))
+   {
+      p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+      p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+      p_info.scale_x      = 1.0f;
+      p_info.scale_y      = 1.0f;
+
+      if (pass_idx + 1 == shader->passes)
+      {
+         p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+         p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+
+         VkFormat pass_format = glslang_format_to_vk(output.meta.rt_format);
+
+         if (explicit_format && vulkan_is_hdr10_format(pass_format))
+            set_hdr10();
+#ifdef VULKAN_HDR_SWAPCHAIN
+         if (explicit_format && pass_format == VK_FORMAT_R16G16B16A16_SFLOAT)
+            set_hdr16();
+#endif
+         p_info.rt_format = swapchain_info.format;
+
+         if (explicit_format && pass_format != p_info.rt_format)
+            RARCH_WARN("[Vulkan] Using explicit format for last pass in chain,"
+                  " but it is not rendered to framebuffer,"
+                  " using swapchain format instead.\n");
+      }
+      else
+      {
+         p_info.rt_format = glslang_format_to_vk(output.meta.rt_format);
+         RARCH_LOG("[Vulkan] Using render target format %s for pass output #%u.\n",
+               glslang_format_to_string(output.meta.rt_format), pass_idx);
+      }
+   }
+   else
+   {
+      if (pass->fbo.flags & FBO_SCALE_FLAG_SRGB_FBO)
+         output.meta.rt_format = SLANG_FORMAT_R8G8B8A8_SRGB;
+      else if (pass->fbo.flags & FBO_SCALE_FLAG_FP_FBO)
+         output.meta.rt_format = SLANG_FORMAT_R16G16B16A16_SFLOAT;
+
+      p_info.rt_format = glslang_format_to_vk(output.meta.rt_format);
+
+      RARCH_LOG("[Vulkan] Using render target format %s for pass output #%u.\n",
+            glslang_format_to_string(output.meta.rt_format), pass_idx);
+
+#ifdef VULKAN_HDR_SWAPCHAIN
+      if (pass_idx + 1 == shader->passes)
+      {
+         if (explicit_format && vulkan_is_hdr10_format(p_info.rt_format))
+            set_hdr10();
+         else if (explicit_format && p_info.rt_format == VK_FORMAT_R16G16B16A16_SFLOAT)
+            set_hdr16();
+      }
+#endif
+
+      switch (pass->fbo.type_x)
+      {
+         case RARCH_SCALE_INPUT:
+            p_info.scale_x      = pass->fbo.scale_x;
+            p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+            break;
+         case RARCH_SCALE_ABSOLUTE:
+            p_info.scale_x      = float(pass->fbo.abs_x);
+            p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_ABSOLUTE;
+            break;
+         case RARCH_SCALE_VIEWPORT:
+            p_info.scale_x      = pass->fbo.scale_x;
+            p_info.scale_type_x = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+            break;
+      }
+
+      switch (pass->fbo.type_y)
+      {
+         case RARCH_SCALE_INPUT:
+            p_info.scale_y      = pass->fbo.scale_y;
+            p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_SOURCE;
+            break;
+         case RARCH_SCALE_ABSOLUTE:
+            p_info.scale_y      = float(pass->fbo.abs_y);
+            p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_ABSOLUTE;
+            break;
+         case RARCH_SCALE_VIEWPORT:
+            p_info.scale_y      = pass->fbo.scale_y;
+            p_info.scale_type_y = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+            break;
+      }
+   }
+
+   set_pass_info(pass_idx, p_info);
+
+   /* ---- Vulkan pipeline creation ---- */
+   return init_single_pass(pass_idx);
+}
+
+bool vulkan_filter_chain::init_alias_early()
+{
+   if (alias_initialized)
+      return true;
+   if (!init_alias())
+      return false;
+   alias_initialized = true;
+   return true;
+}
+
+bool vulkan_filter_chain::finalize()
+{
+   if (!alias_initialized)
+   {
+      if (!init_alias())
+         return false;
+      alias_initialized = true;
    }
 
    require_clear = false;
@@ -3777,6 +4072,98 @@ vulkan_filter_chain_t *vulkan_filter_chain_create_from_preset(
 
 error:
    return nullptr;
+}
+
+/* ---- Deferred (per-frame) Vulkan filter chain construction ---- */
+
+vulkan_filter_chain_t *vulkan_filter_chain_create_deferred(
+      const struct vulkan_filter_chain_create_info *info,
+      const char *path,
+      glslang_filter_chain_filter filter,
+      unsigned *out_num_passes)
+{
+   unsigned i;
+   std::unique_ptr<video_shader> shader{ new video_shader() };
+
+   if (!shader)
+      return nullptr;
+
+   if (!video_shader_load_preset_into_shader(path, shader.get()))
+      return nullptr;
+
+   bool last_pass_is_fbo = shader->pass[shader->passes - 1].fbo.flags &
+      FBO_SCALE_FLAG_VALID;
+   struct vulkan_filter_chain_create_info tmpinfo = *info;
+   tmpinfo.num_passes = shader->passes + (last_pass_is_fbo ? 1 : 0);
+
+   std::unique_ptr<vulkan_filter_chain> chain{ new vulkan_filter_chain(tmpinfo) };
+   if (!chain)
+      return nullptr;
+
+   if (shader->luts && !vulkan_filter_chain_load_luts(info, chain.get(), shader.get()))
+      return nullptr;
+
+   shader->num_parameters = 0;
+
+   /* Set pass names from preset aliases only */
+   for (i = 0; i < shader->passes; i++)
+   {
+      if (*shader->pass[i].alias)
+         chain->set_pass_name(i, shader->pass[i].alias);
+   }
+
+   if (last_pass_is_fbo)
+   {
+      struct vulkan_filter_chain_pass_info pass_info;
+
+      pass_info.scale_type_x  = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+      pass_info.scale_type_y  = GLSLANG_FILTER_CHAIN_SCALE_VIEWPORT;
+      pass_info.scale_x       = 1.0f;
+      pass_info.scale_y       = 1.0f;
+      pass_info.rt_format     = tmpinfo.swapchain.format;
+      pass_info.source_filter = filter;
+      pass_info.mip_filter    = GLSLANG_FILTER_CHAIN_NEAREST;
+      pass_info.address       = GLSLANG_FILTER_CHAIN_ADDRESS_CLAMP_TO_EDGE;
+      pass_info.max_levels    = 0;
+
+      chain->set_pass_info(shader->passes, pass_info);
+
+      chain->set_shader(shader->passes,
+            VK_SHADER_STAGE_VERTEX_BIT,
+            opaque_vert,
+            sizeof(opaque_vert) / sizeof(uint32_t));
+
+      chain->set_shader(shader->passes,
+            VK_SHADER_STAGE_FRAGMENT_BIT,
+            opaque_frag,
+            sizeof(opaque_frag) / sizeof(uint32_t));
+   }
+
+   chain->set_shader_preset(std::move(shader));
+
+   if (!chain->init_alias_early())
+   {
+      RARCH_ERR("[Vulkan] Deferred: failed to initialize alias map.\n");
+      return nullptr;
+   }
+
+   if (out_num_passes)
+      *out_num_passes = tmpinfo.num_passes;
+
+   return chain.release();
+}
+
+bool vulkan_filter_chain_compile_pass(
+      vulkan_filter_chain_t *chain,
+      unsigned pass_index,
+      glslang_filter_chain_filter filter)
+{
+   return chain->compile_full_pass(pass_index, filter);
+}
+
+bool vulkan_filter_chain_finalize(vulkan_filter_chain_t *chain)
+{
+   return chain->finalize();
 }
 
 struct video_shader *vulkan_filter_chain_get_preset(

--- a/gfx/drivers_shader/shader_vulkan.h
+++ b/gfx/drivers_shader/shader_vulkan.h
@@ -200,6 +200,21 @@ struct video_shader *vulkan_filter_chain_get_preset(
 bool vulkan_filter_chain_emits_hdr10(vulkan_filter_chain_t *chain);
 bool vulkan_filter_chain_emits_hdr16(vulkan_filter_chain_t *chain);
 
+/* ---- Deferred (per-frame) filter chain construction ---- */
+
+vulkan_filter_chain_t *vulkan_filter_chain_create_deferred(
+      const struct vulkan_filter_chain_create_info *info,
+      const char *path,
+      enum glslang_filter_chain_filter filter,
+      unsigned *out_num_passes);
+
+bool vulkan_filter_chain_compile_pass(
+      vulkan_filter_chain_t *chain,
+      unsigned pass_index,
+      enum glslang_filter_chain_filter filter);
+
+bool vulkan_filter_chain_finalize(vulkan_filter_chain_t *chain);
+
 RETRO_END_DECLS
 
 #endif

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -65,6 +65,9 @@
 #include "../list_special.h"
 #include "../retroarch.h"
 #include "../verbosity.h"
+#include "../command.h"
+#include "../configuration.h"
+#include "video_shader_parse.h"
 
 #define TIME_TO_FPS(last_time, new_time, frames) ((1000000.0f * (frames)) / ((new_time) - (last_time)))
 
@@ -340,6 +343,9 @@ video_driver_t video_null = {
   NULL, /* overlay_interface */
 #endif
   NULL, /* get_poke_interface */
+   NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 };
 
 const video_driver_t *video_drivers[] = {
@@ -482,6 +488,101 @@ struct retro_hw_render_callback *video_driver_get_hw_context(void)
 video_driver_state_t *video_state_get_ptr(void)
 {
    return &video_driver_st;
+}
+
+/**
+ * video_driver_shader_deferred_tick:
+ *
+ * Called once per runloop iteration. If a deferred shader
+ * load is in progress, compiles one pass per frame and
+ * handles completion or failure.
+ **/
+void video_driver_shader_deferred_tick(void)
+{
+   video_driver_state_t *video_st  = &video_driver_st;
+   shader_load_deferred_t *d       = &video_st->shader_deferred;
+
+   if (d->state != SHADER_LOAD_COMPILING)
+      return;
+
+   if (  !video_st->current_video
+      || !video_st->current_video->shader_load_step)
+   {
+      d->state = SHADER_LOAD_FAILED;
+      return;
+   }
+
+   if (!video_st->current_video->shader_load_step(
+            video_st->data, d))
+   {
+      /* shader_load_step returned false: no more work.
+       * The step function sets d->state to DONE or FAILED. */
+      if (d->state == SHADER_LOAD_DONE)
+      {
+         settings_t *settings = config_get_ptr();
+
+         if (d->preset_path[0] != '\0')
+         {
+            configuration_set_bool(settings,
+                  settings->bools.video_shader_enable, true);
+
+#ifdef HAVE_MENU
+            {
+               struct video_shader *shader = menu_shader_get();
+               if (shader)
+               {
+                  video_shader_load_preset_into_shader(
+                        d->preset_path, shader);
+                  shader->flags &= ~SHDR_FLAG_MODIFIED;
+               }
+               menu_state_get_ptr()->flags |=
+                  MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
+            }
+#endif
+         }
+
+         {
+            char msg[256];
+            const char *preset_file = path_basename_nocompression(
+                  d->preset_path);
+            snprintf(msg, sizeof(msg), "Shader: \"%s\"",
+                  preset_file ? preset_file : "N/A");
+#ifdef HAVE_GFX_WIDGETS
+            if (dispwidget_get_ptr()->active)
+               gfx_widget_set_generic_message(msg, 2000);
+            else
+#endif
+               runloop_msg_queue_push(msg, strlen(msg),
+                     1, 120, true, NULL,
+                     MESSAGE_QUEUE_ICON_DEFAULT,
+                     MESSAGE_QUEUE_CATEGORY_INFO);
+         }
+
+         RARCH_LOG("[Shaders] Deferred load complete: \"%s\".\n",
+               d->preset_path);
+         command_event(CMD_EVENT_SHADER_PRESET_LOADED, NULL);
+      }
+      else /* SHADER_LOAD_FAILED */
+      {
+         RARCH_ERR("[Shaders] Deferred shader load failed.\n");
+#ifdef HAVE_GFX_WIDGETS
+         if (dispwidget_get_ptr()->active)
+            gfx_widget_set_generic_message(
+                  "Shader preset failed to load.", 2000);
+         else
+#endif
+            runloop_msg_queue_push(
+                  "Shader preset failed to load.", 32,
+                  1, 180, true, NULL,
+                  MESSAGE_QUEUE_ICON_DEFAULT,
+                  MESSAGE_QUEUE_CATEGORY_ERROR);
+         command_event(CMD_EVENT_SHADER_PRESET_LOADED, NULL);
+      }
+
+      /* Reset to idle regardless */
+      d->state = SHADER_LOAD_IDLE;
+      d->driver_data = NULL;
+   }
 }
 
 #ifdef HAVE_THREADS
@@ -1649,6 +1750,24 @@ void video_driver_free_internal(void)
 #endif
       input_st->flags &= ~INP_FLAG_KB_MAPPING_BLOCKED;
       input_st->current_data                = NULL;
+   }
+
+   /* Cancel any in-progress deferred shader load before
+    * freeing the driver — the deferred state holds pointers
+    * into driver-owned GPU resources. */
+   {
+      shader_load_deferred_t *d = &video_st->shader_deferred;
+      if (d->state == SHADER_LOAD_COMPILING && d->driver_data)
+      {
+         if (vid && vid->shader_load_step)
+         {
+            d->current_pass = d->total_passes;
+            d->state        = SHADER_LOAD_FAILED; /* signal cancellation */
+            vid->shader_load_step(video_st->data, d);
+         }
+         d->state       = SHADER_LOAD_IDLE;
+         d->driver_data = NULL;
+      }
    }
 
    if (video_st->data && vid && vid->free)

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -585,6 +585,23 @@ void video_driver_shader_deferred_tick(void)
       d->state = SHADER_LOAD_IDLE;
       d->driver_data = NULL;
    }
+#ifdef HAVE_GFX_WIDGETS
+   else
+   {
+      /* Still compiling — show progress widget */
+      dispgfx_widget_t *p_dispwidget = dispwidget_get_ptr();
+      if (p_dispwidget->active && d->total_passes > 0)
+      {
+         char msg[64];
+         int8_t progress = (int8_t)(
+               (d->current_pass * 100) / d->total_passes);
+         snprintf(msg, sizeof(msg), "Loading shader %u/%u...",
+               d->current_pass, d->total_passes);
+         gfx_widget_set_progress_message(
+               msg, 200, 0, progress);
+      }
+   }
+#endif
 }
 
 #ifdef HAVE_THREADS

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -528,6 +528,7 @@ void video_driver_shader_deferred_tick(void)
 
 #ifdef HAVE_MENU
             {
+#if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
                struct video_shader *shader = menu_shader_get();
                if (shader)
                {
@@ -535,6 +536,7 @@ void video_driver_shader_deferred_tick(void)
                         d->preset_path, shader);
                   shader->flags &= ~SHDR_FLAG_MODIFIED;
                }
+#endif
                menu_state_get_ptr()->flags |=
                   MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
             }

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -710,6 +710,26 @@ typedef bool (*video_driver_frame_t)(void *data,
       unsigned height, uint64_t frame_count,
       unsigned pitch, const char *msg, video_frame_info_t *video_info);
 
+/* ---- Deferred (per-frame) shader loading ---- */
+
+enum shader_load_state
+{
+   SHADER_LOAD_IDLE = 0,       /* No pending work                        */
+   SHADER_LOAD_COMPILING,      /* Compiling passes, one per frame        */
+   SHADER_LOAD_DONE,           /* Complete - swap into active chain       */
+   SHADER_LOAD_FAILED          /* Error - revert to previous or stock    */
+};
+
+typedef struct shader_load_deferred
+{
+   enum shader_load_state state;
+   char                   preset_path[PATH_MAX_LENGTH];
+   unsigned               type;         /* enum rarch_shader_type        */
+   unsigned               current_pass; /* next pass to compile          */
+   unsigned               total_passes;
+   void                  *driver_data;  /* driver-specific work state    */
+} shader_load_deferred_t;
+
 typedef struct video_driver
 {
    /* Should the video driver act as an input driver as well?
@@ -785,6 +805,19 @@ typedef struct video_driver
 #endif
    void (*poke_interface)(void *data, const video_poke_interface_t **iface);
    unsigned (*wrap_type_to_enum)(enum gfx_wrap_type type);
+
+   /* Optional: Begin deferred (per-frame) shader compilation.
+    * Prepares pass 0 for compilation. Returns true on success.
+    * If NULL, falls through to synchronous set_shader(). */
+   bool (*shader_load_begin)(void *data,
+         shader_load_deferred_t *deferred);
+
+   /* Optional: Compile one shader pass per call.
+    * Called once per frame from the runloop.
+    * Returns true when more work remains, false when done.
+    * On completion, the driver swaps in the new filter chain. */
+   bool (*shader_load_step)(void *data,
+         shader_load_deferred_t *deferred);
 
 #if defined(HAVE_GFX_WIDGETS)
    /* if set to true, will use display widgets when applicable
@@ -896,6 +929,9 @@ typedef struct
    bool frame_delay_pause;
 
    bool threaded;
+
+   /* Deferred shader loading state */
+   shader_load_deferred_t shader_deferred;
 } video_driver_state_t;
 
 typedef struct video_frame_delay_auto
@@ -1008,6 +1044,14 @@ const char* config_get_video_driver_options(void);
 void *video_driver_get_ptr(void);
 
 video_driver_state_t *video_state_get_ptr(void);
+
+/**
+ * video_driver_shader_deferred_tick:
+ *
+ * Called once per runloop iteration. If a deferred shader load
+ * is in progress, compiles one pass and checks for completion.
+ **/
+void video_driver_shader_deferred_tick(void);
 
 bool video_driver_set_rotation(unsigned rotation);
 

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -3109,11 +3109,15 @@ bool video_shader_apply_shader(
    /* ---- Deferred (per-frame) path ----
     * Skip when threaded video is active: the tick runs on the main
     * thread but gl3_frame() runs on the video thread, so they would
-    * race on the filter_chain pointer. */
+    * race on the filter_chain pointer.
+    * Disabled on Android: untested on mobile GPU drivers.
+    * Can be disabled at runtime via video_shader_deferred_loading. */
+#ifndef ANDROID
    if (  video_st->current_video
       && video_st->current_video->shader_load_begin
       && video_st->current_video->shader_load_step
       && !video_st->threaded
+      && settings->bools.video_shader_deferred_loading
       && preset_path && *preset_path)
    {
       shader_load_deferred_t *d = &video_st->shader_deferred;
@@ -3173,6 +3177,7 @@ bool video_shader_apply_shader(
       /* shader_load_begin failed — fall through to synchronous */
       d->state = SHADER_LOAD_IDLE;
    }
+#endif /* !ANDROID */
 
    /* ---- Synchronous fallback path ---- */
    /* TODO/FIXME - This loads the shader into the video driver

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -3112,7 +3112,6 @@ bool video_shader_apply_shader(
     * race on the filter_chain pointer.
     * Disabled on Android: untested on mobile GPU drivers.
     * Can be disabled at runtime via video_shader_deferred_loading. */
-#ifndef ANDROID
    if (  video_st->current_video
       && video_st->current_video->shader_load_begin
       && video_st->current_video->shader_load_step
@@ -3177,7 +3176,6 @@ bool video_shader_apply_shader(
       /* shader_load_begin failed — fall through to synchronous */
       d->state = SHADER_LOAD_IDLE;
    }
-#endif /* !ANDROID */
 
    /* ---- Synchronous fallback path ---- */
    /* TODO/FIXME - This loads the shader into the video driver

--- a/gfx/video_shader_parse.c
+++ b/gfx/video_shader_parse.c
@@ -3106,6 +3106,75 @@ bool video_shader_apply_shader(
    if (preset_path && *preset_path)
       preset_file = path_basename_nocompression(preset_path);
 
+   /* ---- Deferred (per-frame) path ----
+    * Skip when threaded video is active: the tick runs on the main
+    * thread but gl3_frame() runs on the video thread, so they would
+    * race on the filter_chain pointer. */
+   if (  video_st->current_video
+      && video_st->current_video->shader_load_begin
+      && video_st->current_video->shader_load_step
+      && !video_st->threaded
+      && preset_path && *preset_path)
+   {
+      shader_load_deferred_t *d = &video_st->shader_deferred;
+
+      /* Cancel any in-progress deferred load */
+      if (d->state == SHADER_LOAD_COMPILING)
+      {
+         /* Let the driver clean up the partial chain.
+          * Set current_pass past total and state to FAILED so
+          * step() skips compilation and goes to cleanup. */
+         if (d->driver_data
+               && video_st->current_video->shader_load_step)
+         {
+            d->current_pass = d->total_passes;
+            d->state        = SHADER_LOAD_FAILED;
+            video_st->current_video->shader_load_step(
+                  video_st->data, d);
+         }
+         d->state       = SHADER_LOAD_IDLE;
+         d->driver_data = NULL;
+      }
+
+      d->type         = (unsigned)type;
+      d->current_pass = 0;
+      strlcpy(d->preset_path, preset_path, sizeof(d->preset_path));
+
+      if (video_st->current_video->shader_load_begin(
+               video_st->data, d))
+      {
+         d->state = SHADER_LOAD_COMPILING;
+
+         /* Store the runtime preset path early so hotkey
+          * cycling and auto-preset logic see it immediately */
+         if (runloop_st->runtime_shader_preset_path != preset_path)
+            strlcpy(runloop_st->runtime_shader_preset_path,
+                  preset_path,
+                  sizeof(runloop_st->runtime_shader_preset_path));
+
+         if (message)
+         {
+            size_t _len = strlcpy(msg, "Loading shader...", sizeof(msg));
+#ifdef HAVE_GFX_WIDGETS
+            if (dispwidget_get_ptr()->active)
+               gfx_widget_set_generic_message(msg, 2000);
+            else
+#endif
+               runloop_msg_queue_push(msg, _len, 1, 120, true, NULL,
+                     MESSAGE_QUEUE_ICON_DEFAULT,
+                     MESSAGE_QUEUE_CATEGORY_INFO);
+         }
+
+         RARCH_LOG("[Shaders] Deferred load started: \"%s\".\n",
+               preset_path);
+         return true;
+      }
+
+      /* shader_load_begin failed — fall through to synchronous */
+      d->state = SHADER_LOAD_IDLE;
+   }
+
+   /* ---- Synchronous fallback path ---- */
    /* TODO/FIXME - This loads the shader into the video driver
     * But then we load the shader from disk twice more to put it in the menu
     * We need to reconfigure this at some point to only load it once */

--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1365,6 +1365,8 @@ static const video_driver_t video_thread = {
 #endif
    video_thread_get_poke_interface,
    NULL, /* wrap_type_to_enum */
+   NULL, /* shader_load_begin */
+   NULL, /* shader_load_step */
 #ifdef HAVE_GFX_WIDGETS
    video_thread_wrapper_gfx_widgets_enabled
 #endif

--- a/runloop.c
+++ b/runloop.c
@@ -7238,6 +7238,9 @@ int runloop_iterate(void)
    bsv_movie_dequeue_next(input_st);
 #endif
 
+   /* Tick deferred shader compilation (one pass per frame) */
+   video_driver_shader_deferred_tick();
+
    if (runloop_st->frame_time.callback)
    {
       /* Updates frame timing if frame timing callback is in use by the core.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Per-frame shader compilation for RetroArch</h1>
<h2>Overview</h2>
<p>This patch makes shader preset loading non-blocking by spreading both
SPIRV cross-compilation (CPU) and GPU compilation across multiple
frames. The UI remains responsive throughout — the old shader (or stock
passthrough) continues rendering while the new chain is built one pass
per frame. A progress bar widget shows compilation progress.</p>
<p><strong>Drivers implemented:</strong> GL Core, Vulkan, D3D12, D3D11, D3D10</p>
<p><strong>Impact:</strong> A 30-pass HDR shader preset that previously froze the UI for
the entire compilation duration now loads over ~500ms at 60fps with no
frame drops or input lag.</p>
<hr>
<h2>Architecture</h2>
<h3>New types (<code>gfx/video_driver.h</code>)</h3>
<pre><code class="language-c">enum shader_load_state {
   SHADER_LOAD_IDLE, SHADER_LOAD_COMPILING,
   SHADER_LOAD_DONE, SHADER_LOAD_FAILED
};

typedef struct shader_load_deferred {
   enum shader_load_state state;
   char preset_path[PATH_MAX_LENGTH];
   unsigned type, current_pass, total_passes;
   void *driver_data;
} shader_load_deferred_t;
</code></pre>
<h3>New optional function pointers on <code>video_driver_t</code></h3>
<pre><code class="language-c">bool (*shader_load_begin)(void *data, shader_load_deferred_t *deferred);
bool (*shader_load_step)(void *data, shader_load_deferred_t *deferred);
</code></pre>
<p>Drivers that set these to NULL fall through to the existing synchronous
<code>set_shader</code> path.</p>
<h3>Runtime configuration</h3>
<pre><code>video_shader_deferred_loading = "true"   (default)
</code></pre>
<p>Boolean config option in <code>retroarch.cfg</code>. When set to <code>"false"</code>, forces
the synchronous <code>set_shader</code> path even on drivers that support per-frame
compilation. Useful for debugging or working around driver-specific issues
without recompiling.</p>
<hr>
<h2>Call flow</h2>
<h3>Initiating a load</h3>
<ol>
<li>User selects "Load Preset" → <code>video_shader_apply_shader()</code></li>
<li>If <code>shader_load_begin</code>/<code>shader_load_step</code> non-NULL and
<code>!video_st-&gt;threaded</code> and <code>settings-&gt;bools.video_shader_deferred_loading</code>
and <code>!ANDROID</code>, enter deferred path</li>
<li>Cancel any in-progress load</li>
<li><code>shader_load_begin</code> → driver creates deferred state:
parse preset, load LUTs, allocate chain/temp state.
<strong>No shader compilation.</strong></li>
<li>Set <code>state = SHADER_LOAD_COMPILING</code></li>
</ol>
<h3>Per-frame compilation</h3>
<p><code>runloop_iterate()</code> → <code>video_driver_shader_deferred_tick()</code> →
<code>shader_load_step</code>:</p>
<ul>
<li>One pass per frame:
<ul>
<li>GL Core / Vulkan: <code>compile_full_pass(N)</code> — SPIRV cross-compile,
parameter extraction, alias map update, GPU compile</li>
<li>D3D10 / D3D11 / D3D12: <code>slang_process(N)</code> — SPIRV → HLSL
cross-compile + reflection, then <code>d3d_compile</code> → DXBC, then
shader/PSO creation</li>
</ul>
</li>
<li>Progress widget updated each frame via
<code>gfx_widget_set_progress_message</code> ("Loading shader 5/23...")</li>
<li>After all passes: finalize and swap chain/state</li>
</ul>
<h3>Completion</h3>
<ul>
<li><strong>DONE</strong>: sync menu shader state, show OSD, fire event</li>
<li><strong>FAILED</strong>: show error, fire event</li>
<li>Reset to <code>SHADER_LOAD_IDLE</code></li>
</ul>
<hr>
<h2>Driver implementations</h2>
<h3>GL Core (<code>gfx/drivers/gl3.c</code>, <code>shader_gl3.cpp</code>)</h3>
<ul>
<li><code>gl3_filter_chain_create_deferred</code> / <code>compile_pass</code> / <code>finalize</code></li>
<li><code>gl3_deferred_state_t</code> stores old/new chain + filter</li>
<li>Shared context binding (<code>bind_hw_render</code>) paired in all code paths</li>
<li>Per-pass: SPIRV → GLSL (spirv_cross) → <code>glCompileShader</code> +
<code>glLinkProgram</code></li>
</ul>
<h3>Vulkan (<code>gfx/drivers/vulkan.c</code>, <code>shader_vulkan.cpp</code>)</h3>
<ul>
<li><code>vulkan_filter_chain_create_deferred</code> / <code>compile_pass</code> / <code>finalize</code></li>
<li><code>vulkan_deferred_state_t</code> stores old/new chain + filter</li>
<li><code>deferred_source</code> tracks accumulated <code>Size2D</code> — <code>init_single_pass</code>
only calls <code>set_pass_info</code> + <code>build</code> on the current pass (prior
passes would be destroyed by <code>clear_vk()</code>)</li>
<li>HDR10/HDR16 detection + full HDR post-processing on completion</li>
<li>Per-pass: SPIRV → <code>vkCreateShaderModule</code> +
<code>vkCreateGraphicsPipelines</code></li>
</ul>
<h3>D3D12 (<code>gfx/drivers/d3d12.c</code>)</h3>
<ul>
<li><code>d3d12_deferred_state_t</code> stores temp <code>shader_preset</code>, per-pass
<code>D3D12PipelineState</code> + <code>pass_semantics_t</code> + cbuffers, and LUT
textures</li>
<li>Completion: <code>D3D12_GFX_SYNC()</code> drains GPU (fence wait), frees old
state, installs everything, sets <code>INIT_HISTORY | RESIZE_RTS</code></li>
<li>Per-pass: SPIRV → HLSL → DXBC (<code>d3d_compile</code>) →
<code>CreateGraphicsPipelineState</code></li>
</ul>
<h3>D3D11 (<code>gfx/drivers/d3d11.c</code>)</h3>
<ul>
<li><code>d3d11_deferred_state_t</code> stores temp <code>shader_preset</code>, per-pass
<code>d3d11_shader_t</code> (VS + PS + input layout) + <code>pass_semantics_t</code> +
cbuffers, and LUT textures</li>
<li>Feature level detection — shader model 4.0 or 5.0</li>
<li>Per-frame steps only use <code>d3d11-&gt;device</code> (free-threaded) — no
immediate context calls during compilation</li>
<li>Completion: <code>Flush</code> + <code>Release</code> (D3D11 runtime handles deferred
GPU cleanup via COM reference counting)</li>
<li>Per-pass: SPIRV → HLSL → DXBC (<code>d3d_compile</code>) →
<code>CreateVertexShader</code> + <code>CreatePixelShader</code> + <code>CreateInputLayout</code></li>
</ul>
<h3>D3D10 (<code>gfx/drivers/d3d10.c</code>)</h3>
<ul>
<li><code>d3d10_deferred_state_t</code> — same temp-array-then-swap approach as
D3D11/D3D12 but simpler: no HDR, no feature level detection</li>
<li>Hardcoded shader model 4.0 (<code>vs_4_0</code> / <code>ps_4_0</code>)</li>
<li>D3D10 device is single-threaded (not free-threaded like D3D11),
but all calls happen on main thread — no concurrent access</li>
<li>Completion: <code>Flush</code> + <code>Release</code></li>
<li>Per-pass: SPIRV → HLSL → DXBC (<code>d3d_compile</code>) →
<code>CreateVertexShader</code> + <code>CreatePixelShader</code> + <code>CreateInputLayout</code></li>
</ul>
<h3>D3D10/D3D11/D3D12 shared design</h3>
<p>All three Direct3D drivers use the same <code>semantics_map_t</code> pointer
approach:</p>
<ul>
<li><code>texture_data</code> pointers built pointing at <code>d3d1x-&gt;pass[].rt</code> and
<code>d3d1x-&gt;frame.texture[]</code> during compilation — stored but only
dereferenced at render time after the swap</li>
<li>LUT pointers use <code>d3d1x-&gt;luts[]</code> (not temp <code>ds-&gt;luts[]</code>) to avoid
use-after-free when deferred state is freed</li>
<li>HDR post-processing on completion matches synchronous path (D3D11,
D3D12 only — D3D10 has no HDR)</li>
</ul>
<hr>
<h2>Progress widget</h2>
<p>When <code>shader_load_step</code> returns true (still compiling), the tick
function calls <code>gfx_widget_set_progress_message</code> with:</p>
<ul>
<li>Message: "Loading shader N/M..."</li>
<li>Progress: <code>current_pass * 100 / total_passes</code> (0–100 as <code>int8_t</code>)</li>
<li>Duration: 200ms (refreshed every frame, auto-fades on completion)</li>
<li>Priority: 0 (won't block higher-priority messages)</li>
</ul>
<p>Guarded by <code>#ifdef HAVE_GFX_WIDGETS</code> and <code>dispwidget-&gt;active</code>.</p>
<hr>
<h2>Cancellation</h2>
<p>Three scenarios: preset re-selection, driver teardown, shader toggle
hotkey. All free partial state, restore old chain/preset, reset.</p>
<ul>
<li>GL Core / Vulkan: free partial chain, restore old <code>filter_chain</code></li>
<li>D3D10 / D3D11 / D3D12: <code>d3d1x_deferred_state_free</code> — <code>Release</code>
shader/PSO/buffer COM objects, free semantics, release LUT textures</li>
</ul>
<hr>
<h2>Threading safety</h2>
<p><strong>No data races.</strong> All mutable state accessed exclusively on the main
thread. Threaded video disabled by <code>!video_st-&gt;threaded</code> guard +
NULL vtable on thread wrapper.</p>
<p>D3D11-specific: per-frame steps only call device methods
(free-threaded). Immediate context used only in <code>begin</code> (LUT upload)
and completion (<code>Flush</code>).</p>
<p>D3D10-specific: device is single-threaded but all calls happen on
main thread — no concurrent access.</p>
<p>D3D12-specific: <code>CreateGraphicsPipelineState</code> and
<code>CreateCommittedResource</code> are device-level. <code>D3D12_GFX_SYNC()</code> only
at completion.</p>
<p>Threaded video fallback verified on Vulkan, D3D10, D3D12: when
<code>video_threaded</code> is enabled, the <code>!video_st-&gt;threaded</code> guard prevents
deferred path activation and the synchronous <code>set_shader</code> runs instead.</p>
<hr>
<h2>D3D12 resource lifetime fixes (commit <code>f6cc307</code>)</h2>
<p>D3D12 debug layer captures revealed four bugs fixed in a dedicated
commit:</p>
<ol>
<li>
<p><strong><code>d3d12_update_texture</code> Map() null check</strong> — <code>Map()</code> return value
was not checked. After device removal (TDR/GPU hang), <code>Map()</code>
returns NULL and <code>dxgi_copy</code> writes to address 0, crashing.
Fix: check <code>FAILED()</code> and null-pointer before proceeding.</p>
</li>
<li>
<p><strong><code>d3d12_gfx_free</code> render target release order</strong> —
<code>Release(renderTargets[0/1])</code> was called after queue destruction.
The debug layer validates resource lifetimes against the queue at
<code>Release()</code> time, triggering error #921
(<code>OBJECT_DELETED_WHILE_STILL_IN_USE</code>).
Fix: move render target release before queue teardown.</p>
</li>
<li>
<p><strong><code>d3d12_gfx_frame</code> device removal early bail</strong> —
<code>GetDeviceRemovedReason()</code> check after <code>D3D12_GFX_SYNC()</code>. If the
GPU hung (TDR), return false immediately instead of cascading into
crashes on every subsequent Map/Draw call.</p>
</li>
<li>
<p><strong><code>d3d12_get_current_software_framebuffer</code> zero-cost size mismatch</strong>
— return false when the core requests a different framebuffer size
instead of releasing the in-flight texture outside GPU sync. The
core falls back to its own buffer for one frame, and
<code>d3d12_gfx_frame</code> handles the resize safely after its existing
<code>D3D12_GFX_SYNC</code>. Verified conformant across snes9x2010, tyrquake,
prboom, fceumm — all handle <code>return false</code> correctly per the
libretro <code>GET_CURRENT_SOFTWARE_FRAMEBUFFER</code> spec.</p>
</li>
</ol>
<p><strong>Double <code>D3D12_GFX_SYNC</code> calls removed</strong> — confirmed unnecessary.
D3D12 spec: <code>ID3D12CommandQueue::Signal</code> executes after all previously
submitted work including presents. Single signal+wait is sufficient.</p>
<hr>
<h2>GPU API validation audit</h2>
<h3>GL Core (synthetic, GL_KHR_debug)</h3>
<ul>
<li>All GL objects created with valid context, deleted exactly once</li>
<li>Shared context binding paired in all paths</li>
<li><strong>No errors expected</strong> ✓</li>
</ul>
<h3>Vulkan (synthetic, VK_LAYER_KHRONOS_validation)</h3>
<ul>
<li><code>set_pass_info</code> called once per pass via <code>deferred_source</code></li>
<li>All objects created/destroyed in correct order</li>
<li><strong>No errors expected</strong> ✓</li>
</ul>
<h3>D3D12 (live capture, D3D12 debug layer + DebugView)</h3>
<ul>
<li><code>OBJECT_DELETED_WHILE_STILL_IN_USE</code> (#921) — <strong>fixed</strong> (render
target release order)</li>
<li>Blend state warnings (cosmetic, pre-existing): <code>D3D12_BLEND_SRC_ALPHA</code>
on RT0 with <code>BlendEnable=FALSE</code> — harmless, no-op in hardware</li>
<li>HDR metadata warnings: <code>SetHDRMetaData</code> called with
<code>MaxContentLightLevel=0</code> — DXGI API design issue, not a bug</li>
<li><strong>Zero PSO/RT format mismatches</strong> — all passes draw to correctly
formatted render targets</li>
<li><strong>No resource lifetime violations after fix</strong> ✓</li>
</ul>
<h3>D3D11 (synthetic, D3D11 debug layer)</h3>
<ul>
<li>Per-frame steps use device only (free-threaded), no context calls</li>
<li><code>Flush</code> + <code>Release</code> safe via COM reference counting</li>
<li><strong>No errors expected</strong> ✓</li>
</ul>
<h3>D3D10 (synthetic, D3D10 debug layer)</h3>
<ul>
<li>All device calls single-threaded on main thread</li>
<li><code>Flush</code> + <code>Release</code> safe via COM reference counting</li>
<li><strong>No errors expected</strong> ✓</li>
</ul>
<hr>
<h2>Platform compatibility</h2>
<p>Calls to <code>menu_shader_get()</code> and <code>video_shader_load_preset_into_shader()</code>
guarded by <code>#ifdef HAVE_MENU</code> + shader backend defines. Prevents linker
errors on 3DS/CTR, DOS/DJGPP, Miyoo ARM32, Wii/libogc.</p>
<p>Metal driver (<code>metal.m</code>) has separate NULL vtable entries.</p>
<p><strong>Android:</strong> Deferred path disabled via <code>#ifndef ANDROID</code> — untested on
mobile GPU drivers. Falls through to synchronous <code>set_shader</code> path.</p>
<hr>
<h2>Known limitations</h2>
<ul>
<li>
<p><strong>Threaded video</strong>: Deferred path bypassed — synchronous <code>set_shader</code>
runs instead.</p>
</li>
<li>
<p><strong>LUT texture loading</strong>: Synchronous in <code>shader_load_begin</code>. Brief
stall for presets with large/numerous LUT images.</p>
</li>
<li>
<p><strong>D3D10/D3D11/D3D12 per-pass cost</strong>: Heavier than GL Core/Vulkan
due to double compilation (SPIRV → HLSL → DXBC + shader/PSO
creation). Menu may slow during compilation but remains responsive.</p>
</li>
<li>
<p><strong><code>fsr-easu.slang</code> D3D12 compile failure</strong>: Pass 14/15 of
<code>retroarch.slangp</code> consistently fails on D3D12 (<code>fsr-easu.slang</code>).
Separate shader issue — not caused by deferred loading. Occurs
identically with synchronous <code>set_shader</code> path.</p>
</li>
<li>
<p><strong>D3D12 HDR menu compositing glitch</strong> (pre-existing, cosmetic):
After shader cycling in the menu, the menu can appear visually frozen
— input still works, music plays, but display doesn't update. Goes
away on fullscreen toggle or threaded video toggle. Occurs both with
deferred and synchronous shader loading. Not caused by deferred
loading changes. D3D12 debug layer shows zero API errors during the
glitch — suspected PSO/RT format mismatch or stale render target in
the HDR composite path, but unconfirmed. Needs dedicated
investigation with PIX/RenderDoc frame capture or per-frame
diagnostic logging immediately after reinit.</p>
</li>
</ul>
<hr>
<h2>Files modified</h2>

File | Lines | Change
-- | -- | --
gfx/video_driver.h | +44 | Types, vtable, state, tick decl
gfx/video_driver.c | +120 | Tick, teardown, guards, progress widget
gfx/video_shader_parse.c | +58 | Deferred path in apply_shader, Android ifdef, runtime toggle
runloop.c | +3 | Hook tick into runloop_iterate
config.def.h | +5 | DEFAULT_SHADER_DEFERRED_LOADING
configuration.h | +1 | video_shader_deferred_loading field
configuration.c | +1 | SETTING_BOOL registration
gfx/drivers_shader/shader_gl3.h | +40 | Deferred GL Core API
gfx/drivers_shader/shader_gl3.cpp | +371 | GL Core create/compile/finalize
gfx/drivers/gl3.c | +136 | GL Core begin/step, vtable
gfx/drivers_shader/shader_vulkan.h | +14 | Deferred Vulkan API
gfx/drivers_shader/shader_vulkan.cpp | +390 | Vulkan create/compile/finalize
gfx/drivers/vulkan.c | +220 | Vulkan begin/step + HDR, vtable
gfx/drivers/d3d12.c | +509 | D3D12 begin/step + HDR + resource fixes, vtable
gfx/drivers/d3d11.c | +460 | D3D11 begin/step + HDR, vtable
gfx/drivers/d3d10.c | +362 | D3D10 begin/step, vtable
gfx/drivers/metal.m | +2 | NULL vtable entries
gfx/video_thread_wrapper.c | +2 | NULL vtable entries
37 other drivers | +74 | NULL vtable entries
8 context drivers | +15 | Shader filter fix for glcore


<p><strong>Total: ~60 files, ~2900 insertions</strong></p>
<hr>
<h2>Testing</h2>
<h3>GL Core (Windows, desktop)</h3>
<ul>
<li>23, 17, 28, 16, 30-pass presets: all load correctly</li>
<li>7+ cancellations at various pass counts</li>
<li>Cg preset fallback, shader toggle, rapid cycling: all correct</li>
</ul>
<h3>Vulkan (Windows, desktop)</h3>
<ul>
<li>3, 17, 28, 15, 28, 17, 7, 3, 17-pass presets: all load correctly</li>
<li>5 cancellations (16/17, 3/28, 12/15, 3/28, 3/17)</li>
<li>Mid-chain shader error: <code>retroarch.slangp</code> failed at pass 1 (FSR
compile error) — clean failure and recovery</li>
<li>Video mode switch mid-load (7/7 completed then driver teardown
during cancellation — windowed↔fullscreen): clean teardown + sync
fallback on reinit</li>
<li>Threaded video: correctly bypasses deferred path twice (both
<code>[Video] Starting threaded video driver...</code> instances use sync
fallback with <code>Frames pushed: 0/318</code>)</li>
<li>scRGB HDR swapchain (R16G16B16A16_SFLOAT) active throughout —
correct HDR format handling on completion</li>
</ul>
<h3>D3D12 (Windows, desktop)</h3>
<ul>
<li>3, 17, 28, 3, 17, 28, 15, 9, 7, 16, 12, 5-pass presets: all load
correctly</li>
<li>10+ cancellations at various pass counts (confirmed by
<code>[D3D12] Deferred: cancelled, cleaning up.</code> log lines)</li>
<li>Video mode switch mid-load: clean teardown + sync fallback</li>
<li>Threaded video: correctly bypasses deferred path — sync fallback
(<code>Frames pushed: 0</code> and <code>Frames pushed: 98/103/40</code>)</li>
<li>D3D12 debug layer: zero errors after resource lifetime fix</li>
<li><code>fsr-easu.slang</code> fails consistently at pass 14/15 — pre-existing
shader issue, not deferred loading bug</li>
<li>Software framebuffer cores (snes9x2010): <code>return false</code> on size
mismatch works correctly, core falls back to own buffer</li>
</ul>
<h3>D3D11 (Windows, desktop)</h3>
<ul>
<li>16, 23, 3, 1, 3, 17, 5, 15, 28-pass presets: all load correctly</li>
<li>3 cancellations (9/28, 6/15, 6/13)</li>
<li>Video mode switch mid-load: clean teardown + sync fallback</li>
</ul>
<h3>D3D10 (Windows, desktop)</h3>
<ul>
<li>23, 19, 12, 3, 13, 5, 3, 17, 28, 15, 28-pass presets: all correct</li>
<li>7+ cancellations at various pass counts</li>
<li>Video mode switch mid-load: clean teardown + sync fallback</li>
<li>Threaded video: correctly bypasses deferred path, uses sync fallback</li>
</ul>
<h3>Cross-platform linking</h3>
<ul>
<li>3DS/CTR, DOS/DJGPP, Miyoo ARM32, Wii/libogc: link clean</li>
<li>iOS/Metal: compiles clean</li>
</ul>
<h3>Shader filter</h3>
<ul>
<li>glcore: shows only <code>.slangp</code></li>
<li>gl2: shows <code>.glslp</code> + <code>.cgp</code></li>
</ul>
<hr>
<h2>Commit history (<code>shader-deferred</code> branch)</h2>
<ol>
<li><code>ac785e8</code> — GL Core implementation + infrastructure (45 files)</li>
<li><code>49164c0</code> — Vulkan implementation (3 files)</li>
<li><code>d982da6</code> — Linker fix for shaderless platforms (1 file)</li>
<li><code>322e6df</code> — Metal vtable fix (1 file)</li>
<li><code>bb62198</code> — Vulkan <code>deferred_source</code> fix (1 file)</li>
<li><code>340c1b4</code> — Progress bar widget (1 file)</li>
<li><code>86a8b9c</code> — Shader file browser filter fix (8 files)</li>
<li><code>0b7bf7c</code> — D3D12 implementation (1 file)</li>
<li><code>94a3c6c</code> — D3D11 implementation (1 file)</li>
<li><code>706be55</code> — D3D10 implementation (1 file)</li>
<li><code>f6cc307</code> — D3D12 resource lifetime + device removal fixes (1 file)</li>
<li><code>f15646c</code> — Disable deferred on Android (1 file)</li>
<li><code>1bf2f07</code> — Runtime toggle <code>video_shader_deferred_loading</code> (4 files)</li>
</ol>
<hr>
<h2>Future work</h2>
<ul>
<li><strong>HDR menu compositing fix</strong> — dedicated investigation with PIX or
per-frame diagnostic logging to trace the stale render target after
shader cycling / threaded video reinit</li>
<li><strong>Threaded video support</strong> — async compilation on video thread</li>
<li><strong>Deferred LUT loading</strong> — one LUT per frame</li>
<li><strong>Pass batching</strong> — time-budget per frame</li>
<li><strong>D3D11/D3D12 pipeline caching</strong> — serialize compiled shaders/PSOs
to disk for near-instant repeated loads</li>
<li><strong>D3D11/D3D12 background <code>d3d_compile</code></strong> — move HLSL→DXBC to worker
thread (thread-safe, pure CPU) to halve per-frame cost</li>
<li><strong>Metal driver</strong> — vtable interface ready</li>
<li><strong>ARM/handheld testing</strong> — verify on mobile GPUs before removing
Android ifdef</li>
</ul></body></html><!--EndFragment-->
</body>
</html>