### PR TITLE
menu: Improve the Content Downloader

### DIFF
--- a/libretro-common/include/lists/file_list.h
+++ b/libretro-common/include/lists/file_list.h
@@ -105,6 +105,19 @@ void file_list_free_actiondata(const file_list_t *list, size_t idx);
 void file_list_set_alt_at_offset(file_list_t *list, size_t index,
       const char *alt);
 
+/**
+ * @brief sets the label of the entry at the given offset
+ *
+ * The previous label (if any) is freed and replaced with a copy of
+ * the supplied string.
+ *
+ * @param list The list containing the entry
+ * @param index Offset of the entry whose label should be set
+ * @param label Label to copy into the entry
+ */
+void file_list_set_label_at_offset(file_list_t *list, size_t index,
+      const char *label);
+
 void file_list_sort_on_alt(file_list_t *list);
 
 void file_list_sort_on_type(file_list_t *list);

--- a/libretro-common/lists/file_list.c
+++ b/libretro-common/lists/file_list.c
@@ -226,6 +226,16 @@ static void file_list_get_label_at_offset(const file_list_t *list, size_t idx,
       *label = list->list[idx].label;
 }
 
+void file_list_set_label_at_offset(file_list_t *list, size_t idx,
+      const char *label)
+{
+   if (!list || !label)
+      return;
+   if (list->list[idx].label)
+      free(list->list[idx].label);
+   list->list[idx].label = strdup(label);
+}
+
 void file_list_set_alt_at_offset(file_list_t *list, size_t idx,
       const char *alt)
 {

--- a/menu/cbs/menu_cbs_cancel.c
+++ b/menu/cbs/menu_cbs_cancel.c
@@ -62,7 +62,7 @@ int action_cancel_pop_default(const char *path,
       if (menu_st->driver_ctx->navigation_set)
          menu_st->driver_ctx->navigation_set(menu_st->userdata, false);
       /* Refresh menu */
-      menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH 
+      menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH
                       | MENU_ST_FLAG_PREVENT_POPULATE;
       return 0;
    }
@@ -127,7 +127,7 @@ static int action_cancel_core_content(const char *path,
 
    if (string_is_equal(menu_label, MENU_ENUM_LABEL_DEFERRED_CORE_UPDATER_LIST_STR))
    {
-      menu_search_terms_t *menu_search_terms = 
+      menu_search_terms_t *menu_search_terms =
          menu_entries_search_get_terms();
 
       /* Check whether search terms have been set
@@ -141,7 +141,7 @@ static int action_cancel_core_content(const char *path,
          if (menu_st->driver_ctx->navigation_set)
             menu_st->driver_ctx->navigation_set(menu_st->userdata, false);
          /* Refresh menu */
-         menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH 
+         menu_st->flags |= MENU_ST_FLAG_ENTRIES_NEED_REFRESH
                          | MENU_ST_FLAG_PREVENT_POPULATE;
          return 0;
       }
@@ -153,7 +153,16 @@ static int action_cancel_core_content(const char *path,
    else if (string_is_equal(menu_label, MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS_STR))
       menu_entries_flush_stack(MENU_ENUM_LABEL_ONLINE_UPDATER_STR, 0);
    else if (string_is_equal(menu_label, MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST_STR))
+   {
       menu_entries_flush_stack(MENU_ENUM_LABEL_ONLINE_UPDATER_STR, 0);
+#ifdef HAVE_NETWORKING
+      /* Allow going back from sub-categories within the Content Downloader. */
+      action_ok_core_content_dirs_list(
+            msg_hash_to_str(MENU_ENUM_LABEL_VALUE_DOWNLOAD_CORE_CONTENT),
+            MENU_ENUM_LABEL_DOWNLOAD_CORE_CONTENT_DIRS_STR,
+            MENU_SETTING_ACTION, 0, 0);
+#endif
+   }
    else if (string_is_equal(menu_label, MENU_ENUM_LABEL_DEFERRED_CORE_SYSTEM_FILES_LIST_STR))
       menu_entries_flush_stack(MENU_ENUM_LABEL_ONLINE_UPDATER_STR, 0);
    else

--- a/menu/cbs/menu_cbs_get_value.c
+++ b/menu/cbs/menu_cbs_get_value.c
@@ -1022,6 +1022,35 @@ static size_t menu_action_setting_disp_set_label_entry_url(
    return 0;
 }
 
+#ifdef HAVE_NETWORKING
+static size_t menu_action_setting_disp_set_label_core_content_entry(
+      file_list_t* list,
+      unsigned *w, unsigned type, unsigned i,
+      const char *label,
+      char *s, size_t len,
+      const char *path,
+      char *s2, size_t len2)
+{
+   const char *alt = list->list[i].alt
+      ? list->list[i].alt : list->list[i].path;
+   /* Content downloader will store a "[#]" in the entry
+    * label when the file already exists in the download directory. */
+   const char *entry_label = list->list[i].label;
+   *s = '\0';
+   *w = 0;
+
+   if (alt)
+      strlcpy(s2, alt, len2);
+
+   if (entry_label && *entry_label)
+   {
+      *w = (unsigned)strlen(entry_label);
+      return strlcpy(s, entry_label, len);
+   }
+   return 0;
+}
+#endif
+
 static size_t menu_action_setting_disp_set_label_entry(
       file_list_t* list,
       unsigned *w, unsigned type, unsigned i,
@@ -2332,9 +2361,16 @@ static int menu_cbs_init_bind_get_string_representation_compare_type(
       case 31: /* Database entry */
          BIND_ACTION_GET_VALUE(cbs, menu_action_setting_disp_set_label_db_entry);
          break;
-      case 25: /* URL directory entries */
-      case 26: /* URL entries */
+      case FILE_TYPE_DOWNLOAD_URL: /* URL directory entries */
          BIND_ACTION_GET_VALUE(cbs, menu_action_setting_disp_set_label_entry_url);
+         break;
+      case FILE_TYPE_DOWNLOAD_CORE_CONTENT: /* URL entries */
+#ifdef HAVE_NETWORKING
+         BIND_ACTION_GET_VALUE(cbs,
+               menu_action_setting_disp_set_label_core_content_entry);
+#else
+         BIND_ACTION_GET_VALUE(cbs, menu_action_setting_disp_set_label_entry_url);
+#endif
          break;
       case MENU_SETTING_DROPDOWN_SETTING_INT_ITEM:
       case MENU_SETTING_DROPDOWN_SETTING_UINT_ITEM:

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -5480,7 +5480,16 @@ void cb_generic_download(retro_task_t *task,
    {
       retro_task_t *decompress_task = NULL;
       void *frontend_userdata       = task->frontend_userdata;
+      char extract_dir[PATH_MAX_LENGTH];
       task->frontend_userdata       = NULL;
+
+      /* Content from the Content Downloader is saved into a category
+       * sub-directory. Make sure to extract it to the same directory. */
+      if (transf->enum_idx == MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD)
+      {
+         fill_pathname_basedir(extract_dir, output_path, sizeof(extract_dir));
+         dir_path = extract_dir;
+      }
 
       decompress_task = (retro_task_t*)task_push_decompress(
             output_path,
@@ -5531,6 +5540,8 @@ static int action_ok_download_generic(const char *path,
    char s2[PATH_MAX_LENGTH];
    char s3[PATH_MAX_LENGTH];
    file_transfer_t *transf      = NULL;
+   /* The subdirectory where the file will be downloaded to. */
+   const char *content_subdir   = NULL;
    bool suppress_msg            = false;
    retro_task_callback_t cb     = cb_generic_download;
    settings_t *settings         = config_get_ptr();
@@ -5561,6 +5572,8 @@ static int action_ok_download_generic(const char *path,
                MIN((size_t)(end - menu_label + 1), sizeof(s)));
             else
                strlcpy(s, menu_label, sizeof(s));
+            /* Figure out the subdirectory from the given path, using the label. */
+            content_subdir = path_basename(s);
          }
          break;
       case MENU_ENUM_LABEL_CB_CORE_SYSTEM_FILES_DOWNLOAD:
@@ -5620,7 +5633,19 @@ static int action_ok_download_generic(const char *path,
    if (!transf)
       return 0;
    transf->enum_idx = enum_idx;
-   strlcpy(transf->path, path, sizeof(transf->path));
+
+   /* When there is a content sub-directory, prefix the local
+    * path with the same category path. Otherwise, just grab
+    * the path. */
+   if (content_subdir && *content_subdir)
+   {
+      char rel_path[PATH_MAX_LENGTH];
+      fill_pathname_join_special(rel_path, content_subdir, path,
+            sizeof(rel_path));
+      strlcpy(transf->path, rel_path, sizeof(transf->path));
+   }
+   else
+      strlcpy(transf->path, path, sizeof(transf->path));
 
    if (string_is_equal(path, s))
       net_http_urlencode_full(s3, s, sizeof(s3));

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -213,6 +213,12 @@ static int (funcname)(const char *path, const char *label, unsigned type, size_t
    return generic_action_ok_network(path, label, type, idx, entry_idx, _id); \
 }
 
+#define DEFAULT_ACTION_OK_LIST_NON_STATIC(funcname, _id) \
+int (funcname)(const char *path, const char *label, unsigned type, size_t idx, size_t entry_idx) \
+{ \
+   return generic_action_ok_network(path, label, type, idx, entry_idx, _id); \
+}
+
 #define DEFAULT_ACTION_OK_DOWNLOAD(funcname, _id) \
 static int (funcname)(const char *path, const char *label, unsigned type, size_t idx, size_t entry_idx) \
 { \
@@ -5297,7 +5303,7 @@ static int generic_action_ok_network(const char *path,
 }
 
 DEFAULT_ACTION_OK_LIST(action_ok_core_content_list, MENU_ENUM_LABEL_CB_CORE_CONTENT_LIST)
-DEFAULT_ACTION_OK_LIST(action_ok_core_content_dirs_list, MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST)
+DEFAULT_ACTION_OK_LIST_NON_STATIC(action_ok_core_content_dirs_list, MENU_ENUM_LABEL_CB_CORE_CONTENT_DIRS_LIST)
 DEFAULT_ACTION_OK_LIST(action_ok_core_system_files_list, MENU_ENUM_LABEL_CB_CORE_SYSTEM_FILES_LIST)
 DEFAULT_ACTION_OK_LIST(action_ok_lakka_list, MENU_ENUM_LABEL_CB_LAKKA_LIST)
 

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -5527,6 +5527,35 @@ finish:
       RARCH_LOG("[Updater] Download \"%s\".\n",
             (transf ? transf->path : msg_hash_to_str(MENU_ENUM_LABEL_VALUE_UNKNOWN)));
 
+      /* Content Downloader: Mark downloaded content label with a "[#]". */
+      if (transf && transf->enum_idx == MENU_ENUM_LABEL_CB_CORE_CONTENT_DOWNLOAD)
+      {
+         struct menu_state *menu_st = menu_state_get_ptr();
+         const char *menu_label = NULL;
+         menu_entries_get_last_stack(NULL, &menu_label, NULL, NULL, NULL);
+
+         if (string_is_equal(menu_label, MENU_ENUM_LABEL_DEFERRED_CORE_CONTENT_LIST_STR))
+         {
+            menu_list_t *menu_list     = menu_st->entries.list;
+            file_list_t *selection_buf = menu_list ? MENU_LIST_GET_SELECTION(menu_list, 0) : NULL;
+            const char *filename       = path_basename(transf->path);
+
+            if (selection_buf && filename && *filename)
+            {
+               size_t i;
+               for (i = 0; i < selection_buf->size; i++)
+               {
+                  const char *entry_path = selection_buf->list[i].path;
+                  if (entry_path && string_is_equal(entry_path, filename))
+                  {
+                     file_list_set_label_at_offset(selection_buf, i, "[#]");
+                     break;
+                  }
+               }
+            }
+         }
+      }
+
 #ifdef HAVE_DISCORD
       if (transf && transf->enum_idx == MENU_ENUM_LABEL_CB_DISCORD_AVATAR)
          discord_avatar_set_ready(true);

--- a/menu/menu_cbs.h
+++ b/menu/menu_cbs.h
@@ -277,6 +277,22 @@ int generic_action_cheat_toggle(size_t idx, unsigned type, const char *label,
 int action_ok_path_use_directory(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx);
 
+/**
+ * @brief Open a Content Downloader category list
+ *
+ * Fetches the remote 'cores/.index-dirs' index and pushes the list of
+ * content sub-folders to the menu.
+ *
+ * @param path Path of the originating menu entry (unused for this list)
+ * @param label Label of the originating menu entry (unused for this list)
+ * @param type Type of the originating menu entry
+ * @param idx Index of the originating menu entry
+ * @param entry_idx Entry index of the originating menu entry
+ * @return 0 on success
+ */
+int action_ok_core_content_dirs_list(const char *path,
+      const char *label, unsigned type, size_t idx, size_t entry_idx);
+
 void input_keyboard_mapping_bits(unsigned mode, unsigned key);
 
 unsigned libretro_device_get_size(unsigned *devices, size_t devices_size, unsigned port);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -380,7 +380,7 @@ static int filebrowser_parse(
          for (j = 0; j < search_terms->size; j++)
          {
             const char *search_term = search_terms->terms[j];
-            if (search_term && *search_term 
+            if (search_term && *search_term
                 && !strcasestr(file_path, search_term))
             {
                skip_entry = true;
@@ -416,7 +416,7 @@ static int filebrowser_parse(
                   ? FILE_TYPE_VIDEO_FONT
                   : (enum msg_file_type)type_default;
 
-            if (   type == DISPLAYLIST_CORES_DETECTED 
+            if (   type == DISPLAYLIST_CORES_DETECTED
                 && path_is_compressed_file(file_path))
                file_type = FILE_TYPE_CARCHIVE;
             break;
@@ -3961,17 +3961,17 @@ static int menu_displaylist_parse_horizontal_content_actions(
                         || string_ends_with_size(menu_st->thumbnail_path_data->system, "_history",
                               menu_st->thumbnail_path_data->system_len, STRLEN_CONST("_history"));
 
-                  /* An annoyance: if the user navigates to the 
-                   * information menu, then to the database entry, 
+                  /* An annoyance: if the user navigates to the
+                   * information menu, then to the database entry,
                    * the thumbnail system will be changed.
-                   * This breaks the above 'remove_entry_enabled' 
-                   * check for the history and favorites playlists. 
-                   * We therefore have to check the playlist file 
+                   * This breaks the above 'remove_entry_enabled'
+                   * check for the history and favorites playlists.
+                   * We therefore have to check the playlist file
                    * name as well... */
                   if (   !remove_entry_enabled
                       && settings->bools.quick_menu_show_information
                       && (playlist_file && *playlist_file))
-                     remove_entry_enabled = 
+                     remove_entry_enabled =
                            string_is_equal(playlist_file, FILE_PATH_CONTENT_HISTORY)
                         || string_is_equal(playlist_file, FILE_PATH_CONTENT_FAVORITES);
                }
@@ -5112,7 +5112,7 @@ static unsigned menu_displaylist_parse_content_information(
 
       if (core_info_find(core_path, &core_info))
       {
-         core_supports_no_game = (core_info->flags 
+         core_supports_no_game = (core_info->flags
                                 & CORE_INFO_FLAG_SUPPORTS_NO_GAME);
          if (core_info->display_name && *core_info->display_name)
             strlcpy(core_name, core_info->display_name, sizeof(core_name));
@@ -9768,8 +9768,8 @@ unsigned menu_displaylist_build_list(
                      build_list[i].checked = (gfx_widgets && !cheevos_autopad);
                      break;
                   case MENU_ENUM_LABEL_CHEEVOS_APPEARANCE_PADDING_H:
-                     build_list[i].checked = ((gfx_widgets && !cheevos_autopad) && 
-                     !(cheevos_anchor == CHEEVOS_APPEARANCE_ANCHOR_TOPCENTER || 
+                     build_list[i].checked = ((gfx_widgets && !cheevos_autopad) &&
+                     !(cheevos_anchor == CHEEVOS_APPEARANCE_ANCHOR_TOPCENTER ||
                         cheevos_anchor == CHEEVOS_APPEARANCE_ANCHOR_BOTTOMCENTER));
                      break;
                   default:
@@ -13688,6 +13688,38 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   menu->core_len, FILE_TYPE_DOWNLOAD_CORE_CONTENT,
                   true);
 
+            /* Mark entries with "[#]" if the file already exists in the
+             * download directory (core assets folder + category sub-folder). */
+            {
+               char content_dir[PATH_MAX_LENGTH];
+               const char *core_assets = settings->paths.directory_core_assets;
+               content_dir[0] = '\0';
+
+               if (core_assets && *core_assets && info->path && *info->path)
+               {
+                  const char *category = path_basename(info->path);
+                  if (category && *category)
+                     fill_pathname_join_special(content_dir, core_assets,
+                           category, sizeof(content_dir));
+               }
+
+               if (*content_dir)
+               {
+                  size_t i;
+                  for (i = 0; i < count; i++)
+                  {
+                     char chk_path[PATH_MAX_LENGTH];
+                     const char *fname = info->list->list[i].path;
+                     if (!fname || !*fname)
+                        continue;
+                     fill_pathname_join_special(chk_path, content_dir, fname,
+                           sizeof(chk_path));
+                     if (path_is_valid(chk_path))
+                        file_list_set_label_at_offset(info->list, i, "[#]");
+                  }
+               }
+            }
+
             if (count == 0)
                menu_entries_append(info->list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NO_ENTRIES_TO_DISPLAY),
@@ -15492,7 +15524,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      if (settings->bools.menu_show_load_core)
                      {
 #ifdef HAVE_DYNAMIC
-                        if (    sys_info->info.library_name 
+                        if (    sys_info->info.library_name
                             && *sys_info->info.library_name)
                         {
                            if (MENU_DISPLAYLIST_PARSE_SETTINGS_ENUM(info->list,


### PR DESCRIPTION
This does a few things to improve the Content Downloader user experience...

1. Adds a `[#]` indicator for entries that have already been downloaded, similar to how the Core Downloader indicates it
2. Downloads/extracts content to their related category (Lutro/Bobble.lutro will download to downloads/Lutro/Bobble.lutro)
3. When pressing back from a category, you'll be brought back up to the Content Downloader, rather than back to the Online Updater menu

<img width="1247" height="837" alt="Screenshot from 2026-06-16 11-52-16" src="https://github.com/user-attachments/assets/ef2ee7bf-8294-490d-9a18-ca8b1b6b6714" />

## QA
1. Compile and run
2. Execute Online Updater > Content Downloader > Lutro > Onion Kidd.lutro
3. Expect for it to download, and a `[#]` appear
4. Look in your Downloads directory, and expect to see `downloads/Lutro/Onion Kidd.lutro`, rather than `downloads/Onion Kidd.lutro`