### PR TITLE
webOS: add ARES_PACKAGE_ARGS so we can pass needed extra packaging flags via …

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -29,6 +29,7 @@ SET_BUILD_ID          ?= 0
 #########################
 
 APP_PACKAGE_NAME ?= com.retroarch.webos
+ARES_PACKAGE_ARGS ?=
 IPK_VERSION := $(shell grep '#define PACKAGE_VERSION' version.all | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
 
 WEBOS = 1
@@ -396,7 +397,7 @@ endif
 ifneq ($(DEBUG), 1)
 	$(STRIP) webos/dist/$(TARGET)
 endif
-	cd webos && ares-package dist
+	cd webos && ares-package dist $(ARES_PACKAGE_ARGS)
 ifeq ($(REPACK_64_IPK_FOR_MENU), 1)
 	./webos/patch-aarch64-in-ipk.sh webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(IPK_ARCH).ipk
 	rm webos/$(APP_PACKAGE_NAME)_$(IPK_VERSION)_$(IPK_ARCH).ipk


### PR DESCRIPTION
…github workflow

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

The rust based ares-package used by github workflow needs extra params passed to package the aarch64 IPK correctly. This is different to the one provided by LG used locally.

## Related Issues
## Related Pull Requests
## Reviewers
