### PR TITLE
Remove globals from memstream

### DIFF
--- a/libretro-common/include/streams/memory_stream.h
+++ b/libretro-common/include/streams/memory_stream.h
@@ -32,7 +32,7 @@ RETRO_BEGIN_DECLS
 
 typedef struct memstream memstream_t;
 
-memstream_t *memstream_open(unsigned writing);
+memstream_t *memstream_open(uint8_t *data, uint64_t size, unsigned writing);
 
 void memstream_close(memstream_t *stream);
 
@@ -48,13 +48,11 @@ char *memstream_gets(memstream_t *stream, char *s, size_t len);
 
 uint64_t memstream_pos(memstream_t *stream);
 
+uint64_t memstream_get_size(memstream_t *stream);
+
 void memstream_rewind(memstream_t *stream);
 
 int64_t memstream_seek(memstream_t *stream, int64_t offset, int whence);
-
-void memstream_set_buffer(uint8_t *buffer, uint64_t size);
-
-uint64_t memstream_get_last_size(void);
 
 uint64_t memstream_get_ptr(memstream_t *stream);
 

--- a/libretro-common/streams/interface_stream.c
+++ b/libretro-common/streams/interface_stream.c
@@ -43,12 +43,6 @@ struct intfstream_internal
    struct
    {
       memstream_t *fp;
-      struct
-      {
-         uint8_t *data;
-         uint64_t size;
-      } buf;
-      bool writable;
    } memory;
 #ifdef HAVE_CHD
    struct
@@ -76,7 +70,7 @@ int64_t intfstream_get_size(intfstream_internal_t *intf)
       case INTFSTREAM_FILE:
          return filestream_get_size(intf->file.fp);
       case INTFSTREAM_MEMORY:
-         return intf->memory.buf.size;
+         return memstream_get_size(intf->memory.fp);
       case INTFSTREAM_CHD:
 #ifdef HAVE_CHD
         return chdstream_get_size(intf->chd.fp);
@@ -94,34 +88,6 @@ int64_t intfstream_get_size(intfstream_internal_t *intf)
    return 0;
 }
 
-bool intfstream_resize(intfstream_internal_t *intf, intfstream_info_t *info)
-{
-   if (!intf || !info)
-      return false;
-
-   switch (intf->type)
-   {
-      case INTFSTREAM_FILE:
-         break;
-      case INTFSTREAM_MEMORY:
-         intf->memory.buf.data = info->memory.buf.data;
-         intf->memory.buf.size = info->memory.buf.size;
-
-         memstream_set_buffer(intf->memory.buf.data,
-               intf->memory.buf.size);
-         break;
-      case INTFSTREAM_CHD:
-#ifdef HAVE_CHD
-#endif
-         break;
-      case INTFSTREAM_RZIP:
-         /* Unsupported */
-         return false;
-   }
-
-   return true;
-}
-
 bool intfstream_open(intfstream_internal_t *intf, const char *path,
       unsigned mode, unsigned hints)
 {
@@ -136,7 +102,6 @@ bool intfstream_open(intfstream_internal_t *intf, const char *path,
             return false;
          break;
       case INTFSTREAM_MEMORY:
-         intf->memory.fp = memstream_open(intf->memory.writable);
          if (!intf->memory.fp)
             return false;
          break;
@@ -225,10 +190,7 @@ void *intfstream_init(intfstream_info_t *info)
 
    intf->type            = info->type;
    intf->file.fp         = NULL;
-   intf->memory.buf.data = NULL;
-   intf->memory.buf.size = 0;
    intf->memory.fp       = NULL;
-   intf->memory.writable = false;
 #ifdef HAVE_CHD
    intf->chd.track       = 0;
    intf->chd.fp          = NULL;
@@ -242,12 +204,7 @@ void *intfstream_init(intfstream_info_t *info)
       case INTFSTREAM_FILE:
          break;
       case INTFSTREAM_MEMORY:
-         intf->memory.writable = info->memory.writable;
-         if (!intfstream_resize(intf, info))
-         {
-            free(intf);
-            return NULL;
-         }
+         intf->memory.fp = memstream_open(info->memory.buf.data, info->memory.buf.size, info->memory.writable);
          break;
       case INTFSTREAM_CHD:
 #ifdef HAVE_CHD

--- a/libretro-common/streams/memory_stream.c
+++ b/libretro-common/streams/memory_stream.c
@@ -26,11 +26,6 @@
 
 #include <streams/memory_stream.h>
 
-/* TODO/FIXME - static globals */
-static uint8_t* g_buffer      = NULL;
-static uint64_t g_size         = 0;
-static uint64_t last_file_size = 0;
-
 struct memstream
 {
    uint64_t size;
@@ -40,31 +35,21 @@ struct memstream
    unsigned writing;
 };
 
-void memstream_set_buffer(uint8_t *s, uint64_t len)
-{
-   g_buffer = s;
-   g_size   = len;
-}
 
-memstream_t *memstream_open(unsigned writing)
+memstream_t *memstream_open(uint8_t *buf, uint64_t size, unsigned writing)
 {
    memstream_t *stream;
-   if (!g_buffer || !g_size)
-      return NULL;
 
    stream = (memstream_t*)malloc(sizeof(*stream));
 
    if (!stream)
       return NULL;
 
-   stream->buf       = g_buffer;
-   stream->size      = g_size;
    stream->ptr       = 0;
    stream->max_ptr   = 0;
    stream->writing   = writing;
-
-   g_buffer          = NULL;
-   g_size            = 0;
+   stream->buf       = buf;
+   stream->size      = size;
 
    return stream;
 }
@@ -74,13 +59,17 @@ void memstream_close(memstream_t *stream)
    if (!stream)
       return;
 
-   last_file_size = stream->writing ? stream->max_ptr : stream->size;
    free(stream);
 }
 
 uint64_t memstream_get_ptr(memstream_t *stream)
 {
    return stream->ptr;
+}
+
+uint64_t memstream_get_size(memstream_t *stream)
+{
+   return stream->size;
 }
 
 uint64_t memstream_read(memstream_t *stream, void *data, uint64_t bytes)
@@ -155,7 +144,6 @@ void memstream_rewind(memstream_t *stream)
 
 uint64_t memstream_pos(memstream_t *stream) { return stream->ptr; }
 char *memstream_gets(memstream_t *stream, char *s, size_t len) { return NULL; }
-uint64_t memstream_get_last_size(void) { return last_file_size; }
 
 int memstream_getc(memstream_t *stream)
 {


### PR DESCRIPTION
Memstream is not currently thread-safe and can only be properly used via intfstream.  This change uses the existing buf and size members and changes the initialization of memstream to set them properly.