### PR TITLE
videoprocessor: fix crashes with modern V4L2 devices, detect capture resolutions and frame rates

### DIFF
--- a/AUTHORS.h
+++ b/AUTHORS.h
@@ -499,6 +499,7 @@ Wiktor Strzębała (wiktorek140)
 Woohyun Shin (sinusinu)
 xenomorph-us
 xhp-creations
+Xitee (Xitee1)
 Yari (hyarsan)
 yesfish (huwpascoe)
 Yongwoon Cho (ssangkong)

--- a/cores/libretro-video-processor/Makefile
+++ b/cores/libretro-video-processor/Makefile
@@ -37,6 +37,7 @@ ifneq ($(findstring Linux,$(shell uname -a)),)
    LIBUDEV	= -ludev
    CFLAGS +=	-DHAVE_ALSA
    LIBASOUND	= -lasound
+   LIBPTHREAD	= -lpthread
 endif
 
 ifeq ($(ARCHFLAGS),)
@@ -109,7 +110,7 @@ else
    SHARED := -shared -static-libgcc -static-libstdc++ -s -Wl,--version-script=link.T -Wl,--no-undefined
 endif
 
-LDFLAGS += $(LIBV4L2) $(LIBASOUND) $(LIBUDEV) -lm
+LDFLAGS += $(LIBV4L2) $(LIBASOUND) $(LIBUDEV) $(LIBPTHREAD) -lm
 
 ifeq ($(DEBUG), 1)
    CFLAGS += -O0 -g
@@ -117,7 +118,9 @@ else
    CFLAGS += -O3
 endif
 
-OBJECTS := video_processor_v4l2.o
+# compat_strl provides the strlcpy/strlcat fallback that compat/strl.h
+# routes to on platforms without native strl* (everything but BSD/macOS).
+OBJECTS := video_processor_v4l2.o ../../libretro-common/compat/compat_strl.o
 CFLAGS += -Wall -pedantic $(fpic)
 
 ifneq (,$(findstring qnx,$(platform)))

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -638,17 +638,24 @@ static void list_capture_options(char *capture_resolutions, size_t res_len,
       written += elen;
    }
 }
-RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t cb)
+/* Probed capture option value lists and the device selection they were
+ * probed from. File-scope statics: they survive core restarts when the core
+ * is statically linked into the frontend (an empty-buffer check alone would
+ * never refresh them), and the runtime device-switch path re-registers
+ * through them. */
+static char capture_resolutions[ENVVAR_BUFLEN];
+static char capture_rates[ENVVAR_BUFLEN];
+static char probed_for[ENVVAR_BUFLEN];
+
+/* Enumerate the capture devices, resolve the selected one and register the
+ * complete option set with resolution/rate lists probed from that device.
+ * Called from retro_set_environment and again from the reconfigure path in
+ * retro_run when the user switches capture devices, so the lists always
+ * describe the selected device without requiring a core restart. */
+static void register_options(void)
 {
-   bool no_content = true;
    char video_devices[ENVVAR_BUFLEN];
    char audio_devices[ENVVAR_BUFLEN];
-   static char capture_resolutions[ENVVAR_BUFLEN];
-   static char capture_rates[ENVVAR_BUFLEN];
-   /* Device selection the resolution/rate lists were probed from; statics
-    * survive core restarts when the core is statically linked into the
-    * frontend, so an empty-buffer check alone would never refresh them. */
-   static char probed_for[ENVVAR_BUFLEN];
    struct retro_variable videodev = { "videoproc_videodev", NULL };
    struct retro_variable envvars[] = {
       { "videoproc_videodev", NULL },
@@ -660,10 +667,6 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
       { "videoproc_frame_times","Print frame times to terminal (v4l2 only); Off|On" },
       { NULL, NULL }
    };
-
-   VIDEOPROC_CORE_PREFIX(environment_cb) = cb;
-
-   cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_content);
 
    /* Enumerate all real devices */
    enumerate_video_devices(video_devices, sizeof(video_devices));
@@ -720,6 +723,17 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    }
 
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
+}
+
+RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t cb)
+{
+   bool no_content = true;
+
+   VIDEOPROC_CORE_PREFIX(environment_cb) = cb;
+
+   cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_content);
+
+   register_options();
 }
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_video_refresh)(retro_video_refresh_t cb)
@@ -1653,7 +1667,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
 
    if (VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    {
-      bool video_changed, audio_changed;
+      bool video_changed, audio_changed, device_changed;
 
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &audiodev);
@@ -1665,7 +1679,8 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
       /* Video or Audio device(s) has(ve) been changed
        * TODO We may get away without resetting devices when changing output mode...
        */
-      video_changed = (videodev.value    && (strcmp(video_device, videodev.value) != 0)) ||
+      device_changed = videodev.value && (strcmp(video_device, videodev.value) != 0);
+      video_changed = device_changed ||
           (capturemode.value && (strcmp(video_capture_mode, capturemode.value) != 0)) ||
           (captureresolution.value && (strcmp(video_capture_resolution, captureresolution.value) != 0)) ||
           (capturerate.value && (strcmp(video_capture_rate, capturerate.value) != 0)) ||
@@ -1702,6 +1717,13 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
             struct retro_system_av_info av_info;
             struct retro_system_av_info prev_av_info = video_last_av_info;
             unload_game_internal(keep_audio);
+            /* A different capture device supports different resolutions and
+             * frame rates: re-probe and re-register the options so the menu
+             * lists describe the newly selected device — before the load
+             * reads the values back, so a stale selection the new device's
+             * list doesn't contain resets to that list's default first. */
+            if (device_changed)
+               register_options();
             if (!load_game_internal(false))
             {
                /* Reload failed: the buffers we just freed are gone. Output a

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -86,6 +86,7 @@ struct v4l2_resolution v4l2_resolutions[] =
    {480,320},
    {640,480},
    {720,480},
+   {720,576},
    {800,600},
    {960,720},
    {1024,768},
@@ -115,6 +116,12 @@ static struct  v4l2_format video_format;
 static struct  v4l2_standard video_standard;
 static struct  v4l2_buffer video_buf;
 
+/* Capture frame interval reported by VIDIOC_G_PARM (timeperframe). fps is
+ * video_cap_rate_d / video_cap_rate_n; both 0 when the device doesn't report
+ * a frame rate (then we fall back to the analog standard or 60). */
+static uint32_t video_cap_rate_n;
+static uint32_t video_cap_rate_d;
+
 static uint8_t v4l2_ncapbuf_target;
 static size_t  v4l2_ncapbuf;
 static struct  v4l2_capbuf v4l2_capbuf[VIDEO_BUFFERS_MAX];
@@ -133,6 +140,7 @@ static uint32_t video_cap_height;
 static uint32_t video_out_height;
 static char     video_capture_mode[ENVVAR_BUFLEN];
 static char     video_capture_resolution[ENVVAR_BUFLEN];
+static char     video_capture_rate[ENVVAR_BUFLEN];
 static char     video_output_mode[ENVVAR_BUFLEN];
 static char     video_frame_times[ENVVAR_BUFLEN];
 
@@ -338,25 +346,158 @@ static void enumerate_audio_devices(char *s, size_t len)
 #endif
 }
 
-static void list_resolutions(char *capture_resolutions, size_t len)
+/* Append (width, height) to out[] unless it is already present. Returns the
+ * updated entry count. */
+static size_t add_resolution(struct v4l2_resolution *out, size_t count,
+      size_t max, int width, int height)
 {
-   size_t i, written;
+   size_t i;
+   for (i = 0; i < count; i++)
+      if (out[i].width == width && out[i].height == height)
+         return count;
+   if (count < max)
+   {
+      out[count].width  = width;
+      out[count].height = height;
+      count++;
+   }
+   return count;
+}
+
+/* Probe a single V4L2 device for the capture resolutions it actually
+ * supports and merge them (deduplicated) into out[]. Returns the updated
+ * entry count. Drivers report framesizes either as a discrete list or as a
+ * stepwise/continuous range; for ranges, offer the entries of the built-in
+ * table that fall inside the range. */
+static size_t probe_resolutions(const char *device,
+      struct v4l2_resolution *out, size_t count, size_t max)
+{
+   int fd;
+   uint32_t fmt_index;
+
+   fd = v4l2_open(device, O_RDWR, 0);
+   if (fd == -1)
+      return count;
+
+   for (fmt_index = 0; ; fmt_index++)
+   {
+      struct v4l2_fmtdesc fmtdesc;
+      uint32_t size_index;
+
+      memset(&fmtdesc, 0, sizeof(fmtdesc));
+      fmtdesc.index = fmt_index;
+      fmtdesc.type  = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+      if (v4l2_ioctl(fd, VIDIOC_ENUM_FMT, &fmtdesc) != 0)
+         break;
+
+      for (size_index = 0; ; size_index++)
+      {
+         struct v4l2_frmsizeenum frmsize;
+
+         memset(&frmsize, 0, sizeof(frmsize));
+         frmsize.index        = size_index;
+         frmsize.pixel_format = fmtdesc.pixelformat;
+         if (v4l2_ioctl(fd, VIDIOC_ENUM_FRAMESIZES, &frmsize) != 0)
+            break;
+
+         if (frmsize.type == V4L2_FRMSIZE_TYPE_DISCRETE)
+            count = add_resolution(out, count, max,
+                  (int)frmsize.discrete.width, (int)frmsize.discrete.height);
+         else
+         {
+            /* Stepwise/continuous: index 0 describes the whole range. */
+            size_t i;
+            for (i = 0; i < ARRAY_SIZE(v4l2_resolutions); i++)
+            {
+               if (   v4l2_resolutions[i].width  >= (int)frmsize.stepwise.min_width
+                   && v4l2_resolutions[i].width  <= (int)frmsize.stepwise.max_width
+                   && v4l2_resolutions[i].height >= (int)frmsize.stepwise.min_height
+                   && v4l2_resolutions[i].height <= (int)frmsize.stepwise.max_height)
+                  count = add_resolution(out, count, max,
+                        v4l2_resolutions[i].width, v4l2_resolutions[i].height);
+            }
+            break;
+         }
+      }
+   }
+
+   v4l2_close(fd);
+   return count;
+}
+
+/* Order ascending (width, then height) so the smallest supported mode is the
+ * default option and the menu reads naturally. */
+static int resolution_cmp(const void *a, const void *b)
+{
+   const struct v4l2_resolution *ra = (const struct v4l2_resolution *)a;
+   const struct v4l2_resolution *rb = (const struct v4l2_resolution *)b;
+   if (ra->width != rb->width)
+      return ra->width - rb->width;
+   return ra->height - rb->height;
+}
+
+/* Build the capture-resolution option list by probing capture device(s) for
+ * the sizes they really report. video_devices is either a single device path
+ * ("/dev/videoN") or the option string built by enumerate_video_devices
+ * ("Video capture device; /dev/videoN|..."). Falls back to the built-in
+ * v4l2_resolutions[] table when nothing could be probed (no device
+ * present). */
+static void list_resolutions(char *capture_resolutions, size_t len,
+      const char *video_devices)
+{
+   struct v4l2_resolution probed[128];
+   const struct v4l2_resolution *res;
+   size_t count = 0;
+   size_t i, n, written;
+   char devices[ENVVAR_BUFLEN];
+   char *token;
+   const char *list;
+
+   /* Skip the "Video capture device; " menu label before tokenizing. */
+   list = strchr(video_devices, ';');
+   strlcpy(devices, list ? list + 1 : video_devices, sizeof(devices));
+
+   for (token = strtok(devices, "|"); token != NULL; token = strtok(NULL, "|"))
+   {
+      if (!string_starts_with(token, "/dev/video"))
+         continue;
+      count = probe_resolutions(token, probed, count, ARRAY_SIZE(probed));
+   }
+
+   if (count > 0)
+      qsort(probed, count, sizeof(probed[0]), resolution_cmp);
+
+   /* Fall back to the built-in table when nothing could be probed. */
+   res = (count > 0) ? probed : v4l2_resolutions;
+   n   = (count > 0) ? count  : ARRAY_SIZE(v4l2_resolutions);
+
    written = snprintf(capture_resolutions, len, "Capture resolution; ");
-   for (i = 0; i < sizeof(v4l2_resolutions) / sizeof(v4l2_resolutions[0]); i++)
-      written += snprintf(capture_resolutions + written, len - written, "%s%dx%d", i > 0 ? "|" : "",
-         v4l2_resolutions[i].width,v4l2_resolutions[i].height);
+   for (i = 0; i < n; i++)
+   {
+      char entry[32];
+      size_t elen = (size_t)snprintf(entry, sizeof(entry), "%s%dx%d",
+            i > 0 ? "|" : "", res[i].width, res[i].height);
+      /* Stop before truncating an entry mid-token; the caller still
+       * appends "|auto" and it must always fit. */
+      if (written + elen + STRLEN_CONST("|auto") + 1 > len)
+         break;
+      strlcpy(capture_resolutions + written, entry, len - written);
+      written += elen;
+   }
 }
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t cb)
 {
    bool no_content = true;
    char video_devices[ENVVAR_BUFLEN];
    char audio_devices[ENVVAR_BUFLEN];
-   char capture_resolutions[ENVVAR_BUFLEN];
+   static char capture_resolutions[ENVVAR_BUFLEN];
+   struct retro_variable videodev = { "videoproc_videodev", NULL };
    struct retro_variable envvars[] = {
       { "videoproc_videodev", NULL },
       { "videoproc_audiodev", NULL },
       { "videoproc_capture_mode", "Capture mode; alternate|deinterlaced|interlaced|top|bottom|alternate_hack" },
       { "videoproc_capture_resolution", NULL },
+      { "videoproc_capture_rate", "Capture frame rate; auto|60|59.94|50|30|29.97|25|24|20|15|10" },
       { "videoproc_output_mode","Output mode; progressive|deinterlaced|interlaced" },
       { "videoproc_frame_times","Print frame times to terminal (v4l2 only); Off|On" },
       { NULL, NULL }
@@ -365,9 +506,6 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    VIDEOPROC_CORE_PREFIX(environment_cb) = cb;
 
    cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_content);
-
-   /* Allows retroarch to seed the previous values */
-   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
 
    /* Enumerate all real devices */
    enumerate_video_devices(video_devices, sizeof(video_devices));
@@ -382,9 +520,28 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    envvars[1].key   = "videoproc_audiodev";
    envvars[1].value = audio_devices;
 
-   if(envvars[3].value == NULL)
-      list_resolutions(capture_resolutions, sizeof(capture_resolutions));
-   appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
+   /* Register the options once before the resolution list is known: this
+    * seeds the frontend with the saved values, and a variable can only be
+    * resolved after it has been registered with its value list — so the
+    * saved device selection only becomes queryable now. */
+   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
+   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
+
+   /* Probe the capture device for its real, supported resolutions rather
+    * than offering a fixed table the hardware may not honour. Probe only the
+    * selected device when it is known, so the option list reflects what that
+    * device actually supports; on a fresh configuration (no device selected
+    * yet) probe every enumerated device. Probing opens the device(s), so do
+    * it only once and reuse the list on subsequent calls; restart the core
+    * after switching devices to refresh it. */
+   if (capture_resolutions[0] == '\0')
+   {
+      const char *probe_target =
+            (videodev.value && string_starts_with(videodev.value, "/dev/video"))
+            ? videodev.value : video_devices;
+      list_resolutions(capture_resolutions, sizeof(capture_resolutions), probe_target);
+      appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
+   }
    envvars[3].key   = "videoproc_capture_resolution";
    envvars[3].value = capture_resolutions;
    printf("captures: %s\n", envvars[3].value);
@@ -713,6 +870,35 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_info)(struct retro_system_
    info->block_extract    = true;
 }
 
+/* Convert a "Capture frame rate" option value to a V4L2 timeperframe
+ * (seconds per frame = num/den). Handles the NTSC fractional rates and plain
+ * integer rates. Returns false for "auto"/unrecognised values, meaning "let
+ * the device keep its current rate". */
+static bool rate_to_timeperframe(const char *s, uint32_t *num, uint32_t *den)
+{
+   int r;
+   if (!s || strcmp(s, "auto") == 0)
+      return false;
+   if (strcmp(s, "59.94") == 0)
+   {
+      *num = 1001;
+      *den = 60000;
+      return true;
+   }
+   if (strcmp(s, "29.97") == 0)
+   {
+      *num = 1001;
+      *den = 30000;
+      return true;
+   }
+   r = atoi(s);
+   if (r <= 0)
+      return false;
+   *num = 1;
+   *den = (uint32_t)r;
+   return true;
+}
+
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_system_av_info *info)
 {
    struct v4l2_cropcap cc;
@@ -753,12 +939,25 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_syst
       /* TODO Only double if frames ARE fields (progressive or deinterlaced, full framerate)
        * *2 for fields
        */
-      /* Defaulting to 60 if this this doesn't return a usable number */
-      if(video_standard.frameperiod.denominator == 0 || video_standard.frameperiod.numerator == 0)
-         info->timing.fps = 60;
-      else
+      if(video_standard.frameperiod.denominator != 0 && video_standard.frameperiod.numerator != 0)
+      {
+         /* Analog TV standard available (PAL/NTSC): frameperiod is the frame
+          * rate; *2 yields the field rate. Unchanged legacy behaviour. */
          info->timing.fps = ((double)(video_standard.frameperiod.denominator*2)) /
                              (double)video_standard.frameperiod.numerator;
+      }
+      else if (video_cap_rate_n != 0 && video_cap_rate_d != 0)
+      {
+         /* No analog standard (e.g. UVC/HDMI capture): use the actual frame
+          * rate from VIDIOC_G_PARM. It is the buffer delivery rate, so it maps
+          * directly to the frontend rate, except in "interlaced" mode where the
+          * deinterlacer emits two outputs (one per field) per captured frame. */
+         double cap_fps = (double)video_cap_rate_d / (double)video_cap_rate_n;
+         info->timing.fps = (strcmp(video_capture_mode, "interlaced") == 0)
+                            ? cap_fps * 2.0 : cap_fps;
+      }
+      else
+         info->timing.fps = 60; /* nothing usable reported */
       info->timing.sample_rate   = AUDIO_SAMPLE_RATE;
 
       /* TODO/FIXME Allow for fixed 4:3 and 16:9 modes */
@@ -1153,6 +1352,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
    struct retro_variable audiodev    = { "videoproc_audiodev", NULL };
    struct retro_variable capturemode = { "videoproc_capture_mode", NULL };
    struct retro_variable captureresolution = { "videoproc_capture_resolution", NULL };
+   struct retro_variable capturerate = { "videoproc_capture_rate", NULL };
    struct retro_variable outputmode  = { "videoproc_output_mode", NULL };
    struct retro_variable frametimes  = { "videoproc_frame_times", NULL };
    bool updated = false;
@@ -1165,6 +1365,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &audiodev);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capturemode);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &captureresolution);
+      VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capturerate);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &outputmode);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &frametimes);
       /* Video or Audio device(s) has(ve) been changed
@@ -1173,6 +1374,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
       video_changed = (videodev.value    && (strcmp(video_device, videodev.value) != 0)) ||
           (capturemode.value && (strcmp(video_capture_mode, capturemode.value) != 0)) ||
           (captureresolution.value && (strcmp(video_capture_resolution, captureresolution.value) != 0)) ||
+          (capturerate.value && (strcmp(video_capture_rate, capturerate.value) != 0)) ||
           (outputmode.value  && (strcmp(video_output_mode,  outputmode.value)  != 0));
       audio_changed = (audiodev.value && (strcmp(audio_device, audiodev.value) != 0));
 
@@ -1354,16 +1556,19 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    struct retro_variable audiodev     = { "videoproc_audiodev", NULL };
    struct retro_variable capture_mode = { "videoproc_capture_mode", NULL };
    struct retro_variable capture_resolution = { "videoproc_capture_resolution", NULL };
+   struct retro_variable capture_rate = { "videoproc_capture_rate", NULL };
    struct retro_variable output_mode  = { "videoproc_output_mode", NULL };
    struct retro_variable frame_times  = { "videoproc_frame_times", NULL };
    enum retro_pixel_format pixel_format;
    struct v4l2_standard std;
+   struct v4l2_streamparm parm;
    struct v4l2_requestbuffers reqbufs;
    struct v4l2_buffer buf;
    struct v4l2_format fmt;
    enum v4l2_buf_type type;
    v4l2_std_id std_id;
    uint32_t index;
+   uint32_t rate_n, rate_d;
    bool std_found;
    int error;
 #ifdef HAVE_ALSA
@@ -1408,6 +1613,12 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    else
       strlcpy(video_capture_resolution, "auto", sizeof(video_capture_resolution));
 
+   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capture_rate);
+   if(capture_rate.value != NULL)
+      strlcpy(video_capture_rate, capture_rate.value, sizeof(video_capture_rate));
+   else
+      strlcpy(video_capture_rate, "auto", sizeof(video_capture_rate));
+
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capture_mode);
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &output_mode);
    if (capture_mode.value == NULL || output_mode.value == NULL)
@@ -1422,6 +1633,8 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    /* Reset per-device timing state so nothing leaks from a previously
     * loaded device into av_info/retro_get_region. */
    memset(&video_standard, 0, sizeof(video_standard));
+   video_cap_rate_n = 0;
+   video_cap_rate_d = 0;
 
    if (strcmp(video_device, "dummy") == 0)
       setup_dummy_source();
@@ -1507,6 +1720,39 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
                video_cap_height = fmt.fmt.pix.height / 2;
             break;
       }
+
+      /* Frame rate is controlled/reported via VIDIOC_G/S_PARM (timeperframe),
+       * independent of analog TV standards. Apply the chosen rate (if any),
+       * then read back what the driver actually granted so the timing reported
+       * to the frontend matches the real capture rate. For modern UVC/HDMI
+       * devices (no analog standard) this is the only source of the rate. */
+      memset(&parm, 0, sizeof(parm));
+      parm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+      error = v4l2_ioctl(video_device_fd, VIDIOC_G_PARM, &parm);
+      if (   error == 0
+          && (parm.parm.capture.capability & V4L2_CAP_TIMEPERFRAME)
+          && rate_to_timeperframe(video_capture_rate, &rate_n, &rate_d))
+      {
+         parm.parm.capture.timeperframe.numerator   = rate_n;
+         parm.parm.capture.timeperframe.denominator = rate_d;
+         if (v4l2_ioctl(video_device_fd, VIDIOC_S_PARM, &parm) != 0)
+            printf("VIDIOC_S_PARM failed (non-fatal): %s\n", strerror(errno));
+
+         /* Re-read the granted interval (S_PARM clamps to a supported rate). */
+         memset(&parm, 0, sizeof(parm));
+         parm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+         error = v4l2_ioctl(video_device_fd, VIDIOC_G_PARM, &parm);
+      }
+      if (error == 0)
+      {
+         video_cap_rate_n = parm.parm.capture.timeperframe.numerator;
+         video_cap_rate_d = parm.parm.capture.timeperframe.denominator;
+         if (video_cap_rate_n != 0 && video_cap_rate_d != 0)
+            printf("Capture frame rate %.3f fps\n",
+                  (double)video_cap_rate_d / (double)video_cap_rate_n);
+      }
+      else
+         printf("VIDIOC_G_PARM failed (non-fatal): %s\n", strerror(errno));
 
       /* Query the analog TV standard (PAL/NTSC) for the frame rate. Modern
        * HDMI/USB capture devices generally don't implement analog standards,

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <unistd.h>
 
 #include <linux/videodev2.h>
 #include <libv4l2.h>
@@ -120,6 +121,11 @@ static struct  v4l2_capbuf v4l2_capbuf[VIDEO_BUFFERS_MAX];
 struct v4l2_capability caps;
 
 static float   dummy_pos=0;
+
+/* True while retro_run() reloads the core after an option change: a failing
+ * device is survivable then (blank frames, options stay editable), so
+ * retro_load_game must not fall back to the dummy source. */
+static bool device_reloading;
 
 static int      video_half_feed_rate=0; /* for interlaced captures */
 static uint32_t video_cap_width;
@@ -261,7 +267,6 @@ static void enumerate_video_devices(char *s, size_t len)
 static void enumerate_audio_devices(char *s, size_t len)
 {
 #ifdef HAVE_ALSA
-   int ndevs;
    void **hints, **n;
    char *ioid, *name, *descr;
 #endif
@@ -269,11 +274,14 @@ static void enumerate_audio_devices(char *s, size_t len)
    memset(s, 0, len);
    appendstr(s, "Audio capture device; ", len);
 
+   /* Always offer "none" as the first (default) option so the core can be
+    * started without any audio capture device present. */
+   appendstr(s, "none", len);
+
 #ifdef HAVE_ALSA
    if (snd_device_name_hint(-1, "pcm", &hints) < 0)
       return;
 
-   ndevs = 0;
    for (n = hints; *n; n++)
    {
       ioid = snd_device_name_get_hint(*n, "IOID");
@@ -302,10 +310,10 @@ static void enumerate_audio_devices(char *s, size_t len)
          continue;
       }
 
-      if (ndevs > 0)
-         appendstr(s, "|", len);
+      /* "none" already occupies the first slot, so every enumerated
+       * device needs a leading separator. */
+      appendstr(s, "|", len);
       appendstr(s, name, len);
-      ++ndevs;
 
       /* Not sure if this is necessary
        * but ensuring things are free/NULL */
@@ -411,6 +419,102 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_input_state)(retro_input_state_t 
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_init)(void) { }
 
+#ifdef HAVE_ALSA
+static void close_audio_device(void);
+
+/* Open the ALSA capture device and configure it for 48kHz, 16-bit stereo.
+ * Returns 0 on success or the negative ALSA error code with the handle
+ * closed again, so a failure leaves no half-configured device behind. */
+static int open_audio_device(const char *device)
+{
+   snd_pcm_t *handle = NULL;
+   snd_pcm_hw_params_t *hw_params;
+   unsigned int rate;
+   int error;
+
+   /* Configure a local handle and publish it in audio_handle only when it is
+    * fully set up: RetroArch ignores SET_AUDIO_CALLBACK(NULL), so the async
+    * audio callback can still be registered and must never see the device
+    * mid-setup (its snd_pcm_recover() would start the stream and make
+    * snd_pcm_prepare() below fail with EBUSY). */
+   error = snd_pcm_open(&handle, device, SND_PCM_STREAM_CAPTURE, 0);
+   if (error < 0)
+   {
+      printf("Couldn't open %s: %s\n", device, snd_strerror(error));
+      return error;
+   }
+
+   error = snd_pcm_hw_params_malloc(&hw_params);
+   if (error)
+   {
+      printf("Couldn't allocate hw param structure: %s\n", snd_strerror(error));
+      snd_pcm_close(handle);
+      return error;
+   }
+   error = snd_pcm_hw_params_any(handle, hw_params);
+   if (error)
+   {
+      printf("Couldn't initialize hw param structure: %s\n", snd_strerror(error));
+      goto fail;
+   }
+   error = snd_pcm_hw_params_set_access(handle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED);
+   if (error)
+   {
+      printf("Couldn't set hw param access type: %s\n", snd_strerror(error));
+      goto fail;
+   }
+   error = snd_pcm_hw_params_set_format(handle, hw_params, SND_PCM_FORMAT_S16_LE);
+   if (error)
+   {
+      printf("Couldn't set hw param format to SND_PCM_FORMAT_S16_LE: %s\n", snd_strerror(error));
+      goto fail;
+   }
+   rate = AUDIO_SAMPLE_RATE;
+   error = snd_pcm_hw_params_set_rate_near(handle, hw_params, &rate, 0);
+   if (error)
+   {
+      printf("Couldn't set hw param sample rate to %u: %s\n", rate, snd_strerror(error));
+      goto fail;
+   }
+   if (rate != AUDIO_SAMPLE_RATE)
+   {
+      printf("Hardware doesn't support sample rate %u (returned %u)\n", AUDIO_SAMPLE_RATE, rate);
+      error = -EINVAL;
+      goto fail;
+   }
+   error = snd_pcm_hw_params_set_channels(handle, hw_params, 2);
+   if (error)
+   {
+      printf("Couldn't set hw param channels to 2: %s\n", snd_strerror(error));
+      goto fail;
+   }
+   error = snd_pcm_hw_params(handle, hw_params);
+   if (error)
+   {
+      printf("Couldn't set hw params: %s\n", snd_strerror(error));
+      goto fail;
+   }
+   snd_pcm_hw_params_free(hw_params);
+
+   error = snd_pcm_prepare(handle);
+   if (error)
+   {
+      printf("Couldn't prepare audio interface for use: %s\n", snd_strerror(error));
+      snd_pcm_close(handle);
+      return error;
+   }
+
+   audio_handle = handle;
+   printf("Using ALSA device %s for audio input\n", device);
+   return 0;
+
+fail:
+   snd_pcm_hw_params_free(hw_params);
+   snd_pcm_close(handle);
+   return error;
+}
+#endif
+
 static bool open_devices(void)
 {
    struct retro_variable videodev = { "videoproc_videodev", NULL };
@@ -423,15 +527,15 @@ static bool open_devices(void)
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &audiodev);
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &captureresolution);
 
-   if (strcmp(videodev.value, "dummy") == 0)
-      return true;
-
    /* Video device is required */
    if (videodev.value == NULL)
    {
       printf("v4l2_videodev not defined\n");
       return false;
    }
+
+   if (strcmp(videodev.value, "dummy") == 0)
+      return true;
 
    /* Open the V4L2 device */
    video_device_fd = v4l2_open(videodev.value, O_RDWR, 0);
@@ -447,6 +551,7 @@ static bool open_devices(void)
    {
       printf("VIDIOC_QUERYCAP failed: %s\n", strerror(errno));
       v4l2_close(video_device_fd);
+      video_device_fd = -1;
       return false;
    }
 
@@ -458,100 +563,135 @@ static bool open_devices(void)
          (caps.version >> 8) & 0xff, caps.version & 0xff);
 
 #ifdef HAVE_ALSA
-   if (audiodev.value)
+   /* Skip all audio setup when no capture device is selected. Treat both a
+    * missing variable and the explicit "none" option as "no audio".
+    * Also skip when audio_handle is already open: a video-only reconfigure
+    * (e.g. a resolution change) keeps the existing audio device alive so we
+    * don't close and immediately reopen the same ALSA device while its async
+    * capture callback is still running (which races and returns EBUSY).
+    *
+    * Audio is optional: failing to bring it up must not prevent video capture
+    * from starting. Reopening the device that was closed a moment ago (an
+    * audio device change) can still fail transiently with EBUSY while the
+    * frontend's audio thread winds down, so retry briefly before giving up. */
+   if (audio_handle == NULL && audiodev.value && strcmp(audiodev.value, "none") != 0)
    {
-      snd_pcm_hw_params_t *hw_params;
-      unsigned int rate;
-
-      /*
-       * Open the audio capture device and configure it for 44kHz, 16-bit stereo
-       */
-      error = snd_pcm_open(&audio_handle, audiodev.value, SND_PCM_STREAM_CAPTURE, 0);
-      if (error < 0)
+      int attempt;
+      error = -EBUSY;
+      for (attempt = 0; attempt < 5 && error == -EBUSY; attempt++)
       {
-         printf("Couldn't open %s: %s\n", audiodev.value, snd_strerror(error));
-         return false;
+         if (attempt > 0)
+            usleep(20000);
+         error = open_audio_device(audiodev.value);
       }
-
-      error = snd_pcm_hw_params_malloc(&hw_params);
-      if (error)
+      if (error != 0)
       {
-         printf("Couldn't allocate hw param structure: %s\n", snd_strerror(error));
-         return false;
+         /* Surface the problem in the frontend, too: a silent core with no
+          * on-screen hint is hard to diagnose from the menu. */
+         struct retro_message msg =
+               { "Audio capture device is busy - continuing without audio", 240 };
+         printf("Audio device %s could not be started (non-fatal), continuing without audio\n",
+               audiodev.value);
+         VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
       }
-      error = snd_pcm_hw_params_any(audio_handle, hw_params);
-      if (error)
-      {
-         printf("Couldn't initialize hw param structure: %s\n", snd_strerror(error));
-         return false;
-      }
-      error = snd_pcm_hw_params_set_access(audio_handle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED);
-      if (error)
-      {
-         printf("Couldn't set hw param access type: %s\n", snd_strerror(error));
-         return false;
-      }
-      error = snd_pcm_hw_params_set_format(audio_handle, hw_params, SND_PCM_FORMAT_S16_LE);
-      if (error)
-      {
-         printf("Couldn't set hw param format to SND_PCM_FORMAT_S16_LE: %s\n", snd_strerror(error));
-         return false;
-      }
-      rate = AUDIO_SAMPLE_RATE;
-      error = snd_pcm_hw_params_set_rate_near(audio_handle, hw_params, &rate, 0);
-      if (error)
-      {
-         printf("Couldn't set hw param sample rate to %u: %s\n", rate, snd_strerror(error));
-         return false;
-      }
-      if (rate != AUDIO_SAMPLE_RATE)
-      {
-         printf("Hardware doesn't support sample rate %u (returned %u)\n", AUDIO_SAMPLE_RATE, rate);
-         return false;
-      }
-      error = snd_pcm_hw_params_set_channels(audio_handle, hw_params, 2);
-      if (error)
-      {
-         printf("Couldn't set hw param channels to 2: %s\n", snd_strerror(error));
-         return false;
-      }
-      error = snd_pcm_hw_params(audio_handle, hw_params);
-      if (error)
-      {
-         printf("Couldn't set hw params: %s\n", snd_strerror(error));
-         return false;
-      }
-      snd_pcm_hw_params_free(hw_params);
-
-      error = snd_pcm_prepare(audio_handle);
-      if (error)
-      {
-         printf("Couldn't prepare audio interface for use: %s\n", snd_strerror(error));
-         return false;
-      }
-
-      printf("Using ALSA device %s for audio input\n", audiodev.value);
    }
 #endif
 
    return true;
 }
 
-static void close_devices(void)
+static void unload_game_internal(bool keep_audio);
+
+/* Stop the frontend from invoking audio_callback before the ALSA handle is
+ * closed; otherwise the async callback races snd_pcm_close() and can read
+ * from a freed handle. */
+static void unregister_audio_callback(void)
 {
 #ifdef HAVE_ALSA
-   if (audio_handle)
+   if (audio_handle != NULL)
+      VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK, NULL);
+#endif
+}
+
+static void close_audio_device(void)
+{
+#ifdef HAVE_ALSA
+   snd_pcm_t *handle = audio_handle;
+   if (handle)
    {
-      snd_pcm_close(audio_handle);
+      /* Unpublish the handle first: RetroArch ignores
+       * SET_AUDIO_CALLBACK(NULL), so the async audio callback may still be
+       * registered. New invocations then see NULL; give an in-flight
+       * snd_pcm_readi() (64 frames, ~1.3ms) a moment to drain before the
+       * handle is closed underneath it. */
       audio_handle = NULL;
+      usleep(5000);
+      snd_pcm_close(handle);
    }
 #endif
+}
 
+static void close_video_device(void)
+{
    if (video_device_fd != -1)
    {
       v4l2_close(video_device_fd);
       video_device_fd = -1;
    }
+}
+
+static void close_devices(void)
+{
+   close_audio_device();
+   close_video_device();
+}
+
+/* Unmap all capture buffers mapped so far and forget them. Leaked mappings
+ * keep the V4L2 device busy even after its fd is closed, which makes every
+ * later VIDIOC_S_FMT on it fail with EBUSY. */
+static void release_video_buffers(void)
+{
+   size_t i;
+   for (i = 0; i < v4l2_ncapbuf; i++)
+      if (v4l2_capbuf[i].start && v4l2_capbuf[i].start != MAP_FAILED)
+         v4l2_munmap(v4l2_capbuf[i].start, v4l2_capbuf[i].len);
+   memset(v4l2_capbuf, 0, sizeof(v4l2_capbuf));
+   v4l2_ncapbuf = 0;
+}
+
+/* Configure the built-in test pattern source. Also used as the fallback when
+ * the configured capture device cannot be started, so the core still runs
+ * and the device option remains editable from the menu. */
+static void setup_dummy_source(void)
+{
+   if (strcmp(video_capture_mode, "interlaced") == 0)
+   {
+       video_format.fmt.pix.height = 480;
+       video_cap_height            = 480;
+       video_buf.field             = V4L2_FIELD_INTERLACED;
+   }
+   else if (     strcmp(video_capture_mode, "alternate") == 0
+              || strcmp(video_capture_mode, "top") == 0
+              || strcmp(video_capture_mode, "bottom") == 0
+              || strcmp(video_capture_mode, "alternate_hack") == 0)
+   {
+       video_format.fmt.pix.height = 240;
+       video_cap_height            = 240;
+       video_buf.field             = V4L2_FIELD_TOP;
+   }
+   else
+   {
+       /* "deinterlaced": full frames. Without this branch the height stayed
+        * 0 (or stale from a previous device) and the zero-height geometry
+        * reported to the frontend crashed its video driver. */
+       video_format.fmt.pix.height = 480;
+       video_cap_height            = 480;
+       video_buf.field             = V4L2_FIELD_NONE;
+   }
+
+   dummy_pos                  = 0;
+   video_format.fmt.pix.width = 640;
+   video_cap_width            = 640;
 }
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_deinit)(void)
@@ -575,17 +715,12 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_info)(struct retro_system_
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_system_av_info *info)
 {
-   struct retro_variable videodev = { "videoproc_videodev", NULL };
-   struct retro_variable capture_resolution = { "videoproc_capture_resolution", NULL };
    struct v4l2_cropcap cc;
    int error;
-   char splitresolution[ENVVAR_BUFLEN];
-   char* token;
 
-   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
-   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capture_resolution);
-
-   if (strcmp(videodev.value, "dummy") == 0)
+   /* Judge by the device that is actually running, not the option value:
+    * retro_load_game may have fallen back to the dummy source. */
+   if (video_device[0] == '\0' || strcmp(video_device, "dummy") == 0)
    {
       info->geometry.aspect_ratio = 4.0/3.0;
       info->geometry.base_width   = info->geometry.max_width = video_cap_width;
@@ -604,24 +739,13 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_syst
       cc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
       error = v4l2_ioctl(video_device_fd, VIDIOC_CROPCAP, &cc);
 
+      /* video_format already holds the resolution the driver granted in
+       * retro_load_game (clamped to a supported mode). Report that directly;
+       * re-parsing the requested option string here would overwrite it with a
+       * size the hardware may have rejected and desync the buffers. */
       info->geometry.base_width  = info->geometry.max_width = video_format.fmt.pix.width;
       info->geometry.base_height = video_format.fmt.pix.height;
 
-      if(capture_resolution.value != NULL)
-         strlcpy(video_capture_resolution, capture_resolution.value, sizeof(video_capture_resolution));
-      else
-         strlcpy(video_capture_resolution, "auto", sizeof(video_capture_resolution));
-
-      if (strcmp(video_capture_resolution, "auto") != 0)
-      {
-         strlcpy(splitresolution, video_capture_resolution, sizeof(splitresolution));
-         token = strtok(splitresolution, "x");
-         info->geometry.base_width  = info->geometry.max_width = video_format.fmt.pix.width = atoi(token);
-         token = strtok(NULL, "x");
-         info->geometry.base_height = video_format.fmt.pix.height = atoi(token);
-         printf("Resolution postfix %ux%u\n", info->geometry.base_width,
-                info->geometry.base_height);
-      }
       /* no doubling for interlaced or deinterlaced capture */
       nodouble = strcmp(video_capture_mode, "deinterlaced") == 0 || strcmp(video_capture_mode, "interlaced") == 0;
       info->geometry.max_height = nodouble ? video_format.fmt.pix.height : video_format.fmt.pix.height * 2;
@@ -755,6 +879,15 @@ void source_dummy(int width, int height)
       video_buf.field = V4L2_FIELD_TOP;
 }
 
+/* frame_cap is allocated as video_cap_width * video_cap_height * 3 bytes.
+ * Copy no more than that, and never read past the captured buffer. */
+static void copy_frame_cap(const struct v4l2_capbuf *capbuf)
+{
+   size_t copy_size = MIN((size_t)video_cap_width * video_cap_height * 3,
+         capbuf->len);
+   memcpy(frame_cap, capbuf->start, copy_size);
+}
+
 void source_v4l2_normal(int width, int height)
 {
    struct v4l2_buffer bufcp;
@@ -774,7 +907,7 @@ void source_v4l2_normal(int width, int height)
    }
 
    bufcp = video_buf;
-   memcpy( (uint32_t*) frame_cap, (uint8_t*) v4l2_capbuf[video_buf.index].start, video_format.fmt.pix.width * video_format.fmt.pix.height * 3);
+   copy_frame_cap(&v4l2_capbuf[video_buf.index]);
 
    error = v4l2_ioctl(video_device_fd, VIDIOC_QBUF, &video_buf);
    if (error != 0)
@@ -819,9 +952,7 @@ void source_v4l2_alternate_hack(int width, int height)
 
    /* Let's get the data as fast as possible! */
    bufcp = video_buf;
-   memcpy( (uint32_t*) frame_cap,
-         (uint8_t*)v4l2_capbuf[video_buf.index].start,
-         video_format.fmt.pix.width * video_format.fmt.pix.height * 3);
+   copy_frame_cap(&v4l2_capbuf[video_buf.index]);
 
    v4l2_munmap(v4l2_capbuf[0].start, v4l2_capbuf[0].len);
 
@@ -1028,23 +1159,53 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
 
    if (VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    {
+      bool video_changed, audio_changed;
+
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &audiodev);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capturemode);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &captureresolution);
+      VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &outputmode);
       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &frametimes);
       /* Video or Audio device(s) has(ve) been changed
        * TODO We may get away without resetting devices when changing output mode...
        */
-      if ((videodev.value    && (strcmp(video_device, videodev.value) != 0)) ||\
-          (audiodev.value    && (strcmp(audio_device, audiodev.value) != 0)) ||\
-          (capturemode.value && (strcmp(video_capture_mode, capturemode.value) != 0)) ||\
-          (captureresolution.value && (strcmp(video_capture_resolution, captureresolution.value) != 0)) ||\
-          (outputmode.value  && (strcmp(video_output_mode,  outputmode.value)  != 0)))
+      video_changed = (videodev.value    && (strcmp(video_device, videodev.value) != 0)) ||
+          (capturemode.value && (strcmp(video_capture_mode, capturemode.value) != 0)) ||
+          (captureresolution.value && (strcmp(video_capture_resolution, captureresolution.value) != 0)) ||
+          (outputmode.value  && (strcmp(video_output_mode,  outputmode.value)  != 0));
+      audio_changed = (audiodev.value && (strcmp(audio_device, audiodev.value) != 0));
+
+      if (video_changed || audio_changed)
       {
-          VIDEOPROC_CORE_PREFIX(retro_unload_game)();
+          /* Keep the audio device alive across a video-only reconfigure so the
+           * running ALSA capture isn't torn down and reopened (which races its
+           * async callback and fails with EBUSY). Switching to the dummy device
+           * stops audio capture, so tear it down in that case. */
+          bool keep_audio = !audio_changed && (audio_device[0] != '\0')
+                && videodev.value && (strcmp(videodev.value, "dummy") != 0);
+          unload_game_internal(keep_audio);
           /* This core does not cares for the retro_game_info * argument? */
-          VIDEOPROC_CORE_PREFIX(retro_load_game)(NULL);
+          device_reloading = true;
+          if (!VIDEOPROC_CORE_PREFIX(retro_load_game)(NULL))
+          {
+             /* Reload failed: the buffers we just freed are gone. Output a
+              * blank frame and stay idle rather than dereferencing them; the
+              * user can pick a working configuration to retry. */
+             device_reloading = false;
+             VIDEOPROC_CORE_PREFIX(video_refresh_cb)(NULL, 0, 0, 0);
+             return;
+          }
+          device_reloading = false;
+          /* The device may have granted a different geometry or frame rate
+           * than the previous configuration; push the new av_info so the
+           * frontend adjusts its buffers and pacing (required whenever the
+           * max geometry can grow). */
+          {
+             struct retro_system_av_info av_info;
+             VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(&av_info);
+             VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
+          }
       }
 
       if (frametimes.value != NULL)
@@ -1052,6 +1213,14 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
    }
 
    VIDEOPROC_CORE_PREFIX(input_poll_cb)();
+
+   /* No frame buffers means a previous (re)load left the core without a usable
+    * device. Stay idle instead of dereferencing NULL buffers. */
+   if (frame_cap == NULL || frame_out == NULL)
+   {
+      VIDEOPROC_CORE_PREFIX(video_refresh_cb)(NULL, 0, 0, 0);
+      return;
+   }
 
    /* printf("%d %d %d %s\n", video_cap_width, video_cap_height, video_buf.field, video_output_mode);
     * TODO pass frame_curr to source_* functions
@@ -1087,8 +1256,13 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
    /* Converts from bgr to xrgb, deinterlacing, final copy to the outpuit buffer (frame_out)
     * Every frame except frame_cap shall be encoded in xrgb
     * Every frame except frame_out shall have the same height
-    */
-   if (strcmp(video_output_mode, "deinterlaced") == 0)
+    *
+    * "deinterlaced" capture already delivers full frames, so there is nothing
+    * to deinterlace: route it through the plain conversion below. Running the
+    * deinterlacer on it would write twice the capture height into frame_out,
+    * which is only video_out_height (== video_cap_height) rows tall. */
+   if (   strcmp(video_output_mode, "deinterlaced") == 0
+       && strcmp(video_capture_mode, "deinterlaced") != 0)
    {
       processing_bgr_xrgb(frame_cap, frame_curr, video_cap_width, video_cap_height);
       /* When deinterlacing a interlaced input, we need to process both fields of a frame,
@@ -1192,18 +1366,24 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    uint32_t index;
    bool std_found;
    int error;
-   char splitresolution[ENVVAR_BUFLEN];
-   char* token;
+#ifdef HAVE_ALSA
+   bool had_audio = (audio_handle != NULL);
+#endif
 
    if (open_devices() == false)
    {
       printf("Couldn't open capture device\n");
+      unregister_audio_callback();
       close_devices();
-      return false;
+      goto device_fallback;
    }
 
 #ifdef HAVE_ALSA
-   if (audio_handle != NULL)
+   /* Only (re)register the async audio callback when the audio device was
+    * freshly opened. On a video-only reconfigure the device (and its already
+    * registered callback) is kept alive, so re-registering would needlessly
+    * restart it. */
+   if (!had_audio && audio_handle != NULL)
    {
        struct retro_audio_callback audio_cb;
        audio_cb.callback = audio_callback;
@@ -1214,10 +1394,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
 
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
    if (videodev.value == NULL)
-   {
-       close_devices();
-       return false;
-   }
+      goto error;
    strlcpy(video_device, videodev.value, sizeof(video_device));
 
    /* Audio device is optional... */
@@ -1234,10 +1411,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &capture_mode);
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &output_mode);
    if (capture_mode.value == NULL || output_mode.value == NULL)
-   {
-       close_devices();
-       return false;
-   }
+      goto error;
    strlcpy(video_capture_mode, capture_mode.value, sizeof(video_capture_mode));
    strlcpy(video_output_mode,  output_mode.value,  sizeof(video_output_mode));
 
@@ -1245,28 +1419,12 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    if (frame_times.value != NULL)
       strlcpy(video_frame_times, frame_times.value, sizeof(video_frame_times));
 
-   if (strcmp(video_device, "dummy") == 0)
-   {
-      if (strcmp(video_capture_mode, "interlaced") == 0)
-      {
-          video_format.fmt.pix.height = 480;
-          video_cap_height            = 480;
-          video_buf.field             = V4L2_FIELD_INTERLACED;
-      }
-      else if (     strcmp(video_capture_mode, "alternate") == 0
-                 || strcmp(video_capture_mode, "top") == 0
-                 || strcmp(video_capture_mode, "bottom") == 0
-                 || strcmp(video_capture_mode, "alternate_hack") == 0)
-      {
-          video_format.fmt.pix.height = 240;
-          video_cap_height            = 240;
-          video_buf.field             = V4L2_FIELD_TOP;
-      }
+   /* Reset per-device timing state so nothing leaks from a previously
+    * loaded device into av_info/retro_get_region. */
+   memset(&video_standard, 0, sizeof(video_standard));
 
-      dummy_pos                  = 0;
-      video_format.fmt.pix.width = 640;
-      video_cap_width            = 640;
-   }
+   if (strcmp(video_device, "dummy") == 0)
+      setup_dummy_source();
    else
    {
       memset(&fmt, 0, sizeof(fmt));
@@ -1277,75 +1435,94 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
       if (error != 0)
       {
          printf("VIDIOC_G_FMT failed: %s\n", strerror(errno));
-         return false;
+         goto device_fallback;
       }
 
       fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_BGR24;
-      fmt.fmt.pix.colorspace = V4L2_COLORSPACE_REC709;
       fmt.fmt.pix.colorspace = V4L2_COLORSPACE_SRGB;
       fmt.fmt.pix.quantization = V4L2_QUANTIZATION_LIM_RANGE;
 
       /* Applied set resolution if not set to auto */
       if (strcmp(video_capture_resolution, "auto") != 0)
       {
-         strlcpy(splitresolution, video_capture_resolution, sizeof(splitresolution));
-         token = strtok(splitresolution, "x");
-         fmt.fmt.pix.width = atoi(token);
-         token = strtok(NULL, "x");
-         fmt.fmt.pix.height = atoi(token);
+         unsigned width, height;
+         if (   sscanf(video_capture_resolution, "%ux%u", &width, &height) == 2
+             && width != 0 && height != 0)
+         {
+            fmt.fmt.pix.width  = width;
+            fmt.fmt.pix.height = height;
+         }
+         else
+            printf("Invalid capture resolution \"%s\", using device default\n",
+                  video_capture_resolution);
       }
-      fmt.fmt.pix.field = V4L2_FIELD_TOP;
+      fmt.fmt.pix.field   = V4L2_FIELD_TOP;
+      v4l2_ncapbuf_target = 2;
       /* TODO Query the size and FPS */
       if (strcmp(video_capture_mode, "interlaced") == 0)
+         fmt.fmt.pix.field = V4L2_FIELD_INTERLACED;
+      else if (strcmp(video_capture_mode, "alternate") == 0)
+         fmt.fmt.pix.field = V4L2_FIELD_ALTERNATE;
+      else if (strcmp(video_capture_mode, "top") == 0)
+         fmt.fmt.pix.field = V4L2_FIELD_TOP;
+      else if (strcmp(video_capture_mode, "bottom") == 0)
+         fmt.fmt.pix.field = V4L2_FIELD_BOTTOM;
+      else if (strcmp(video_capture_mode, "alternate_hack") == 0)
       {
-         v4l2_ncapbuf_target         = 2;
-         fmt.fmt.pix.field           = V4L2_FIELD_INTERLACED;
-         video_format.fmt.pix.height = fmt.fmt.pix.height;
-         video_cap_height            = fmt.fmt.pix.height;
+         fmt.fmt.pix.field   = V4L2_FIELD_TOP;
+         v4l2_ncapbuf_target = 1;
       }
-      else
-      {
-         v4l2_ncapbuf_target         = 2;
-         video_format.fmt.pix.height = fmt.fmt.pix.height/2;
-         video_cap_height            = fmt.fmt.pix.height/2;
-         if (strcmp(video_capture_mode, "deinterlaced") == 0)
-         {
-            v4l2_ncapbuf_target         = 2;
-            video_format.fmt.pix.height = fmt.fmt.pix.height;
-            video_cap_height            = fmt.fmt.pix.height;
-         } else if (strcmp(video_capture_mode, "alternate") == 0)
-            fmt.fmt.pix.field = V4L2_FIELD_ALTERNATE;
-         else if (strcmp(video_capture_mode, "top") == 0)
-            fmt.fmt.pix.field = V4L2_FIELD_TOP;
-         else if (strcmp(video_capture_mode, "bottom") == 0)
-            fmt.fmt.pix.field = V4L2_FIELD_BOTTOM;
-         else if (strcmp(video_capture_mode, "alternate_hack") == 0)
-         {
-            fmt.fmt.pix.field   = V4L2_FIELD_TOP;
-            v4l2_ncapbuf_target = 1;
-         }
-      }
-
-      video_cap_width = fmt.fmt.pix.width;
 
       error = v4l2_ioctl(video_device_fd, VIDIOC_S_FMT, &fmt);
       if (error != 0)
       {
          printf("VIDIOC_S_FMT failed: %s\n", strerror(errno));
-         return false;
+         goto device_fallback;
       }
 
-      /* skipping this for (magewell usb) since the std ioctl gives errors
-       * unsure if this will impact other cards
-       */
-      if(strcmp((const char*)caps.driver, "uvcvideo")  != 0)
+      /* S_FMT does not fail on an unsupported resolution: the driver silently
+       * clamps width/height (and may even change the pixelformat) to the
+       * nearest mode it supports and returns success. Derive every buffer
+       * dimension from the *granted* fmt, never from what we requested, so the
+       * conversion buffer (video_cap_width * video_cap_height * 3) and the
+       * source_v4l2_* memcpy always match the V4L2 buffer the driver actually
+       * allocated (otherwise: heap overflow / crash, see issue #16457). */
+      video_cap_width = fmt.fmt.pix.width;
+      switch (fmt.fmt.pix.field)
       {
-         error = v4l2_ioctl(video_device_fd, VIDIOC_G_STD, &std_id);
-         if (error != 0)
-         {
-            printf("VIDIOC_G_STD failed: %s\n", strerror(errno));
-            return false;
-         }
+         case V4L2_FIELD_TOP:
+         case V4L2_FIELD_BOTTOM:
+         case V4L2_FIELD_ALTERNATE:
+            /* The driver granted a per-field format: pix.height is already
+             * the height of a single field. */
+            video_cap_height = fmt.fmt.pix.height;
+            break;
+         default:
+            /* The driver delivers whole frames; in the field-based capture
+             * modes only one half-height field of each frame is consumed. */
+            if (   strcmp(video_capture_mode, "interlaced")   == 0
+                || strcmp(video_capture_mode, "deinterlaced") == 0)
+               video_cap_height = fmt.fmt.pix.height;
+            else
+               video_cap_height = fmt.fmt.pix.height / 2;
+            break;
+      }
+
+      /* Query the analog TV standard (PAL/NTSC) for the frame rate. Modern
+       * HDMI/USB capture devices generally don't implement analog standards,
+       * so any failure here is non-fatal: fall back to the default timing in
+       * retro_get_system_av_info. */
+      error = v4l2_ioctl(video_device_fd, VIDIOC_G_STD, &std_id);
+      if (error != 0)
+      {
+         if (errno == ENOTTY)
+            printf("Analog TV standards not supported by this device"
+                  " (normal for HDMI/USB capture)\n");
+         else
+            printf("VIDIOC_G_STD failed (non-fatal): %s\n", strerror(errno));
+      }
+      else
+      {
          for (index = 0, std_found = false; ; index++)
          {
             memset(&std, 0, sizeof(std));
@@ -1361,12 +1538,17 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
             printf("VIDIOC_ENUMSTD[%u]: %s%s\n", index, std.name, std.id == std_id ? " [*]" : "");
          }
          if (!std_found)
-         {
-            printf("VIDIOC_ENUMSTD did not contain std ID %08x\n", (unsigned)std_id);
-            return false;
-         }
+            printf("VIDIOC_ENUMSTD did not contain std ID %08x (non-fatal)\n", (unsigned)std_id);
       }
       video_format = fmt;
+      /* fmt still holds the device's full frame height, but for the
+       * non-"interlaced"/non-"deinterlaced" capture modes we only copy a
+       * half-height field into frame_cap (video_cap_height). Keep
+       * video_format in sync with the buffer that is actually allocated
+       * (video_cap_width * video_cap_height * 3) to avoid a heap overflow
+       * in the source_v4l2_* memcpy (see issue #16457). */
+      video_format.fmt.pix.width  = video_cap_width;
+      video_format.fmt.pix.height = video_cap_height;
       /* TODO Check if what we got is indeed what we asked for */
 
       memset(&reqbufs, 0, sizeof(reqbufs));
@@ -1378,10 +1560,14 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
       if (error != 0)
       {
          printf("VIDIOC_REQBUFS failed: %s\n", strerror(errno));
-         return false;
+         goto device_fallback;
       }
       v4l2_ncapbuf = reqbufs.count;
       printf("GOT v4l2_ncapbuf=%" PRI_SIZET "\n", v4l2_ncapbuf);
+
+      /* Forget any previous session's pointers before the mmap loop so a
+       * mid-loop failure never releases stale mappings. */
+      memset(v4l2_capbuf, 0, sizeof(v4l2_capbuf));
 
       for (index = 0; index < v4l2_ncapbuf; index++)
       {
@@ -1394,7 +1580,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
          if (error != 0)
          {
             printf("VIDIOC_QUERYBUF failed for %u: %s\n", index, strerror(errno));
-            return false;
+            goto device_fallback;
          }
 
          v4l2_capbuf[index].len   = buf.length;
@@ -1403,7 +1589,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
          if (v4l2_capbuf[index].start == MAP_FAILED)
          {
             printf("v4l2_mmap failed: %s\n", strerror(errno));
-            return false;
+            goto device_fallback;
          }
       }
 
@@ -1419,7 +1605,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
          {
             printf("VIDIOC_QBUF failed for %u: %s\n", index,
                   strerror(errno));
-            return false;
+            goto device_fallback;
          }
       }
 
@@ -1428,10 +1614,20 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
       if (error != 0)
       {
          printf("VIDIOC_STREAMON failed: %s\n", strerror(errno));
-         return false;
+         goto device_fallback;
       }
 
       /* videoinput_set_control_v4l2(V4L2_CID_HUE, (double) 0.4f); */
+   }
+
+device_ready:
+   /* Never report or allocate zero-sized frames: a zero-height geometry
+    * passed on to the frontend crashes its video driver (GPU fault). */
+   if (video_cap_width == 0 || video_cap_height == 0)
+   {
+      printf("Invalid capture dimensions %ux%u\n",
+            video_cap_width, video_cap_height);
+      goto error;
    }
 
    /* TODO/FIXME Framerates?
@@ -1447,7 +1643,10 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
          printf("WARNING: Capture mode %s with output mode %s is not"
                " properly supported yet... (Is this even useful?)\n", \
                  video_capture_mode, video_output_mode);
-         video_out_height = video_cap_height*2;
+         /* Pass the frames through at capture height: the conversion reads
+          * from frame_cap, which only holds video_cap_height rows (doubling
+          * here made it read past the end of the conversion buffer). */
+         video_out_height = video_cap_height;
       }
       /* Each frame has one field, full frame-rate */
    }
@@ -1483,7 +1682,7 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
 
    /* TODO: Check frames[] allocation */
    if (!frame_out || !frame_cap)
-      return false;
+      goto error;
 
    printf("Allocated %" PRI_SIZET " byte conversion buffer\n",
          (size_t)(video_cap_width * video_cap_height) * sizeof(uint32_t));
@@ -1492,19 +1691,59 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
    if (!VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &pixel_format))
    {
       printf("Cannot set pixel format\n");
-      return false;
+      goto error;
    }
 
    return true;
+
+device_fallback:
+   /* While the core is already running, a failed reconfigure is survivable
+    * (blank frames, options stay editable), so treat it as a plain error and
+    * let the user retry. Only on the *initial* load fall back to the built-in
+    * test pattern: the device choice is persisted, and a broken one would
+    * otherwise prevent the core from ever starting again. */
+   if (device_reloading)
+      goto error;
+   printf("Capture device could not be started, falling back to the dummy video source\n");
+   {
+      struct retro_message msg =
+            { "Capture device could not be started - showing the test pattern", 240 };
+      VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
+   }
+   release_video_buffers();
+   close_video_device();
+   strlcpy(video_device, "dummy", sizeof(video_device));
+   setup_dummy_source();
+   {
+      /* Reflect the fallback in the core option so the menu shows what is
+       * actually running. */
+      struct retro_variable var;
+      var.key   = "videoproc_videodev";
+      var.value = "dummy";
+      VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLE, &var);
+   }
+   goto device_ready;
+
+error:
+   /* Leave no stale state behind: a later option change runs
+    * unload_game_internal() again, which must not munmap old buffer
+    * pointers or touch a dead ALSA handle. */
+   unregister_audio_callback();
+   release_video_buffers();
+   close_devices();
+   return false;
 }
 
-RETRO_API void VIDEOPROC_CORE_PREFIX(retro_unload_game)(void)
+/* keep_audio leaves the audio device, its async callback and audio_device[]
+ * untouched. Used for a video-only reconfigure (resolution/capture mode/output
+ * mode change) so the running ALSA capture isn't bounced; see open_devices(). */
+static void unload_game_internal(bool keep_audio)
 {
    int i;
    struct v4l2_requestbuffers reqbufs;
 
 #ifdef HAVE_ALSA
-   if (audio_handle != NULL)
+   if (!keep_audio && audio_handle != NULL)
    {
        VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK, NULL);
    }
@@ -1512,15 +1751,13 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_unload_game)(void)
 
    if ((strcmp(video_device, "dummy") != 0) && (video_device_fd != -1))
    {
-      uint32_t index;
       enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
       int               error = v4l2_ioctl(video_device_fd,
             VIDIOC_STREAMOFF, &type);
       if (error != 0)
          printf("VIDIOC_STREAMOFF failed: %s\n", strerror(errno));
 
-      for (index = 0; index < v4l2_ncapbuf; index++)
-         v4l2_munmap(v4l2_capbuf[index].start, v4l2_capbuf[index].len);
+      release_video_buffers();
 
       reqbufs.count = 0;
       reqbufs.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -1562,9 +1799,18 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_unload_game)(void)
       ft_info2 = NULL;
    }
 
-   close_devices();
+   close_video_device();
    video_device[0] = '\0';
-   audio_device[0] = '\0';
+   if (!keep_audio)
+   {
+      close_audio_device();
+      audio_device[0] = '\0';
+   }
+}
+
+RETRO_API void VIDEOPROC_CORE_PREFIX(retro_unload_game)(void)
+{
+   unload_game_internal(false);
 }
 
 RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game_special)(unsigned game_type,

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2016 Jared McNeill <jmcneill@invisible.ca>
+ * Copyright (c) 2026 Xitee <59659167+Xitee1@users.noreply.github.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -58,6 +59,7 @@
 
 #ifdef HAVE_ALSA
 #include <alsa/asoundlib.h>
+#include <pthread.h>
 #endif
 
 #ifdef HAVE_UDEV
@@ -129,11 +131,6 @@ struct v4l2_capability caps;
 
 static float   dummy_pos=0;
 
-/* True while retro_run() reloads the core after an option change: a failing
- * device is survivable then (blank frames, options stay editable), so
- * retro_load_game must not fall back to the dummy source. */
-static bool device_reloading;
-
 static int      video_half_feed_rate=0; /* for interlaced captures */
 static uint32_t video_cap_width;
 static uint32_t video_cap_height;
@@ -163,6 +160,10 @@ int ft_fcount;
  */
 #ifdef HAVE_ALSA
 static snd_pcm_t *audio_handle;
+/* Serializes audio_handle access between the frontend's async audio
+ * callback (which runs on the frontend's audio thread) and the main-thread
+ * (re)configuration paths; see close_audio_device(). */
+static pthread_mutex_t audio_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 /*
@@ -179,16 +180,30 @@ static retro_input_state_t VIDEOPROC_CORE_PREFIX(input_state_cb);
 static void audio_callback(void)
 {
    int16_t audio_data[128];
+   int frames  = -1;
+   bool opened = false;
 
+   pthread_mutex_lock(&audio_lock);
    if (audio_handle)
    {
-      const int frames = snd_pcm_readi(audio_handle,
+      opened = true;
+      frames = snd_pcm_readi(audio_handle,
             audio_data, sizeof(audio_data) / 4);
 
       if (frames < 0)
          snd_pcm_recover(audio_handle, frames, true);
-      else
-         VIDEOPROC_CORE_PREFIX(audio_sample_batch_cb)(audio_data, frames);
+   }
+   pthread_mutex_unlock(&audio_lock);
+
+   if (frames >= 0)
+      VIDEOPROC_CORE_PREFIX(audio_sample_batch_cb)(audio_data, frames);
+   else if (!opened)
+   {
+      /* No capture device: the frontend's audio thread paces itself on this
+       * callback blocking in snd_pcm_readi(), and it cannot be unregistered
+       * (SET_AUDIO_CALLBACK(NULL) is ignored). Sleep briefly so the thread
+       * doesn't spin at 100% CPU while audio capture is off. */
+      usleep(10000);
    }
 }
 
@@ -303,6 +318,7 @@ static void enumerate_audio_devices(char *s, size_t len)
       name = snd_device_name_get_hint(*n, "NAME");
       if (name == NULL || strstr(name, "front:") == NULL)
       {
+         free(ioid);
          free(name);
          name = NULL;
          continue;
@@ -313,8 +329,8 @@ static void enumerate_audio_devices(char *s, size_t len)
       descr = snd_device_name_get_hint(*n, "DESC");
       if (!descr)
       {
-         free(descr);
-         descr = NULL;
+         free(ioid);
+         free(name);
          continue;
       }
 
@@ -459,6 +475,10 @@ static void list_resolutions(char *capture_resolutions, size_t len,
 
    for (token = strtok(devices, "|"); token != NULL; token = strtok(NULL, "|"))
    {
+      /* The menu label ends in "; ", so the first token carries a leading
+       * space — trim it or the first device is never matched. */
+      while (*token == ' ')
+         token++;
       if (!string_starts_with(token, "/dev/video"))
          continue;
       count = probe_resolutions(token, probed, count, ARRAY_SIZE(probed));
@@ -491,6 +511,10 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    char video_devices[ENVVAR_BUFLEN];
    char audio_devices[ENVVAR_BUFLEN];
    static char capture_resolutions[ENVVAR_BUFLEN];
+   /* Device selection the resolution list was probed from; statics survive
+    * core restarts when the core is statically linked into the frontend, so
+    * an empty-buffer check alone would never refresh the list. */
+   static char probed_for[ENVVAR_BUFLEN];
    struct retro_variable videodev = { "videoproc_videodev", NULL };
    struct retro_variable envvars[] = {
       { "videoproc_videodev", NULL },
@@ -519,11 +543,21 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    envvars[0].value = video_devices;
    envvars[1].key   = "videoproc_audiodev";
    envvars[1].value = audio_devices;
+   envvars[3].key   = "videoproc_capture_resolution";
+   envvars[3].value = capture_resolutions;
 
-   /* Register the options once before the resolution list is known: this
-    * seeds the frontend with the saved values, and a variable can only be
-    * resolved after it has been registered with its value list — so the
-    * saved device selection only becomes queryable now. */
+   /* Register the options once before the probed resolution list is known:
+    * this seeds the frontend with the saved values, and a variable can only
+    * be resolved after it has been registered with its value list — so the
+    * saved device selection only becomes queryable now. Values must not be
+    * NULL (only the {NULL, NULL} entry terminates the array), so seed the
+    * resolution list with the built-in table; it is rebuilt from the actual
+    * device below. */
+   if (capture_resolutions[0] == '\0')
+   {
+      list_resolutions(capture_resolutions, sizeof(capture_resolutions), "");
+      appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
+   }
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
 
@@ -531,19 +565,20 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
     * than offering a fixed table the hardware may not honour. Probe only the
     * selected device when it is known, so the option list reflects what that
     * device actually supports; on a fresh configuration (no device selected
-    * yet) probe every enumerated device. Probing opens the device(s), so do
-    * it only once and reuse the list on subsequent calls; restart the core
-    * after switching devices to refresh it. */
-   if (capture_resolutions[0] == '\0')
+    * yet) probe every enumerated device. Probing opens the device(s), so
+    * cache the list and rebuild it only when the probed selection changes
+    * (i.e. on the first core start after switching devices). */
    {
       const char *probe_target =
             (videodev.value && string_starts_with(videodev.value, "/dev/video"))
             ? videodev.value : video_devices;
-      list_resolutions(capture_resolutions, sizeof(capture_resolutions), probe_target);
-      appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
+      if (strcmp(probed_for, probe_target) != 0)
+      {
+         list_resolutions(capture_resolutions, sizeof(capture_resolutions), probe_target);
+         appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
+         strlcpy(probed_for, probe_target, sizeof(probed_for));
+      }
    }
-   envvars[3].key   = "videoproc_capture_resolution";
-   envvars[3].value = capture_resolutions;
    printf("captures: %s\n", envvars[3].value);
 
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
@@ -661,7 +696,9 @@ static int open_audio_device(const char *device)
       return error;
    }
 
+   pthread_mutex_lock(&audio_lock);
    audio_handle = handle;
+   pthread_mutex_unlock(&audio_lock);
    printf("Using ALSA device %s for audio input\n", device);
    return 0;
 
@@ -669,6 +706,36 @@ fail:
    snd_pcm_hw_params_free(hw_params);
    snd_pcm_close(handle);
    return error;
+}
+
+/* Open the ALSA device with a brief retry (reopening a device that was
+ * closed a moment ago can fail transiently with EBUSY while the frontend's
+ * audio thread winds down). Audio is optional: on failure, tell the user on
+ * screen and continue without audio. Returns true when capturing. */
+static bool start_audio_capture(const char *device)
+{
+   int attempt;
+   int error = -EBUSY;
+
+   for (attempt = 0; attempt < 5 && error == -EBUSY; attempt++)
+   {
+      if (attempt > 0)
+         usleep(20000);
+      error = open_audio_device(device);
+   }
+   if (error != 0)
+   {
+      /* Surface the problem in the frontend, too: a silent core with no
+       * on-screen hint is hard to diagnose from the menu. The specific
+       * reason is printed to the terminal by open_audio_device(). */
+      struct retro_message msg =
+            { "Audio capture could not be started - continuing without audio", 240 };
+      printf("Audio device %s could not be started (non-fatal), continuing without audio\n",
+            device);
+      VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
+      return false;
+   }
+   return true;
 }
 #endif
 
@@ -728,36 +795,16 @@ static bool open_devices(void)
     * capture callback is still running (which races and returns EBUSY).
     *
     * Audio is optional: failing to bring it up must not prevent video capture
-    * from starting. Reopening the device that was closed a moment ago (an
-    * audio device change) can still fail transiently with EBUSY while the
-    * frontend's audio thread winds down, so retry briefly before giving up. */
+    * from starting. */
    if (audio_handle == NULL && audiodev.value && strcmp(audiodev.value, "none") != 0)
-   {
-      int attempt;
-      error = -EBUSY;
-      for (attempt = 0; attempt < 5 && error == -EBUSY; attempt++)
-      {
-         if (attempt > 0)
-            usleep(20000);
-         error = open_audio_device(audiodev.value);
-      }
-      if (error != 0)
-      {
-         /* Surface the problem in the frontend, too: a silent core with no
-          * on-screen hint is hard to diagnose from the menu. */
-         struct retro_message msg =
-               { "Audio capture device is busy - continuing without audio", 240 };
-         printf("Audio device %s could not be started (non-fatal), continuing without audio\n",
-               audiodev.value);
-         VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
-      }
-   }
+      start_audio_capture(audiodev.value);
 #endif
 
    return true;
 }
 
 static void unload_game_internal(bool keep_audio);
+static bool load_game_internal(bool allow_fallback);
 
 /* Stop the frontend from invoking audio_callback before the ALSA handle is
  * closed; otherwise the async callback races snd_pcm_close() and can read
@@ -773,18 +820,18 @@ static void unregister_audio_callback(void)
 static void close_audio_device(void)
 {
 #ifdef HAVE_ALSA
-   snd_pcm_t *handle = audio_handle;
+   snd_pcm_t *handle;
+   /* Unpublish the handle under the lock: RetroArch ignores
+    * SET_AUDIO_CALLBACK(NULL), so the async audio callback may still be
+    * registered. Taking the lock waits for an in-flight snd_pcm_readi() to
+    * drain, and later invocations see NULL — the handle is never closed
+    * underneath a reader. */
+   pthread_mutex_lock(&audio_lock);
+   handle       = audio_handle;
+   audio_handle = NULL;
+   pthread_mutex_unlock(&audio_lock);
    if (handle)
-   {
-      /* Unpublish the handle first: RetroArch ignores
-       * SET_AUDIO_CALLBACK(NULL), so the async audio callback may still be
-       * registered. New invocations then see NULL; give an in-flight
-       * snd_pcm_readi() (64 frames, ~1.3ms) a moment to drain before the
-       * handle is closed underneath it. */
-      audio_handle = NULL;
-      usleep(5000);
       snd_pcm_close(handle);
-   }
 #endif
 }
 
@@ -821,34 +868,35 @@ static void release_video_buffers(void)
  * and the device option remains editable from the menu. */
 static void setup_dummy_source(void)
 {
+   uint32_t height;
+
    if (strcmp(video_capture_mode, "interlaced") == 0)
    {
-       video_format.fmt.pix.height = 480;
-       video_cap_height            = 480;
-       video_buf.field             = V4L2_FIELD_INTERLACED;
+      height          = 480;
+      video_buf.field = V4L2_FIELD_INTERLACED;
    }
    else if (     strcmp(video_capture_mode, "alternate") == 0
               || strcmp(video_capture_mode, "top") == 0
               || strcmp(video_capture_mode, "bottom") == 0
               || strcmp(video_capture_mode, "alternate_hack") == 0)
    {
-       video_format.fmt.pix.height = 240;
-       video_cap_height            = 240;
-       video_buf.field             = V4L2_FIELD_TOP;
+      height          = 240;
+      video_buf.field = V4L2_FIELD_TOP;
    }
    else
    {
-       /* "deinterlaced": full frames. Without this branch the height stayed
-        * 0 (or stale from a previous device) and the zero-height geometry
-        * reported to the frontend crashed its video driver. */
-       video_format.fmt.pix.height = 480;
-       video_cap_height            = 480;
-       video_buf.field             = V4L2_FIELD_NONE;
+      /* "deinterlaced": full frames. Without this branch the height stayed
+       * 0 (or stale from a previous device) and the zero-height geometry
+       * reported to the frontend crashed its video driver. */
+      height          = 480;
+      video_buf.field = V4L2_FIELD_NONE;
    }
 
-   dummy_pos                  = 0;
-   video_format.fmt.pix.width = 640;
-   video_cap_width            = 640;
+   video_format.fmt.pix.height = height;
+   video_cap_height            = height;
+   dummy_pos                   = 0;
+   video_format.fmt.pix.width  = 640;
+   video_cap_width             = 640;
 }
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_deinit)(void)
@@ -897,6 +945,23 @@ static bool rate_to_timeperframe(const char *s, uint32_t *num, uint32_t *den)
    *num = 1;
    *den = (uint32_t)r;
    return true;
+}
+
+/* The av_info most recently reported to the frontend, used to skip the
+ * expensive SET_SYSTEM_AV_INFO (a full frontend AV reinit) after an option
+ * change that granted identical geometry and timing. */
+static struct retro_system_av_info video_last_av_info;
+
+static bool av_info_equal(const struct retro_system_av_info *a,
+      const struct retro_system_av_info *b)
+{
+   return a->geometry.base_width   == b->geometry.base_width
+       && a->geometry.base_height  == b->geometry.base_height
+       && a->geometry.max_width    == b->geometry.max_width
+       && a->geometry.max_height   == b->geometry.max_height
+       && a->geometry.aspect_ratio == b->geometry.aspect_ratio
+       && a->timing.fps            == b->timing.fps
+       && a->timing.sample_rate    == b->timing.sample_rate;
 }
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_system_av_info *info)
@@ -951,9 +1016,13 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_syst
          /* No analog standard (e.g. UVC/HDMI capture): use the actual frame
           * rate from VIDIOC_G_PARM. It is the buffer delivery rate, so it maps
           * directly to the frontend rate, except in "interlaced" mode where the
-          * deinterlacer emits two outputs (one per field) per captured frame. */
+          * deinterlacer emits two outputs (one per field) per captured frame.
+          * That only happens when the driver really granted an interlaced
+          * format; if it clamped the request to progressive, buffers arrive
+          * (and are output) once per frame at cap_fps. */
          double cap_fps = (double)video_cap_rate_d / (double)video_cap_rate_n;
-         info->timing.fps = (strcmp(video_capture_mode, "interlaced") == 0)
+         info->timing.fps = (   strcmp(video_capture_mode, "interlaced") == 0
+                             && video_format.fmt.pix.field == V4L2_FIELD_INTERLACED)
                             ? cap_fps * 2.0 : cap_fps;
       }
       else
@@ -961,10 +1030,19 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(struct retro_syst
       info->timing.sample_rate   = AUDIO_SAMPLE_RATE;
 
       /* TODO/FIXME Allow for fixed 4:3 and 16:9 modes */
-      if (error == 0)
+      /* Default to square pixels when the driver reports no cropping/pixel
+       * aspect information (common for UVC/HDMI grabbers and v4l2loopback);
+       * leaving the field unset would push uninitialized stack data to the
+       * frontend through SET_SYSTEM_AV_INFO in retro_run(). */
+      if (error == 0 && cc.pixelaspect.numerator != 0 && cc.pixelaspect.denominator != 0)
          info->geometry.aspect_ratio = (double)info->geometry.base_width / (double)info->geometry.max_height /
             ((double)cc.pixelaspect.numerator / (double)cc.pixelaspect.denominator);
+      else
+         info->geometry.aspect_ratio = (double)info->geometry.base_width /
+               (double)info->geometry.max_height;
    }
+
+   video_last_av_info = *info;
 
    printf("Aspect ratio: %f\n",info->geometry.aspect_ratio);
    printf("Buffer Resolution %ux%u %f fps\n", info->geometry.base_width,
@@ -979,8 +1057,11 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_controller_port_device)(unsigned 
 
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_reset)(void)
 {
-   close_devices();
-   open_devices();
+   /* Tear the whole pipeline down and bring it back up. Merely closing and
+    * reopening the device fds (the old behaviour) left the V4L2 stream dead
+    * — no S_FMT/REQBUFS/STREAMON — until the next option change. */
+   unload_game_internal(false);
+   load_game_internal(true);
 }
 
 /* TODO improve this mess and make it generic enough for use with dummy mode */
@@ -1082,7 +1163,13 @@ void source_dummy(int width, int height)
  * Copy no more than that, and never read past the captured buffer. */
 static void copy_frame_cap(const struct v4l2_capbuf *capbuf)
 {
-   size_t copy_size = MIN((size_t)video_cap_width * video_cap_height * 3,
+   size_t copy_size;
+   /* alternate_hack re-maps its buffer every frame; a transient mmap failure
+    * leaves the pointer invalid. Keep the previous frame instead of reading
+    * from a bad mapping. */
+   if (capbuf->start == NULL || capbuf->start == MAP_FAILED)
+      return;
+   copy_size = MIN((size_t)video_cap_width * video_cap_height * 3,
          capbuf->len);
    memcpy(frame_cap, capbuf->start, copy_size);
 }
@@ -1153,7 +1240,8 @@ void source_v4l2_alternate_hack(int width, int height)
    bufcp = video_buf;
    copy_frame_cap(&v4l2_capbuf[video_buf.index]);
 
-   v4l2_munmap(v4l2_capbuf[0].start, v4l2_capbuf[0].len);
+   if (v4l2_capbuf[0].start && v4l2_capbuf[0].start != MAP_FAILED)
+      v4l2_munmap(v4l2_capbuf[0].start, v4l2_capbuf[0].len);
 
    if (video_buf.field == V4L2_FIELD_TOP)
        fmt.fmt.pix.field = V4L2_FIELD_BOTTOM;
@@ -1178,7 +1266,9 @@ void source_v4l2_alternate_hack(int width, int height)
    {
       printf("VIDIOC_REQBUFS failed: %s\n", strerror(errno));
    }
-   v4l2_ncapbuf = reqbufs.count;
+   /* The driver can grant more buffers than requested; v4l2_capbuf[] only
+    * holds VIDEO_BUFFERS_MAX entries and only that many are mapped/queued. */
+   v4l2_ncapbuf = MIN(reqbufs.count, VIDEO_BUFFERS_MAX);
    /* printf("GOT v4l2_ncapbuf=%ld\n", v4l2_ncapbuf); */
 
    index            = 0;
@@ -1187,10 +1277,17 @@ void source_v4l2_alternate_hack(int width, int height)
    video_buf.type   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
    video_buf.memory = V4L2_MEMORY_MMAP;
 
-   v4l2_ioctl(video_device_fd, VIDIOC_QUERYBUF, &video_buf);
+   if (v4l2_ioctl(video_device_fd, VIDIOC_QUERYBUF, &video_buf) != 0)
+      printf("VIDIOC_QUERYBUF failed: %s\n", strerror(errno));
    v4l2_capbuf[index].len   = video_buf.length;
    v4l2_capbuf[index].start = v4l2_mmap(NULL, video_buf.length,
          PROT_READ|PROT_WRITE, MAP_SHARED, video_device_fd, video_buf.m.offset);
+   if (v4l2_capbuf[index].start == MAP_FAILED)
+   {
+      printf("v4l2_mmap failed: %s\n", strerror(errno));
+      v4l2_capbuf[index].start = NULL;
+      v4l2_capbuf[index].len   = 0;
+   }
    memset(&video_buf, 0, sizeof(struct v4l2_buffer));
 
    video_buf.index  = index;
@@ -1380,34 +1477,51 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
 
       if (video_changed || audio_changed)
       {
-          /* Keep the audio device alive across a video-only reconfigure so the
-           * running ALSA capture isn't torn down and reopened (which races its
-           * async callback and fails with EBUSY). Switching to the dummy device
-           * stops audio capture, so tear it down in that case. */
-          bool keep_audio = !audio_changed && (audio_device[0] != '\0')
-                && videodev.value && (strcmp(videodev.value, "dummy") != 0);
-          unload_game_internal(keep_audio);
-          /* This core does not cares for the retro_game_info * argument? */
-          device_reloading = true;
-          if (!VIDEOPROC_CORE_PREFIX(retro_load_game)(NULL))
-          {
-             /* Reload failed: the buffers we just freed are gone. Output a
-              * blank frame and stay idle rather than dereferencing them; the
-              * user can pick a working configuration to retry. */
-             device_reloading = false;
-             VIDEOPROC_CORE_PREFIX(video_refresh_cb)(NULL, 0, 0, 0);
-             return;
-          }
-          device_reloading = false;
-          /* The device may have granted a different geometry or frame rate
-           * than the previous configuration; push the new av_info so the
-           * frontend adjusts its buffers and pacing (required whenever the
-           * max geometry can grow). */
-          {
-             struct retro_system_av_info av_info;
-             VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(&av_info);
-             VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
-          }
+         bool reload = true;
+#ifdef HAVE_ALSA
+         /* When only the audio device changed and audio capture is already
+          * running, swap the ALSA device in place instead of rebuilding the
+          * whole video pipeline. Enabling audio from "none" still takes the
+          * reload path: SET_AUDIO_CALLBACK is only honoured during
+          * retro_load_game. */
+         if (!video_changed && audio_handle != NULL && audiodev.value)
+         {
+            close_audio_device();
+            strlcpy(audio_device, audiodev.value, sizeof(audio_device));
+            if (strcmp(audiodev.value, "none") != 0)
+               start_audio_capture(audiodev.value);
+            reload = false;
+         }
+#endif
+         if (reload)
+         {
+            /* Keep the audio device alive across a video-only reconfigure so
+             * the running ALSA capture isn't torn down and reopened (which
+             * races its async callback and fails with EBUSY). Switching to
+             * the dummy device stops audio capture, so tear it down in that
+             * case. */
+            bool keep_audio = !audio_changed && (audio_device[0] != '\0')
+                  && videodev.value && (strcmp(videodev.value, "dummy") != 0);
+            struct retro_system_av_info av_info;
+            struct retro_system_av_info prev_av_info = video_last_av_info;
+            unload_game_internal(keep_audio);
+            if (!load_game_internal(false))
+            {
+               /* Reload failed: the buffers we just freed are gone. Output a
+                * blank frame and stay idle rather than dereferencing them;
+                * the user can pick a working configuration to retry. */
+               VIDEOPROC_CORE_PREFIX(video_refresh_cb)(NULL, 0, 0, 0);
+               return;
+            }
+            /* The device may have granted a different geometry or frame rate
+             * than the previous configuration; push the new av_info so the
+             * frontend adjusts its buffers and pacing — but only when it
+             * really changed, since SET_SYSTEM_AV_INFO makes the frontend
+             * reinitialize its video/audio drivers. */
+            VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(&av_info);
+            if (!av_info_equal(&av_info, &prev_av_info))
+               VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
+         }
       }
 
       if (frametimes.value != NULL)
@@ -1550,7 +1664,13 @@ static void videoinput_set_control_v4l2( uint32_t id, double val)
 }
 #endif
 
-RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_info *game)
+/* Device bring-up shared by retro_load_game and the runtime-reconfigure path
+ * in retro_run. allow_fallback selects the failure policy: on the initial
+ * load a failing device falls back to the built-in test pattern (the device
+ * choice is persisted, and a broken one would otherwise prevent the core
+ * from ever starting again), while a failed reconfigure of a running core is
+ * survivable as a plain error (blank frames, options stay editable). */
+static bool load_game_internal(bool allow_fallback)
 {
    struct retro_variable videodev     = { "videoproc_videodev", NULL };
    struct retro_variable audiodev     = { "videoproc_audiodev", NULL };
@@ -1577,9 +1697,10 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
 
    if (open_devices() == false)
    {
+      /* Nothing to clean up here: open_devices() leaves no half-open video
+       * fd behind, and the fallback/error paths below release whatever else
+       * is held. */
       printf("Couldn't open capture device\n");
-      unregister_audio_callback();
-      close_devices();
       goto device_fallback;
    }
 
@@ -1808,7 +1929,11 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
          printf("VIDIOC_REQBUFS failed: %s\n", strerror(errno));
          goto device_fallback;
       }
-      v4l2_ncapbuf = reqbufs.count;
+      /* The driver can grant more buffers than requested (some need 3+ to
+       * operate); v4l2_capbuf[] only holds VIDEO_BUFFERS_MAX entries, and
+       * only the buffers actually mapped and queued here are ever returned
+       * by VIDIOC_DQBUF. Going past the array corrupts adjacent state. */
+      v4l2_ncapbuf = MIN(reqbufs.count, VIDEO_BUFFERS_MAX);
       printf("GOT v4l2_ncapbuf=%" PRI_SIZET "\n", v4l2_ncapbuf);
 
       /* Forget any previous session's pointers before the mmap loop so a
@@ -1943,12 +2068,7 @@ device_ready:
    return true;
 
 device_fallback:
-   /* While the core is already running, a failed reconfigure is survivable
-    * (blank frames, options stay editable), so treat it as a plain error and
-    * let the user retry. Only on the *initial* load fall back to the built-in
-    * test pattern: the device choice is persisted, and a broken one would
-    * otherwise prevent the core from ever starting again. */
-   if (device_reloading)
+   if (!allow_fallback)
       goto error;
    printf("Capture device could not be started, falling back to the dummy video source\n");
    {
@@ -1980,6 +2100,12 @@ error:
    return false;
 }
 
+RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_info *game)
+{
+   /* This core ignores the content argument (SET_SUPPORT_NO_GAME). */
+   return load_game_internal(true);
+}
+
 /* keep_audio leaves the audio device, its async callback and audio_device[]
  * untouched. Used for a video-only reconfigure (resolution/capture mode/output
  * mode change) so the running ALSA capture isn't bounced; see open_devices(). */
@@ -1988,12 +2114,8 @@ static void unload_game_internal(bool keep_audio)
    int i;
    struct v4l2_requestbuffers reqbufs;
 
-#ifdef HAVE_ALSA
-   if (!keep_audio && audio_handle != NULL)
-   {
-       VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_AUDIO_CALLBACK, NULL);
-   }
-#endif
+   if (!keep_audio)
+      unregister_audio_callback();
 
    if ((strcmp(video_device, "dummy") != 0) && (video_device_fd != -1))
    {

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -380,13 +380,85 @@ static size_t add_resolution(struct v4l2_resolution *out, size_t count,
    return count;
 }
 
-/* Probe a single V4L2 device for the capture resolutions it actually
- * supports and merge them (deduplicated) into out[]. Returns the updated
- * entry count. Drivers report framesizes either as a discrete list or as a
- * stepwise/continuous range; for ranges, offer the entries of the built-in
- * table that fall inside the range. */
+/* Append fps to rates[] unless an equal rate (within rounding noise) is
+ * already present. Returns the updated entry count. */
+static size_t add_rate(double *rates, size_t count, size_t max, double fps)
+{
+   size_t i;
+   for (i = 0; i < count; i++)
+      if (fabs(rates[i] - fps) < 0.005)
+         return count;
+   if (count < max && fps > 0.0)
+   {
+      rates[count] = fps;
+      count++;
+   }
+   return count;
+}
+
+/* Rates offered when a driver reports a continuous frame-interval range,
+ * or none at all (no device to probe). */
+static const double v4l2_standard_rates[] =
+      { 60, 59.94, 50, 30, 29.97, 25, 24, 20, 15, 10 };
+
+/* Collect the frame rates a device supports for one pixel format and frame
+ * size (VIDIOC_ENUM_FRAMEINTERVALS) into rates[]. Returns the updated entry
+ * count. */
+static size_t probe_rates(int fd, uint32_t pixel_format,
+      uint32_t width, uint32_t height, double *rates, size_t count, size_t max)
+{
+   uint32_t index;
+
+   for (index = 0; ; index++)
+   {
+      struct v4l2_frmivalenum ival;
+
+      memset(&ival, 0, sizeof(ival));
+      ival.index        = index;
+      ival.pixel_format = pixel_format;
+      ival.width        = width;
+      ival.height       = height;
+      if (v4l2_ioctl(fd, VIDIOC_ENUM_FRAMEINTERVALS, &ival) != 0)
+         break;
+
+      if (ival.type == V4L2_FRMIVAL_TYPE_DISCRETE)
+      {
+         if (ival.discrete.numerator != 0)
+            count = add_rate(rates, count, max,
+                  (double)ival.discrete.denominator
+                  / (double)ival.discrete.numerator);
+      }
+      else
+      {
+         /* Stepwise/continuous: index 0 describes the whole interval range
+          * (min = shortest interval = fastest rate); offer the standard
+          * rates that fall inside it. */
+         size_t i;
+         double fast = (ival.stepwise.min.numerator != 0)
+               ? (double)ival.stepwise.min.denominator
+                 / (double)ival.stepwise.min.numerator : 0.0;
+         double slow = (ival.stepwise.max.numerator != 0)
+               ? (double)ival.stepwise.max.denominator
+                 / (double)ival.stepwise.max.numerator : 0.0;
+         for (i = 0; i < ARRAY_SIZE(v4l2_standard_rates); i++)
+            if (   v4l2_standard_rates[i] >= slow - 0.005
+                && v4l2_standard_rates[i] <= fast + 0.005)
+               count = add_rate(rates, count, max, v4l2_standard_rates[i]);
+         break;
+      }
+   }
+   return count;
+}
+
+/* Probe a single V4L2 device for the capture resolutions and frame rates it
+ * actually supports and merge them (deduplicated) into out[]/rates[].
+ * Returns the updated resolution count and updates *nrates. Drivers report
+ * framesizes either as a discrete list or as a stepwise/continuous range;
+ * for ranges, offer the entries of the built-in table that fall inside the
+ * range. */
 static size_t probe_resolutions(const char *device,
-      struct v4l2_resolution *out, size_t count, size_t max)
+      struct v4l2_resolution *out, size_t count, size_t max,
+      double *rates, size_t *nrates, size_t rates_max)
 {
    int fd;
    uint32_t fmt_index;
@@ -417,8 +489,13 @@ static size_t probe_resolutions(const char *device,
             break;
 
          if (frmsize.type == V4L2_FRMSIZE_TYPE_DISCRETE)
-            count = add_resolution(out, count, max,
+         {
+            count   = add_resolution(out, count, max,
                   (int)frmsize.discrete.width, (int)frmsize.discrete.height);
+            *nrates = probe_rates(fd, fmtdesc.pixelformat,
+                  frmsize.discrete.width, frmsize.discrete.height,
+                  rates, *nrates, rates_max);
+         }
          else
          {
             /* Stepwise/continuous: index 0 describes the whole range. */
@@ -432,6 +509,9 @@ static size_t probe_resolutions(const char *device,
                   count = add_resolution(out, count, max,
                         v4l2_resolutions[i].width, v4l2_resolutions[i].height);
             }
+            *nrates = probe_rates(fd, fmtdesc.pixelformat,
+                  frmsize.stepwise.max_width, frmsize.stepwise.max_height,
+                  rates, *nrates, rates_max);
             break;
          }
       }
@@ -452,18 +532,48 @@ static int resolution_cmp(const void *a, const void *b)
    return ra->height - rb->height;
 }
 
-/* Build the capture-resolution option list by probing capture device(s) for
- * the sizes they really report. video_devices is either a single device path
- * ("/dev/videoN") or the option string built by enumerate_video_devices
- * ("Video capture device; /dev/videoN|..."). Falls back to the built-in
- * v4l2_resolutions[] table when nothing could be probed (no device
+/* Order descending so the fastest supported rate leads the list ("auto"
+ * still precedes it as the default). */
+static int rate_cmp(const void *a, const void *b)
+{
+   double ra = *(const double *)a;
+   double rb = *(const double *)b;
+   if (ra < rb)
+      return 1;
+   if (ra > rb)
+      return -1;
+   return 0;
+}
+
+/* Format a probed rate the way users know it (the NTSC fractional rates by
+ * their conventional names). Must round-trip through rate_to_timeperframe. */
+static void rate_to_string(double fps, char *out, size_t len)
+{
+   if (fabs(fps - 60000.0 / 1001.0) < 0.01)
+      strlcpy(out, "59.94", len);
+   else if (fabs(fps - 30000.0 / 1001.0) < 0.01)
+      strlcpy(out, "29.97", len);
+   else if (fabs(fps - 24000.0 / 1001.0) < 0.01)
+      strlcpy(out, "23.976", len);
+   else
+      snprintf(out, len, "%g", fps);
+}
+
+/* Build the capture-resolution and capture-rate option lists by probing
+ * capture device(s) for the sizes and frame intervals they really report.
+ * video_devices is either a single device path ("/dev/videoN") or the option
+ * string built by enumerate_video_devices ("Video capture device;
+ * /dev/videoN|..."). Falls back to the built-in v4l2_resolutions[] /
+ * v4l2_standard_rates[] tables when nothing could be probed (no device
  * present). */
-static void list_resolutions(char *capture_resolutions, size_t len,
-      const char *video_devices)
+static void list_capture_options(char *capture_resolutions, size_t res_len,
+      char *capture_rates, size_t rates_len, const char *video_devices)
 {
    struct v4l2_resolution probed[128];
+   double rates[32];
    const struct v4l2_resolution *res;
-   size_t count = 0;
+   size_t count  = 0;
+   size_t nrates = 0;
    size_t i, n, written;
    char devices[ENVVAR_BUFLEN];
    char *token;
@@ -481,7 +591,8 @@ static void list_resolutions(char *capture_resolutions, size_t len,
          token++;
       if (!string_starts_with(token, "/dev/video"))
          continue;
-      count = probe_resolutions(token, probed, count, ARRAY_SIZE(probed));
+      count = probe_resolutions(token, probed, count, ARRAY_SIZE(probed),
+            rates, &nrates, ARRAY_SIZE(rates));
    }
 
    if (count > 0)
@@ -491,7 +602,7 @@ static void list_resolutions(char *capture_resolutions, size_t len,
    res = (count > 0) ? probed : v4l2_resolutions;
    n   = (count > 0) ? count  : ARRAY_SIZE(v4l2_resolutions);
 
-   written = snprintf(capture_resolutions, len, "Capture resolution; ");
+   written = snprintf(capture_resolutions, res_len, "Capture resolution; ");
    for (i = 0; i < n; i++)
    {
       char entry[32];
@@ -499,9 +610,31 @@ static void list_resolutions(char *capture_resolutions, size_t len,
             i > 0 ? "|" : "", res[i].width, res[i].height);
       /* Stop before truncating an entry mid-token; the caller still
        * appends "|auto" and it must always fit. */
-      if (written + elen + STRLEN_CONST("|auto") + 1 > len)
+      if (written + elen + STRLEN_CONST("|auto") + 1 > res_len)
          break;
-      strlcpy(capture_resolutions + written, entry, len - written);
+      strlcpy(capture_resolutions + written, entry, res_len - written);
+      written += elen;
+   }
+
+   /* Rate list: "auto" (keep the device's current rate) is always first and
+    * stays the default. */
+   if (nrates == 0)
+      for (i = 0; i < ARRAY_SIZE(v4l2_standard_rates); i++)
+         nrates = add_rate(rates, nrates, ARRAY_SIZE(rates),
+               v4l2_standard_rates[i]);
+   qsort(rates, nrates, sizeof(rates[0]), rate_cmp);
+
+   written = snprintf(capture_rates, rates_len, "Capture frame rate; auto");
+   for (i = 0; i < nrates; i++)
+   {
+      char entry[32];
+      char rstr[16];
+      size_t elen;
+      rate_to_string(rates[i], rstr, sizeof(rstr));
+      elen = (size_t)snprintf(entry, sizeof(entry), "|%s", rstr);
+      if (written + elen + 1 > rates_len)
+         break;
+      strlcpy(capture_rates + written, entry, rates_len - written);
       written += elen;
    }
 }
@@ -511,9 +644,10 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    char video_devices[ENVVAR_BUFLEN];
    char audio_devices[ENVVAR_BUFLEN];
    static char capture_resolutions[ENVVAR_BUFLEN];
-   /* Device selection the resolution list was probed from; statics survive
-    * core restarts when the core is statically linked into the frontend, so
-    * an empty-buffer check alone would never refresh the list. */
+   static char capture_rates[ENVVAR_BUFLEN];
+   /* Device selection the resolution/rate lists were probed from; statics
+    * survive core restarts when the core is statically linked into the
+    * frontend, so an empty-buffer check alone would never refresh them. */
    static char probed_for[ENVVAR_BUFLEN];
    struct retro_variable videodev = { "videoproc_videodev", NULL };
    struct retro_variable envvars[] = {
@@ -521,7 +655,7 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
       { "videoproc_audiodev", NULL },
       { "videoproc_capture_mode", "Capture mode; alternate|deinterlaced|interlaced|top|bottom|alternate_hack" },
       { "videoproc_capture_resolution", NULL },
-      { "videoproc_capture_rate", "Capture frame rate; auto|60|59.94|50|30|29.97|25|24|20|15|10" },
+      { "videoproc_capture_rate", NULL },
       { "videoproc_output_mode","Output mode; progressive|deinterlaced|interlaced" },
       { "videoproc_frame_times","Print frame times to terminal (v4l2 only); Off|On" },
       { NULL, NULL }
@@ -545,36 +679,41 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
    envvars[1].value = audio_devices;
    envvars[3].key   = "videoproc_capture_resolution";
    envvars[3].value = capture_resolutions;
+   envvars[4].key   = "videoproc_capture_rate";
+   envvars[4].value = capture_rates;
 
-   /* Register the options once before the probed resolution list is known:
-    * this seeds the frontend with the saved values, and a variable can only
-    * be resolved after it has been registered with its value list — so the
-    * saved device selection only becomes queryable now. Values must not be
-    * NULL (only the {NULL, NULL} entry terminates the array), so seed the
-    * resolution list with the built-in table; it is rebuilt from the actual
-    * device below. */
+   /* Register the options once before the probed resolution/rate lists are
+    * known: this seeds the frontend with the saved values, and a variable
+    * can only be resolved after it has been registered with its value list
+    * — so the saved device selection only becomes queryable now. Values
+    * must not be NULL (only the {NULL, NULL} entry terminates the array),
+    * so seed the lists with the built-in tables; they are rebuilt from the
+    * actual device below. */
    if (capture_resolutions[0] == '\0')
    {
-      list_resolutions(capture_resolutions, sizeof(capture_resolutions), "");
+      list_capture_options(capture_resolutions, sizeof(capture_resolutions),
+            capture_rates, sizeof(capture_rates), "");
       appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
    }
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
 
-   /* Probe the capture device for its real, supported resolutions rather
-    * than offering a fixed table the hardware may not honour. Probe only the
-    * selected device when it is known, so the option list reflects what that
-    * device actually supports; on a fresh configuration (no device selected
-    * yet) probe every enumerated device. Probing opens the device(s), so
-    * cache the list and rebuild it only when the probed selection changes
-    * (i.e. on the first core start after switching devices). */
+   /* Probe the capture device for its real, supported resolutions and frame
+    * rates rather than offering fixed tables the hardware may not honour.
+    * Probe only the selected device when it is known, so the option lists
+    * reflect what that device actually supports; on a fresh configuration
+    * (no device selected yet) probe every enumerated device. Probing opens
+    * the device(s), so cache the lists and rebuild them only when the probed
+    * selection changes (i.e. on the first core start after switching
+    * devices). */
    {
       const char *probe_target =
             (videodev.value && string_starts_with(videodev.value, "/dev/video"))
             ? videodev.value : video_devices;
       if (strcmp(probed_for, probe_target) != 0)
       {
-         list_resolutions(capture_resolutions, sizeof(capture_resolutions), probe_target);
+         list_capture_options(capture_resolutions, sizeof(capture_resolutions),
+               capture_rates, sizeof(capture_rates), probe_target);
          appendstr(capture_resolutions, "|auto", ENVVAR_BUFLEN);
          strlcpy(probed_for, probe_target, sizeof(probed_for));
       }
@@ -942,12 +1081,15 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_get_system_info)(struct retro_system_
 }
 
 /* Convert a "Capture frame rate" option value to a V4L2 timeperframe
- * (seconds per frame = num/den). Handles the NTSC fractional rates and plain
- * integer rates. Returns false for "auto"/unrecognised values, meaning "let
- * the device keep its current rate". */
+ * (seconds per frame = num/den). The NTSC fractional rates map to their
+ * exact 1001-based intervals; any other value (integer or decimal, e.g. a
+ * probed "7.5") is parsed generically. Returns false for
+ * "auto"/unrecognised values, meaning "let the device keep its current
+ * rate". */
 static bool rate_to_timeperframe(const char *s, uint32_t *num, uint32_t *den)
 {
-   int r;
+   double fps;
+   char *end;
    if (!s || strcmp(s, "auto") == 0)
       return false;
    if (strcmp(s, "59.94") == 0)
@@ -962,11 +1104,17 @@ static bool rate_to_timeperframe(const char *s, uint32_t *num, uint32_t *den)
       *den = 30000;
       return true;
    }
-   r = atoi(s);
-   if (r <= 0)
+   if (strcmp(s, "23.976") == 0)
+   {
+      *num = 1001;
+      *den = 24000;
+      return true;
+   }
+   fps = strtod(s, &end);
+   if (end == s || fps <= 0.0)
       return false;
-   *num = 1;
-   *den = (uint32_t)r;
+   *num = 1000;
+   *den = (uint32_t)(fps * 1000.0 + 0.5);
    return true;
 }
 
@@ -1892,6 +2040,26 @@ static bool load_game_internal(bool allow_fallback)
             else
                video_cap_height = fmt.fmt.pix.height / 2;
             break;
+      }
+
+      /* Prefer a constant frame rate over auto-exposure: cameras (webcams)
+       * with "exposure auto priority" enabled (exposure_dynamic_framerate in
+       * v4l2-ctl; browsers/meeting software often switch it on and it sticks
+       * until the camera is replugged) may extend the exposure time beyond
+       * the frame interval in dim light. The camera then silently delivers
+       * only ~10-15 fps while G_PARM still reports the nominal rate, and the
+       * whole frontend paces on the slow delivery — everything (menu,
+       * shaders) is slow/laggy/choppy except the capture picture itself.
+       * Disabling the priority makes the camera clamp exposure to the frame
+       * interval instead. HDMI/SDI grabbers have no exposure and don't
+       * implement the control; the failed ioctl is simply ignored. */
+      {
+         struct v4l2_control ctrl;
+         memset(&ctrl, 0, sizeof(ctrl));
+         ctrl.id    = V4L2_CID_EXPOSURE_AUTO_PRIORITY;
+         ctrl.value = 0;
+         if (v4l2_ioctl(video_device_fd, VIDIOC_S_CTRL, &ctrl) == 0)
+            printf("Disabled exposure auto priority (constant frame rate)\n");
       }
 
       /* Frame rate is controlled/reported via VIDIOC_G/S_PARM (timeperframe),

--- a/cores/libretro-video-processor/video_processor_v4l2.c
+++ b/cores/libretro-video-processor/video_processor_v4l2.c
@@ -579,7 +579,6 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_environment)(retro_environment_t 
          strlcpy(probed_for, probe_target, sizeof(probed_for));
       }
    }
-   printf("captures: %s\n", envvars[3].value);
 
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_VARIABLES, envvars);
 }
@@ -743,13 +742,11 @@ static bool open_devices(void)
 {
    struct retro_variable videodev = { "videoproc_videodev", NULL };
    struct retro_variable audiodev = { "videoproc_audiodev", NULL };
-   struct retro_variable captureresolution = { "videoproc_capture_resolution", NULL };
    int error;
 
    /* Get the video and audio capture device names from the environment */
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &videodev);
    VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &audiodev);
-   VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE, &captureresolution);
 
    /* Video device is required */
    if (videodev.value == NULL)
@@ -861,6 +858,32 @@ static void release_video_buffers(void)
          v4l2_munmap(v4l2_capbuf[i].start, v4l2_capbuf[i].len);
    memset(v4l2_capbuf, 0, sizeof(v4l2_capbuf));
    v4l2_ncapbuf = 0;
+}
+
+/* Free the conversion/output frame buffers and forget the deinterlacer's
+ * rotation pointers. retro_run treats NULL buffers as "stay idle". */
+static void release_frame_buffers(void)
+{
+   int i;
+
+   if (frame_out)
+      free(frame_out);
+   frame_out = NULL;
+
+   if (frame_cap)
+      free(frame_cap);
+   frame_cap = NULL;
+
+   for (i = 0; i < 4; ++i)
+   {
+      if (frames[i])
+         free(frames[i]);
+      frames[i] = NULL;
+   }
+   frame_curr  = NULL;
+   frame_prev1 = NULL;
+   frame_prev2 = NULL;
+   frame_prev3 = NULL;
 }
 
 /* Configure the built-in test pattern source. Also used as the fallback when
@@ -1055,19 +1078,29 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_set_controller_port_device)(unsigned 
 {
 }
 
+/* Set when the pipeline was rebuilt outside retro_run (retro_reset): the
+ * device can come back with a different granted geometry or frame rate, and
+ * without pushing it the frontend keeps pacing on the old timing. The libretro
+ * spec allows SET_SYSTEM_AV_INFO only from within retro_run, so the push is
+ * deferred to the next iteration. */
+static bool av_info_dirty;
+
 RETRO_API void VIDEOPROC_CORE_PREFIX(retro_reset)(void)
 {
    /* Tear the whole pipeline down and bring it back up. Merely closing and
     * reopening the device fds (the old behaviour) left the V4L2 stream dead
     * — no S_FMT/REQBUFS/STREAMON — until the next option change. */
    unload_game_internal(false);
-   load_game_internal(true);
+   if (load_game_internal(true))
+      av_info_dirty = true;
 }
 
 /* TODO improve this mess and make it generic enough for use with dummy mode */
 void v4l2_frame_times(struct v4l2_buffer buf)
 {
-   if (strcmp("Off", video_frame_times) == 0)
+   /* Opt-in only: video_frame_times can still be empty (not fetched yet)
+    * when running under a frontend that doesn't resolve the variable. */
+   if (strcmp("On", video_frame_times) != 0)
        return;
 
    if (ft_info == NULL)
@@ -1095,6 +1128,9 @@ void v4l2_frame_times(struct v4l2_buffer buf)
          ft_info2, buf.sequence, buf.index, buf.field, ft_ftime/1000,
          (!(ft_fcount % 7)) ? "\n" : "");
    free(ft_info2);
+   /* Leaving this dangling made unload_game_internal() free it a second
+    * time on the next reconfigure (double free → abort). */
+   ft_info2 = NULL;
 
    ft_prevtime2 = buf.timestamp;
 }
@@ -1454,6 +1490,19 @@ RETRO_API void VIDEOPROC_CORE_PREFIX(retro_run)(void)
    struct retro_variable frametimes  = { "videoproc_frame_times", NULL };
    bool updated = false;
 
+   /* A reset rebuilt the pipeline outside retro_run; sync the frontend with
+    * whatever geometry/timing the device granted afterwards (deferred here
+    * because SET_SYSTEM_AV_INFO may only be called from within retro_run). */
+   if (av_info_dirty)
+   {
+      struct retro_system_av_info av_info;
+      struct retro_system_av_info prev_av_info = video_last_av_info;
+      av_info_dirty = false;
+      VIDEOPROC_CORE_PREFIX(retro_get_system_av_info)(&av_info);
+      if (!av_info_equal(&av_info, &prev_av_info))
+         VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &av_info);
+   }
+
    if (VIDEOPROC_CORE_PREFIX(environment_cb)(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
    {
       bool video_changed, audio_changed;
@@ -1751,11 +1800,14 @@ static bool load_game_internal(bool allow_fallback)
    if (frame_times.value != NULL)
       strlcpy(video_frame_times, frame_times.value, sizeof(video_frame_times));
 
-   /* Reset per-device timing state so nothing leaks from a previously
-    * loaded device into av_info/retro_get_region. */
+   /* Reset per-device timing and pacing state so nothing leaks from a
+    * previously loaded device into av_info/retro_get_region, and a stale
+    * half-feed flag from an interlaced session doesn't skip the first
+    * capture of the new one. */
    memset(&video_standard, 0, sizeof(video_standard));
-   video_cap_rate_n = 0;
-   video_cap_rate_d = 0;
+   video_cap_rate_n     = 0;
+   video_cap_rate_d     = 0;
+   video_half_feed_rate = 0;
 
    if (strcmp(video_device, "dummy") == 0)
       setup_dummy_source();
@@ -2051,8 +2103,8 @@ device_ready:
    frame_prev2 = frames[2];
    frame_prev3 = frames[3];
 
-   /* TODO: Check frames[] allocation */
-   if (!frame_out || !frame_cap)
+   if (   !frame_out  || !frame_cap
+       || !frames[0] || !frames[1] || !frames[2] || !frames[3])
       goto error;
 
    printf("Allocated %" PRI_SIZET " byte conversion buffer\n",
@@ -2078,6 +2130,13 @@ device_fallback:
    }
    release_video_buffers();
    close_video_device();
+   /* The reconfigure path in retro_run tears audio down when the user
+    * switches to the dummy source; falling back to it behaves the same
+    * instead of leaving an audio capture running under the test pattern.
+    * audio_device[] is kept so selecting a working video device later
+    * brings audio back up. */
+   unregister_audio_callback();
+   close_audio_device();
    strlcpy(video_device, "dummy", sizeof(video_device));
    setup_dummy_source();
    {
@@ -2093,9 +2152,12 @@ device_fallback:
 error:
    /* Leave no stale state behind: a later option change runs
     * unload_game_internal() again, which must not munmap old buffer
-    * pointers or touch a dead ALSA handle. */
+    * pointers or touch a dead ALSA handle, and retro_run must see the
+    * NULL frame buffers and stay idle (a partial allocation failure
+    * would otherwise leave a half-usable buffer set around). */
    unregister_audio_callback();
    release_video_buffers();
+   release_frame_buffers();
    close_devices();
    return false;
 }
@@ -2111,7 +2173,6 @@ RETRO_API bool VIDEOPROC_CORE_PREFIX(retro_load_game)(const struct retro_game_in
  * mode change) so the running ALSA capture isn't bounced; see open_devices(). */
 static void unload_game_internal(bool keep_audio)
 {
-   int i;
    struct v4l2_requestbuffers reqbufs;
 
    if (!keep_audio)
@@ -2136,24 +2197,7 @@ static void unload_game_internal(bool keep_audio)
 
    }
 
-   if (frame_out)
-      free(frame_out);
-   frame_out = NULL;
-
-   if (frame_cap)
-      free(frame_cap);
-   frame_cap = NULL;
-
-   for (i = 0; i<4; ++i)
-   {
-      if (frames[i])
-         free(frames[i]);
-      frames[i] = NULL;
-   }
-   frame_curr = NULL;
-   frame_prev1 = NULL;
-   frame_prev2 = NULL;
-   frame_prev3 = NULL;
+   release_frame_buffers();
 
    if (ft_info)
    {


### PR DESCRIPTION
> **Note on AI assistance:** This PR was developed with substantial help from an AI coding assistant (see commit trailers). I'm not sure what the community's guidelines on AI-assisted contributions are — please tell me if this is an issue. I have tested everything manually on real hardware myself, but I have not hand-reviewed every single line of the code.

## What & why

The built-in video processor core has been broken with modern V4L2 capture devices (UVC/HDMI USB grabbers) for a long time (#16457), and its option lists were fixed tables the hardware may not support. This PR makes the core work reliably with modern devices and derives its options from what the selected device actually reports.

## Changes

- **Crash fixes:** all buffer sizes derive from the format/counts the driver actually *granted* (`VIDIOC_S_FMT` silently clamps unsupported requests — this was the startup heap overflow), all error and reconfigure paths release their resources, and a double free in the frame-times debug output is fixed. A failing device falls back to the built-in test pattern with an on-screen message instead of locking the user out of the core options.
- **Modern device support:** missing analog TV standards are non-fatal; frame timing comes from `VIDIOC_G/S_PARM` and the *granted* rate is what gets reported to the frontend.
- **Options reflect the real device:** capture resolutions and frame rates are probed from the selected device (`VIDIOC_ENUM_FRAMESIZES` / `VIDIOC_ENUM_FRAMEINTERVALS`), and both lists refresh immediately when the capture device is switched at runtime. The fixed tables remain as fallback when no device is present.
- **Constant camera frame rate:** exposure auto-priority is disabled on devices that have it. Cameras otherwise silently deliver ~10–15 fps in dim light while still reporting their nominal rate, which paces the whole frontend down and is very hard to diagnose.
- **Audio robustness:** audio capture is optional (`none` default) and never takes video down; it survives video-only reconfigures, audio-only changes swap the ALSA device in place, and teardown is mutex-synchronized with the frontend's async audio callback (no more `EBUSY` on repeated device changes).
- **Lifecycle:** restart fully reinitializes the capture stream and resyncs av_info; `SET_SYSTEM_AV_INFO` (a full frontend AV reinit) is only pushed when geometry/timing actually changed.
- **Standalone core build:** fixed linking of the `strlcpy` fallback (broken before this PR).

## Testing

Tested manually on real hardware (UVC HDMI grabber, Logitech C920, v4l2loopback): startup, runtime switching of device/resolution/frame rate/capture/output modes, fallback paths (missing/busy device), audio device switching, restart, and repeated core reloads in one session. All builds are warning-free (`-Wall`, C89 and C++ compatible, standalone + `RARCH_INTERNAL`, with and without ALSA). A headless ASan harness drives the reconfigure/reset/device-switch paths against the real devices with no findings.

Quick check: start the core without content → live image appears; compare the resolution/rate option lists against `v4l2-ctl -d /dev/videoN --list-formats-ext`; switch devices, resolutions and rates at runtime.

## Known behavior / out of scope

- Hot-unplugging the device freezes the last frame until another device is selected (stale fd, pre-existing).
- Analog capture cards (bttv/saa7134) were not available for testing — field handling follows the V4L2 spec; **testers welcome.**

## Related

- Fixes #16457, fixes #12889 (older report of the same startup crash)
- #14950 (closed): the v4l2loopback segfault reproduced there is fixed as well
- Builds on #17799 / #17803, which added resolution options but not the crash fixes
