### PR TITLE
Fix network command MENU_TOGGLE lost during single-instance runahead

### DIFF
--- a/command.c
+++ b/command.c
@@ -160,7 +160,16 @@ static void command_parse_sub_msg(command_t *handle, const char *tok)
             RARCH_ERR("[Command] Command \"%s\" failed.\n", arg);
       }
       else
-         handle->state[map[index].id] = true;
+      {
+         /* For MENU_TOGGLE, bypass the press-and-release mechanism
+          * by directly invoking the command event.  This avoids
+          * timing issues with runahead (single-instance) where the
+          * 1-frame pulse from network commands can be lost. */
+         if (map[index].id == RARCH_MENU_TOGGLE)
+            command_event(CMD_EVENT_MENU_TOGGLE, NULL);
+         else
+            handle->state[map[index].id] = true;
+      }
    }
    else
       RARCH_WARN(msg_hash_to_str(MSG_UNRECOGNIZED_COMMAND), tok);


### PR DESCRIPTION
## Description

When runahead (single-instance) is enabled and netplay is disabled, the MENU_TOGGLE network command fails to open the menu (closing works fine).

RARCH_MENU_TOGGLE uses a press-and-release mechanism in input_driver.c that requires the input to span at least two polling frames — one frame pressed, then one frame released — before the toggle is registered. Network command UDP packets produce a single-frame pulse, which works in most configurations but fails under single-instance runahead.

In command_parse_sub_msg(), when MENU_TOGGLE is received via network command, directly invoke command_event(CMD_EVENT_MENU_TOGGLE, NULL) instead of setting handle->state[RARCH_MENU_TOGGLE] = true. This bypasses the press-and-release timing requirement entirely.


## Test results
command: `echo -n "MENU_TOGGLE" | nc -u -w1 127.0.0.1 55355`

| Config | Before | After |
| :--- | :--- | :--- |
| Netplay enabled (any runahead) | Works | Works |
| Netplay disabled + runahead + secondary instance | Works | Works |
| Netplay disabled + runahead + single instance | Broken | Fixed |
| No runahead | Works | Works |
