### PR TITLE
Extra menu layer removal for Import Content

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1663,7 +1663,7 @@ int generic_action_ok_displaylist_push(
          info.type          = type;
          info.directory_ptr = idx;
          info_path          = path;
-         info_label         = MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST_STR;
+         info_label         = msg_hash_to_str(MENU_ENUM_LABEL_ADD_CONTENT_LIST);
          info.enum_idx      = MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST;
          dl_type            = DISPLAYLIST_PENDING_CLEAR;
          break;
@@ -2633,7 +2633,7 @@ static int generic_action_ok(const char *path,
          ret        = set_path_generic(menu_label, action_path);
          break;
       case ACTION_OK_SET_MANUAL_CONTENT_SCAN_DAT_FILE:
-         flush_char = MENU_ENUM_LABEL_DEFERRED_MANUAL_CONTENT_SCAN_LIST_STR;
+         flush_char = msg_hash_to_str(MENU_ENUM_LABEL_ADD_CONTENT_LIST);
          ret        = set_path_generic(menu_label, action_path);
          break;
       case ACTION_OK_SET_PATH:
@@ -4418,7 +4418,7 @@ static int action_ok_path_manual_scan_directory(const char *path,
    manual_content_scan_set_menu_content_dir(content_dir);
 
    /* Return to 'manual content scan' menu */
-   menu_entries_flush_stack(MENU_ENUM_LABEL_DEFERRED_MANUAL_CONTENT_SCAN_LIST_STR, flush_type);
+   menu_entries_flush_stack(msg_hash_to_str(MENU_ENUM_LABEL_ADD_CONTENT_LIST), flush_type);
 
    return 0;
 }

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -8660,6 +8660,13 @@ static enum menu_action ozone_parse_menu_entry_action(
       free input fields (passwords...). This is good enough. */
    is_current_entry_settings = ozone_is_current_entry_settings(selection);
 
+   /* Avoid left/right action skip if we are not in a submenu
+      (needed when Import Content is next to playlists) */
+   if (ozone->depth == 1)
+      menu_st->flags |= MENU_ST_FLAG_PREVENT_BOOL_SPECIAL_FILTER;
+   else
+      menu_st->flags &= ~MENU_ST_FLAG_PREVENT_BOOL_SPECIAL_FILTER;
+
    /* Scan user inputs */
    switch (action)
    {

--- a/menu/menu_defines.h
+++ b/menu/menu_defines.h
@@ -55,7 +55,8 @@ enum menu_state_flags
    /* When enabled, a configuration file load (full driver/menu
     * reinit) has been requested and will be performed on the next
     * frame, outside of menu iteration */
-   MENU_ST_FLAG_PENDING_CONFIG_REPLACE      = (1 << 15)
+   MENU_ST_FLAG_PENDING_CONFIG_REPLACE      = (1 << 15),
+   MENU_ST_FLAG_PREVENT_BOOL_SPECIAL_FILTER = (1 << 16)
 };
 
 enum menu_scroll_mode

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -6583,7 +6583,7 @@ static unsigned populate_playlist_thumbnail_mode_dropdown_list(
 }
 
 static unsigned menu_displaylist_parse_manual_content_scan_list(
-      file_list_t *info_list)
+      file_list_t *info_list, bool is_main_view)
 {
    unsigned count = 0;
    settings_t *settings = config_get_ptr();
@@ -6593,7 +6593,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MANUAL_CONTENT_SCAN_DIR),
          MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_DIR_STR,
          MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_DIR,
-         MENU_SETTING_MANUAL_CONTENT_SCAN_DIR, 0, 0, NULL))
+         MENU_SETTING_ACTION, 0, 0, NULL))
       count++;
 
    /* Scan method - automatic or custom (more entries) */
@@ -6601,7 +6601,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_METHOD),
          msg_hash_to_str(MENU_ENUM_LABEL_SCAN_METHOD),
          MENU_ENUM_LABEL_SCAN_METHOD,
-         MENU_SETTING_SCAN_METHOD, 0, 0, NULL))
+         MENU_SETTING_ACTION, 0, 0, NULL))
       count++;
 
    if (manual_content_scan_get_scan_method_enum() == MANUAL_CONTENT_SCAN_METHOD_CUSTOM)
@@ -6611,7 +6611,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_USE_DB),
             msg_hash_to_str(MENU_ENUM_LABEL_SCAN_USE_DB),
             MENU_ENUM_LABEL_SCAN_USE_DB,
-            MENU_SETTING_SCAN_USE_DB, 0, 0, NULL))
+            MENU_SETTING_ACTION, 0, 0, NULL))
          count++;
 
       if (manual_content_scan_get_scan_use_db_enum() == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE ||
@@ -6630,7 +6630,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
                msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_DB_SELECT),
                msg_hash_to_str(MENU_ENUM_LABEL_SCAN_DB_SELECT),
                MENU_ENUM_LABEL_SCAN_DB_SELECT,
-               MENU_SETTING_SCAN_DB_SELECT, 0, 0, NULL))
+               MENU_SETTING_ACTION, 0, 0, NULL))
             count++;
       }
 
@@ -6639,7 +6639,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MANUAL_CONTENT_SCAN_SYSTEM_NAME),
             msg_hash_to_str(MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_SYSTEM_NAME),
             MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_SYSTEM_NAME,
-            MENU_SETTING_MANUAL_CONTENT_SCAN_SYSTEM_NAME, 0, 0, NULL))
+            MENU_SETTING_ACTION, 0, 0, NULL))
          count++;
 
       if (manual_content_scan_get_menu_system_name_type() == MANUAL_CONTENT_SCAN_SYSTEM_NAME_CUSTOM)
@@ -6669,7 +6669,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
             msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MANUAL_CONTENT_SCAN_CORE_NAME),
             msg_hash_to_str(MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_CORE_NAME),
             MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_CORE_NAME,
-            MENU_SETTING_MANUAL_CONTENT_SCAN_CORE_NAME, 0, 0, NULL))
+            MENU_SETTING_ACTION, 0, 0, NULL))
          count++;
 
       /* File extensions */
@@ -6747,7 +6747,7 @@ static unsigned menu_displaylist_parse_manual_content_scan_list(
          msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MANUAL_CONTENT_SCAN_START),
          MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_START_STR,
          MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_START,
-         MENU_SETTING_ACTION_MANUAL_CONTENT_SCAN_START, 0, 0, NULL))
+         MENU_SETTING_ACTION, 0, 0, NULL))
       count++;
 
    return count;
@@ -8128,13 +8128,15 @@ unsigned menu_displaylist_build_list(
                   MENU_ENUM_LABEL_SCAN_FILE,
                   MENU_SETTING_ACTION, 0, 0, NULL))
             count++;
-#endif
          if (menu_entries_append(list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MANUAL_CONTENT_SCAN_LIST),
                   MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_LIST_STR,
                   MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_LIST,
                   MENU_SETTING_ACTION, 0, 0, NULL))
             count++;
+#endif
+         count = menu_displaylist_parse_manual_content_scan_list(list, true);
+
          break;
       case DISPLAYLIST_INFORMATION_LIST:
          count              = menu_displaylist_parse_information_list(list);
@@ -8681,7 +8683,7 @@ unsigned menu_displaylist_build_list(
          }
          break;
       case DISPLAYLIST_ADD_CONTENT_LIST:
-#ifdef HAVE_LIBRETRODB
+#if 0
          if (menu_entries_append(list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SCAN_DIRECTORY),
                   MENU_ENUM_LABEL_SCAN_DIRECTORY_STR,
@@ -8694,13 +8696,14 @@ unsigned menu_displaylist_build_list(
                   MENU_ENUM_LABEL_SCAN_FILE,
                   MENU_SETTING_ACTION, 0, 0, NULL))
             count++;
-#endif
          if (menu_entries_append(list,
                   msg_hash_to_str(MENU_ENUM_LABEL_VALUE_MANUAL_CONTENT_SCAN_LIST),
                   MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_LIST_STR,
                   MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_LIST,
                   MENU_SETTING_ACTION, 0, 0, NULL))
             count++;
+#endif
+         count = menu_displaylist_parse_manual_content_scan_list(list, false);
          break;
       case DISPLAYLIST_NETWORK_INFO:
 #if defined(HAVE_NETWORKING) && defined(HAVE_IFINFO)
@@ -16218,7 +16221,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
             break;
          case DISPLAYLIST_MANUAL_CONTENT_SCAN_LIST:
             menu_entries_clear(info->list);
-            count = menu_displaylist_parse_manual_content_scan_list(info->list);
+            count = menu_displaylist_parse_manual_content_scan_list(info->list, false);
 
             menu_displaylist_no_entries_fallback(info->list, count, FILE_TYPE_NONE);
 

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5610,7 +5610,7 @@ unsigned menu_event(
             setting_type = ST_BOOL;
 #endif
 
-         if (setting_type == ST_BOOL)
+         if (!(menu_st->flags & MENU_ST_FLAG_PREVENT_BOOL_SPECIAL_FILTER) && setting_type == ST_BOOL)
          {
             char value[8];
 

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -533,7 +533,7 @@ struct menu_state
    /* int16_t alignment */
    menu_input_pointer_hw_state_t input_pointer_hw_state;
 
-   uint16_t flags;
+   uint32_t flags;
 #ifdef HAVE_OVERLAY
    uint16_t overlay_types;
 #endif


### PR DESCRIPTION
## Description

The Import Content menu now directly holds the scan options. Some extra logic was needed to avoid troubles when this menu is opened directly from Ozone main menu / XMB horizontal menu - in practice, this means that left/right does not change menu item values when in Ozone main menu, and horizontal scrolling only works for the first and last menu entry when this item is in its own horizontal tab for XMB.

This was one of the postponed issues in the original PR #18641. In some menu structures, "Scan Directory" / "Scan File" still remained, that is now also removed. Tested with all menu drivers * content scan in main menu / submenu combinations, should work as expected.

## Related Pull Requests

#18641
