### PR TITLE
Fix threaded video shader-backend detection (black screen / crash on glcore)

### DIFF
--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -1428,10 +1428,21 @@ bool video_init_thread(const video_driver_t **out_driver, void **out_data,
    thr->driver = drv;
    *out_driver = &thr->video_thread;
    *out_data   = thr;
-   if (!video_thread_init(thr, info, input, input_data))
-      return false;
 
+   /* Mark the wrapper active before running the underlying driver's
+    * init(): that init() runs on the worker thread and may query
+    * video_driver_get_ident() (e.g. via the context driver's get_flags
+    * for shader-backend detection).  current_video already points at the
+    * thread wrapper here, so without the flag set get_ident() would
+    * resolve to "Thread wrapper" instead of the wrapped driver ("glcore"),
+    * causing shader-backend detection to fail. */
    video_state_get_ptr()->flags |= VIDEO_FLAG_THREAD_WRAPPER_ACTIVE;
+   if (!video_thread_init(thr, info, input, input_data))
+   {
+      video_state_get_ptr()->flags &= ~VIDEO_FLAG_THREAD_WRAPPER_ACTIVE;
+      return false;
+   }
+
    return true;
 }
 


### PR DESCRIPTION
## Description

With `video_threaded = true`, the `glcore` driver fails to create its slang filter chain, resulting in a black screen (audio only). On some platforms (e.g. H700) this crashes with a SIGSEGV in the video thread:
```
#0  0x0000000000ba1d20 in std::vector<std::unique_ptr<gl3_shader::Pass, std::default_delete<gl3_shader::Pass> >, std::allocator<std::unique_ptr<gl3_shader::Pass, std::default_delete<gl3_shader::Pass> > > >::size (this=0x0)
    at /data/rocknix/build.ROCKNIX-H700.aarch64/toolchain/aarch64-rocknix-linux-gnu/include/c++/15.2.0/bits/stl_vector.h:1119
#1  0x0000000000b997f0 in gl3_filter_chain::set_frame_count (this=0x0, count=0) at gfx/drivers_shader/shader_gl3.cpp:2645
#2  0x0000000000b9b50c in gl3_filter_chain_set_frame_count (chain=0x0, count=0) at gfx/drivers_shader/shader_gl3.cpp:3235
#3  0x0000000000b8f6cc in gl3_frame (data=0xffffec000b70, frame=0xfffff250f010, frame_width=256, frame_height=224, frame_count=0, pitch=1024, msg=0x0, video_info=0xfffff250d1d0) at gfx/drivers/gl3.c:4283
#4  0x0000000000b4f94c in video_thread_loop (data=0x1d29a00) at gfx/video_thread_wrapper.c:476
#5  0x0000000000b4deec in thread_wrap (data_=0x25cbe90) at libretro-common/rthreads/rthreads.c:150
#6  0x0000fffff4f987c8 in ?? () from /usr/lib/libc.so.6
#7  0x0000fffff501664c in ?? () from /usr/lib/libc.so.6
```

`gl3_get_fallback_shader_type()` queries the context driver's advertised shader flags, which (e.g. in `gfx_ctx_wl_get_flags`) gate on `video_driver_get_ident()` matching glcore.

In `video_init_thread()`, current_video is repointed to the thread wrapper before the underlying driver's `init()` runs, but `VIDEO_FLAG_THREAD_WRAPPER_ACTIVE` is only set after `init()` completes. During that window the underlying `gl3_init()` runs on the worker thread and calls `video_driver_get_ident()`, which — with the flag still unset — resolves to the wrapper's ident Thread wrapper instead of the wrapped driver glcore.

As a result the slang backend is not detected, `gl3_get_fallback_shader_type()` returns `RARCH_SHADER_NONE`, and no filter chain is ever created (`filter_chain` and `filter_chain_default` both NULL), which `gl3_frame()` then dereferences. In non-threaded mode current_video is the real driver at init time, so it works.

## Related Pull Requests

The change was introduced by [#18151](https://github.com/libretro/RetroArch/issues/18151), which made glcore shader-backend selection depend on the context-driver ident.

