### PR TITLE
Use task error message if there is one.

### DIFF
--- a/gfx/gfx_widgets.c
+++ b/gfx/gfx_widgets.c
@@ -261,13 +261,21 @@ void gfx_widgets_msg_queue_push(
 
          if (task)
          {
-            len                                 = strlen(task->title);
-            msg_title = msg_widget->msg         = strdup(task->title);
+
+            if (task->error && *task->error)
+            {
+               msg_widget->flags               |= DISPWIDG_FLAG_TASK_ERROR;
+               len                              = strlen(task->error);
+               msg_title = msg_widget->msg      = strdup(task->error);
+            }
+            else
+            {
+               len                              = strlen(task->title);
+               msg_title = msg_widget->msg      = strdup(task->title);
+            }
             msg_widget->msg_new                 = strdup(msg_title);
             msg_widget->msg_len                 = len;
 
-            if (task->error && *task->error)
-               msg_widget->flags               |= DISPWIDG_FLAG_TASK_ERROR;
             if ((task->flags & RETRO_TASK_FLG_CANCELLED) != 0)
                msg_widget->flags               |= DISPWIDG_FLAG_TASK_CANCELLED;
             if ((task->flags & RETRO_TASK_FLG_FINISHED) != 0)

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -836,7 +836,7 @@ not_found:
       snprintf(msg, sizeof(msg), "%s \"%s\".",
             msg_hash_to_str(MSG_FAILED_TO_LOAD_STATE),
             path_basename(state->path));
-      task_set_title(task, strdup(msg));
+      task_set_error(task, strdup(msg));
    }
 
 end:


### PR DESCRIPTION
## Description

Task state was not set in case of state loading failure, also task error was not used for displaying.
I checked briefly other uses of `task_set_error,` the messages seem to be reasonable.

## Related Issues

Fixes #10323 , thank you for reporting.

## Reviewers

@sonninnos 
