### PR TITLE
Allows SAVE_STATE to fire during replay recording without truncating the .replay file

### DIFF
--- a/input/bsv/bsvmovie.c
+++ b/input/bsv/bsvmovie.c
@@ -1173,6 +1173,7 @@ bool replay_get_serialized_data(void* buffer)
       buf                     = ((uint8_t *)buffer) + sizeof(uint32_t);
       intfstream_rewind(handle->file);
       read_amt                = intfstream_read(handle->file, buf, file_end);
+      intfstream_seek(handle->file, file_end, SEEK_SET);
       if (handle->frame_counter > UINT32_MAX) {
          RARCH_ERR("[Replay] Frame counter too big to fit in 32 bits\n");
          return false;


### PR DESCRIPTION
Previously, any SAVE_STATE during a recording silently ended the input track at that frame. Playback would end at the first save.

`replay_get_serialized_data` rewinds the recording stream and reads it back to embed in the .state file. An input op on an update-mode stream must precede output with a positioning call (per [C99 §7.19.5.3](https://port70.net/~nsz/c/c99/n1256.html#7.19.5.3)) without this seek the next `intfstream_write` from `bsv_movie_next_frame` silently no-ops.

Tested: no-saves (regression test), 3 saves over 20s, 5 saves over 60s. All play back fully. Bug since [#15070](https://github.com/libretro/RetroArch/pull/15070).