### PR TITLE
Fix empty logs on Xbox UWP

### DIFF
--- a/libretro-common/compat/fopen_utf8.c
+++ b/libretro-common/compat/fopen_utf8.c
@@ -22,10 +22,19 @@
 
 #include <compat/fopen_utf8.h>
 #include <encodings/utf.h>
+#include <string.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__WINRT__)
+#include <stdint.h>
+#include <windows.h>
+#include <fileapifromapp.h>
+#include <io.h>
+#include <fcntl.h>
+#endif
 
-#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0500 || defined(_XBOX)
+#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0500 || (defined(_XBOX) && !defined(__WINRT__))
 #ifndef LEGACY_WIN32
 #define LEGACY_WIN32
 #endif
@@ -49,12 +58,75 @@ void *fopen_utf8(const char * filename, const char * mode)
    if (filename_w)
    {
       FILE    *ret       = NULL;
+#if defined(__WINRT__)
+      HANDLE   file_handle = INVALID_HANDLE_VALUE;
+      DWORD    desired_access = 0;
+      DWORD    creation_disposition = OPEN_EXISTING;
+      int      open_flags = O_BINARY;
+      int      fd = -1;
+      bool     append = mode && strchr(mode, 'a');
+      bool     write = mode && strchr(mode, 'w');
+      bool     plus = mode && strchr(mode, '+');
+      wchar_t *path = filename_w;
+
+      while (*path)
+      {
+         if (*path == L'/')
+            *path = L'\\';
+         path++;
+      }
+
+      if (mode && strchr(mode, 'r'))
+         desired_access |= GENERIC_READ;
+      if (write || append || plus)
+         desired_access |= GENERIC_WRITE;
+      if (plus)
+         desired_access |= GENERIC_READ;
+
+      if (append)
+         creation_disposition = OPEN_ALWAYS;
+      else if (write)
+         creation_disposition = CREATE_ALWAYS;
+
+      if (plus)
+         open_flags |= O_RDWR;
+      else if (append || write)
+         open_flags |= O_WRONLY;
+      else
+         open_flags |= O_RDONLY;
+
+      if (append)
+         open_flags |= O_APPEND;
+      if (write || append)
+         open_flags |= O_CREAT;
+      if (write)
+         open_flags |= O_TRUNC;
+
+      file_handle = CreateFile2FromAppW(filename_w, desired_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            creation_disposition, NULL);
+      if (file_handle != INVALID_HANDLE_VALUE)
+      {
+         fd = _open_osfhandle((intptr_t)file_handle, open_flags);
+         if (fd != -1)
+            ret = _fdopen(fd, mode);
+
+         if (!ret)
+         {
+            if (fd != -1)
+               _close(fd);
+            else
+               CloseHandle(file_handle);
+         }
+      }
+#else
       wchar_t *mode_w    = utf8_to_utf16_string_alloc(mode);
       if (mode_w)
       {
          ret             = _wfopen(filename_w, mode_w);
          free(mode_w);
       }
+#endif
       free(filename_w);
       return ret;
    }


### PR DESCRIPTION
Add Windows Runtime support to fopen_utf8 by using CreateFile2FromAppW and _open_osfhandle when __WINRT__ is defined. Map C mode flags to WinRT access, creation disposition and POSIX-like open flags (r/w/a/+), normalize forward slashes to backslashes, and correctly handle fd/handle cleanup on failure. Also add required headers (string.h, stdbool.h, stdint.h, windows.h, fileapifromapp.h, io.h, fcntl.h) and keep the existing _wfopen fallback for non-WinRT Windows builds.

