### PR TITLE
Display server refactor

### DIFF
--- a/frontend/drivers/platform_ctr.c
+++ b/frontend/drivers/platform_ctr.c
@@ -635,6 +635,7 @@ frontend_ctx_driver_t frontend_ctx_ctr =
    NULL,                         /* is_narrator_running            */
    NULL,                         /* accessibility_speak            */
    NULL,                         /* set_gamemode                   */
+   NULL, /* get_display_type */
    "ctr",                        /* ident                          */
    NULL                          /* get_video_driver               */
 };

--- a/frontend/drivers/platform_darwin.m
+++ b/frontend/drivers/platform_darwin.m
@@ -1096,6 +1096,7 @@ frontend_ctx_driver_t frontend_ctx_darwin = {
    frontend_darwin_is_narrator_running, /* is_narrator_running */
    frontend_darwin_accessibility_speak, /* accessibility_speak */
    NULL,                            /* set_gamemode        */
+   NULL,                            /* get_display_type   */
    "darwin",                        /* ident               */
    NULL                             /* get_video_driver    */
 };

--- a/frontend/drivers/platform_dos.c
+++ b/frontend/drivers/platform_dos.c
@@ -202,6 +202,7 @@ frontend_ctx_driver_t frontend_ctx_dos = {
 	NULL,                         /* is_narrator_running */
 	NULL,                         /* accessibility_speak */
 	NULL,                         /* set_gamemode        */
+	NULL, /* get_display_type */
 	"dos",                        /* ident               */
    NULL                          /* get_video_driver    */
 };

--- a/frontend/drivers/platform_emscripten.c
+++ b/frontend/drivers/platform_emscripten.c
@@ -1094,6 +1094,7 @@ frontend_ctx_driver_t frontend_ctx_emscripten = {
    NULL,                                /* is_narrator_running */
    NULL,                                /* accessibility_speak */
    NULL,                                /* set_gamemode        */
+   NULL, /* get_display_type */
    "emscripten",                        /* ident               */
    NULL                                 /* get_video_driver    */
 };

--- a/frontend/drivers/platform_gx.c
+++ b/frontend/drivers/platform_gx.c
@@ -602,6 +602,7 @@ frontend_ctx_driver_t frontend_ctx_gx = {
    NULL,                            /* is_narrator_running */
    NULL,                            /* accessibility_speak */
    NULL,                            /* set_gamemode        */
+   NULL, /* get_display_type */
    "gx",                            /* ident               */
    NULL                             /* get_video_driver    */
 };

--- a/frontend/drivers/platform_orbis.c
+++ b/frontend/drivers/platform_orbis.c
@@ -356,6 +356,7 @@ frontend_ctx_driver_t frontend_ctx_orbis = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "orbis",                      /* ident */
    NULL                          /* get_video_driver */
 };

--- a/frontend/drivers/platform_ps2.c
+++ b/frontend/drivers/platform_ps2.c
@@ -585,6 +585,7 @@ frontend_ctx_driver_t frontend_ctx_ps2 = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "ps2",                        /* ident */
    NULL                          /* get_video_driver */
 };

--- a/frontend/drivers/platform_ps3.c
+++ b/frontend/drivers/platform_ps3.c
@@ -687,6 +687,7 @@ frontend_ctx_driver_t frontend_ctx_ps3 = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "ps3",                        /* ident */
    NULL                          /* get_video_driver */
 };

--- a/frontend/drivers/platform_psp.c
+++ b/frontend/drivers/platform_psp.c
@@ -624,12 +624,14 @@ frontend_ctx_driver_t frontend_ctx_psp = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "vita",                       /* ident */
 #else
    NULL,                         /* get_user_language */
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "psp",                        /* ident */
 #endif
    NULL                          /* get_video_driver */

--- a/frontend/drivers/platform_qnx.c
+++ b/frontend/drivers/platform_qnx.c
@@ -196,6 +196,7 @@ frontend_ctx_driver_t frontend_ctx_qnx = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode        */
+   NULL, /* get_display_type */
    "qnx",                        /* ident               */
    NULL                          /* get_video_driver    */
 };

--- a/frontend/drivers/platform_switch.c
+++ b/frontend/drivers/platform_switch.c
@@ -807,6 +807,7 @@ frontend_ctx_driver_t frontend_ctx_switch =
    NULL,                               /* is_narrator_running */
    NULL,                               /* accessibility_speak */
    NULL,                               /* set_gamemode */
+   NULL, /* get_display_type */
    "switch",                           /* ident */
    NULL                                /* get_video_driver */
 };

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -3320,6 +3320,21 @@ static bool accessibility_speak_android(int speed,
 }
 #endif
 
+static enum rarch_display_type frontend_unix_get_display_type(void)
+{
+#if defined(ANDROID)
+   return RARCH_DISPLAY_NONE;
+#elif defined(HAVE_WAYLAND)
+   if (getenv("WAYLAND_DISPLAY"))
+      return RARCH_DISPLAY_WAYLAND;
+#endif
+#if defined(HAVE_X11)
+   if (getenv("DISPLAY"))
+      return RARCH_DISPLAY_X11;
+#endif
+   return RARCH_DISPLAY_NONE;
+}
+
 frontend_ctx_driver_t frontend_ctx_unix = {
    frontend_unix_get_env,       /* get_env */
    frontend_unix_init,          /* init */
@@ -3384,6 +3399,7 @@ frontend_ctx_driver_t frontend_ctx_unix = {
 #else
    NULL,
 #endif
+   frontend_unix_get_display_type,
 #ifdef ANDROID
    "android",                    /* ident               */
 #else

--- a/frontend/drivers/platform_uwp.c
+++ b/frontend/drivers/platform_uwp.c
@@ -367,6 +367,7 @@ frontend_ctx_driver_t frontend_ctx_uwp = {
    NULL,                            /* is_narrator_running */
    NULL,                            /* accessibility_speak */
    NULL,                            /* set_gamemode        */
+   NULL, /* get_display_type */
    "uwp",                           /* ident               */
    NULL                             /* get_video_driver    */
 };

--- a/frontend/drivers/platform_wiiu.c
+++ b/frontend/drivers/platform_wiiu.c
@@ -358,6 +358,7 @@ frontend_ctx_driver_t frontend_ctx_wiiu =
    NULL,                         /* is_narrator_running            */
    NULL,                         /* accessibility_speak            */
    NULL,                         /* set_gamemode                   */
+   NULL, /* get_display_type */
    "wiiu",                       /* ident                          */
    NULL                          /* get_video_driver               */
 };

--- a/frontend/drivers/platform_win32.c
+++ b/frontend/drivers/platform_win32.c
@@ -1311,6 +1311,11 @@ static bool accessibility_speak_windows(int speed,
 }
 #endif
 
+static enum rarch_display_type frontend_win32_get_display_type(void)
+{
+   return RARCH_DISPLAY_WIN32;
+}
+
 frontend_ctx_driver_t frontend_ctx_win32 = {
    frontend_win32_env_get,         /* env_get   */
    frontend_win32_init,            /* init      */
@@ -1357,6 +1362,7 @@ frontend_ctx_driver_t frontend_ctx_win32 = {
    NULL,                            /* accessibility_speak */
 #endif
    NULL,                            /* set_gamemode        */
+   frontend_win32_get_display_type,
    "win32",                         /* ident               */
    NULL                             /* get_video_driver    */
 };

--- a/frontend/drivers/platform_xdk.c
+++ b/frontend/drivers/platform_xdk.c
@@ -434,6 +434,7 @@ frontend_ctx_driver_t frontend_ctx_xdk = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "xdk",                        /* ident */
    NULL                          /* get_video_driver */
 };

--- a/frontend/drivers/platform_xenon.c
+++ b/frontend/drivers/platform_xenon.c
@@ -92,6 +92,7 @@ frontend_ctx_driver_t frontend_ctx_qnx = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL, /* get_display_type */
    "xenon",                      /* ident */
    NULL                          /* get_video_driver */
 };

--- a/frontend/frontend_driver.c
+++ b/frontend/frontend_driver.c
@@ -71,6 +71,7 @@ static frontend_ctx_driver_t frontend_ctx_null = {
    NULL,                         /* is_narrator_running */
    NULL,                         /* accessibility_speak */
    NULL,                         /* set_gamemode */
+   NULL,                         /* get_display_type */
    "null",
    NULL,                         /* get_video_driver */
 };

--- a/frontend/frontend_driver.h
+++ b/frontend/frontend_driver.h
@@ -114,6 +114,8 @@ typedef struct frontend_ctx_driver
          const char* speak_text, int priority);
    bool (*set_gamemode)(bool on);
 
+   enum rarch_display_type (*get_display_type)(void);
+
    const char *ident;
 
    const struct video_driver *(*get_video_driver)(void);

--- a/frontend/frontend_driver.h
+++ b/frontend/frontend_driver.h
@@ -25,6 +25,7 @@
 #include <lists/string_list.h>
 
 #include <libretro.h>
+#include "../gfx/video_defines.h"
 
 RETRO_BEGIN_DECLS
 

--- a/gfx/display_servers/dispserv_android.c
+++ b/gfx/display_servers/dispserv_android.c
@@ -131,6 +131,11 @@ const video_display_server_t dispserv_android = {
    NULL, /* get_output_options */
    android_display_server_set_screen_orientation,
    NULL, /* get_screen_orientation */
+   NULL, /* get_refresh_rate */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_metrics */
    android_display_server_get_flags,
    "android"
 };

--- a/gfx/display_servers/dispserv_apple.m
+++ b/gfx/display_servers/dispserv_apple.m
@@ -549,6 +549,11 @@ const video_display_server_t dispserv_apple = {
    NULL, /* set_screen_orientation */
    NULL, /* get_screen_orientation */
 #endif
+   NULL, /* get_refresh_rate */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_metrics */
    NULL, /* get_flags */
    "apple"
 };

--- a/gfx/display_servers/dispserv_kms.c
+++ b/gfx/display_servers/dispserv_kms.c
@@ -234,6 +234,11 @@ const video_display_server_t dispserv_kms = {
    NULL, /* get output options */
    NULL, /* kms_display_server_set_screen_orientation */
    NULL, /* kms_display_server_get_screen_orientation */
+   NULL, /* get_refresh_rate */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_metrics */
    kms_display_server_get_flags,
    "kms"
 };

--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -538,6 +538,35 @@ void win32_display_server_set_screen_orientation(void *data,
 }
 #endif
 
+static float win32_display_server_get_refresh_rate(void *data)
+{
+   return win32_get_refresh_rate(data);
+}
+
+static void win32_display_server_get_video_output_size(void *data,
+      unsigned *width, unsigned *height, char *s, size_t len)
+{
+   win32_get_video_output_size(data, width, height, s, len);
+}
+
+static void win32_display_server_get_video_output_prev(void *data)
+{
+   unsigned width = 0, height = 0;
+   win32_get_video_output_prev(&width, &height);
+}
+
+static void win32_display_server_get_video_output_next(void *data)
+{
+   unsigned width = 0, height = 0;
+   win32_get_video_output_next(&width, &height);
+}
+
+static bool win32_display_server_get_metrics(void *data,
+      enum display_metric_types type, float *value)
+{
+   return win32_get_metrics(data, type, value);
+}
+
 static uint32_t win32_display_server_get_flags(void *data)
 {
    uint32_t             flags   = 0;
@@ -563,6 +592,11 @@ const video_display_server_t dispserv_win32 = {
    NULL,
    NULL,
 #endif
+   win32_display_server_get_refresh_rate,
+   win32_display_server_get_video_output_size,
+   win32_display_server_get_video_output_prev,
+   win32_display_server_get_video_output_next,
+   win32_display_server_get_metrics,
    win32_display_server_get_flags,
    "win32"
 };

--- a/gfx/display_servers/dispserv_x11.c
+++ b/gfx/display_servers/dispserv_x11.c
@@ -782,6 +782,11 @@ const video_display_server_t dispserv_x11 = {
    NULL, /* set_screen_orientation */
    NULL, /* get_screen_orientation */
 #endif
+   NULL, /* get_refresh_rate */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_metrics */
    x11_display_server_get_flags,
    "x11"
 };

--- a/gfx/video_display_server.h
+++ b/gfx/video_display_server.h
@@ -58,6 +58,13 @@ typedef struct video_display_server
    const char *(*get_output_options)(void *data);
    void (*set_screen_orientation)(void *data, enum rotation rotation);
    enum rotation (*get_screen_orientation)(void *data);
+   float (*get_refresh_rate)(void *data);
+   void (*get_video_output_size)(void *data,
+         unsigned *width, unsigned *height, char *s, size_t len);
+   void (*get_video_output_prev)(void *data);
+   void (*get_video_output_next)(void *data);
+   bool (*get_metrics)(void *data, enum display_metric_types type,
+         float *value);
    uint32_t (*get_flags)(void *data);
    const char *ident;
 } video_display_server_t;
@@ -85,6 +92,18 @@ const char *video_display_server_get_output_options(void);
 const char *video_display_server_get_ident(void);
 
 void video_display_server_set_screen_orientation(enum rotation rotation);
+
+float video_display_server_get_refresh_rate(void);
+
+bool video_display_server_get_video_output_size(
+      unsigned *width, unsigned *height, char *s, size_t len);
+
+bool video_display_server_get_video_output_prev(void);
+
+bool video_display_server_get_video_output_next(void);
+
+bool video_display_server_get_metrics(
+      enum display_metric_types type, float *value);
 
 bool video_display_server_can_set_screen_orientation(void);
 

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -97,6 +97,11 @@ static const video_display_server_t dispserv_null = {
    NULL, /* get_output_options */
    NULL, /* set_screen_orientation */
    NULL, /* get_screen_orientation */
+   NULL, /* get_refresh_rate */
+   NULL, /* get_video_output_size */
+   NULL, /* get_video_output_prev */
+   NULL, /* get_video_output_next */
+   NULL, /* get_metrics */
    NULL, /* get_flags */
    "null"
 };
@@ -1528,6 +1533,63 @@ enum rotation video_display_server_get_screen_orientation(void)
       return current_display_server->get_screen_orientation(
             video_st->current_display_server_data);
    return ORIENTATION_NORMAL;
+}
+
+
+float video_display_server_get_refresh_rate(void)
+{
+   video_driver_state_t *video_st = &video_driver_st;
+   if (current_display_server && current_display_server->get_refresh_rate)
+      return current_display_server->get_refresh_rate(
+            video_st->current_display_server_data);
+   return 0.0f;
+}
+
+bool video_display_server_get_video_output_size(
+      unsigned *width, unsigned *height, char *s, size_t len)
+{
+   video_driver_state_t *video_st = &video_driver_st;
+   if (current_display_server && current_display_server->get_video_output_size)
+   {
+      current_display_server->get_video_output_size(
+            video_st->current_display_server_data, width, height, s, len);
+      return true;
+   }
+   return false;
+}
+
+bool video_display_server_get_video_output_prev(void)
+{
+   video_driver_state_t *video_st = &video_driver_st;
+   if (current_display_server && current_display_server->get_video_output_prev)
+   {
+      current_display_server->get_video_output_prev(
+            video_st->current_display_server_data);
+      return true;
+   }
+   return false;
+}
+
+bool video_display_server_get_video_output_next(void)
+{
+   video_driver_state_t *video_st = &video_driver_st;
+   if (current_display_server && current_display_server->get_video_output_next)
+   {
+      current_display_server->get_video_output_next(
+            video_st->current_display_server_data);
+      return true;
+   }
+   return false;
+}
+
+bool video_display_server_get_metrics(
+      enum display_metric_types type, float *value)
+{
+   video_driver_state_t *video_st = &video_driver_st;
+   if (current_display_server && current_display_server->get_metrics)
+      return current_display_server->get_metrics(
+            video_st->current_display_server_data, type, value);
+   return false;
 }
 
 bool video_display_server_get_flags(gfx_ctx_flags_t *flags)

--- a/retroarch.c
+++ b/retroarch.c
@@ -6207,6 +6207,22 @@ int rarch_main(int argc, char *argv[], void *data)
 
    frontend_driver_init_first(data);
 
+   /* Early display server init — allows querying display metrics
+    * (resolution, DPI, refresh rate) before the video driver creates
+    * a window.  The frontend provides get_display_type() to determine
+    * the platform's display type without needing a window. */
+   {
+      frontend_state_t *frontend_st = frontend_state_get_ptr();
+      if (     frontend_st
+            && frontend_st->current_frontend_ctx
+            && frontend_st->current_frontend_ctx->get_display_type)
+      {
+         enum rarch_display_type dtype =
+            frontend_st->current_frontend_ctx->get_display_type();
+         video_display_server_init(dtype);
+      }
+   }
+
    if (runloop_st->flags & RUNLOOP_FLAG_IS_INITED)
       driver_uninit(DRIVERS_CMD_ALL, (enum driver_lifetime_flags)0);
 


### PR DESCRIPTION
Add get_refresh_rate, get_video_output_size, get_video_output_prev, get_video_output_next, and get_metrics to the display server vtable. These operations are platform concerns (they query the display hardware) rather than driver concerns, but were previously only accessible through per-driver poke/ctx interfaces.

Wire all 5 slots in dispserv_win32.c, delegating to the existing win32_get_refresh_rate, win32_get_video_output_size, win32_get_video_output_prev/next, and win32_get_metrics functions. Other display servers (x11, kms, android, apple, null) get NULL for now.

Add get_display_type to frontend_ctx_driver_t so the platform can report its display type without needing a window.  Implement for Win32 (compile-time constant) and Unix (runtime detection via WAYLAND_DISPLAY / DISPLAY environment variables).  All other frontends (darwin, uwp, ctr, dos, gx, orbis, ps2, ps3, psp, qnx, switch, wiiu, xdk, xenon, emscripten, null) pass NULL which falls back to RARCH_DISPLAY_NONE.

Move video_display_server_init() to run early - right after frontend_driver_init_first() in rarch_main() - so the display server is available before video_driver_init_internal() computes window dimensions.  The existing late init inside
video_driver_init_internal() remains as a safety net and will reinit if the display type changed.

This is the infrastructure commit.  Follow-up commits can:
- Route video_driver.c dispatch through the display server instead of poke/ctx for these 5 operations
- Remove the identical boilerplate wrappers from d3d10/11/12/gdi
- Use display server queries for max window size instead of DEFAULT_WINDOW_AUTO_WIDTH_MAX

No functional change - existing poke/ctx call paths are untouched.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
