### PR TITLE
Partially restore sync load and load wallpaper earlier to fix texture load time regression

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2561,7 +2561,6 @@ static void materialui_update_savestate_thumbnail_image(void *data)
 static void materialui_context_reset_textures(materialui_handle_t *mui)
 {
    int i;
-   bool supports_rgba = (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA);
 
    /* Loop through all textures */
    for (i = 0; i < MUI_TEXTURE_LAST; i++)
@@ -2570,9 +2569,9 @@ static void materialui_context_reset_textures(materialui_handle_t *mui)
       fill_pathname_join_special(texpath,
             mui->icons_path, materialui_texture_path(i),
             sizeof(texpath));
-      gfx_display_load_icon(texpath, supports_rgba,
-            &mui->textures.list[i], mui_icon_load_gen,
-            &mui_icon_load_gen);
+      gfx_display_reset_icon_texture(texpath,
+         &mui->textures.list[i], TEXTURE_FILTER_LINEAR,
+         NULL, NULL);
    }
 }
 
@@ -9917,14 +9916,15 @@ static void materialui_context_reset(void *data, bool is_threaded)
    gfx_display_deinit_white_texture();
    gfx_display_init_white_texture();
    materialui_context_reset_textures(mui);
-   if (mui->textures.playlist.size >= 1)
-      materialui_context_reset_playlist_icons(mui);
-   menu_screensaver_context_destroy(mui->screensaver);
 
    if (path_is_valid(path_menu_wallpaper))
       task_push_image_load(path_menu_wallpaper,
             (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA), 0,
             menu_display_handle_wallpaper_upload, NULL);
+
+   if (mui->textures.playlist.size >= 1)
+      materialui_context_reset_playlist_icons(mui);
+   menu_screensaver_context_destroy(mui->screensaver);
 
    if (path_is_valid(mui->savestate_thumbnail_file_path))
       materialui_update_savestate_thumbnail_image(mui);

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -2963,7 +2963,6 @@ static void ozone_reset_theme_textures(ozone_handle_t *ozone)
    };
    unsigned i, j;
    char theme_path[NAME_MAX_LENGTH];
-   bool supports_rgba = (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA);
 
    for (j = 0; j < ARRAY_SIZE(ozone_themes); j++)
    {
@@ -2985,9 +2984,9 @@ static void ozone_reset_theme_textures(ozone_handle_t *ozone)
          fill_pathname_join_special(texpath,
                theme_path, OZONE_THEME_TEXTURES_FILES[i],
                sizeof(texpath));
-         gfx_display_load_icon(texpath, supports_rgba,
-               &theme->textures[i], ozone_ctx_icon_load_gen,
-               &ozone_ctx_icon_load_gen);
+         gfx_display_reset_icon_texture(texpath,
+            &theme->textures[i], TEXTURE_FILTER_LINEAR,
+            NULL, NULL);
       }
    }
 }
@@ -9841,7 +9840,6 @@ static void ozone_context_reset(void *data, bool is_threaded)
       "cursor_border.png"
    };
    unsigned i;
-   bool supports_rgba             = (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA);
    ozone_handle_t *ozone      = (ozone_handle_t*) data;
 
    if (ozone)
@@ -9866,9 +9864,9 @@ static void ozone_context_reset(void *data, bool is_threaded)
          fill_pathname_join_special(texpath,
                ozone->png_path, OZONE_TEXTURES_FILES[i],
                sizeof(texpath));
-         gfx_display_load_icon(texpath, supports_rgba,
-               &ozone->textures[i], ozone_ctx_icon_load_gen,
-               &ozone_ctx_icon_load_gen);
+         gfx_display_reset_icon_texture(texpath,
+               &ozone->textures[i], TEXTURE_FILTER_LINEAR,
+               NULL, NULL);
       }
 
       /* Sidebar textures */
@@ -9890,9 +9888,9 @@ static void ozone_context_reset(void *data, bool is_threaded)
                      sizeof(texpath));
                break;
          }
-         gfx_display_load_icon(texpath, supports_rgba,
-               &ozone->tab_textures[i], ozone_ctx_icon_load_gen,
-               &ozone_ctx_icon_load_gen);
+         gfx_display_reset_icon_texture(texpath,
+               &ozone->tab_textures[i], TEXTURE_FILTER_LINEAR,
+               NULL, NULL);
       }
 
       /* Theme textures */
@@ -9905,9 +9903,9 @@ static void ozone_context_reset(void *data, bool is_threaded)
          fill_pathname_join_special(texpath,
                ozone->icons_path, ozone_entries_icon_texture_path(i),
                sizeof(texpath));
-         gfx_display_load_icon(texpath, supports_rgba,
-               &ozone->icons_textures[i], ozone_ctx_icon_load_gen,
-               &ozone_ctx_icon_load_gen);
+         gfx_display_reset_icon_texture(texpath,
+               &ozone->icons_textures[i], TEXTURE_FILTER_LINEAR,
+               NULL, NULL);
       }
 
       gfx_display_deinit_white_texture();

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -524,6 +524,7 @@ static int xmb_menu_entry_action(void *userdata,
       menu_entry_t *entry, size_t i, enum menu_action action);
 static bool xmb_load_image(void *userdata, void *data,
       enum menu_image_type type);
+static void xmb_context_bg_destroy(xmb_handle_t *xmb);
 static void xmb_navigation_set(void *data, bool scroll);
 static uintptr_t xmb_icon_get_id(xmb_handle_t *xmb,
       xmb_node_t *core_node, xmb_node_t *node,
@@ -1269,9 +1270,23 @@ static void xmb_update_dynamic_wallpaper(xmb_handle_t *xmb, bool reset)
    {
       if (path_is_valid(path))
       {
-         task_push_image_load(path,
-               (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA), 0,
-               menu_display_handle_wallpaper_upload, NULL);
+         if (reset)
+         {
+            xmb_context_bg_destroy(xmb);
+
+            if (!gfx_display_reset_icon_texture(path,
+                  &xmb->textures.bg, TEXTURE_FILTER_LINEAR,
+                  NULL, NULL))
+               task_push_image_load(path,
+                     (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA), 0,
+                     menu_display_handle_wallpaper_upload, NULL);
+
+            gfx_display_init_white_texture();
+         }
+         else
+            task_push_image_load(path,
+                  (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA), 0,
+                  menu_display_handle_wallpaper_upload, NULL);
 
          free(xmb->bg_file_path);
          xmb->bg_file_path = strdup(path);
@@ -6656,7 +6671,6 @@ static void xmb_context_reset_textures(
       unsigned menu_xmb_theme)
 {
    unsigned i;
-   bool supports_rgba = (video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA);
 
    /* Invalidate in-flight context texture loads */
    xmb_ctx_icon_load_gen++;
@@ -6681,14 +6695,11 @@ static void xmb_context_reset_textures(
 
       fill_pathname_join_special(texpath,
             iconpath, texture_path, sizeof(texpath));
-      gfx_display_load_icon(texpath, supports_rgba,
-            &xmb->textures.list[i], xmb_ctx_icon_load_gen,
-            &xmb_ctx_icon_load_gen);
+      gfx_display_reset_icon_texture(texpath,
+         &xmb->textures.list[i], TEXTURE_FILTER_LINEAR,
+         NULL, NULL);
    }
 
-   /* Tab node icons will be populated from textures.list[]
-    * once the async loads complete — handled by the draw-time
-    * check in xmb_draw_icon_predot / xmb_frame. */
    xmb->main_menu_node.icon              = 0;
    xmb->settings_tab_node.icon           = 0;
    xmb->history_tab_node.icon            = 0;
@@ -6812,9 +6823,9 @@ static void xmb_context_reset_internal(xmb_handle_t *xmb,
       xmb->allow_dynamic_wallpaper       = true;
    }
 
+   xmb_update_dynamic_wallpaper(xmb, true);
    xmb_context_reset_horizontal_list(xmb);
    xmb_set_title(xmb);
-   xmb_update_dynamic_wallpaper(xmb, true);
 
    menu_screensaver_context_destroy(xmb->screensaver);
 
@@ -8080,12 +8091,6 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       uintptr_t tex_bg = xmb->textures.bg;
       memcpy(tex_list, xmb->textures.list, sizeof(tex_list));
 
-   /* Async icon sync: context textures are loaded asynchronously and
-    * may complete across multiple frames.  Continuously propagate
-    * finished textures into the tab node icon fields.  The writes
-    * are single-pointer stores so there is no race with the async
-    * callback, and the per-frame cost is negligible (a few pointer
-    * comparisons). */
    if (tex_list[XMB_TEXTURE_MAIN_MENU])
       xmb->main_menu_node.icon             = tex_list[XMB_TEXTURE_MAIN_MENU];
    if (tex_list[XMB_TEXTURE_SETTINGS])


### PR DESCRIPTION
## Description

This is a proposed fix to address the slowdown regression introduced with some of the recent changes, namely those that added async texture loading, while still partly retaining the asynchronous process.
As observed in https://github.com/libretro/RetroArch/issues/18943, in certain scenarios both menu texture icons and custom wallpapers (if any) would exhibit slower load times at startup in RA, resulting in laggier menu composition.

This change attempts to fix this regression by implementing the following:

- crucial startup-related textures have been moved back to synchronous loading for Ozone, MaterialUI and XMB;
- furthermore, in XMB and MaterialUI the wallpaper loading functions have been moved earlier on in the sequence;
- an added mitigation was implemented on XMB so that, upon context reset (for example, when toggling between Fullscreen and Windowed modes), the wallpaper is loaded synchronously. This should completely eliminate situations where you might still see a brief flash of the base theme color when toggling modes, due to the wallpaper async loading taking too long to happen on certain slow-loading systems.

## Related Issues

Hopefully fixes https://github.com/libretro/RetroArch/issues/18943

## Reviewers

@LibretroAdmin