### PR TITLE
webOS: patch 64 bit IPK so it can be installed onto webOS menu

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -22,6 +22,7 @@ SDL2_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/downloa
 64TO32_BRIDGE_DIR     ?= /media/developer/apps/usr/palm/applications/org.webosbrew.bridge-64to32
 ELF_INTERPRETER_BIN   ?= /lib/ld-linux-aarch64.so.1
 SET_ELF_INTERPRETER   ?= 0
+REPACK_64_IPK_FOR_MENU ?= 0
 SET_BUILD_ID          ?= 0
 
 #########################
@@ -159,9 +160,11 @@ DEF_FLAGS += -Wall -Wno-unused-variable
 LIBS := -ldl -lz -lrt -pthread
 ifeq ($(findstring arm64,$(ARCH)),arm64)
   ARCHFLAGS := -mcpu=cortex-a53
+  IPK_ARCH := aarch64
 else
   ARCHFLAGS := -mcpu=cortex-a9 -mtune=cortex-a53 -mfloat-abi=softfp
   HAVE_NEON = 1
+  IPK_ARCH := arm
 endif
 CFLAGS := $(ARCHFLAGS)
 CFLAGS += -DWEBOS_APP_ID=\"$(APP_PACKAGE_NAME)\"
@@ -377,6 +380,9 @@ endif
 ipk: prebuild $(TARGET) sdl2
 	rm -rf webos/dist
 	mkdir -p webos/dist/lib
+ifeq ($(SET_ELF_INTERPRETER), 1)
+	patchelf --set-interpreter $(ELF_INTERPRETER) $(TARGET)
+endif
 	echo "$$APPINFO" > webos/dist/appinfo.json
 	cp -t webos/dist -vf $(TARGET) webos/icon160.png
 	cp -t webos/dist/lib -vf $(WEBOS_USR_LIB_DIR)/libstdc++.so.6
@@ -390,10 +396,12 @@ endif
 ifneq ($(DEBUG), 1)
 	$(STRIP) webos/dist/$(TARGET)
 endif
-ifeq ($(SET_ELF_INTERPRETER), 1)
-	patchelf --set-interpreter $(ELF_INTERPRETER) $(TARGET)
-endif
 	cd webos && ares-package dist
+ifeq ($(REPACK_64_IPK_FOR_MENU), 1)
+	./webos/patch-aarch64-in-ipk.sh webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(IPK_ARCH).ipk
+	rm webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(IPK_ARCH).ipk
+	mv webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(IPK_ARCH)-patched.ipk webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(IPK_ARCH).ipk
+endif
 
 install: ipk
 	ares-install webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(ARCH).ipk

--- a/webos/patch-aarch64-in-ipk.sh
+++ b/webos/patch-aarch64-in-ipk.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <package.ipk>"
+  exit 1
+fi
+
+IPK="$1"
+IPK="$(realpath "$IPK")"
+IPK_DIR="$(dirname "$IPK")"
+IPK_BASE="$(basename "$IPK")"
+OUTNAME="${IPK_BASE%.ipk}-patched.ipk"
+
+WORKDIR=$(mktemp -d)
+
+echo "[*] Working in: $WORKDIR"
+
+cp "$IPK" "$WORKDIR/"
+cd "$WORKDIR"
+
+echo "[*] Extracting IPK..."
+ar x "$IPK_BASE"
+
+echo "[*] Extracting control..."
+mkdir control
+tar -xf control.tar.gz -C control
+
+echo "[*] Patching Architecture field..."
+sed -i 's/^Architecture: *aarch64/Architecture: arm/' control/control
+
+echo "[*] Rebuilding control..."
+tar -czf control.tar.gz -C control control
+
+echo "[*] Repacking..."
+ar rcs "$OUTNAME" debian-binary control.tar.gz data.tar.gz
+
+echo "[*] Copying result back..."
+mv "$OUTNAME" "$IPK_DIR/"
+
+echo "[+] Done: $IPK_DIR/$OUTNAME"


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

One of the last remaining issues, was to be able to launch RetroArch 64-bit from the webOS menu as aarch64 is normally rejected. But I built a workaround, so all is good :+1: 

## Related Issues

## Related Pull Requests

## Reviewers
