### PR TITLE
Add underlay functionality to OGL1/2/3 and vulkan drivers

### DIFF
--- a/gfx/common/gl2_common.h
+++ b/gfx/common/gl2_common.h
@@ -58,10 +58,11 @@ enum gl2_flags
    GL2_FLAG_PBO_READBACK_ENABLE    = (1 << 16),
    GL2_FLAG_OVERLAY_ENABLE         = (1 << 17),
    GL2_FLAG_OVERLAY_FULLSCREEN     = (1 << 18),
-   GL2_FLAG_MENU_TEXTURE_ENABLE    = (1 << 19),
-   GL2_FLAG_MENU_TEXTURE_FULLSCREEN= (1 << 20),
-   GL2_FLAG_NONE                   = (1 << 21),
-   GL2_FLAG_FRAME_DUPE_LOCK        = (1 << 22)
+   GL2_FLAG_OVERLAY_BACKGROUND_FILL= (1 << 19),
+   GL2_FLAG_MENU_TEXTURE_ENABLE    = (1 << 20),
+   GL2_FLAG_MENU_TEXTURE_FULLSCREEN= (1 << 21),
+   GL2_FLAG_NONE                   = (1 << 22),
+   GL2_FLAG_FRAME_DUPE_LOCK        = (1 << 23)
 };
 
 struct gl2

--- a/gfx/common/gl3_defines.h
+++ b/gfx/common/gl3_defines.h
@@ -44,14 +44,15 @@ enum gl3_flags
    GL3_FLAG_USE_SHARED_CONTEXT     = (1 <<  3),
    GL3_FLAG_OVERLAY_ENABLE         = (1 <<  4),
    GL3_FLAG_OVERLAY_FULLSCREEN     = (1 <<  5),
-   GL3_FLAG_MENU_TEXTURE_ENABLE    = (1 <<  6),
-   GL3_FLAG_MENU_TEXTURE_FULLSCREEN= (1 <<  7),
-   GL3_FLAG_VSYNC                  = (1 <<  8),
-   GL3_FLAG_FULLSCREEN             = (1 <<  9),
-   GL3_FLAG_QUITTING               = (1 << 10),
-   GL3_FLAG_SHOULD_RESIZE          = (1 << 11),
-   GL3_FLAG_KEEP_ASPECT            = (1 << 12),
-   GL3_FLAG_FRAME_DUPE_LOCK        = (1 << 13)
+   GL3_FLAG_OVERLAY_BACKGROUND_FILL= (1 <<  6),
+   GL3_FLAG_MENU_TEXTURE_ENABLE    = (1 <<  7),
+   GL3_FLAG_MENU_TEXTURE_FULLSCREEN= (1 <<  8),
+   GL3_FLAG_VSYNC                  = (1 <<  9),
+   GL3_FLAG_FULLSCREEN             = (1 << 10),
+   GL3_FLAG_QUITTING               = (1 << 11),
+   GL3_FLAG_SHOULD_RESIZE          = (1 << 12),
+   GL3_FLAG_KEEP_ASPECT            = (1 << 13),
+   GL3_FLAG_FRAME_DUPE_LOCK        = (1 << 14)
 };
 
 RETRO_END_DECLS

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -108,7 +108,8 @@ enum vk_flags
    VK_FLAG_READBACK_STREAMED   = (1 << 13),
    VK_FLAG_OVERLAY_ENABLE      = (1 << 14),
    VK_FLAG_OVERLAY_FULLSCREEN  = (1 << 15),
-   VK_FLAG_SDR_PIPELINE        = (1 << 16)
+   VK_FLAG_OVERLAY_BACKGROUND_FILL = (1 << 16),
+   VK_FLAG_SDR_PIPELINE        = (1 << 17)
 };
 
 enum vk_texture_type

--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -108,12 +108,13 @@ enum gl1_flags
    GL1_FLAG_MENU_SMOOTH             = (1 << 9),
    GL1_FLAG_OVERLAY_ENABLE          = (1 << 10),
    GL1_FLAG_OVERLAY_FULLSCREEN      = (1 << 11),
-   GL1_FLAG_FRAME_DUPE_LOCK         = (1 << 12),
+   GL1_FLAG_OVERLAY_BACKGROUND_FILL = (1 << 12),
+   GL1_FLAG_FRAME_DUPE_LOCK         = (1 << 13),
    /* GL_UNSIGNED_SHORT_4_4_4_4 is core in GL 1.2; on strict 1.1
     * implementations it is provided by GL_EXT_packed_pixels.  When
     * neither is available, the menu path falls back to expanding
     * RGUI's RGBA4444 framebuffer to BGRA8888 on the CPU. */
-   GL1_FLAG_SUPPORTS_PACKED_PIXELS  = (1 << 13)
+   GL1_FLAG_SUPPORTS_PACKED_PIXELS  = (1 << 14)
 };
 
 typedef struct gl1
@@ -1753,6 +1754,22 @@ static bool gl1_frame(void *data, const void *frame,
       glEnable(GL_BLEND);
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+#ifdef HAVE_OVERLAY
+      /* Render background overlay (behind game viewport) */
+      if ((gl1->flags & GL1_FLAG_OVERLAY_ENABLE) && (gl1->flags & GL1_FLAG_OVERLAY_BACKGROUND_FILL))
+      {
+         /* Save current fullscreen state and force full screen for background overlay */
+         bool saved_fullscreen = (gl1->flags & GL1_FLAG_OVERLAY_FULLSCREEN) != 0;
+         gl1->flags |= GL1_FLAG_OVERLAY_FULLSCREEN;
+
+         gl1_render_overlay(gl1, video_width, video_height);
+
+         /* Restore fullscreen state */
+         if (!saved_fullscreen)
+            gl1->flags &= ~GL1_FLAG_OVERLAY_FULLSCREEN;
+      }
+#endif
+
       if (frame_to_copy)
          gl1_draw_tex(gl1, pot_width, pot_height,
                width, height, gl1->tex, frame_to_copy, false);
@@ -1846,7 +1863,8 @@ static bool gl1_frame(void *data, const void *frame,
    }
 
 #ifdef HAVE_OVERLAY
-   if ((gl1->flags & GL1_FLAG_OVERLAY_ENABLE) && overlay_behind_menu)
+   if ((gl1->flags & GL1_FLAG_OVERLAY_ENABLE) && overlay_behind_menu
+         && !(gl1->flags & GL1_FLAG_OVERLAY_BACKGROUND_FILL))
       gl1_render_overlay(gl1, video_width, video_height);
 #endif
 
@@ -1880,7 +1898,8 @@ static bool gl1_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_OVERLAY
-   if ((gl1->flags & GL1_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu)
+   if ((gl1->flags & GL1_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu
+         && !(gl1->flags & GL1_FLAG_OVERLAY_BACKGROUND_FILL))
       gl1_render_overlay(gl1, video_width, video_height);
 #endif
 
@@ -2579,6 +2598,19 @@ static void gl1_overlay_full_screen(void *data, bool enable)
    }
 }
 
+static void gl1_overlay_background_fill(void *data, bool enable)
+{
+   gl1_t *gl = (gl1_t*)data;
+
+   if (gl)
+   {
+      if (enable)
+         gl->flags |=  GL1_FLAG_OVERLAY_BACKGROUND_FILL;
+      else
+         gl->flags &= ~GL1_FLAG_OVERLAY_BACKGROUND_FILL;
+   }
+}
+
 static void gl1_overlay_set_alpha(void *data, unsigned image, float mod)
 {
    GLfloat *color = NULL;
@@ -2601,6 +2633,7 @@ static const video_overlay_interface_t gl1_overlay_interface = {
    gl1_overlay_vertex_geom,
    gl1_overlay_full_screen,
    gl1_overlay_set_alpha,
+   gl1_overlay_background_fill,
 };
 
 static void gl1_get_overlay_interface(void *data,

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -3756,18 +3756,22 @@ static bool gl2_frame(void *data, const void *frame,
    /* Render background overlay (behind game viewport) */
    if ((gl->flags & GL2_FLAG_OVERLAY_ENABLE) && (gl->flags & GL2_FLAG_OVERLAY_BACKGROUND_FILL))
    {
-      /* Save current fullscreen state and force full screen for background overlay */
       uint64_t saved_flags = gl->flags & GL2_FLAG_OVERLAY_FULLSCREEN;
+      struct video_coords saved_coords = gl->coords;
+
       gl->flags |= GL2_FLAG_OVERLAY_FULLSCREEN;
 
       gl2_render_overlay(gl);
 
-      /* Restore fullscreen state and viewport */
+      /* Restore state */
       if (!saved_flags)
          gl->flags &= ~GL2_FLAG_OVERLAY_FULLSCREEN;
 
-      /* Restore viewport for game rendering */
+      gl->coords = saved_coords;
       glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
+
+      /* Re-bind game texture since overlay rendering left overlay texture bound */
+      glBindTexture(GL_TEXTURE_2D, gl->texture[gl->tex_index]);
    }
 #endif
 

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -3752,6 +3752,25 @@ static bool gl2_frame(void *data, const void *frame,
 
    glClear(GL_COLOR_BUFFER_BIT);
 
+#ifdef HAVE_OVERLAY
+   /* Render background overlay (behind game viewport) */
+   if ((gl->flags & GL2_FLAG_OVERLAY_ENABLE) && (gl->flags & GL2_FLAG_OVERLAY_BACKGROUND_FILL))
+   {
+      /* Save current fullscreen state and force full screen for background overlay */
+      uint64_t saved_flags = gl->flags & GL2_FLAG_OVERLAY_FULLSCREEN;
+      gl->flags |= GL2_FLAG_OVERLAY_FULLSCREEN;
+
+      gl2_render_overlay(gl);
+
+      /* Restore fullscreen state and viewport */
+      if (!saved_flags)
+         gl->flags &= ~GL2_FLAG_OVERLAY_FULLSCREEN;
+
+      /* Restore viewport for game rendering */
+      glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
+   }
+#endif
+
    params.vp_width         = gl->out_vp_width;
    params.vp_height        = gl->out_vp_height;
    params.width            = frame_width;
@@ -3795,7 +3814,8 @@ static bool gl2_frame(void *data, const void *frame,
          chain, &gl->tex_info);
 
 #ifdef HAVE_OVERLAY
-   if ((gl->flags & GL2_FLAG_OVERLAY_ENABLE) && overlay_behind_menu)
+   if ((gl->flags & GL2_FLAG_OVERLAY_ENABLE) && overlay_behind_menu
+         && !(gl->flags & GL2_FLAG_OVERLAY_BACKGROUND_FILL))
       gl2_render_overlay(gl);
 #endif
 
@@ -3816,7 +3836,8 @@ static bool gl2_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_OVERLAY
-   if ((gl->flags & GL2_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu)
+   if ((gl->flags & GL2_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu
+         && !(gl->flags & GL2_FLAG_OVERLAY_BACKGROUND_FILL))
       gl2_render_overlay(gl);
 #endif
 
@@ -5231,6 +5252,18 @@ static void gl2_overlay_full_screen(void *data, bool enable)
       gl->flags &= ~GL2_FLAG_OVERLAY_FULLSCREEN;
 }
 
+static void gl2_overlay_background_fill(void *data, bool enable)
+{
+   gl2_t *gl = (gl2_t*)data;
+   if (!gl)
+      return;
+
+   if (enable)
+      gl->flags |=  GL2_FLAG_OVERLAY_BACKGROUND_FILL;
+   else
+      gl->flags &= ~GL2_FLAG_OVERLAY_BACKGROUND_FILL;
+}
+
 static void gl2_overlay_set_alpha(void *data, unsigned image, float mod)
 {
    GLfloat *color;
@@ -5253,6 +5286,7 @@ static const video_overlay_interface_t gl2_overlay_interface = {
    gl2_overlay_vertex_geom,
    gl2_overlay_full_screen,
    gl2_overlay_set_alpha,
+   gl2_overlay_background_fill,
 };
 
 static void gl2_get_overlay_interface(void *data,

--- a/gfx/drivers/gl3.c
+++ b/gfx/drivers/gl3.c
@@ -3245,6 +3245,18 @@ static void gl3_overlay_full_screen(void *data, bool enable)
    }
 }
 
+static void gl3_overlay_background_fill(void *data, bool enable)
+{
+   gl3_t *gl = (gl3_t*)data;
+   if (gl)
+   {
+      if (enable)
+         gl->flags |=  GL3_FLAG_OVERLAY_BACKGROUND_FILL;
+      else
+         gl->flags &= ~GL3_FLAG_OVERLAY_BACKGROUND_FILL;
+   }
+}
+
 static void gl3_overlay_set_alpha(void *data, unsigned image, float mod)
 {
    GLfloat *color = NULL;
@@ -3267,6 +3279,7 @@ static const video_overlay_interface_t gl3_overlay_interface = {
    gl3_overlay_vertex_geom,
    gl3_overlay_full_screen,
    gl3_overlay_set_alpha,
+   gl3_overlay_background_fill,
 };
 
 static void gl3_get_overlay_interface(void *data,
@@ -4247,6 +4260,22 @@ static bool gl3_frame(void *data, const void *frame,
       glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
       glClear(GL_COLOR_BUFFER_BIT);
 
+#ifdef HAVE_OVERLAY
+      /* Render background overlay (behind game viewport) */
+      if ((gl->flags & GL3_FLAG_OVERLAY_ENABLE) && (gl->flags & GL3_FLAG_OVERLAY_BACKGROUND_FILL))
+      {
+         /* Save current fullscreen state and force full screen for background overlay */
+         uint64_t saved_flags = gl->flags & GL3_FLAG_OVERLAY_FULLSCREEN;
+         gl->flags |= GL3_FLAG_OVERLAY_FULLSCREEN;
+
+         gl3_render_overlay(gl, width, height);
+
+         /* Restore fullscreen state */
+         if (!saved_flags)
+            gl->flags &= ~GL3_FLAG_OVERLAY_FULLSCREEN;
+      }
+#endif
+
       gl->chain.shader->set_params(&params, gl->chain.shader_data);
 
       gl->chain.coords.vertices = 4;
@@ -4358,6 +4387,23 @@ static bool gl3_frame(void *data, const void *frame,
       glBindFramebuffer(GL_FRAMEBUFFER, 0);
       glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
       glClear(GL_COLOR_BUFFER_BIT);
+
+#ifdef HAVE_OVERLAY
+      /* Render background overlay (behind game viewport) */
+      if ((gl->flags & GL3_FLAG_OVERLAY_ENABLE) && (gl->flags & GL3_FLAG_OVERLAY_BACKGROUND_FILL))
+      {
+         /* Save current fullscreen state and force full screen for background overlay */
+         uint64_t saved_flags = gl->flags & GL3_FLAG_OVERLAY_FULLSCREEN;
+         gl->flags |= GL3_FLAG_OVERLAY_FULLSCREEN;
+
+         gl3_render_overlay(gl, width, height);
+
+         /* Restore fullscreen state */
+         if (!saved_flags)
+            gl->flags &= ~GL3_FLAG_OVERLAY_FULLSCREEN;
+      }
+#endif
+
       gl3_filter_chain_build_viewport_pass(filter_chain,
             &gl->filter_chain_vp,
             (gl->flags & GL3_FLAG_HW_RENDER_BOTTOM_LEFT)
@@ -4368,7 +4414,8 @@ static bool gl3_frame(void *data, const void *frame,
 #endif /* HAVE_SLANG */
 
 #ifdef HAVE_OVERLAY
-   if ((gl->flags & GL3_FLAG_OVERLAY_ENABLE) && overlay_behind_menu)
+   if ((gl->flags & GL3_FLAG_OVERLAY_ENABLE) && overlay_behind_menu
+         && !(gl->flags & GL3_FLAG_OVERLAY_BACKGROUND_FILL))
       gl3_render_overlay(gl, width, height);
 #endif
 
@@ -4388,7 +4435,8 @@ static bool gl3_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_OVERLAY
-   if ((gl->flags & GL3_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu)
+   if ((gl->flags & GL3_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu
+         && !(gl->flags & GL3_FLAG_OVERLAY_BACKGROUND_FILL))
       gl3_render_overlay(gl, width, height);
 #endif
 

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -6761,7 +6761,18 @@ static bool vulkan_frame(void *data, const void *frame,
 #endif /* VULKAN_HDR_SWAPCHAIN */
 
 #ifdef HAVE_OVERLAY
-      if ((vk->flags & VK_FLAG_OVERLAY_ENABLE) && overlay_behind_menu)
+      /* Render background overlay (behind game viewport) */
+      if ((vk->flags & VK_FLAG_OVERLAY_ENABLE) && (vk->flags & VK_FLAG_OVERLAY_BACKGROUND_FILL))
+      {
+         uint64_t saved_flags = vk->flags & VK_FLAG_OVERLAY_FULLSCREEN;
+
+         vk->flags |= VK_FLAG_OVERLAY_FULLSCREEN;
+         vulkan_render_overlay(vk, video_width, video_height);
+
+         if (!saved_flags)
+            vk->flags &= ~VK_FLAG_OVERLAY_FULLSCREEN;
+      }
+      else if ((vk->flags & VK_FLAG_OVERLAY_ENABLE) && overlay_behind_menu)
          vulkan_render_overlay(vk, video_width, video_height);
 #endif
 
@@ -6818,7 +6829,8 @@ static bool vulkan_frame(void *data, const void *frame,
 #endif
 
 #ifdef HAVE_OVERLAY
-      if ((vk->flags & VK_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu)
+      if ((vk->flags & VK_FLAG_OVERLAY_ENABLE) && !overlay_behind_menu
+            && !(vk->flags & VK_FLAG_OVERLAY_BACKGROUND_FILL))
          vulkan_render_overlay(vk, video_width, video_height);
 #endif
 
@@ -7965,6 +7977,18 @@ static void vulkan_overlay_full_screen(void *data, bool enable)
       vk->flags &= ~VK_FLAG_OVERLAY_FULLSCREEN;
 }
 
+static void vulkan_overlay_background_fill(void *data, bool enable)
+{
+   vk_t *vk = (vk_t*)data;
+   if (!vk)
+      return;
+
+   if (enable)
+      vk->flags |=  VK_FLAG_OVERLAY_BACKGROUND_FILL;
+   else
+      vk->flags &= ~VK_FLAG_OVERLAY_BACKGROUND_FILL;
+}
+
 static void vulkan_overlay_free(vk_t *vk)
 {
    int i;
@@ -8288,6 +8312,7 @@ static const video_overlay_interface_t vulkan_overlay_interface = {
    vulkan_overlay_vertex_geom,
    vulkan_overlay_full_screen,
    vulkan_overlay_set_alpha,
+   vulkan_overlay_background_fill,
 };
 
 static void vulkan_get_overlay_interface(void *data,

--- a/gfx/drivers_shader/slang_cache.cpp
+++ b/gfx/drivers_shader/slang_cache.cpp
@@ -4,6 +4,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <file/file_path.h>
 #include <streams/file_stream.h>
 #include <vfs/vfs.h>
@@ -26,18 +27,14 @@
 static bool spirv_cache_get_dir(char *cache_dir_out, size_t cache_dir_out_len)
 {
    settings_t *settings = config_get_ptr();
-   int ret;
 
    if (!settings || !settings->paths.directory_cache[0])
       return false;
 
    /* Build the spirv subdirectory path */
-   ret = snprintf(cache_dir_out, cache_dir_out_len, "%s/%s",
-         settings->paths.directory_cache, SPIRV_CACHE_SUBDIR);
-
-   /* Check if snprintf truncated the output */
-   if (ret < 0 || (size_t)ret >= cache_dir_out_len)
-      return false;
+   fill_pathname_join_special(cache_dir_out,
+         settings->paths.directory_cache, SPIRV_CACHE_SUBDIR,
+         cache_dir_out_len);
 
    return true;
 }
@@ -69,17 +66,14 @@ static bool spirv_cache_get_filename(const char *hash,
       char *cache_file_out, size_t cache_file_out_len)
 {
    char cache_dir[PATH_MAX_LENGTH];
-   int ret;
+   char hash_filename[128];
 
    if (!spirv_cache_get_dir(cache_dir, sizeof(cache_dir)))
       return false;
 
-   ret = snprintf(cache_file_out, cache_file_out_len, "%s/%s.spirv",
-         cache_dir, hash);
-
-   /* Check if snprintf truncated the output */
-   if (ret < 0 || (size_t)ret >= cache_file_out_len)
-      return false;
+   snprintf(hash_filename, sizeof(hash_filename), "%s.spirv", hash);
+   fill_pathname_join_special(cache_file_out, cache_dir, hash_filename,
+         cache_file_out_len);
 
    return true;
 }
@@ -93,12 +87,15 @@ static bool spirv_cache_get_filename(const char *hash,
  */
 static bool spirv_cache_write_string(RFILE *file, const std::string &str)
 {
-   uint32_t len = str.length();
+   uint32_t _len;
+   if (str.length() > UINT32_MAX)
+      return false;
+   _len = (uint32_t)str.length();
 
-   if (filestream_write(file, &len, sizeof(uint32_t)) != sizeof(uint32_t))
+   if (filestream_write(file, &_len, sizeof(uint32_t)) != sizeof(uint32_t))
       return false;
 
-   if (len > 0 && filestream_write(file, str.c_str(), len) != len)
+   if (_len > 0 && filestream_write(file, str.c_str(), _len) != _len)
       return false;
 
    return true;
@@ -113,29 +110,30 @@ static bool spirv_cache_write_string(RFILE *file, const std::string &str)
  */
 static bool spirv_cache_read_string(RFILE *file, std::string &str_out)
 {
-   uint32_t len;
+   uint32_t _len;
+   char *buf;
 
-   if (filestream_read(file, &len, sizeof(uint32_t)) != sizeof(uint32_t))
+   if (filestream_read(file, &_len, sizeof(uint32_t)) != sizeof(uint32_t))
       return false;
 
-   if (len == 0)
+   if (_len == 0)
    {
       str_out.clear();
       return true;
    }
 
    /* Allocate and read string */
-   char *buf = new char[len + 1];
+   buf = new char[_len + 1];
    if (!buf)
       return false;
 
-   if (filestream_read(file, buf, len) != len)
+   if (filestream_read(file, buf, _len) != _len)
    {
       delete[] buf;
       return false;
    }
 
-   buf[len] = '\0';
+   buf[_len] = '\0';
    str_out = buf;
    delete[] buf;
 
@@ -144,18 +142,18 @@ static bool spirv_cache_read_string(RFILE *file, std::string &str_out)
 
 extern "C" {
 
-bool spirv_cache_compute_hash(const char *vertex_source, const char *fragment_source,
-      char *hash_out)
+bool spirv_cache_compute_hash(const char *vertex_source, const char *fragment_source, char *hash_out)
 {
+   uint8_t *combined;
+   size_t vertex_len, fragment_len, total_len;
    if (!vertex_source || !fragment_source || !hash_out)
       return false;
 
    /* Build combined hash input: vertex + "|" + fragment */
-   size_t vertex_len = strlen(vertex_source);
-   size_t fragment_len = strlen(fragment_source);
-   size_t total_len = vertex_len + 1 + fragment_len;  /* 1 for "|" separator */
-
-   uint8_t *combined = new uint8_t[total_len];
+   vertex_len   = strlen(vertex_source);
+   fragment_len = strlen(fragment_source);
+   total_len    = vertex_len + 1 + fragment_len;  /* 1 for "|" separator */
+   combined     = new uint8_t[total_len];
    if (!combined)
       return false;
 
@@ -173,8 +171,8 @@ bool spirv_cache_compute_hash(const char *vertex_source, const char *fragment_so
 bool spirv_cache_load(const char *hash, struct glslang_output *output)
 {
    RFILE *file;
-   char cache_file[PATH_MAX_LENGTH];
    uint8_t version;
+   char cache_file[PATH_MAX_LENGTH];
    uint32_t vertex_size, fragment_size, param_count, i;
    uint16_t rt_format;
 
@@ -269,10 +267,10 @@ error:
 bool spirv_cache_save(const char *hash, const struct glslang_output *output)
 {
    RFILE *file;
+   uint16_t rt_format;
    char cache_file[PATH_MAX_LENGTH];
    uint8_t version = SPIRV_CACHE_VERSION;
    uint32_t vertex_size, fragment_size, param_count, i;
-   uint16_t rt_format;
 
    if (!hash || !output)
       return false;
@@ -294,7 +292,9 @@ bool spirv_cache_save(const char *hash, const struct glslang_output *output)
       goto error;
 
    /* Write vertex SPIR-V */
-   vertex_size = output->vertex.size();
+   if (output->vertex.size() > UINT32_MAX)
+      goto error;
+   vertex_size = (uint32_t)output->vertex.size();
    if (filestream_write(file, &vertex_size, sizeof(uint32_t)) != sizeof(uint32_t))
       goto error;
    if (vertex_size > 0)
@@ -304,7 +304,9 @@ bool spirv_cache_save(const char *hash, const struct glslang_output *output)
    }
 
    /* Write fragment SPIR-V */
-   fragment_size = output->fragment.size();
+   if (output->fragment.size() > UINT32_MAX)
+      goto error;
+   fragment_size = (uint32_t)output->fragment.size();
    if (filestream_write(file, &fragment_size, sizeof(uint32_t)) != sizeof(uint32_t))
       goto error;
    if (fragment_size > 0)
@@ -314,7 +316,9 @@ bool spirv_cache_save(const char *hash, const struct glslang_output *output)
    }
 
    /* Write parameters */
-   param_count = output->meta.parameters.size();
+   if (output->meta.parameters.size() > UINT32_MAX)
+      goto error;
+   param_count = (uint32_t)output->meta.parameters.size();
    if (filestream_write(file, &param_count, sizeof(uint32_t)) != sizeof(uint32_t))
       goto error;
 
@@ -359,3 +363,4 @@ error:
 }
 
 } /* extern "C" */
+

--- a/gfx/drivers_shader/slang_cache.cpp
+++ b/gfx/drivers_shader/slang_cache.cpp
@@ -26,13 +26,18 @@
 static bool spirv_cache_get_dir(char *cache_dir_out, size_t cache_dir_out_len)
 {
    settings_t *settings = config_get_ptr();
+   int ret;
 
    if (!settings || !settings->paths.directory_cache[0])
       return false;
 
    /* Build the spirv subdirectory path */
-   snprintf(cache_dir_out, cache_dir_out_len, "%s/%s",
+   ret = snprintf(cache_dir_out, cache_dir_out_len, "%s/%s",
          settings->paths.directory_cache, SPIRV_CACHE_SUBDIR);
+
+   /* Check if snprintf truncated the output */
+   if (ret < 0 || (size_t)ret >= cache_dir_out_len)
+      return false;
 
    return true;
 }
@@ -64,12 +69,17 @@ static bool spirv_cache_get_filename(const char *hash,
       char *cache_file_out, size_t cache_file_out_len)
 {
    char cache_dir[PATH_MAX_LENGTH];
+   int ret;
 
    if (!spirv_cache_get_dir(cache_dir, sizeof(cache_dir)))
       return false;
 
-   snprintf(cache_file_out, cache_file_out_len, "%s/%s.spirv",
+   ret = snprintf(cache_file_out, cache_file_out_len, "%s/%s.spirv",
          cache_dir, hash);
+
+   /* Check if snprintf truncated the output */
+   if (ret < 0 || (size_t)ret >= cache_file_out_len)
+      return false;
 
    return true;
 }

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -3396,6 +3396,10 @@ void input_overlay_load_active(
    if (ol->iface->full_screen)
       ol->iface->full_screen(ol->iface_data,
             (ol->active->flags & OVERLAY_FULL_SCREEN));
+
+   if (ol->iface->background_fill)
+      ol->iface->background_fill(ol->iface_data,
+            (ol->active->flags & OVERLAY_BACKGROUND_FILL));
 }
 
 /**

--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -132,7 +132,8 @@ enum OVERLAY_FLAGS
    OVERLAY_AUTO_X_SEPARATION  = (1 << 4),
    OVERLAY_AUTO_Y_SEPARATION  = (1 << 5),
    OVERLAY_HAS_VIEWPORT       = (1 << 6),
-   OVERLAY_VIEWPORT_FILL      = (1 << 7)
+   OVERLAY_VIEWPORT_FILL      = (1 << 7),
+   OVERLAY_BACKGROUND_FILL    = (1 << 8)
 };
 
 enum OVERLAY_DESC_FLAGS
@@ -193,6 +194,7 @@ typedef struct video_overlay_interface
          float x, float y, float w, float h);
    void (*full_screen)(void *data, bool enable);
    void (*set_alpha)(void *data, unsigned image, float mod);
+   void (*background_fill)(void *data, bool enable);
 } video_overlay_interface_t;
 
 typedef struct overlay_eightway_config
@@ -325,7 +327,7 @@ struct overlay
 
    char name[64];
 
-   uint8_t flags;
+   uint16_t flags;
 };
 
 typedef struct input_overlay_state

--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -852,6 +852,13 @@ static void task_overlay_deferred_load(retro_task_t *task)
       else
          overlay->flags &= ~OVERLAY_FULL_SCREEN;
 
+      strlcpy(conf_key + _len, "_background_fill", sizeof(conf_key) - _len);
+      if (config_get_bool(conf, conf_key, &tmp_bool)
+            && tmp_bool)
+         overlay->flags |= OVERLAY_BACKGROUND_FILL;
+      else
+         overlay->flags &= ~OVERLAY_BACKGROUND_FILL;
+
       /* Precache load image array for simplicity. */
       texture_img = (struct texture_image*)
          calloc(1 + overlay->size, sizeof(struct texture_image));


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

A lot of people use overlays cosmetically for borders/bezels, and they currently have to include a transparent cutout to match the content exactly, which means separate overlays for integer and non-integer, and no freedom to change aspect ratios from, say, nominal 4:3 to 8:7 (1:1 PAR for S/NES) without introducing either black borders or cutting off game content.

This PR adds a "overlayX_background_fill" flag to the overlay subsystem to allow users to put an overlay *behind* the game image instead of on top of it, so the overlay gets obscured when the game image changes size instead of the other way around.

I haven't yet added this to any of the D3D drivers because I don't have any good way of testing them, and they're currently experiencing a lot of churn.

## Related Issues

closes https://github.com/libretro/RetroArch/issues/9536 and closes https://github.com/libretro/RetroArch/issues/15138

## Related Pull Requests

none

## Reviewers

@sonninnos and @LibretroAdmin (in case you'd like to add support to the D3D drivers)
