### PR TITLE
Map xkb fd as private to comply with wayland v7

### DIFF
--- a/input/drivers_keyboard/keyboard_event_xkb.c
+++ b/input/drivers_keyboard/keyboard_event_xkb.c
@@ -72,7 +72,7 @@ int init_xkb(int fd, size_t len)
    {
       if (fd >= 0)
       {
-         char *map_str = (char*)mmap(NULL, len, PROT_READ, MAP_SHARED, fd, 0);
+         char *map_str = (char*)mmap(NULL, len, PROT_READ, MAP_PRIVATE, fd, 0);
          if (map_str == MAP_FAILED)
             goto error;
 


### PR DESCRIPTION
From the wayland core spec:
> From version 7 onwards, the fd must be mapped with MAP_PRIVATE by the recipient, as MAP_SHARED may fail.

https://wayland.app/protocols/wayland#wl_keyboard:event:keymap

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This makes it so that if RetroArch writes to the mapped keyboard layout memory those changes aren't shared with other processes. This should have no effect in reality but was added to the wayland protocol spec.

## Related Issues


## Related Pull Requests


## Reviewers
