### PR TITLE
apple: fix crash when video_threaded is enabled with the Cocoa/Metal driver

### DIFF
--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -19,6 +19,10 @@
 #include <limits.h>
 #include <math.h>
 
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h> /* CFRunLoopRunInMode: init-time main-thread pump */
+#endif
+
 #include <compat/strl.h>
 #include <features/features_cpu.h>
 
@@ -79,6 +83,31 @@ static void video_thread_send_packet(thread_video_t *thr,
 /* user -> thread */
 static void video_thread_wait_reply(thread_video_t *thr, thread_packet_t *pkt)
 {
+#if defined(__APPLE__)
+   /* macOS: the worker thread performs AppKit (NSWindow/NSView) work on the
+    * main queue during driver init -- e.g. -[CocoaView setViewType:].  A
+    * plain scond_wait would park the main thread here and deadlock that
+    * dispatch.  For CMD_INIT only, pump the main run loop while waiting so
+    * the main-queue work can run.  All other commands keep the cheap wait. */
+   if (pkt->type == CMD_INIT)
+   {
+      for (;;)
+      {
+         bool done;
+         slock_lock(thr->lock);
+         done = (pkt->type == thr->reply_cmd);
+         if (done)
+         {
+            *pkt               = thr->cmd_data;
+            thr->cmd_data.type = CMD_VIDEO_NONE;
+         }
+         slock_unlock(thr->lock);
+         if (done)
+            return;
+         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.002, true);
+      }
+   }
+#endif
    slock_lock(thr->lock);
 
    while (pkt->type != thr->reply_cmd)

--- a/ui/drivers/ui_cocoa.m
+++ b/ui/drivers/ui_cocoa.m
@@ -749,6 +749,19 @@ static ui_application_t ui_application_cocoa = {
 
 - (void)setViewType:(apple_view_type_t)vt
 {
+   /* The NSWindow/NSView mutation below must run on the main thread.  Under
+    * threaded video the graphics driver init -- and therefore this call --
+    * runs on the video worker thread, which would abort with "NSWindow
+    * should only be modified on the main thread".  Bounce to the main queue;
+    * the main thread pumps its run loop during CMD_INIT (see
+    * video_thread_wait_reply), so this dispatch_sync completes instead of
+    * deadlocking. */
+   if (!NSThread.isMainThread)
+   {
+      dispatch_sync(dispatch_get_main_queue(), ^{ [self setViewType:vt]; });
+      return;
+   }
+
    if (vt == _vt)
       return;
 
@@ -823,6 +836,15 @@ static ui_application_t ui_application_cocoa = {
 
 - (void)setVideoMode:(gfx_ctx_mode_t)mode
 {
+   /* Window/fullscreen mutation must run on the main thread.  Under threaded
+    * video this is called from the worker thread during driver init; bounce
+    * to the main queue (which pumps during CMD_INIT -- see -setViewType:). */
+   if (!NSThread.isMainThread)
+   {
+      dispatch_sync(dispatch_get_main_queue(), ^{ [self setVideoMode:mode]; });
+      return;
+   }
+
    BOOL is_fullscreen = (self.window.styleMask
          & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen;
    if (mode.fullscreen)


### PR DESCRIPTION
## Summary

Enabling `video_threaded = true` on macOS crashes RetroArch immediately with the
Cocoa/Metal driver.

The threaded-video worker thread runs graphics-driver init, which calls into the
Cocoa UI layer — `-[CocoaView setViewType:]` and `-[CocoaView setVideoMode:]` —
and mutates `NSWindow`/`NSView` state off the main thread. AppKit forbids that,
so the process aborts ("NSWindow should only be modified on the main thread").

A plain `dispatch_sync` to the main queue is not enough on its own: during
`CMD_INIT` the main thread is parked in `scond_wait()` inside
`video_thread_wait_reply()`, so it never drains the main queue and the dispatch
would deadlock.

## Fix

Two halves, both required:

- **`gfx/video_thread_wrapper.c`** — for `CMD_INIT` on Apple platforms, wait by
  pumping the main run loop in short slices (`CFRunLoopRunInMode`, 2 ms) and
  polling for the reply, instead of `scond_wait()`. All other commands keep the
  original lightweight wait, so there is no change off the init path.
- **`ui/drivers/ui_cocoa.m`** — `-[CocoaView setViewType:]` and
  `-[CocoaView setVideoMode:]` bounce to the main thread when invoked off it;
  combined with the pump above, the `dispatch_sync` completes instead of
  deadlocking.

## Testing

Built on macOS (Apple Silicon, Metal). Before: `video_threaded=true` +
`video_driver=metal` crashes on load. After: launches and runs normally. The
default `video_threaded=false` path is unchanged — new code is gated to
`CMD_INIT` on `__APPLE__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
