### PR TITLE
This extends the direct input behavior recently added for exact cheat search to the Equal + N and Equal - N search entries.

### DIFF
--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -1264,8 +1264,10 @@ int cheat_manager_search_exact(rarch_setting_t *setting, size_t idx, bool wrapar
    return cheat_manager_search(CHEAT_SEARCH_TYPE_EXACT);
 }
 
-static void cheat_manager_search_exact_input_cb(void *userdata,
-      const char *line)
+static void cheat_manager_search_input_cb_common(
+      const char *line,
+      unsigned *target,
+      enum cheat_search_type search_type)
 {
    char *end             = NULL;
    unsigned long value   = 0;
@@ -1292,15 +1294,48 @@ static void cheat_manager_search_exact_input_cb(void *userdata,
    if (value > max_value)
       value = max_value;
 
-   cheat_manager_state.search_exact_value = (unsigned)value;
+   *target = (unsigned)value;
 
    menu_input_dialog_end();
 
-   cheat_manager_search(CHEAT_SEARCH_TYPE_EXACT);
+   cheat_manager_search(search_type);
 }
 
-int cheat_manager_search_exact_input(rarch_setting_t *setting,
-      size_t idx, bool wraparound)
+static void cheat_manager_search_exact_input_cb(void *userdata,
+      const char *line)
+{
+   cheat_manager_search_input_cb_common(
+         line,
+         &cheat_manager_state.search_exact_value,
+         CHEAT_SEARCH_TYPE_EXACT);
+}
+
+static void cheat_manager_search_eqplus_input_cb(void *userdata,
+      const char *line)
+{
+   cheat_manager_search_input_cb_common(
+         line,
+         &cheat_manager_state.search_eqplus_value,
+         CHEAT_SEARCH_TYPE_EQPLUS);
+}
+
+static void cheat_manager_search_eqminus_input_cb(void *userdata,
+      const char *line)
+{
+   cheat_manager_search_input_cb_common(
+         line,
+         &cheat_manager_state.search_eqminus_value,
+         CHEAT_SEARCH_TYPE_EQMINUS);
+}
+
+static int cheat_manager_search_input_start(
+      rarch_setting_t *setting,
+      size_t idx,
+      bool wraparound,
+      unsigned current_value,
+      enum msg_hash_enums label_value,
+      enum msg_hash_enums label,
+      input_keyboard_line_complete_t cb)
 {
 #ifdef HAVE_MENU
    char value_buf[32];
@@ -1308,20 +1343,67 @@ int cheat_manager_search_exact_input(rarch_setting_t *setting,
 
    memset(&line, 0, sizeof(line));
 
-   snprintf(value_buf, sizeof(value_buf), "%u",
-         cheat_manager_state.search_exact_value);
+   snprintf(value_buf, sizeof(value_buf), "%u", current_value);
 
-   line.label         = msg_hash_to_str(MENU_ENUM_LABEL_VALUE_CHEAT_SEARCH_EXACT);
+   line.label         = msg_hash_to_str(label_value);
    line.label_setting = value_buf;
-   line.type          = MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT;
+   line.type          = label;
    line.idx           = idx;
-   line.cb            = cheat_manager_search_exact_input_cb;
+   line.cb            = cb;
 
    if (menu_input_dialog_start(&line))
       return 0;
 #endif
 
+   return -1;
+}
+
+int cheat_manager_search_exact_input(rarch_setting_t *setting,
+      size_t idx, bool wraparound)
+{
+   if (cheat_manager_search_input_start(
+            setting,
+            idx,
+            wraparound,
+            cheat_manager_state.search_exact_value,
+            MENU_ENUM_LABEL_VALUE_CHEAT_SEARCH_EXACT,
+            MENU_ENUM_LABEL_CHEAT_SEARCH_EXACT,
+            cheat_manager_search_exact_input_cb) == 0)
+      return 0;
+
    return cheat_manager_search_exact(setting, idx, wraparound);
+}
+
+int cheat_manager_search_eqplus_input(rarch_setting_t *setting,
+      size_t idx, bool wraparound)
+{
+   if (cheat_manager_search_input_start(
+            setting,
+            idx,
+            wraparound,
+            cheat_manager_state.search_eqplus_value,
+            MENU_ENUM_LABEL_VALUE_CHEAT_SEARCH_EQPLUS,
+            MENU_ENUM_LABEL_CHEAT_SEARCH_EQPLUS,
+            cheat_manager_search_eqplus_input_cb) == 0)
+      return 0;
+
+   return cheat_manager_search_eqplus(setting, idx, wraparound);
+}
+
+int cheat_manager_search_eqminus_input(rarch_setting_t *setting,
+      size_t idx, bool wraparound)
+{
+   if (cheat_manager_search_input_start(
+            setting,
+            idx,
+            wraparound,
+            cheat_manager_state.search_eqminus_value,
+            MENU_ENUM_LABEL_VALUE_CHEAT_SEARCH_EQMINUS,
+            MENU_ENUM_LABEL_CHEAT_SEARCH_EQMINUS,
+            cheat_manager_search_eqminus_input_cb) == 0)
+      return 0;
+
+   return cheat_manager_search_eqminus(setting, idx, wraparound);
 }
 
 int cheat_manager_search_lt(rarch_setting_t *setting, size_t idx, bool wraparound)

--- a/cheat_manager.h
+++ b/cheat_manager.h
@@ -250,6 +250,10 @@ int cheat_manager_search_exact(rarch_setting_t *setting, size_t idx, bool wrapar
 
 int cheat_manager_search_exact_input(rarch_setting_t *setting, size_t idx, bool wraparound);
 
+int cheat_manager_search_eqplus_input(rarch_setting_t *setting, size_t idx, bool wraparound);
+
+int cheat_manager_search_eqminus_input(rarch_setting_t *setting, size_t idx, bool wraparound);
+
 int cheat_manager_search_lt(rarch_setting_t *setting, size_t idx, bool wraparound);
 
 int cheat_manager_search_gt(rarch_setting_t *setting, size_t idx, bool wraparound);

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -13065,7 +13065,7 @@ static bool setting_append_list(
          menu_settings_list_current_add_range(list, list_info,
                0, cheat_manager_get_state_search_size(cheat_manager_state.search_bit_size), 1, true, true);
          (*list)[list_info->index - 1].get_string_representation = &setting_get_string_representation_uint_cheat_eqplus;
-         (*list)[list_info->index - 1].action_ok = &cheat_manager_search_eqplus;
+         (*list)[list_info->index - 1].action_ok = &cheat_manager_search_eqplus_input;
 
          CONFIG_UINT(
                list, list_info,
@@ -13081,7 +13081,7 @@ static bool setting_append_list(
          menu_settings_list_current_add_range(list, list_info,
                0, cheat_manager_get_state_search_size(cheat_manager_state.search_bit_size), 1, true, true);
          (*list)[list_info->index - 1].get_string_representation = &setting_get_string_representation_uint_cheat_eqminus;
-         (*list)[list_info->index - 1].action_ok = &cheat_manager_search_eqminus;
+         (*list)[list_info->index - 1].action_ok = &cheat_manager_search_eqminus_input;
 
          CONFIG_UINT(
                list, list_info,


### PR DESCRIPTION
The entries now open the existing menu input dialog on OK, parse decimal or 0x-prefixed hexadecimal input, clamp the value to the current search size, close the input dialog, and then run the corresponding cheat search.

Tested on Android aarch64 debug build:
- Search Equal + N accepts direct numeric input and returns to the cheat menu
- Search Equal - N accepts direct numeric input and returns to the cheat menu
- Match count notice is shown after search