### PR TITLE
android: legacy jdk fix for updated docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -621,6 +621,8 @@ build-retroarch-android-normal:
   script:
     - |
       set -e
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      export PATH="$JAVA_HOME/bin:$PATH"
       cd pkg/android/phoenix
       ./gradlew assembleNormalRelease
       cd -
@@ -638,6 +640,8 @@ build-retroarch-android-aarch64:
   script:
     - |
       set -e
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      export PATH="$JAVA_HOME/bin:$PATH"
       cd pkg/android/phoenix
       ./gradlew assembleAarch64Release
       cd -
@@ -655,6 +659,8 @@ build-retroarch-android-ra32:
   script:
     - |
       set -e
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      export PATH="$JAVA_HOME/bin:$PATH"
       cd pkg/android/phoenix
       ./gradlew assembleRa32Release
       cd -
@@ -672,6 +678,8 @@ build-retroarch-android-playstore-normal:
   script:
     - |
       set -e
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      export PATH="$JAVA_HOME/bin:$PATH"
       cd pkg/android/phoenix
       ./gradlew bundlePlayStoreNormalRelease
       cd -
@@ -689,6 +697,8 @@ build-retroarch-android-playstore-plus:
   script:
     - |
       set -e
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      export PATH="$JAVA_HOME/bin:$PATH"
       cd pkg/android/phoenix
       ./gradlew bundlePlayStorePlusRelease
       cd -


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This allows the current (outdated) phoenix to build on the updated docker by forcing the use of the legacy JDK 8.

This will be removed when the updated phoenix (using JDK 17) is merged again.

## Related Issues

## Related Pull Requests


## Reviewers

@LibretroAdmin 