### PR TITLE
fix compilation of shader bezel/koko-aio under D3D11

### DIFF
--- a/gfx/drivers_shader/slang_process.cpp
+++ b/gfx/drivers_shader/slang_process.cpp
@@ -174,7 +174,7 @@ static bool slang_process_reflection(
    std::unordered_map<std::string, slang_texture_semantic_map> texture_semantic_map;
    std::unordered_map<std::string, slang_texture_semantic_map> texture_semantic_uniform_map;
 
-   for (i = 0; i <= pass_number; i++)
+   for (i = 0; i < shader_info->passes; i++)
    {
       if (!*shader_info->pass[i].alias)
          continue;


### PR DESCRIPTION
textures, named by shader pass identifier, should also be accessible in passes that come earlier in the shader chain.
this fix affects shader parsing for D3D and Metal drivers.
