### PR TITLE
Fix Run-Ahead/Preemptive Frames setting UI regression

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -10784,30 +10784,24 @@ unsigned menu_displaylist_build_list(
                 && !retroarch_ctl(RARCH_CTL_IS_DUMMY_CORE, NULL))
                runahead_supported = core_info_current_supports_runahead();
 
-            if (runahead_supported)
+            for (i = 0; i < ARRAY_SIZE(build_list); i++)
             {
-               for (i = 0; i < ARRAY_SIZE(build_list); i++)
+               switch (build_list[i].enum_idx)
                {
-                  switch (build_list[i].enum_idx)
-                  {
-                     case MENU_ENUM_LABEL_RUNAHEAD_MODE:
-                        build_list[i].checked = true;
-                        break;
-                     case MENU_ENUM_LABEL_RUN_AHEAD_FRAMES:
-                        if (runahead_enabled)
-                           build_list[i].checked = true;
-                        break;
-                     case MENU_ENUM_LABEL_PREEMPT_FRAMES:
-                        if (preempt_enabled)
-                           build_list[i].checked = true;
-                        break;
-                     case MENU_ENUM_LABEL_RUN_AHEAD_HIDE_WARNINGS:
-                        if (runahead_enabled || preempt_enabled)
-                           build_list[i].checked = true;
-                        break;
-                     default:
-                        break;
-                  }
+                  case MENU_ENUM_LABEL_RUNAHEAD_MODE:
+                     build_list[i].checked = runahead_supported;
+                     break;
+                  case MENU_ENUM_LABEL_RUN_AHEAD_FRAMES:
+                     build_list[i].checked = runahead_supported && runahead_enabled;
+                     break;
+                  case MENU_ENUM_LABEL_PREEMPT_FRAMES:
+                     build_list[i].checked = runahead_supported && preempt_enabled;
+                     break;
+                  case MENU_ENUM_LABEL_RUN_AHEAD_HIDE_WARNINGS:
+                     build_list[i].checked = runahead_supported && (runahead_enabled || preempt_enabled);
+                     break;
+                  default:
+                     break;
                }
             }
 #endif


### PR DESCRIPTION
## Description

After commit 5e46f0c1a4fb3dd7c8b2784e2187db601c6ba9e5, which turned most instances of `menu_displaylist_build_info_selective_t build_list[]` to `static`, the Run-Ahead frames setting was not reacting properly anymore to the user-selected Run-Ahead mode. 
Namely, the "Number of Preemptive Frames" setting was being displayed next to the other options whenever switching to the Preemptive Frames mode, instead of dynamically replacing the normal Run-Ahead Frames setting in the menu.

This PR fixes the issue by tightening the conditions for the visibility of the Run-Ahead settings, so that the mutual appearance of the two options mentioned above is preserved while still retaining the `static` attribute.

## Related Issues

Fixes #18947.

## Reviewers

@LibretroAdmin