### PR TITLE
video/sdl: fix unthreaded video output on nullified video_cb

### DIFF
--- a/gfx/drivers/sdl_gfx.c
+++ b/gfx/drivers/sdl_gfx.c
@@ -368,47 +368,43 @@ static bool sdl_gfx_frame(void *data, const void *frame, unsigned width,
    bool menu_is_alive = (video_info->menu_st_flags & MENU_ST_FLAG_ALIVE) ? true : false;
 #endif
 
-   if (!vid)
+   if (!frame)
       return true;
 
    title[0] = '\0';
 
    video_driver_get_window_title(title, sizeof(title));
 
-   if (vid->menu.active)
-   {
+   if (SDL_MUSTLOCK(vid->screen))
+      SDL_LockSurface(vid->screen);
+
+   video_frame_scale(
+         &vid->scaler,
+         vid->screen->pixels,
+         frame,
+         vid->scaler.in_fmt,
+         vid->screen->w,
+         vid->screen->h,
+         vid->screen->pitch,
+         width,
+         height,
+         pitch);
+
 #ifdef HAVE_MENU
-      menu_driver_frame(menu_is_alive, video_info);
-#endif
+   menu_driver_frame(menu_is_alive, video_info);
+
+   if (vid->menu.active)
       SDL_BlitSurface(vid->menu.frame, NULL, vid->screen, NULL);
-   }
-   else
-   {
-      if (SDL_MUSTLOCK(vid->screen))
-         SDL_LockSurface(vid->screen);
+#endif
 
-      video_frame_scale(
-            &vid->scaler,
-            vid->screen->pixels,
-            frame,
-            vid->scaler.in_fmt,
-            vid->screen->w,
-            vid->screen->h,
-            vid->screen->pitch,
-            width,
-            height,
-            pitch);
+   if (msg)
+      sdl_render_msg(vid, vid->screen,
+            msg, vid->screen->w, vid->screen->h, vid->screen->format,
+            video_info->font_msg_pos_x,
+            video_info->font_msg_pos_y);
 
-
-      if (SDL_MUSTLOCK(vid->screen))
-         SDL_UnlockSurface(vid->screen);
-
-      if (msg)
-         sdl_render_msg(vid, vid->screen,
-         msg, vid->screen->w, vid->screen->h, vid->screen->format,
-         video_info->font_msg_pos_x,
-         video_info->font_msg_pos_y);
-   }
+   if (SDL_MUSTLOCK(vid->screen))
+      SDL_UnlockSurface(vid->screen);
 
    if (title[0])
       SDL_WM_SetCaption(title, NULL);

--- a/gfx/drivers/sdl_rs90_gfx.c
+++ b/gfx/drivers/sdl_rs90_gfx.c
@@ -1079,7 +1079,7 @@ static bool sdl_rs90_gfx_frame(void *data, const void *frame,
     * - Menu is inactive and input 'content' frame
     *   data is NULL (may happen when e.g. a running
     *   core skips a frame) */
-   if (unlikely(!vid))
+   if (unlikely(!vid || (!frame && !vid->menu_active)))
       return true;
 
    /* If fast forward is currently active, we may


### PR DESCRIPTION

## Description

Reverting these commits fix two drivers on disabled video threading when dropping frames:
- SDL: fix segfault when frameskipping
- SDL_rs90: fix forcing drawing NULL frame when frameskipping (see issue below), for context see commented notes in: https://github.com/libretro/RetroArch/commit/eb259174b820c74f65a4703f9c21f54837f6bf43

## Related Issues

downstream: https://github.com/TriForceX/MiyooCFW/issues/585 (EDIT)

## Reviewers

@jdgleaver 
