### PR TITLE
Fix dvd chd achievement hashing when unit & hunk size differ

### DIFF
--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -418,7 +418,7 @@ chdstream_t *chdstream_open(const char *path, int32_t track)
          break;
       case 'D': /* DVD */
          stream->frame_size   = hd->unitbytes;
-         meta.frames          = hd->totalhunks;
+         meta.frames          = hd->totalhunks * (hd->hunkbytes / hd->unitbytes);
          break;
       default:
          stream->frame_size   = hd->unitbytes;


### PR DESCRIPTION
- Fix #19040. 
- Related:
  - #18005
  - #16145

Some CHDs created with `chdman createdvd` fail to generate a proper retroachievements hash because the frame count is calculated incorrectly when the Hunk Size and Unit Size differ. I observed a failed RA hash on 1/6 chd's I tested, both `rahasher` and a recompress of the chd via `createcd` hashed correctly. Even though `meta.frames` is not correctly calculated, many `createdvd` chd's still appear to hash correctly.

Currently, `chd_stream.c` sets `meta.frames` equal to `totalhunks`. While this always works if the ratio is 1:1, hunk sizes larger than the unit size (e.g., 4096 hunk / 2048 unit) may result in an incorrect frames calculation, causing a bad hash.

`chdman` documentation states that hunk size is guaranteed to be a multiple of the unit/sector size.

> The hunk size must be no smaller than 16 bytes and no larger than 1048576
> bytes (1 MiB). The hunk size must be a multiple of the sector size or unit size
> of the media. Larger hunk sizes may give better compression ratios, but reduce
> performance for small random reads as an entire hunk needs to be read and
> decompressed at a time.

This patch calculates `meta.frames` using the ratio of `hunkbytes / unitbytes` to ensure the full logical size of the DVD is accessible.

Example of a failing CHD:
```
chdman - MAME Compressed Hunks of Data (CHD) manager 0.287 (mame0287-dirty)
Input file:   nfshp2-dvd.chd
File Version: 5
Logical size: 3,121,184,768 bytes
Hunk Size:    4,096 bytes
Total Hunks:  762,008
Unit Size:    2,048 bytes
Total Units:  1,524,016
Compression:  lzma (LZMA), zlib (Deflate), huff (Huffman), flac (FLAC)
CHD size:     2,374,600,327 bytes
Ratio:        76.1%
SHA1:         377a964628024b089233767bb08c69af8e16671e
Data SHA1:    6a9335758f8faa1bd9e910eb4db40b5aa279e968
Metadata:     Tag='DVD '  Index=0  Length=1 bytes
              .
```

---

Any feedback is welcome. I've been sitting on this for a few days just testing the chd's I have access to. I have not tested MAME chd's so if anyone is able  to test some that would help a lot. I tested a number of ps2 cd and dvd chd's with varrying `--hunksize`.

I'm unsure where to make improvements at the moment, so any help would be appreciated.
