### PR TITLE
cdfs: fix createdvd CHD hashing for PS2/PSP RetroAchievements

### DIFF
--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -320,6 +320,13 @@ chdstream_find_special_track(chd_file *fd, int32_t track, metadata_t *meta)
             }
             break;
          case CHDSTREAM_TRACK_PRIMARY:
+            /* DVD tracks have no frame count in metadata but are always
+             * the primary data track - select immediately */
+            if (strcmp(iter.type, "DVD") == 0)
+            {
+               *meta = iter;
+               return true;
+            }
             if (strcmp(iter.type, "AUDIO") && iter.frames > largest_size)
             {
                largest_size  = iter.frames;


### PR DESCRIPTION
## Description

PS2 and PSP games stored as `createdvd` CHDs fail RetroAchievements hash
generation with "hash generation failed", while the same games boot and
play correctly.

`createdvd` CHDs have no CD track metadata, only a `DVD_METADATA_TAG`
entry which sets `type="DVD"` but leaves `frames=0`. When
`chdstream_find_special_track` is called with `CHDSTREAM_TRACK_PRIMARY`,
it evaluates `iter.frames > largest_size` as `0 > 0` which is false, so
the DVD track is never selected. The function returns false,
`chdstream_open` returns NULL, and hashing fails.

This is inconsistent as games whose hashing logic happens to request
`CHDSTREAM_TRACK_LAST` work correctly (that path returns the last found
track regardless of frame count), while games requesting
`CHDSTREAM_TRACK_PRIMARY` always fail.

The fix returns DVD tracks immediately when `CHDSTREAM_TRACK_PRIMARY` is
requested, since a `createdvd` CHD only ever has one track, and it is
always data.

## Related Issues

Solves all concerns with #16145, not just related to PSP games