### PR TITLE
menu: allow direct input for exact cheat search value

### DIFF
--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -1264,6 +1264,64 @@ int cheat_manager_search_exact(rarch_setting_t *setting, size_t idx, bool wrapar
    return cheat_manager_search(CHEAT_SEARCH_TYPE_EXACT);
 }
 
+static void cheat_manager_search_exact_input_cb(void *userdata,
+      const char *line)
+{
+   char *end             = NULL;
+   unsigned long value   = 0;
+   unsigned max_value    = 0;
+
+   if (!line || !*line)
+   {
+      menu_input_dialog_end();
+      return;
+   }
+
+   errno = 0;
+   value = strtoul(line, &end, 0);
+
+   if (errno || end == line)
+   {
+      menu_input_dialog_end();
+      return;
+   }
+
+   max_value = cheat_manager_get_state_search_size(
+         cheat_manager_state.search_bit_size);
+
+   if (value > max_value)
+      value = max_value;
+
+   cheat_manager_state.search_exact_value = (unsigned)value;
+
+   menu_input_dialog_end();
+
+   cheat_manager_search(CHEAT_SEARCH_TYPE_EXACT);
+}
+
+int cheat_manager_search_exact_input(rarch_setting_t *setting,
+      size_t idx, bool wraparound)
+{
+#ifdef HAVE_MENU
+   char value_buf[32];
+   menu_input_ctx_line_t line = {0};
+
+   snprintf(value_buf, sizeof(value_buf), "%u",
+         cheat_manager_state.search_exact_value);
+
+   line.label         = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_SEARCH_EXACT);
+   line.label_setting = value_buf;
+   line.type          = MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT;
+   line.idx           = idx;
+   line.cb            = cheat_manager_search_exact_input_cb;
+
+   if (menu_input_dialog_start(&line))
+      return 0;
+#endif
+
+   return cheat_manager_search_exact(setting, idx, wraparound);
+}
+
 int cheat_manager_search_lt(rarch_setting_t *setting, size_t idx, bool wraparound)
 {
    return cheat_manager_search(CHEAT_SEARCH_TYPE_LT);

--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -1304,7 +1304,9 @@ int cheat_manager_search_exact_input(rarch_setting_t *setting,
 {
 #ifdef HAVE_MENU
    char value_buf[32];
-   menu_input_ctx_line_t line = {0};
+   menu_input_ctx_line_t line;
+
+   memset(&line, 0, sizeof(line));
 
    snprintf(value_buf, sizeof(value_buf), "%u",
          cheat_manager_state.search_exact_value);

--- a/cheat_manager.h
+++ b/cheat_manager.h
@@ -248,6 +248,8 @@ int cheat_manager_initialize_memory(rarch_setting_t *setting, size_t idx, bool w
 
 int cheat_manager_search_exact(rarch_setting_t *setting, size_t idx, bool wraparound);
 
+int cheat_manager_search_exact_input(rarch_setting_t *setting, size_t idx, bool wraparound);
+
 int cheat_manager_search_lt(rarch_setting_t *setting, size_t idx, bool wraparound);
 
 int cheat_manager_search_gt(rarch_setting_t *setting, size_t idx, bool wraparound);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -12966,8 +12966,9 @@ static bool setting_append_list(
          menu_settings_list_current_add_range(list, list_info,
                0, cheat_manager_get_state_search_size(cheat_manager_state.search_bit_size), 1, true, true);
          (*list)[list_info->index - 1].get_string_representation = &setting_get_string_representation_uint_cheat_exact;
-         (*list)[list_info->index - 1].action_ok = &cheat_manager_search_exact;
+         // (*list)[list_info->index - 1].action_ok = &cheat_manager_search_exact;
 
+         (*list)[list_info->index - 1].action_ok = &cheat_manager_search_exact_input;
          CONFIG_UINT(
                list, list_info,
                &cheat_manager_state.dummy,

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -12966,8 +12966,6 @@ static bool setting_append_list(
          menu_settings_list_current_add_range(list, list_info,
                0, cheat_manager_get_state_search_size(cheat_manager_state.search_bit_size), 1, true, true);
          (*list)[list_info->index - 1].get_string_representation = &setting_get_string_representation_uint_cheat_exact;
-         // (*list)[list_info->index - 1].action_ok = &cheat_manager_search_exact;
-
          (*list)[list_info->index - 1].action_ok = &cheat_manager_search_exact_input;
          CONFIG_UINT(
                list, list_info,


### PR DESCRIPTION
Tested on Android aarch64 debug build.

- Opened Quick Menu > Cheats > Start or Restart Cheat Search
- Selected Search Exact
- Entered a decimal value via the menu input dialog
- Confirmed that the exact search runs and match count notice is shown
- Confirmed that the input dialog closes and returns to the cheat menu