### PR TITLE
add `CMD_EVENT_VIDEO_FILTER_INIT` case & free flt on deinit

### DIFF
--- a/command.h
+++ b/command.h
@@ -115,6 +115,8 @@ enum event_command
    CMD_EVENT_FPS_TOGGLE,
    /* Toggles statistics display. */
    CMD_EVENT_STATISTICS_TOGGLE,
+   /* Initializes video filter. */
+   CMD_EVENT_VIDEO_FILTER_INIT,
    /* Initializes overlay. */
    CMD_EVENT_OVERLAY_INIT,
    /* Frees or caches overlay. */

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3706,6 +3706,7 @@ static int action_ok_shader_preset_remove_game(const char *path,
 static int action_ok_video_filter_remove(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
+#ifdef HAVE_VIDEO_FILTER
    struct menu_state *menu_st = menu_state_get_ptr();
    settings_t *settings       = config_get_ptr();
    if (!settings)
@@ -3714,11 +3715,12 @@ static int action_ok_video_filter_remove(const char *path,
    {
       /* Unload video filter */
       settings->paths.path_softfilter_plugin[0] = '\0';
-      command_event(CMD_EVENT_REINIT, NULL);
+      video_driver_filter_free();
       /* Refresh menu */
       menu_st->flags         |=  MENU_ST_FLAG_ENTRIES_NEED_REFRESH
                              |  MENU_ST_FLAG_PREVENT_POPULATE;
    }
+#endif
    return 0;
 }
 

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -14822,7 +14822,8 @@ static bool setting_append_list(
             (*list)[list_info->index - 1].get_string_representation =
                &setting_get_string_representation_video_filter;
             MENU_SETTINGS_LIST_CURRENT_ADD_VALUES(list, list_info, "filt");
-            MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info, CMD_EVENT_REINIT);
+            MENU_SETTINGS_LIST_CURRENT_ADD_CMD(list, list_info,
+                  CMD_EVENT_VIDEO_FILTER_INIT);
             SETTINGS_DATA_LIST_CURRENT_ADD_FLAGS(list, list_info, SD_FLAG_LAKKA_ADVANCED);
 
             END_SUB_GROUP(list, list_info, parent_group);

--- a/retroarch.c
+++ b/retroarch.c
@@ -3183,7 +3183,17 @@ bool command_event(enum event_command cmd, void *data)
 #ifdef HAVE_OVERLAY
          input_overlay_init();
 #endif
+	 break;
+      case CMD_EVENT_VIDEO_FILTER_INIT:
+      {
+#ifdef HAVE_VIDEO_FILTER
+	const enum retro_pixel_format
+	   video_driver_pix_fmt                = video_st->pix_fmt;
+	settings_t  *settings          = config_get_ptr();
+        video_driver_init_filter(video_driver_pix_fmt, settings);
+#endif
          break;
+      }
       case CMD_EVENT_CHEAT_INDEX_PLUS:
 #ifdef HAVE_CHEATS
          cheat_manager_index_next();


### PR DESCRIPTION
## Description

Instead of cmd reinit all drivers, just init/deinit video_filter to switch it on/off. Works faster and seems safer.

init) CMD_EVENT_VIDEO_FILTER_INIT -> menu_setting.c
deinit) video_driver_filter_free-> menu_cbs_ok.c

## Related Issues

downstream: https://github.com/TriForceX/MiyooCFW/issues/603 (not necessary direct fix, but won't trigger that bug when Vsync off)

## Reviewers

Not sure who to tag, smb who decided to do CMD_EVENT_REINIT for video_filter init/deinit ?
