### PR TITLE
Fix no input driver found segfault, compile error without EGL

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -66,7 +66,7 @@ HAVE_FREETYPE = 1
 HAVE_GDI = 0
 HAVE_GETADDRINFO = 1
 HAVE_GETOPT_LONG = 1
-HAVE_GLSL = 1
+HAVE_GLSL ?= 1
 HAVE_GLSLANG = 0
 HAVE_GLSLANG_HLSL = 0
 HAVE_GLSLANG_OGLCOMPILER = 0
@@ -187,7 +187,10 @@ ifeq ($(HAVE_OPENGLES3_2),1)
 endif
 ifeq ($(HAVE_WAYLAND),1)
   DEFINES += -DHAVE_WAYLAND=1
-  WAYLAND_LIBS = -lwayland-client -lwayland-cursor -lwayland-egl
+  WAYLAND_LIBS = -lwayland-client -lwayland-cursor
+  ifeq ($(HAVE_EGL),1)
+    WAYLAND_LIBS += -lwayland-egl
+  endif
 endif
 ifeq ($(HAVE_WEBOS_EXTRA_PROTOS),1)
   DEFINES += -DHAVE_WEBOS_EXTRA_PROTOS=1

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include "wayland_common.h"
+#include "../gfx/video_driver.h"
 #include "../../frontend/frontend_driver.h"
 #include "../../verbosity.h"
 

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -30,6 +30,7 @@
 #endif
 
 #include "../common/wayland_common.h"
+#include "../gfx/video_driver.h"
 #include "../../frontend/frontend_driver.h"
 #include "../../input/common/wayland_common.h"
 #include "../../input/input_driver.h"

--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -564,7 +564,8 @@ bool gfx_ctx_wl_init_webos(
 
    if (wl->shell_surface == NULL)
    {
-      RARCH_LOG("[wayland/webOS] Can't create shell surface");
+      RARCH_ERR("[wayland/webOS] Can't create shell surface");
+      return false;
    }
 
    wl_shell_surface_set_toplevel(wl->shell_surface);
@@ -574,7 +575,8 @@ bool gfx_ctx_wl_init_webos(
 
    if (wl->webos_shell_surface == NULL)
    {
-      RARCH_LOG("[wayland/webOS] Can't create webos shell surface");
+      RARCH_ERR("[wayland/webOS] Can't create webos shell surface");
+      return false;
    }
 
    wl_webos_shell_surface_add_listener(wl->webos_shell_surface,

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -5032,7 +5032,7 @@ void input_event_osk_append(
 void *input_driver_init_wrap(input_driver_t *input, const char *name)
 {
    void *ret = NULL;
-   if (!input)
+   if (!input || !input->init)
       return NULL;
    if ((ret = input->init(name)))
    {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

1. Allow compile webOS without GLSL/EGL
2. Fix segfault when no input driver found, instead it now exits as normal with error in logs.

```
Thread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x000000000044c4e0 in input_driver_init_wrap ()
#2  0x000000000044cac0 in video_driver_init_input ()
#3  0x0000000000456768 in video_driver_init_internal ()
#4  0x0000000000413cbc in drivers_init ()
#5  0x0000000000415f28 in retroarch_main_init ()
#6  0x0000000000432194 in content_load ()
#7  0x0000000000432e5c in task_load_content_internal.constprop ()
#8  0x0000000000414cf0 in rarch_main ()
#9  0x0000007ff7b4866c in ?? ()
#10 0x00000000004083f4 in _start ()
```

When compiling without EGL fix missing includes:

```
gfx/drivers_context/wayland_ctx.c:606:33: error: implicit declaration of function ‘video_driver_get_ident’; did you mean ‘video_driver_init_input’? [-Wimplicit-function-declaration]
  606 |    const char *video_ident    = video_driver_get_ident();
      |                                 ^~~~~~~~~~~~~~~~~~~~~~
      |                                 video_driver_init_input
gfx/drivers_context/wayland_ctx.c:606:33: error: initialization of ‘const char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
gfx/drivers_context/wayland_ctx.c: At top level:
gfx/drivers_context/wayland_ctx.c:654:7: error: unknown type name ‘gfx_ctx_driver_t’
  654 | const gfx_ctx_driver_t gfx_ctx_wayland = {
      |       ^~~~~~~~~~~~~~~~
gfx/drivers_context/wayland_ctx.c:655:4: error: initialization of ‘int’ from ‘void * (*)(void *)’ makes integer from pointer without a cast [-Wint-conversion]
  655 |    gfx_ctx_wl_init,
```

## Related Issues

## Related Pull Requests

## Reviewers
