### PR TITLE
Fix replay seek while recording v2

### DIFF
--- a/input/bsv/bsvmovie.c
+++ b/input/bsv/bsvmovie.c
@@ -1569,7 +1569,7 @@ int64_t bsv_movie_write_deduped_state(bsv_movie_t *movie, uint8_t *state,
    size_t superblock_count     = state_size / superblock_byte_size + (state_size % superblock_byte_size != 0);
    uint32_t *superblock_buf    = (uint32_t*)calloc(superblock_size, sizeof(uint32_t));
    uint8_t *padded_block       = NULL;
-   intfstream_t *out_stream    = intfstream_open_writable_memory(output,
+   intfstream_t *out_stream    = intfstream_open_memory(output,
          RETRO_VFS_FILE_ACCESS_READ_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE,
          output_capacity);
    bool can_compare_saves = movie->cur_save_valid && movie->last_save
@@ -1641,7 +1641,7 @@ int64_t bsv_movie_write_deduped_state(bsv_movie_t *movie, uint8_t *state,
             rmsgpack_write_int(out_stream, BSV_IFRAME_NEW_BLOCK_TOKEN);
             rmsgpack_write_int(out_stream, found_block.index);
             /* Cast is fine, a single block can't be super big */
-            rmsgpack_write_bin(out_stream, state+block_start, (uint32_t)block_byte_size);
+            rmsgpack_write_bin(out_stream, (uint8_t*)uint32s_index_get(movie->blocks, found_block.index), block_byte_size);
          }
          else
             reused_blocks++;

--- a/input/bsv/bsvmovie.c
+++ b/input/bsv/bsvmovie.c
@@ -1035,6 +1035,7 @@ void bsv_movie_next_frame(input_driver_state_t *input_st)
       size_t last_pos        = handle->frame_pos[(MAX(handle->frame_counter,2)-2) & handle->frame_mask];
       size_t cur_pos         = intfstream_tell(handle->file);
       uint32_t back_distance = swap_if_big32((uint32_t)(cur_pos-last_pos));
+      intfstream_seek(handle->file, 0, SEEK_CUR);
       /* write backref */
       intfstream_write(handle->file, &back_distance, sizeof(uint32_t));
       /* write key events, frame is over */

--- a/input/bsv/uint32s_index.c
+++ b/input/bsv/uint32s_index.c
@@ -235,7 +235,7 @@ void uint32s_index_commit(uint32s_index_t *index)
    for (i = prev.first_index; i < limit; i++)
    {
       struct uint32s_bucket *bucket;
-      if (index->counts[i] >= threshold)
+      if (index->counts[i] >= threshold || index->objects[i] == NULL)
          continue;
       free(index->objects[i]);
       index->objects[i] = NULL;
@@ -282,22 +282,23 @@ void uint32s_index_pop(uint32s_index_t *index)
 {
    uint32_t idx  = RBUF_LEN(index->objects)-1;
    uint32_t hash = index->hashes[idx];
-   struct uint32s_bucket *bucket = RHMAP_PTR(index->index, hash);
-   uint32_t old_len = bucket->len;
-   if (old_len == 0) {
-      RARCH_ERR("[STATESTREAM] trying to pop from empty bucket\n");
-      return;
+   if (index->objects[idx] != NULL) {
+      struct uint32s_bucket *bucket = RHMAP_PTR(index->index, hash);
+      uint32_t old_len = bucket->len;
+      if (old_len == 0)
+         RARCH_ERR("[STATESTREAM] Trying to remove from empty bucket, this should never happen");
+      if (!uint32s_bucket_remove(bucket, idx))
+         RARCH_WARN("[STATESTREAM] Failed to remove idx from bucket");
+      if (old_len == 1) {
+         uint32s_bucket_free(bucket);
+         if (!RHMAP_DEL(index->index, hash))
+            RARCH_ERR("[STATESTREAM] Trying to remove absent hash %x\n",hash);
+      }
    }
+   /* else: already garbage collected, just adjust counts */
    RBUF_RESIZE(index->objects, idx);
    RBUF_RESIZE(index->counts, idx);
    RBUF_RESIZE(index->hashes, idx);
-   uint32s_bucket_remove(bucket, idx);
-   if (old_len - 1 == 0)
-   {
-      uint32s_bucket_free(bucket);
-      if (!RHMAP_DEL(index->index, hash))
-         RARCH_ERR("[STATESTREAM] Trying to remove absent hash %x\n",hash);
-   }
 }
 
 /* goes backwards from end of additions */


### PR DESCRIPTION
When garbage collecting rare datablocks in checkpoints is used to keep RAM usage down, removing later blocks during seek (sometimes when seeking back/forward by checkpoint or especially by loading an earlier state) doesn't work properly and can cause an infinite loop. This change correctly handles GC'd blocks rather than try to remove them again.

The changes in bsvmovie.c are to handle states that are not an even multiple of block size, and to add a no-op seek before writing after a read when the replay is recording (per @amcknight's 1abde384c8df7dabe742442dcbd740680fee4b67).

In uint32s_index.c, there are several changes to do with handling garbage collected index slots instead of trying to pop empty or freed buckets.