### PR TITLE
Save/cleanup remaps earlier during core deinit

### DIFF
--- a/runloop.c
+++ b/runloop.c
@@ -4082,6 +4082,21 @@ void runloop_event_deinit_core(void)
       autosave_deinit();
 #endif
 
+   /* Remap save and cleanup logic should be placed before
+    * core_unload_game(), to ensure that input description data
+    * does not become invalid before remaps are saved. */
+   if (     (runloop_st->flags & RUNLOOP_FLAG_REMAPS_CORE_ACTIVE)
+         || (runloop_st->flags & RUNLOOP_FLAG_REMAPS_CONTENT_DIR_ACTIVE)
+         || (runloop_st->flags & RUNLOOP_FLAG_REMAPS_GAME_ACTIVE)
+         || (runloop_st->name.remapfile && *runloop_st->name.remapfile)
+      )
+   {
+      input_remapping_deinit(settings->bools.remap_save_on_exit);
+      input_remapping_set_defaults(true);
+   }
+   else
+      input_remapping_restore_global_config(true, false);
+
    core_unload_game();
 
    /* Reset core sensor tracking — the core is going away */
@@ -4113,18 +4128,6 @@ void runloop_event_deinit_core(void)
             );
       runloop_st->fastmotion_override.pending = false;
    }
-
-   if (     (runloop_st->flags & RUNLOOP_FLAG_REMAPS_CORE_ACTIVE)
-         || (runloop_st->flags & RUNLOOP_FLAG_REMAPS_CONTENT_DIR_ACTIVE)
-         || (runloop_st->flags & RUNLOOP_FLAG_REMAPS_GAME_ACTIVE)
-         || (runloop_st->name.remapfile && *runloop_st->name.remapfile)
-      )
-   {
-      input_remapping_deinit(settings->bools.remap_save_on_exit);
-      input_remapping_set_defaults(true);
-   }
-   else
-      input_remapping_restore_global_config(true, false);
 
    RARCH_LOG("[Core] Unloading core symbols...\n");
    uninit_libretro_symbols(&runloop_st->current_core);


### PR DESCRIPTION
## Description

As explained in https://github.com/libretro/RetroArch/issues/18999, at present RetroArch will segfault on `input_remapping_save_file()` whenever using any content/core with Run-Ahead set to "Second Instance Mode" and having an input remap file (.rmp) for that specific content/core. 
I suspect this was a long-standing issue which never came to the surface until now, rather than it being the consequence of a recent regression.

The reason for the crash appears to be the following:
- in the current code, when we deinitialize the core in `runloop_event_deinit_core()`, the remap saving only happens after `core_unload_game()`. 
- This makes it so that, if a second copy of the core exists in the background (for Run-Ahead Second Instance), the input descriptor pointers end up becoming invalid by the time we reach the remap saving in the unload process.

This PR fixes the issue by moving the remap saving right before `core_unload_game()`. 
The change is minor and it is consistent with other shutdown-style paths in the codebase, where remaps are reset early on (for example, in CMD_EVENT_UNLOAD_CORE in retroarch.c). No adverse effects were observed.

## Related Issues

Fixes https://github.com/libretro/RetroArch/issues/18999

## Reviewers

@LibretroAdmin