### PR TITLE
stop 'viewport override' logspam

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -2839,7 +2839,11 @@ void video_driver_update_viewport(
             int ol_y      = (int)(ol->viewport.y * vp->full_height);
             unsigned ol_w = (unsigned)(ol->viewport.w * vp->full_width);
             unsigned ol_h = (unsigned)(ol->viewport.h * vp->full_height);
-            RARCH_LOG("[Overlay] Applying viewport override!\n");
+            if (!ol->viewport_override_logged)
+            {
+               RARCH_LOG("[Overlay] Applying viewport override!\n");
+               ((struct overlay *)ol)->viewport_override_logged = true;
+            }
 
             if (ol->flags & OVERLAY_VIEWPORT_FILL)
             {

--- a/input/input_overlay.h
+++ b/input/input_overlay.h
@@ -326,6 +326,7 @@ struct overlay
    char name[64];
 
    uint8_t flags;
+    bool viewport_override_logged;
 };
 
 typedef struct input_overlay_state

--- a/retroarch.c
+++ b/retroarch.c
@@ -4155,6 +4155,7 @@ bool command_event(enum event_command cmd, void *data)
 
             ol->index                      = ol->next_index;
             ol->active                     = &ol->overlays[ol->index];
+            ((struct overlay *)ol->active)->viewport_override_logged = false;
 
             input_overlay_opacity          = (ol->flags & INPUT_OVERLAY_IS_OSK)
                   ? settings->floats.input_osk_overlay_opacity


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Warmenhoven's excellent overlay viewport resizing feature (5259c14ad08a820adc94e9904e9ec9484c64a8e6) works a treat, but it also spams `Applying viewport override!` to logs/stdout on every frame while active. This PR just sets a flag to suppress any further copies of the message until the next overlay init.

## Related Issues

none that I know of

## Related Pull Requests

none

## Reviewers

@warmenhoven 
