### PR TITLE
webOS: add aarch64 build to CI

### DIFF
--- a/.github/workflows/webOS.yml
+++ b/.github/workflows/webOS.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download ares-cli-rs
         uses: robinraju/release-downloader@v1
@@ -44,9 +44,12 @@ jobs:
         run: sudo apt-get -yq update
 
       - name: Install webOS CLI
-        run: sudo apt-get -yq install ./temp/*.deb
+        run: |
+          sudo apt-get -yq install \
+            ./temp/ares-package_*_amd64.deb \
+            ./temp/webosbrew-toolbox-gen-manifest_*.deb
 
-      - name: Download webOS NDK
+      - name: Download webOS (arm) NDK
         uses: robinraju/release-downloader@v1
         with:
           repository: "openlgtv/buildroot-nc4"
@@ -54,12 +57,22 @@ jobs:
           fileName: "arm-webos-linux-gnueabi_sdk-buildroot-x86_64.tar.gz"
           out-file-path: "/tmp"
 
-      - name: Extract webOS NDK
+      - name: Download webOS (aarch64) NDK
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: "cscd98/buildroot-nc4"
+          latest: true
+          fileName: "aarch64-webos-linux-gnu_sdk-buildroot-x86_64.tar.gz"
+          out-file-path: "/tmp"
+
+      - name: Extract webOS NDKs
         shell: bash
         working-directory: /tmp
         run: |
           tar xzf arm-webos-linux-gnueabi_sdk-buildroot-x86_64.tar.gz
           ./arm-webos-linux-gnueabi_sdk-buildroot/relocate-sdk.sh
+          tar xzf aarch64-webos-linux-gnu_sdk-buildroot-x86_64.tar.gz
+          ./aarch64-webos-linux-gnu_sdk-buildroot/relocate-sdk.sh
 
       - name: Load RARCH_VERSION from version.all
         id: version
@@ -76,16 +89,18 @@ jobs:
           make -f Makefile.webos clean
           make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 \
           -j"$(getconf _NPROCESSORS_ONLN)"
+          mkdir -p webos/arm
           mv webos/com.retroarch.webos_${RARCH_VERSION}_arm.ipk \
-             webos/com.retroarch.webos-legacy-gles2-no-wayland_${RARCH_VERSION}_arm.ipk
+             webos/arm/com.retroarch.webos-legacy-gles2-no-wayland_${RARCH_VERSION}_arm.ipk
         env:
           DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
 
       - name: Upload GLES2 artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_${{ github.sha }}_arm.ipk
-          path: webos/com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_arm.ipk
+          path: webos/arm/com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_arm.ipk
+          archive: false
 
       - name: Compile RA (default)
         shell: bash
@@ -97,23 +112,52 @@ jobs:
           make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 \
           HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 HAVE_WAYLAND=1 \
           HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1 -j"$(getconf _NPROCESSORS_ONLN)"
+          mkdir -p webos/arm
+          mv webos/com.retroarch.webos_${RARCH_VERSION}_arm.ipk \
+            webos/arm/com.retroarch.webos_${RARCH_VERSION}_arm.ipk
         env:
           DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
 
       - name: Upload default artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: com.retroarch.webos_${{ env.RARCH_VERSION }}_${{ github.sha }}_arm.ipk
-          path: webos/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk
+          path: webos/arm/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk
+          archive: false
 
       - name: Generate Manifest (default only)
         if: github.repository == 'webosbrew/Retroarch'
         shell: bash
         run: |
           webosbrew-gen-manifest -o webos/${PACKAGE_NAME}.manifest.json \
-              -p webos/${PACKAGE_NAME}_${RARCH_VERSION}_arm.ipk \
+              -p webos/arm/${PACKAGE_NAME}_${RARCH_VERSION}_arm.ipk \
               -i https://github.com/webosbrew/RetroArch/raw/webos/webos/icon160.png \
               -l https://github.com/webosbrew/RetroArch
+
+      - name: Compile RA (aarch64)
+        shell: bash
+        run: |
+          . /tmp/aarch64-webos-linux-gnu_sdk-buildroot/environment-setup
+          export SDK_PATH=/tmp/aarch64-webos-linux-gnu_sdk-buildroot
+          make -f Makefile.webos clean
+          bash gfx/common/wayland/generate_wayland_protos.sh
+          make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=0 \
+          HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 HAVE_WAYLAND=1 \
+          HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1 \
+          HAVE_WAYLAND_BACKPORT=0 HAVE_64TO32BIT_BRIDGE=1 SET_ELF_INTERPRETER=1 HAVE_UDEV=1 \
+          ARES_PACKAGE_ARGS="-A arm" -j"$(getconf _NPROCESSORS_ONLN)"
+          mkdir -p webos/aarch64
+          mv webos/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk \
+            webos/aarch64/com.retroarch.webos_${{ env.RARCH_VERSION }}_aarch64.ipk
+        env:
+          DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
+
+      - name: Upload aarch64 artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: com.retroarch.webos_${{ env.RARCH_VERSION }}_${{ github.sha }}_aarch64.ipk
+          path: webos/aarch64/com.retroarch.webos_${{ env.RARCH_VERSION }}_aarch64.ipk
+          archive: false
 
       - name: Release
         if: github.event_name == 'release' && github.repository == 'webosbrew/Retroarch'
@@ -126,6 +170,7 @@ jobs:
           omitBody: true
           omitPrereleaseDuringUpdate: true
           artifacts: |
-            webos/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk
-            webos/com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_arm.ipk
+            webos/arm/com.retroarch.webos_${{ env.RARCH_VERSION }}_arm.ipk
+            webos/arm/com.retroarch.webos-legacy-gles2-no-wayland_${{ env.RARCH_VERSION }}_arm.ipk
+            webos/aarch64/com.retroarch.webos_${{ env.RARCH_VERSION }}_aarch64.ipk
             webos/${{ env.PACKAGE_NAME }}.manifest.json

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -282,12 +282,18 @@ endif
 
 RARCH_OBJ := $(addprefix $(OBJDIR)/,$(OBJ))
 
+ifeq ($(findstring arm64,$(ARCH)),arm64)
+  IPK_TITLE := RetroArch (64-bit)
+else
+  IPK_TITLE := RetroArch
+endif
+
 define APPINFO
 {
     "id": "$(APP_PACKAGE_NAME)",
     "version": "$(IPK_VERSION)",
     "vendor": "webosbrew.org",
-    "title": "RetroArch",
+    "title": "$(IPK_TITLE)",
     "icon": "icon160.png",
     "main": "retroarch",
     "iconColor": "#333333",


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Creates a webOS aarch64 build for the CI.
Also fixes the release build which was broken.

## Related Issues
## Related Pull Requests
## Reviewers

