### PR TITLE
webOS: use STAGING_DIR, not SDK_PATH

### DIFF
--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -33,10 +33,10 @@ done
 WAYSCAN="$(exists wayland-scanner || :)"
 
 if [ -n "${CROSS_COMPILE:-}" ] && echo "${CROSS_COMPILE:-}" | grep -q "webos"; then
-   if [ -z "${SDK_PATH:-}" ]; then
-      die 1 "Error: WEBOS=1 but SDK_PATH not set"
+   if [ -z "${STAGING_DIR:-}" ]; then
+      die 1 "Error: WEBOS=1 but STAGING_DIR not set"
    fi
-   WAYSCAN="$SDK_PATH/bin/wayland-scanner"
+   WAYSCAN="$STAGING_DIR/../../bin/wayland-scanner"
 fi
 
 PKGCONFIG="$(exists pkg-config || :)"
@@ -84,10 +84,10 @@ generate_source 'staging/single-pixel-buffer' 'single-pixel-buffer-v1'
 generate_source 'staging/xdg-toplevel-icon' 'xdg-toplevel-icon-v1'
 
 if [ -n "${CROSS_COMPILE:-}" ] && echo "${CROSS_COMPILE:-}" | grep -q "webos"; then
-   if [ -z "${SDK_PATH:-}" ]; then
-      die 1 "Error: WEBOS=1 but SDK_PATH not set"
+   if [ -z "${STAGING_DIR:-}" ]; then
+      die 1 "Error: WEBOS=1 but STAGING_DIR not set"
    fi
-   WAYLAND_PROTOS="$SDK_PATH/arm-webos-linux-gnueabi/sysroot/usr/share"
+   WAYLAND_PROTOS="$STAGING_DIR/usr/share"
 
    generate_source 'wayland-webos' 'webos-shell'
    generate_source 'wayland-webos' 'webos-foreign'


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Remove need to set SDK_PATH as we already have STAGING_DIR set by buildroot environment-setup.

## Related Issues
## Related Pull Requests
## Reviewers
