### PR TITLE
Fixing missing include

### DIFF
--- a/gfx/drivers_context/drm_go2_ctx.c
+++ b/gfx/drivers_context/drm_go2_ctx.c
@@ -51,6 +51,10 @@
 #include "../common/egl_common.h"
 #endif
 
+#ifdef HAVE_OPENGL
+#include "../common/gl_common.h"
+#endif
+
 #ifdef HAVE_MENU
 #include "../../menu/menu_driver.h"
 #endif


### PR DESCRIPTION
## Description

This fixes a missing include that raises a missing declaration warning that breaks build with strict compilation options

## Related Issues

None

## Related Pull Requests

From batocera repo: https://github.com/batocera-linux/batocera.linux/pull/15853
