### PR TITLE
Android: add RetroAchievements host override receiver

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -61,6 +61,12 @@
  * cannot preprocess. */
 void android_app_set_window_settings(bool notch_write_over,
       bool auto_mouse_grab);
+#ifdef HAVE_CHEEVOS
+void android_app_set_cheevos_settings(const char *host,
+      bool hardcore_enabled);
+bool android_app_get_cheevos_override(char *s, size_t len,
+      bool *hardcore_enabled);
+#endif
 #endif
 
 #include "list_special.h"
@@ -7084,6 +7090,23 @@ static bool config_load_file(global_t *global,
    android_app_set_window_settings(
          settings->bools.video_notch_write_over_enable,
          settings->bools.input_auto_mouse_grab);
+#ifdef HAVE_CHEEVOS
+   {
+      bool hardcore_enabled = false;
+      char cheevos_host[sizeof(settings->arrays.cheevos_custom_host)];
+
+      if (android_app_get_cheevos_override(cheevos_host,
+               sizeof(cheevos_host), &hardcore_enabled))
+      {
+         strlcpy(settings->arrays.cheevos_custom_host, cheevos_host,
+               sizeof(settings->arrays.cheevos_custom_host));
+         settings->bools.cheevos_hardcore_mode_enable = hardcore_enabled;
+      }
+
+      android_app_set_cheevos_settings(settings->arrays.cheevos_custom_host,
+            settings->bools.cheevos_hardcore_mode_enable);
+   }
+#endif
 #endif
    recording_driver_update_streaming_url();
 

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -57,6 +57,7 @@
 
 #ifdef ANDROID
 #include <sys/system_properties.h>
+#include "../../cheevos/cheevos.h"
 #ifdef HAVE_SAF
 #include <vfs/vfs_implementation_saf.h>
 #include "../../menu/menu_cbs.h"
@@ -738,6 +739,66 @@ JNIEXPORT void JNICALL Java_com_retroarch_browser_retroactivity_RetroActivityCom
       (*env)->ExceptionDescribe(env);
       (*env)->ExceptionClear(env);
    }
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_retroarch_browser_retroactivity_RetroActivityFuture_applyRetroAchievementsHostOverride
+      (JNIEnv *env, jclass clazz, jstring host_obj, jboolean hardcore_enabled)
+{
+#ifdef HAVE_CHEEVOS
+   const char *host = NULL;
+   settings_t *settings = config_get_ptr();
+   rcheevos_locals_t *locals = get_rcheevos_locals();
+#ifdef HAVE_MENU
+   struct menu_state *menu_st = menu_state_get_ptr();
+#endif
+
+   (void)clazz;
+
+   if (!settings)
+      return;
+
+   if (host_obj)
+   {
+      host = (*env)->GetStringUTFChars(env, host_obj, NULL);
+      if ((*env)->ExceptionOccurred(env))
+      {
+         (*env)->ExceptionDescribe(env);
+         (*env)->ExceptionClear(env);
+         return;
+      }
+   }
+
+   strlcpy(settings->arrays.cheevos_custom_host,
+         host ? host : "", sizeof(settings->arrays.cheevos_custom_host));
+   settings->bools.cheevos_hardcore_mode_enable = (hardcore_enabled == JNI_TRUE);
+
+   if (locals && locals->client)
+      rc_client_set_host(locals->client, settings->arrays.cheevos_custom_host);
+
+   rcheevos_hardcore_enabled_changed();
+   rcheevos_validate_config_settings();
+
+#ifdef HAVE_MENU
+   if (menu_st && (menu_st->flags & MENU_ST_FLAG_ALIVE))
+      menu_st->flags |= MENU_ST_FLAG_PREVENT_POPULATE
+                     | MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
+#endif
+
+   if (host)
+   {
+      (*env)->ReleaseStringUTFChars(env, host_obj, host);
+      if ((*env)->ExceptionOccurred(env))
+      {
+         (*env)->ExceptionDescribe(env);
+         (*env)->ExceptionClear(env);
+      }
+   }
+#else
+   (void)env;
+   (void)clazz;
+   (void)host_obj;
+   (void)hardcore_enabled;
 #endif
 }
 

--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -46,6 +46,8 @@
 #ifdef ANDROID
 #include <android/log.h>
 #include <sys/system_properties.h>
+#include "../../cheevos/cheevos.h"
+#include "../../cheevos/cheevos_locals.h"
 #ifdef HAVE_SAF
 #include <vfs/vfs_implementation_saf.h>
 #include "../../menu/menu_cbs.h"
@@ -1664,6 +1666,66 @@ JNIEXPORT void JNICALL Java_com_retroarch_browser_retroactivity_RetroActivityCom
    }
 
    android_vfs_authorized_locations_refresh();
+#endif
+}
+
+JNIEXPORT void JNICALL Java_com_retroarch_browser_retroactivity_RetroActivityFuture_applyRetroAchievementsHostOverride
+      (JNIEnv *env, jclass clazz, jstring host_obj, jboolean hardcore_enabled)
+{
+#ifdef HAVE_CHEEVOS
+   const char *host = NULL;
+   settings_t *settings = config_get_ptr();
+   rcheevos_locals_t *locals = get_rcheevos_locals();
+#ifdef HAVE_MENU
+   struct menu_state *menu_st = menu_state_get_ptr();
+#endif
+
+   (void)clazz;
+
+   if (!settings)
+      return;
+
+   if (host_obj)
+   {
+      host = (*env)->GetStringUTFChars(env, host_obj, NULL);
+      if ((*env)->ExceptionOccurred(env))
+      {
+         (*env)->ExceptionDescribe(env);
+         (*env)->ExceptionClear(env);
+         return;
+      }
+   }
+
+   strlcpy(settings->arrays.cheevos_custom_host,
+         host ? host : "", sizeof(settings->arrays.cheevos_custom_host));
+   settings->bools.cheevos_hardcore_mode_enable = (hardcore_enabled == JNI_TRUE);
+
+   if (locals && locals->client)
+      rc_client_set_host(locals->client, settings->arrays.cheevos_custom_host);
+
+   rcheevos_hardcore_enabled_changed();
+   rcheevos_validate_config_settings();
+
+#ifdef HAVE_MENU
+   if (menu_st && (menu_st->flags & MENU_ST_FLAG_ALIVE))
+      menu_st->flags |= MENU_ST_FLAG_PREVENT_POPULATE
+                     | MENU_ST_FLAG_ENTRIES_NEED_REFRESH;
+#endif
+
+   if (host)
+   {
+      (*env)->ReleaseStringUTFChars(env, host_obj, host);
+      if ((*env)->ExceptionOccurred(env))
+      {
+         (*env)->ExceptionDescribe(env);
+         (*env)->ExceptionClear(env);
+      }
+   }
+#else
+   (void)env;
+   (void)clazz;
+   (void)host_obj;
+   (void)hardcore_enabled;
 #endif
 }
 
@@ -3427,6 +3489,10 @@ static void frontend_unix_init(void *data)
          "setSustainedPerformanceMode", "(Z)V");
    GET_METHOD_ID(env, android_app->setWindowSettings, class,
          "setWindowSettings", "(ZZ)V");
+   GET_METHOD_ID(env, android_app->setCheevosSettings, class,
+         "setCheevosSettings", "(Ljava/lang/String;Z)V");
+   GET_METHOD_ID(env, android_app->getCheevosOverride, class,
+         "getCheevosOverride", "()Ljava/lang/String;");
    GET_METHOD_ID(env, android_app->setScreenOrientation, class,
          "setScreenOrientation", "(I)V");
    GET_METHOD_ID(env, android_app->doVibrate, class,
@@ -3970,6 +4036,64 @@ void android_app_set_window_settings(bool notch_write_over,
       CALL_VOID_METHOD_PARAM(env, g_android->activity->clazz,
             g_android->setWindowSettings,
             (jboolean)notch_write_over, (jboolean)auto_mouse_grab);
+#endif
+}
+
+void android_app_set_cheevos_settings(const char *host, bool hardcore_enabled)
+{
+#ifdef ANDROID
+   JNIEnv *env = jni_thread_getenv();
+
+   if (!env || !g_android || !g_android->setCheevosSettings)
+      return;
+
+   CALL_VOID_METHOD_PARAM(env, g_android->activity->clazz,
+         g_android->setCheevosSettings,
+         (*env)->NewStringUTF(env, host ? host : ""),
+         (jboolean)hardcore_enabled);
+#endif
+}
+
+bool android_app_get_cheevos_override(char *s, size_t len,
+      bool *hardcore_enabled)
+{
+#ifdef ANDROID
+   jobject jstr = NULL;
+   const char *state = NULL;
+   const char *separator = NULL;
+   JNIEnv *env = jni_thread_getenv();
+
+   if (!env || !g_android || !g_android->getCheevosOverride)
+      return false;
+
+   CALL_OBJ_METHOD(env, jstr, g_android->activity->clazz,
+         g_android->getCheevosOverride);
+
+   if (!jstr)
+      return false;
+
+   state = (*env)->GetStringUTFChars(env, jstr, 0);
+
+   if (!state || !(separator = strchr(state, '\t')))
+   {
+      if (state)
+         (*env)->ReleaseStringUTFChars(env, jstr, state);
+      return false;
+   }
+
+   {
+      size_t host_len = (size_t)(separator - state) + 1;
+
+      if (host_len > len)
+         host_len = len;
+      strlcpy(s, state, host_len);
+   }
+   *hardcore_enabled = (separator[1] == '1');
+
+   (*env)->ReleaseStringUTFChars(env, jstr, state);
+   return true;
+#else
+   return false;
 #endif
 }
 

--- a/frontend/drivers/platform_unix.h
+++ b/frontend/drivers/platform_unix.h
@@ -224,6 +224,8 @@ struct android_app
    jmethodID getBatteryLevel;
    jmethodID setSustainedPerformanceMode;
    jmethodID setWindowSettings;
+   jmethodID setCheevosSettings;
+   jmethodID getCheevosOverride;
    jmethodID setScreenOrientation;
    jmethodID getUserLanguageString;
    jmethodID doVibrate;
@@ -541,6 +543,15 @@ bool is_screen_reader_enabled(void);
  * activity, so the Java side never reads them from the config file. */
 void android_app_set_window_settings(bool notch_write_over,
       bool auto_mouse_grab);
+
+/* Hands the live achievement settings to the activity, and takes back
+ * the values the host override receiver wants applied on top of the
+ * loaded config, so the receiver needs no config file of its own. */
+void android_app_set_cheevos_settings(const char *host,
+      bool hardcore_enabled);
+
+bool android_app_get_cheevos_override(char *s, size_t len,
+      bool *hardcore_enabled);
 
 #ifdef HAVE_SAF
 struct retro_vfs_authorized_locations;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -107,6 +107,10 @@
  * cannot preprocess. */
 void android_app_set_window_settings(bool notch_write_over,
       bool auto_mouse_grab);
+#ifdef HAVE_CHEEVOS
+void android_app_set_cheevos_settings(const char *host,
+      bool hardcore_enabled);
+#endif
 #endif
 #include "../location_driver.h"
 #include "../network/cloud_sync_driver.h"
@@ -9990,6 +9994,14 @@ static void overlay_show_mouse_cursor_change_handler(rarch_setting_t *setting)
 static void achievement_hardcore_mode_write_handler(rarch_setting_t *setting)
 {
    rcheevos_hardcore_enabled_changed();
+#ifdef ANDROID
+   {
+      settings_t *settings = config_get_ptr();
+
+      android_app_set_cheevos_settings(settings->arrays.cheevos_custom_host,
+            settings->bools.cheevos_hardcore_mode_enable);
+   }
+#endif
 }
 
 static void achievement_leaderboard_trackers_enabled_write_handler(rarch_setting_t* setting)

--- a/pkg/android/phoenix-common/src/com/retroarch/browser/receiver/RetroAchievementsHostOverrideReceiver.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/receiver/RetroAchievementsHostOverrideReceiver.java
@@ -1,0 +1,186 @@
+package com.retroarch.browser.receiver;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.retroarch.browser.preferences.util.ConfigFile;
+import com.retroarch.browser.preferences.util.UserPreferences;
+import com.retroarch.browser.retroactivity.RetroActivityFuture;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+public class RetroAchievementsHostOverrideReceiver extends BroadcastReceiver
+{
+   private static final String TAG = "RetroArch";
+   private static final String ACTION_SET_SUFFIX = ".action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE";
+   private static final String ACTION_CLEAR_SUFFIX = ".action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE";
+   private static final String EXTRA_HOST = "host";
+   private static final String EXTRA_DISABLE_HARDCORE = "disableHardcore";
+   private static final String HOST_KEY = "cheevos_custom_host";
+   private static final String HARDCORE_KEY = "cheevos_hardcore_mode_enable";
+   private static final String HARDCORE_RESTORE_KEY = "raofflineproxy_hardcore_restore";
+
+   @Override
+   public void onReceive(Context context, Intent intent)
+   {
+      String packageName = context.getPackageName();
+      String action = intent.getAction();
+      String setAction = packageName + ACTION_SET_SUFFIX;
+      String clearAction = packageName + ACTION_CLEAR_SUFFIX;
+
+      if (setAction.equals(action))
+      {
+         String normalizedHost = normalizeHost(intent.getStringExtra(EXTRA_HOST));
+         if (normalizedHost == null)
+         {
+            Log.w(TAG, "Rejected invalid RetroAchievements host override");
+            setResultCode(Activity.RESULT_CANCELED);
+            return;
+         }
+
+         boolean shouldDisableHardcore = intent.getBooleanExtra(EXTRA_DISABLE_HARDCORE, true);
+         if (!persistOverride(context, normalizedHost, shouldDisableHardcore))
+         {
+            setResultCode(Activity.RESULT_CANCELED);
+            return;
+         }
+
+         applyOverrideIfRunning(normalizedHost, !shouldDisableHardcore);
+         setResultCode(Activity.RESULT_OK);
+         return;
+      }
+
+      if (clearAction.equals(action))
+      {
+         Boolean restoreHardcore = clearOverride(context);
+         if (restoreHardcore == null)
+         {
+            setResultCode(Activity.RESULT_CANCELED);
+            return;
+         }
+
+         applyOverrideIfRunning("", restoreHardcore.booleanValue());
+         setResultCode(Activity.RESULT_OK);
+      }
+   }
+
+   private static String normalizeHost(String host)
+   {
+      String trimmed = host != null ? host.trim() : "";
+      if (trimmed.isEmpty())
+         return null;
+
+      String candidate = trimmed.contains("://") ? trimmed : "http://" + trimmed;
+
+      try
+      {
+         URI uri = new URI(candidate);
+         String scheme = uri.getScheme();
+         String normalizedScheme = scheme != null ? scheme.toLowerCase(Locale.US) : null;
+         String normalizedHost = uri.getHost();
+         normalizedHost = normalizedHost != null ? normalizedHost.toLowerCase(Locale.US) : null;
+         String path = uri.getRawPath();
+
+         if (!"http".equals(normalizedScheme))
+            return null;
+
+         if (!"127.0.0.1".equals(normalizedHost) && !"localhost".equals(normalizedHost))
+            return null;
+
+         if (uri.getPort() < 1 || uri.getPort() > 65535)
+            return null;
+
+         if (uri.getRawQuery() != null || uri.getRawFragment() != null || uri.getUserInfo() != null)
+            return null;
+
+         if (path != null && path.length() > 0 && !"/".equals(path) && !"/dorequest.php".equals(path))
+            return null;
+
+         return normalizedHost + ":" + uri.getPort();
+      }
+      catch (URISyntaxException ignored)
+      {
+         return null;
+      }
+   }
+
+    private static boolean persistOverride(Context context, String host, boolean shouldDisableHardcore)
+    {
+       String path = UserPreferences.getDefaultConfigPath(context);
+       ConfigFile config = new ConfigFile(path);
+
+       try
+       {
+          if (shouldDisableHardcore)
+          {
+             String previousRestore = config.keyExists(HARDCORE_RESTORE_KEY)
+                   ? config.getString(HARDCORE_RESTORE_KEY)
+                  : "";
+            if (previousRestore == null || previousRestore.length() == 0)
+            {
+               String currentValue = config.keyExists(HARDCORE_KEY)
+                     ? Boolean.toString(config.getBoolean(HARDCORE_KEY))
+                     : "false";
+               config.setString(HARDCORE_RESTORE_KEY, currentValue);
+            }
+         }
+
+          config.setString(HOST_KEY, host);
+          if (shouldDisableHardcore)
+             config.setBoolean(HARDCORE_KEY, false);
+          config.write(path);
+          return true;
+      }
+      catch (IOException e)
+      {
+         Log.e(TAG, "Failed to persist RetroAchievements host override", e);
+         return false;
+      }
+   }
+
+   private static Boolean clearOverride(Context context)
+   {
+      String path = UserPreferences.getDefaultConfigPath(context);
+      ConfigFile config = new ConfigFile(path);
+
+      try
+      {
+         String restoreValue = config.keyExists(HARDCORE_RESTORE_KEY)
+               ? config.getString(HARDCORE_RESTORE_KEY)
+               : "";
+         boolean restoreHardcore = Boolean.parseBoolean(restoreValue);
+
+         config.setString(HOST_KEY, "");
+         config.setBoolean(HARDCORE_KEY, restoreHardcore);
+         config.setString(HARDCORE_RESTORE_KEY, "");
+         config.write(path);
+         return Boolean.valueOf(restoreHardcore);
+      }
+      catch (IOException e)
+      {
+         Log.e(TAG, "Failed to clear RetroAchievements host override", e);
+         return null;
+      }
+   }
+
+    private static void applyOverrideIfRunning(String host, boolean hardcoreEnabled)
+    {
+      if (!RetroActivityFuture.isRunning)
+         return;
+
+      try
+      {
+         RetroActivityFuture.applyRetroAchievementsHostOverride(host, hardcoreEnabled);
+      }
+      catch (UnsatisfiedLinkError e)
+      {
+         Log.w(TAG, "Could not apply RetroAchievements host override live", e);
+      }
+   }
+}

--- a/pkg/android/phoenix-common/src/com/retroarch/browser/receiver/RetroAchievementsHostOverrideReceiver.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/receiver/RetroAchievementsHostOverrideReceiver.java
@@ -1,0 +1,191 @@
+package com.retroarch.browser.receiver;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import com.retroarch.browser.preferences.util.UserPreferences;
+import com.retroarch.browser.retroactivity.RetroActivityFuture;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+public class RetroAchievementsHostOverrideReceiver extends BroadcastReceiver
+{
+   private static final String TAG = "RetroArch";
+   private static final String ACTION_SET_SUFFIX = ".action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE";
+   private static final String ACTION_CLEAR_SUFFIX = ".action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE";
+   private static final String EXTRA_HOST = "host";
+   private static final String EXTRA_DISABLE_HARDCORE = "disableHardcore";
+
+   private static final String PREF_ACTIVE = "cheevos_host_override_active";
+   private static final String PREF_HOST = "cheevos_host_override_host";
+   private static final String PREF_DISABLE_HARDCORE = "cheevos_host_override_disable_hardcore";
+   private static final String PREF_USER_HOST = "cheevos_host_override_user_host";
+   private static final String PREF_USER_HARDCORE = "cheevos_host_override_user_hardcore";
+
+   /* Matches the config default, so a restore that predates the first
+    * recorded settings does not silently turn hardcore off. */
+   private static final boolean DEFAULT_HARDCORE = true;
+
+   @Override
+   public void onReceive(Context context, Intent intent)
+   {
+      String packageName = context.getPackageName();
+      String action = intent.getAction();
+      String setAction = packageName + ACTION_SET_SUFFIX;
+      String clearAction = packageName + ACTION_CLEAR_SUFFIX;
+
+      if (setAction.equals(action))
+      {
+         String normalizedHost = normalizeHost(intent.getStringExtra(EXTRA_HOST));
+         if (normalizedHost == null)
+         {
+            Log.w(TAG, "Rejected invalid RetroAchievements host override");
+            setResultCode(Activity.RESULT_CANCELED);
+            return;
+         }
+
+         boolean shouldDisableHardcore = intent.getBooleanExtra(EXTRA_DISABLE_HARDCORE, true);
+         SharedPreferences prefs = UserPreferences.getPreferences(context);
+         boolean hardcoreEnabled = !shouldDisableHardcore
+               && prefs.getBoolean(PREF_USER_HARDCORE, DEFAULT_HARDCORE);
+
+         prefs.edit()
+               .putBoolean(PREF_ACTIVE, true)
+               .putString(PREF_HOST, normalizedHost)
+               .putBoolean(PREF_DISABLE_HARDCORE, shouldDisableHardcore)
+               .apply();
+
+         applyOverrideIfRunning(normalizedHost, hardcoreEnabled);
+         setResultCode(Activity.RESULT_OK);
+         return;
+      }
+
+      if (clearAction.equals(action))
+      {
+         SharedPreferences prefs = UserPreferences.getPreferences(context);
+
+         prefs.edit().putBoolean(PREF_ACTIVE, false).apply();
+
+         applyOverrideIfRunning(prefs.getString(PREF_USER_HOST, ""),
+               prefs.getBoolean(PREF_USER_HARDCORE, DEFAULT_HARDCORE));
+         setResultCode(Activity.RESULT_OK);
+      }
+   }
+
+   /**
+    * Records the achievement settings the native side just loaded, so an
+    * override sent while RetroArch is not running knows what to restore.
+    * Ignored while an override is active, where the live values are the
+    * override's own.
+    */
+   public static void recordSettings(Context context, String host, boolean hardcoreEnabled)
+   {
+      SharedPreferences prefs = UserPreferences.getPreferences(context);
+
+      if (prefs.getBoolean(PREF_ACTIVE, false))
+         return;
+
+      prefs.edit()
+            .putString(PREF_USER_HOST, host != null ? host : "")
+            .putBoolean(PREF_USER_HARDCORE, hardcoreEnabled)
+            .apply();
+   }
+
+   /**
+    * Returns the achievement settings the native side should apply on top of
+    * the loaded config, as "host\t0|1", or null when the config is to be left
+    * alone. The restore values handed out after a clear are consumed, so a
+    * later config change is not overridden by them.
+    */
+   public static String consumeOverride(Context context)
+   {
+      SharedPreferences prefs = UserPreferences.getPreferences(context);
+
+      if (prefs.getBoolean(PREF_ACTIVE, false))
+      {
+         boolean hardcoreEnabled = !prefs.getBoolean(PREF_DISABLE_HARDCORE, true)
+               && prefs.getBoolean(PREF_USER_HARDCORE, DEFAULT_HARDCORE);
+
+         return prefs.getString(PREF_HOST, "") + '\t' + (hardcoreEnabled ? '1' : '0');
+      }
+
+      /* PREF_HOST outliving a cleared override means the config still
+       * carries it, so the restore runs even where the settings were
+       * never recorded. */
+      if (!prefs.contains(PREF_USER_HOST) && !prefs.contains(PREF_HOST))
+         return null;
+
+      String host = prefs.getString(PREF_USER_HOST, "");
+      boolean hardcoreEnabled = prefs.getBoolean(PREF_USER_HARDCORE, DEFAULT_HARDCORE);
+
+      prefs.edit()
+            .remove(PREF_USER_HOST)
+            .remove(PREF_USER_HARDCORE)
+            .remove(PREF_HOST)
+            .remove(PREF_DISABLE_HARDCORE)
+            .apply();
+
+      return host + '\t' + (hardcoreEnabled ? '1' : '0');
+   }
+
+   private static String normalizeHost(String host)
+   {
+      String trimmed = host != null ? host.trim() : "";
+      if (trimmed.isEmpty())
+         return null;
+
+      String candidate = trimmed.contains("://") ? trimmed : "http://" + trimmed;
+
+      try
+      {
+         URI uri = new URI(candidate);
+         String scheme = uri.getScheme();
+         String normalizedScheme = scheme != null ? scheme.toLowerCase(Locale.US) : null;
+         String normalizedHost = uri.getHost();
+         normalizedHost = normalizedHost != null ? normalizedHost.toLowerCase(Locale.US) : null;
+         String path = uri.getRawPath();
+
+         if (!"http".equals(normalizedScheme))
+            return null;
+
+         if (!"127.0.0.1".equals(normalizedHost) && !"localhost".equals(normalizedHost))
+            return null;
+
+         if (uri.getPort() < 1 || uri.getPort() > 65535)
+            return null;
+
+         if (uri.getRawQuery() != null || uri.getRawFragment() != null || uri.getUserInfo() != null)
+            return null;
+
+         if (path != null && path.length() > 0 && !"/".equals(path) && !"/dorequest.php".equals(path))
+            return null;
+
+         return normalizedHost + ":" + uri.getPort();
+      }
+      catch (URISyntaxException ignored)
+      {
+         return null;
+      }
+   }
+
+   private static void applyOverrideIfRunning(String host, boolean hardcoreEnabled)
+   {
+      if (!RetroActivityFuture.isRunning)
+         return;
+
+      try
+      {
+         RetroActivityFuture.applyRetroAchievementsHostOverride(host, hardcoreEnabled);
+      }
+      catch (UnsatisfiedLinkError e)
+      {
+         Log.w(TAG, "Could not apply RetroAchievements host override live", e);
+      }
+   }
+}

--- a/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
+++ b/pkg/android/phoenix-common/src/com/retroarch/browser/retroactivity/RetroActivityCommon.java
@@ -16,6 +16,7 @@ package com.retroarch.browser.retroactivity;
 
 import com.retroarch.BuildConfig;
 import com.retroarch.browser.preferences.util.UserPreferences;
+import com.retroarch.browser.receiver.RetroAchievementsHostOverrideReceiver;
 import com.retroarch.playcore.PlayCoreManager;
 
 import android.annotation.TargetApi;
@@ -1078,6 +1079,19 @@ public class RetroActivityCommon extends NativeActivity
    * notch setting takes effect without waiting for the next resume. */
   protected void onNotchSettingChanged()
   {
+  }
+
+  /* Achievement settings handed to and taken from the host override
+   * receiver, which owns no config file of its own (see
+   * android_app_set_cheevos_settings in platform_unix.c). */
+  public void setCheevosSettings(String host, boolean hardcoreEnabled)
+  {
+    RetroAchievementsHostOverrideReceiver.recordSettings(this, host, hardcoreEnabled);
+  }
+
+  public String getCheevosOverride()
+  {
+    return RetroAchievementsHostOverrideReceiver.consumeOverride(this);
   }
 
   @TargetApi(24)

--- a/pkg/android/phoenix-jelly-bean/AndroidManifest.xml
+++ b/pkg/android/phoenix-jelly-bean/AndroidManifest.xml
@@ -55,6 +55,12 @@
                 <action android:name="com.retroarch.QUERY_INSTALLED_CORES" />
             </intent-filter>
         </receiver>
+        <receiver android:name="com.retroarch.browser.receiver.RetroAchievementsHostOverrideReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
       <provider
         android:name="com.retroarch.browser.provider.RetroDocumentsProvider"
         android:authorities="${applicationId}.documents"

--- a/pkg/android/phoenix-jelly-bean/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix-jelly-bean/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -156,6 +156,8 @@ public final class RetroActivityFuture extends RetroActivityCamera {
     isRunning = false;
   }
 
+  public static native void applyRetroAchievementsHostOverride(String host, boolean hardcoreEnabled);
+
   @Override
   public void onWindowFocusChanged(boolean hasFocus) {
     super.onWindowFocusChanged(hasFocus);

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -45,6 +45,12 @@
                 <action android:name="com.retroarch.QUERY_INSTALLED_CORES" />
             </intent-filter>
         </receiver>
+        <receiver android:name="com.retroarch.browser.receiver.RetroAchievementsHostOverrideReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
       <provider
         android:name="com.retroarch.browser.provider.RetroDocumentsProvider"
         android:authorities="${applicationId}.documents"

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -57,6 +57,12 @@
                 <action android:name="com.retroarch.QUERY_INSTALLED_CORES" />
             </intent-filter>
         </receiver>
+        <receiver android:name="com.retroarch.browser.receiver.RetroAchievementsHostOverrideReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.SET_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+                <action android:name="${applicationId}.action.CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE" />
+            </intent-filter>
+        </receiver>
       <provider
         android:name="com.retroarch.browser.provider.RetroDocumentsProvider"
         android:authorities="${applicationId}.documents"

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -139,6 +139,8 @@ public final class RetroActivityFuture extends RetroActivityCamera {
     isRunning = false;
   }
 
+  public static native void applyRetroAchievementsHostOverride(String host, boolean hardcoreEnabled);
+
   @Override
   public void onWindowFocusChanged(boolean hasFocus) {
     super.onWindowFocusChanged(hasFocus);

--- a/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/retroactivity/RetroActivityFuture.java
@@ -245,6 +245,8 @@ public final class RetroActivityFuture extends RetroActivityCamera {
     isRunning = false;
   }
 
+  public static native void applyRetroAchievementsHostOverride(String host, boolean hardcoreEnabled);
+
   @Override
   public void onWindowFocusChanged(boolean hasFocus) {
     super.onWindowFocusChanged(hasFocus);


### PR DESCRIPTION
[RAOfflineProxy](https://raofflineproxy.com/) is an Android app that proxies RetroAchievements traffic through `127.0.0.1`, enabling offline softcore achievement play through local caching and later sync.

On Android, controlling the RetroAchievements host override through a broadcast receiver is a cleaner integration point than relying on external tools to patch `retroarch.cfg` directly.

This makes the host override controllable by another Android app at runtime instead of requiring external file edits, which is more brittle and harder to integrate cleanly.

## Summary

- Add an Android broadcast receiver for setting and clearing the RetroAchievements host override
- Persist the override across app restarts
- Apply host and hardcore changes live while RetroArch is already running
- Disable hardcore while the override is active and restore the prior hardcore preference when clearing the override
- Refresh the Achievements menu after live changes so the updated settings are reflected immediately

## Testing

- Built and installed the Android `aarch64` debug build on device
- Verified `SET_RETROACHIEVEMENTS_HOST_OVERRIDE` persists `cheevos_custom_host` and applies the override live while RetroArch is open
- Verified the live apply path disables hardcore while the override is active
- Verified `CLEAR_RETROACHIEVEMENTS_HOST_OVERRIDE` removes the stored override, reapplies the default host live, and restores the prior hardcore preference
- Verified the host-override broadcasts do not restart the RetroArch process

## Related

- Same Android host-override integration already merged for [ARMSX2](https://github.com/ARMSX2/ARMSX2/pull/164) and shipped in the current build
- Same Android host-override receiver also shipped in [ARMSX1](https://github.com/ARMSX2/ARMSX1), which inherits it from the ARMSX2 codebase
- Same Android host-override integration already merged for [PPSSPP](https://github.com/hrydgard/ppsspp/pull/21760) and planned for the upcoming release
- Same Android host-override integration already merged for [flycast](https://github.com/flyinghead/flycast/pull/2371) and planned for the upcoming release
- Same Android host-override integration already merged for [mupen64plus-ae](https://github.com/JoeysRetroHandhelds/mupen64plus-ae-retroachievements/pull/1)
- Same Android host-override integration already shipped in [WatermelonDS](https://github.com/SapphireRhodonite/WatermelonDS)
- Same integration pending for [SeedlessDS](https://github.com/SapphireRhodonite/SeedlessDS)
- Same integration proposed for [Dolphin](https://github.com/dolphin-emu/dolphin/pull/14671), pending a maintainer decision
- Same integration proposed for [NetherSX2](https://github.com/Trixarian/NetherSX2-patch/pull/343), pending review
