### PR TITLE
add overlay 4-way flag to analog descriptors

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2885,6 +2885,23 @@ static void input_overlay_get_analog_state(
    x_val_sat = x_val   / desc->analog_saturate_pct;
    y_val_sat = y_val   / desc->analog_saturate_pct;
 
+   if (desc->four_way)
+   {
+      float abs_x = fabs(x_val_sat);
+      float abs_y = fabs(y_val_sat);
+      
+      if (abs_x > abs_y)
+      {
+         x_val_sat = (x_val_sat >= 0.0f) ? 1.0f : -1.0f;
+         y_val_sat = 0.0f;
+      }
+      else
+      {
+         y_val_sat = (y_val_sat >= 0.0f) ? 1.0f : -1.0f;
+         x_val_sat = 0.0f;
+      }
+   }
+
    out->analog[base + 0] = clamp_float(x_val_sat, -1.0f, 1.0f) * 32767.0f;
    out->analog[base + 1] = clamp_float(y_val_sat, -1.0f, 1.0f) * 32767.0f;
 }

--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -261,6 +261,7 @@ struct overlay_desc
    uint32_t touch_mask;
    uint32_t old_touch_mask;
 
+   bool four_way;
    uint8_t flags;
 };
 

--- a/tasks/task_overlay.c
+++ b/tasks/task_overlay.c
@@ -568,6 +568,12 @@ static bool task_overlay_load_desc(
    if (config_get_float(conf, conf_key, &tmp_float))
       desc->range_mod = tmp_float;
 
+   strlcpy(conf_key + _len, "_4way",   sizeof(conf_key) - _len);
+   desc->four_way = false;
+   if (config_get_bool(conf, conf_key, &tmp_bool)
+         && tmp_bool)
+      desc->four_way = true;
+
    strlcpy(conf_key + _len, "_exclusive",   sizeof(conf_key) - _len);
    desc->flags &= ~OVERLAY_DESC_EXCLUSIVE;
    if (config_get_bool(conf, conf_key, &tmp_bool)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This adds an optional flag to overlays' analog descs that forces 4-way digital operation, which should greatly improve playability on a lot of classic arcade games, like pacman.

The syntax is: `overlayX_descY_4way = true/false` (default value is false) and descY must call out an analog.

This doesn't touch regular inputs outside of overlays, which would be a lot more complicated to implement, and I'm not even sure if such an implementation would affect overlays if it were implemented.

## Related Issues

None that I know of. This one is related, but for physical gamepads: https://github.com/libretro/RetroArch/issues/4994

## Related Pull Requests

none

## Reviewers

@neil4 
