### PR TITLE
webOS: add 32/64-bit info to log, remove wayland stub as no longer ne…

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -146,7 +146,6 @@ HAVE_WEBOS_EXTRA_PROTOS ?= 0
 HAVE_CORE_INFO_CACHE = 1
 HAVE_WAYLAND ?= 0
 HAVE_WAYLAND_BACKPORT ?= 1
-HAVE_WAYLAND_CLIENTSTUB ?= 0
 HAVE_64TO32BIT_BRIDGE ?= 0
 
 OS = Linux
@@ -205,16 +204,9 @@ ifeq ($(HAVE_OPENGLES3_2),1)
 endif
 ifeq ($(HAVE_WAYLAND),1)
   DEFINES += -DHAVE_WAYLAND=1
-  ifeq ($(HAVE_WAYLAND_CLIENTSTUB),1)
-    WAYLAND_LIBS = -lwayland-client-stub
-  endif
   WAYLAND_LIBS += -lwayland-client -lwayland-cursor
   ifeq ($(HAVE_EGL),1)
     WAYLAND_LIBS += -lwayland-egl
-  endif
-  ifeq ($(HAVE_WAYLAND_CLIENTSTUB),1)
-    WAYLAND_LIBS += \
-      -Wl,--no-as-needed -lwayland-client -Wl,--as-needed
   endif
 endif
 ifeq ($(HAVE_WEBOS_EXTRA_PROTOS),1)

--- a/retroarch.c
+++ b/retroarch.c
@@ -8180,9 +8180,14 @@ bool retroarch_main_init(int argc, char *argv[])
                if (frontend && frontend->get_os)
                {
                   frontend->get_os(osbuf, sizeof(osbuf), &major, &minor);
+#ifdef __aarch64__
+                  const char *arch = " (64-bit)";
+#else
+                  const char *arch = " (32-bit)";
+#endif
                   _len += snprintf(str_output + _len, sizeof(str_output) - _len,
-                        FILE_PATH_LOG_INFO " Running on: %s\n",
-                        osbuf);
+                     FILE_PATH_LOG_INFO " Running on: %s%s\n",
+                     osbuf, arch);
                }
             }
          }


### PR DESCRIPTION
…eded for 64-bit

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

webOS changes:

1. Remove unused option wayland stub
2. Add 32-bit/64-bit to log for webOS so I can tell from users in the future when they file bug reports what arch they are using.

## Related Issues

## Related Pull Requests

## Reviewers

