### PR TITLE
file_path: avoid fortified realpath() buffer size abort

### DIFF
--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -793,12 +793,16 @@ char *path_resolve_realpath(char *s, size_t len, bool resolve_symlinks)
    const char *buf_end;
    if (resolve_symlinks)
    {
+      char *real_path;
       strlcpy(tmp, s, sizeof(tmp));
-      if (!realpath(tmp, s))
+      real_path = realpath(tmp, NULL);
+      if (!real_path)
       {
          strlcpy(s, tmp, len);
          return NULL;
       }
+      strlcpy(s, real_path, len);
+      free(real_path);
       return s;
    }
    t       = 0;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Some distributions now build packages with stricter default toolchain hardening, including `_FORTIFY_SOURCE=3`. Under those settings, glibc’s fortified `realpath()` performs a compile/runtime object-size check on the destination buffer and aborts if it is smaller than the system `PATH_MAX`.

glibc's fortified realpath() checks that the destination buffer is at least PATH_MAX bytes. path_resolve_realpath() was passing the caller's buffer directly, which may be smaller than the system PATH_MAX despite being sized to RetroArch's PATH_MAX_LENGTH.

With _FORTIFY_SOURCE=3 this can abort in __realpath_chk when resolving core updater paths.

Resolve into an allocated realpath() buffer instead, then copy the result back into the caller-provided buffer using the provided length.