### PR TITLE
libShake: fix gcc 15 compilation due incorrect listElementDelete defi…

### DIFF
--- a/deps/libShake/src/common/helpers.h
+++ b/deps/libShake/src/common/helpers.h
@@ -8,7 +8,7 @@ typedef struct ListElement
 } ListElement;
 
 ListElement *listElementPrepend(ListElement *head);
-ListElement *listElementDelete(ListElement *head, ListElement *toDelNode, void(*itemDel)());
+ListElement *listElementDelete(ListElement *head, ListElement *toDelNode, void(*itemDel)(void *item));
 ListElement *listElementDeleteAll(ListElement *head, void(*itemDel)(void *item));
 ListElement *listElementGet(ListElement *head, unsigned int id);
 unsigned int listLength(ListElement *head);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Compiling RetroArch under GCC 15 will fail with:

```
deps/libShake/src/common/helpers.c:19:14: error: conflicting types for ‘listElementDelete’; have ‘ListElement *(ListElement *, ListElement *, void (*)(void *))’
   19 | ListElement *listElementDelete(ListElement *head, ListElement *toDelNode, void(*itemDel)(void *item))
      |              ^~~~~~~~~~~~~~~~~
In file included from deps/libShake/src/common/helpers.c:1:
deps/libShake/src/common/helpers.h:11:14: note: previous declaration of ‘listElementDelete’ with type ‘ListElement *(ListElement *, ListElement *, void (*)(void))’
   11 | ListElement *listElementDelete(ListElement *head, ListElement *toDelNode, void(*itemDel)());
```

This fixes that.

Same PR made to [libShake.](https://github.com/zear/libShake/pull/23)

## Related Issues

## Related Pull Requests

## Reviewers
