### PR TITLE
metal: load default.metallib by path when newDefaultLibrary returns nil

### DIFF
--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -2438,6 +2438,15 @@ static const NSUInteger kConstantAlignment = 4;
 + (instancetype)newFilterWithFunctionName:(NSString *)name device:(id<MTLDevice>)device library:(id<MTLLibrary>)library error:(NSError **)error
 {
    id<MTLFunction> function = [library newFunctionWithName:name];
+   if (!function)
+   {
+      /* newComputePipelineStateWithFunction asserts (not errors) on a nil
+       * function, so guard it: return nil and let the caller degrade
+       * gracefully instead of aborting the process. */
+      RARCH_ERR("[Metal] compute function \"%s\" not found (library %s).\n",
+            name.UTF8String, library ? "loaded" : "is NIL");
+      return nil;
+   }
    id<MTLComputePipelineState> kernel = [device newComputePipelineStateWithFunction:function error:error];
    if (*error != nil)
       return nil;
@@ -3955,6 +3964,28 @@ static void metal_pull_cached_frame_cb(void *userdata,
 - (bool)_initMetal
 {
    _library = [_device newDefaultLibrary];
+   if (!_library)
+   {
+      /* newDefaultLibrary only resolves the metallib from inside a .app
+       * bundle's resources.  For a bare CLI binary it returns nil, so fall
+       * back to loading default.metallib explicitly from the executable's own
+       * directory (where `make install` places it). */
+      NSString *exe = [[NSBundle mainBundle] executablePath];
+      if (exe)
+      {
+         NSString *path = [[exe stringByDeletingLastPathComponent]
+               stringByAppendingPathComponent:@"default.metallib"];
+         NSError  *lerr = nil;
+         _library = [_device newLibraryWithURL:[NSURL fileURLWithPath:path]
+                                          error:&lerr];
+         if (_library)
+            RARCH_LOG("[Metal] loaded shader library from %s\n",
+                  path.UTF8String);
+         else
+            RARCH_ERR("[Metal] could not load %s: %s\n", path.UTF8String,
+                  lerr ? lerr.localizedDescription.UTF8String : "unknown error");
+      }
+   }
    _context = [[Context alloc] initWithDevice:_device
                                         layer:_layer
                                       library:_library];


### PR DESCRIPTION
## Summary

On macOS, `-[MTLDevice newDefaultLibrary]` only resolves `default.metallib`
from inside a `.app` bundle's resources. For a bare executable — CLI builds,
non-`.app` installs, or a dev build run in place — it returns **nil**, leaving
the Metal driver with no shader library. Every `-newFunctionWithName:` then
returns nil.

That nil function is passed straight to
`-newComputePipelineStateWithFunction:error:` when building the pixel-format
conversion filters, which **asserts** (`computeFunction must not be nil`) and
aborts the process. Depending on timing it can instead surface as a
half-initialized driver or a plain "Cannot open video driver".

## Fix

- When `newDefaultLibrary` returns nil, fall back to loading `default.metallib`
  explicitly via `-newLibraryWithURL:error:` from the executable's own directory
  (where `make install` places it). The normal `.app` bundle path is unaffected.
- Guard `-newFunctionWithName:` in `+[Filter newFilterWithFunctionName:...]`: a
  nil function now returns gracefully with an error log instead of tripping the
  NSAssert.

## Testing

macOS (Apple Silicon, Metal), running the binary outside a `.app` bundle:
before, it aborts at init with the `computeFunction must not be nil` assertion;
after, it logs `loaded shader library from …/default.metallib` and runs
normally. The `.app` build path is unchanged — the fallback only runs when
`newDefaultLibrary` is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
