### PR TITLE
cheat_manager: fix realloc (p, 0) leading to double free

### DIFF
--- a/cheat_manager.c
+++ b/cheat_manager.c
@@ -610,9 +610,12 @@ bool cheat_manager_realloc(unsigned new_size, unsigned default_handler)
          cheat_st->cheats[i].desc = NULL;
       }
 
-      val = (struct item_cheat*)
-            realloc(cheat_st->cheats,
-            new_size * sizeof(struct item_cheat));
+      if (new_size != 0)
+      {
+         val = (struct item_cheat*)
+               realloc(cheat_st->cheats,
+               new_size * sizeof(struct item_cheat));
+      }
 
       /* realloc-to-tmp: on OOM 'val' is NULL, the original
        * cheat_st->cheats is still valid.  Pre-patch did


### PR DESCRIPTION
## Description

I made sure the cheat_st->cheats is only freed once by making sure that realloc does not take that responsibility.

## Related Issues

closes #19105

## Reviewers

LibretroAdmin does not seem like a personal account, but is still the author of the commit with mentioned regression.
@LibretroAdmin 