### PR TITLE
Add core downloader URL for aarch64 linux architecture

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1868,6 +1868,8 @@
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/linux/x86_64/latest/"
 #elif defined(__i386__) || defined(__i486__) || defined(__i686__)
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/linux/x86/latest/"
+#elif defined(__aarch64__)
+#define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/linux/aarch64/latest/"
 #elif defined(__arm__) && __ARM_ARCH == 7 && defined(__ARM_PCS_VFP)
 #define DEFAULT_BUILDBOT_SERVER_URL "http://buildbot.libretro.com/nightly/linux/armhf/latest/"
 #else


### PR DESCRIPTION
Adds the aarch64 linux core downloader url to the defaults. As mentioned by myself here https://github.com/libretro/libretro-super/issues/1874#issuecomment-4323177296 it is still missing even though aarch64 linux builds have been re-enabled.

@gouchi