### PR TITLE
README: update and remove links

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The links below belong to our official channels. Links other than this may have 
 - [YouTube](https://www.youtube.com/@Libretro)
 - [Google Post](https://posts.google.com/share/55Nhs2jG)
 - [Steam](https://store.steampowered.com/app/1118310/RetroArch/)
-- [YouTube Topic](https://www.youtube.com/channel/UC5q007PYyQPgin0HHbzF0zQ)
+- [YouTube Topic](https://www.youtube.com/channel/UCyXchL2xdEpHNzqE52w8XYw)
 - [Patreon](https://www.patreon.com/libretro)
 - [BOUNTYSOURCE](https://www.bountysource.com/teams/libretro/issues)
 - [Discord](https://discord.gg/C4amCeV)

--- a/README.md
+++ b/README.md
@@ -332,7 +332,6 @@ The links below belong to our official channels. Links other than this may have 
 - [Twitter](https://twitter.com/libretro)
 - [Reddit](https://www.reddit.com/r/RetroArch/)
 - [YouTube](https://www.youtube.com/@Libretro)
-- [Google Post](https://posts.google.com/share/55Nhs2jG)
 - [Steam](https://store.steampowered.com/app/1118310/RetroArch/)
 - [YouTube Topic](https://www.youtube.com/channel/UCyXchL2xdEpHNzqE52w8XYw)
 - [Patreon](https://www.patreon.com/libretro)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/libretro/RetroArch.svg?branch=master)](https://travis-ci.org/libretro/RetroArch)
 [![Crowdin](https://badges.crowdin.net/retroarch/localized.svg)](https://crowdin.com/project/retroarch)
 
 # RetroArch

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The links below belong to our official channels. Links other than this may have 
 - [Facebook](https://www.facebook.com/libretro)
 - [Twitter](https://twitter.com/libretro)
 - [Reddit](https://www.reddit.com/r/RetroArch/)
-- [YouTube](https://www.youtube.com/Libretro)
+- [YouTube](https://www.youtube.com/@Libretro)
 - [Google Post](https://posts.google.com/share/55Nhs2jG)
 - [Steam](https://store.steampowered.com/app/1118310/RetroArch/)
 - [YouTube Topic](https://www.youtube.com/channel/UC5q007PYyQPgin0HHbzF0zQ)

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ The links below belong to our official channels. Links other than this may have 
 - [Steam](https://store.steampowered.com/app/1118310/RetroArch/)
 - [YouTube Topic](https://www.youtube.com/channel/UCyXchL2xdEpHNzqE52w8XYw)
 - [Patreon](https://www.patreon.com/libretro)
-- [BOUNTYSOURCE](https://www.bountysource.com/teams/libretro/issues)
 - [Discord](https://discord.gg/C4amCeV)
 - [Teespring](https://teespring.com/stores/retroarch)
 - [Documentation](https://docs.libretro.com/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/libretro/RetroArch.svg?branch=master)](https://travis-ci.org/libretro/RetroArch)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/8936/badge.svg)](https://scan.coverity.com/projects/retroarch)
 [![Crowdin](https://badges.crowdin.net/retroarch/localized.svg)](https://crowdin.com/project/retroarch)
 
 # RetroArch


### PR DESCRIPTION
## Description

- The coverity link in the README is less than useful since the last scan was in 2018. The other alternative is of course to do a coverity scan so that it provides useful information.
- The travis CI link links to something that either is not available, or no longer exists.
- YouTube has changed how they link to channels, which I fixed.
- The youtube topic has changed link, which I updated.
- The google post no longer exists, which I removed.
- Bountysource is discontinued, so I removed the link.