### PR TITLE
menu: Quality-of-life changes when renaming Playlist Entries

### DIFF
--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -88,6 +88,7 @@
 
 /* Depends on ASCII character values */
 #define ISPRINT(c) (((int)(c) >= ' ' && (int)(c) <= '~') ? 1 : 0)
+#define IS_UTF8_CONTINUATION(c) ((((uint8_t)(c)) & 0xc0) == 0x80)
 
 #define INPUT_REMOTE_KEY_PRESSED(input_st, key, port) (input_st->remote_st_ptr.buttons[(port)] & (UINT64_C(1) << (key)))
 
@@ -4909,25 +4910,27 @@ static bool input_keyboard_line_event(
    }
    else if (c == '\b' || c == '\x7f') /* 0x7f is ASCII for del */
    {
-      if (state->ptr)
+      if (state->ptr && state->buffer)
       {
-         unsigned i;
+         size_t ptr = state->ptr;
 
-         for (i = 0; i < input_st->osk_last_codepoint_len; i++)
+         while (state->ptr)
          {
-            memmove(state->buffer + state->ptr - 1,
-                  state->buffer + state->ptr,
-                  state->size - state->ptr + 1);
             state->ptr--;
-            state->size--;
+            if (!IS_UTF8_CONTINUATION(state->buffer[state->ptr]))
+               break;
          }
+
+         memmove(state->buffer + state->ptr,
+               state->buffer + ptr,
+               state->size - ptr + 1);
+         state->size -= ptr - state->ptr;
 
          word     = state->buffer;
       }
    }
    else if (ISPRINT(c))
    {
-      /* Handle left/right here when suitable */
       char *newbuf = (char*)
          realloc(state->buffer, state->size + 2);
       if (!newbuf)
@@ -8067,17 +8070,13 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
       }
       else if (display_kb && input && input->input_state)
       {
-         /* Allow arrows, LCtrl as OK, character map switches,
+         /* Allow LCtrl as OK, character map switches,
           * and set RetroPad Select bit when pressing Escape
           * in order to clear the input window and close it. */
          unsigned i;
          unsigned ids[][2] =
          {
             {RETROK_LCTRL,     RETRO_DEVICE_ID_JOYPAD_A      },
-            {RETROK_UP,        RETRO_DEVICE_ID_JOYPAD_UP     },
-            {RETROK_DOWN,      RETRO_DEVICE_ID_JOYPAD_DOWN   },
-            {RETROK_LEFT,      RETRO_DEVICE_ID_JOYPAD_LEFT   },
-            {RETROK_RIGHT,     RETRO_DEVICE_ID_JOYPAD_RIGHT  },
             {RETROK_PAGEUP,    RETRO_DEVICE_ID_JOYPAD_L      },
             {RETROK_PAGEDOWN,  RETRO_DEVICE_ID_JOYPAD_R      },
             {RETROK_ESCAPE,    RETRO_DEVICE_ID_JOYPAD_SELECT },
@@ -8318,11 +8317,46 @@ void input_keyboard_event(bool down, unsigned code,
    }
    else if (input_st->keyboard_line.enabled)
    {
+      input_keyboard_line_t *line = &input_st->keyboard_line;
+
       if (!down)
          return;
 
-      if (!input_keyboard_line_event(input_st,
-            &input_st->keyboard_line, character))
+      switch (code)
+      {
+         case RETROK_LEFT:
+            if (line->ptr && line->buffer)
+            {
+               while (line->ptr)
+               {
+                  line->ptr--;
+                  if (!IS_UTF8_CONTINUATION(line->buffer[line->ptr]))
+                     break;
+               }
+            }
+            return;
+         case RETROK_RIGHT:
+            if (line->buffer && line->ptr < line->size)
+            {
+               while (line->ptr < line->size)
+               {
+                  line->ptr++;
+                  if ((line->ptr >= line->size) || !IS_UTF8_CONTINUATION(line->buffer[line->ptr]))
+                     break;
+               }
+            }
+            return;
+         case RETROK_UP:
+            line->ptr = 0;
+            return;
+         case RETROK_DOWN:
+            line->ptr = line->size;
+            return;
+         default:
+            break;
+      }
+
+      if (!input_keyboard_line_event(input_st, line, character))
          return;
 
       /* Line is complete, can free it now. */

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -3950,10 +3950,30 @@ DEFAULT_ACTION_DIALOG_START(action_ok_disable_kiosk_mode,
    msg_hash_to_str(MSG_INPUT_KIOSK_MODE_PASSWORD),
    (unsigned)entry_idx,
    menu_input_st_string_cb_disable_kiosk_mode)
-DEFAULT_ACTION_DIALOG_START(action_ok_rename_entry,
-   msg_hash_to_str(MSG_INPUT_RENAME_ENTRY),
-   (unsigned)entry_idx,
-   menu_input_st_string_cb_rename_entry)
+static int action_ok_rename_entry(const char *path,
+      const char *label_setting, unsigned type, size_t idx, size_t entry_idx)
+{
+   menu_input_ctx_line_t line;
+   playlist_t *playlist;
+   const struct playlist_entry *entry = NULL;
+
+   line.label                         = msg_hash_to_str(MSG_INPUT_RENAME_ENTRY);
+   line.label_setting                 = label_setting;
+   line.type                          = type;
+   line.idx                           = (unsigned)entry_idx;
+   line.cb                            = menu_input_st_string_cb_rename_entry;
+
+   if (!menu_input_dialog_start(&line))
+      return -1;
+
+   if ((playlist = playlist_get_cached()))
+      playlist_get_index(playlist, entry_idx, &entry);
+   if (entry && entry->label && *entry->label)
+      input_keyboard_line_append(&input_state_get_ptr()->keyboard_line,
+            entry->label, strlen(entry->label));
+
+   return 0;
+}
 
 
 static int generic_action_ok_remap_file_operation(const char *path,

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -2810,6 +2810,7 @@ static void materialui_render_messagebox(
       unsigned video_height,
       int y_centre,
       const char *msg,
+      bool draw_caret,
       math_matrix_4x4 *mymat)
 {
    int i;
@@ -2822,6 +2823,8 @@ static void materialui_render_messagebox(
    int slice_y                = 0;
    int slice_w                = 0;
    int slice_h                = 0;
+   unsigned cursor_line       = 0;
+   int cursor_x               = 0;
    size_t wrapped_len         = 0;
    char wrapped_msg[MENU_LABEL_MAX_LENGTH];
    const char *lines[64];
@@ -2895,6 +2898,55 @@ static void materialui_render_messagebox(
    if (confirm_dialog && longest_width < (int)video_width / 4)
       longest_width = video_width / 4;
 
+   if (draw_caret)
+   {
+      input_driver_state_t *input_st = input_state_get_ptr();
+      input_keyboard_line_t *line    = &input_st->keyboard_line;
+      const char *input              = strchr(msg, '\n');
+
+      draw_caret = false;
+
+      if (input && line->buffer
+            && ((menu_driver_get_current_time() / 500000) & 1))
+      {
+         char cursor_msg[MENU_LABEL_MAX_LENGTH];
+         size_t len = (size_t)(input - msg + 1);
+         size_t ptr = line->ptr;
+
+         if (ptr > line->size)
+            ptr = line->size;
+         if (len < sizeof(cursor_msg))
+         {
+            if (ptr >= sizeof(cursor_msg) - len)
+               ptr = sizeof(cursor_msg) - len - 1;
+
+            memcpy(cursor_msg, msg, len);
+            memcpy(cursor_msg + len, line->buffer, ptr);
+            cursor_msg[len + ptr] = '\0';
+
+            (mui->word_wrap)(
+                  cursor_msg, sizeof(cursor_msg),
+                  cursor_msg, strlen(cursor_msg),
+                  usable_width / (int)mui->font_data.list.glyph_width,
+                  mui->font_data.list.wideglyph_width, 0);
+
+            input = cursor_msg;
+            while ((input = strchr(input, '\n')))
+            {
+               cursor_line++;
+               input++;
+            }
+            input    = strrchr(cursor_msg, '\n');
+            input    = input ? input + 1 : cursor_msg;
+            cursor_x = font_driver_get_message_width(
+                  mui->font_data.list.font,
+                  input, strlen(input), 1.0f);
+
+            draw_caret = true;
+         }
+      }
+   }
+
    slice_x                 = x - longest_width / 2.0 - mui->margin * 2.0;
    slice_y                 = y - mui->margin * 2.0;
    slice_w                 = longest_width + mui->margin * 4.0;
@@ -2932,6 +2984,21 @@ static void materialui_render_messagebox(
                video_width, video_height, mui->colors.list_text,
                TEXT_ALIGN_LEFT, 1.0f, false, 0.0f, true);
    }
+
+   if (draw_caret && (cursor_line < (unsigned)line_count))
+      gfx_display_draw_quad(
+            p_disp,
+            userdata,
+            video_width,
+            video_height,
+            x - longest_width / 2.0f + cursor_x,
+            y + (cursor_line * mui->font_data.list.line_height),
+            2,
+            mui->font_data.list.line_ascender,
+            video_width,
+            video_height,
+            mui->colors.list_icon,
+            NULL);
 
    if (confirm_dialog)
    {
@@ -8410,8 +8477,9 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
    {
       size_t _len;
       char msg[NAME_MAX_LENGTH];
-      const char *str             = menu_input_dialog_get_buffer();
-      const char *label           = menu_st->input_dialog_kb_label;
+      input_driver_state_t *input_st = input_state_get_ptr();
+      const char *str                = menu_input_dialog_get_buffer();
+      const char *label              = menu_st->input_dialog_kb_label;
 
       /* Darken screen */
       gfx_display_set_alpha(
@@ -8431,16 +8499,15 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
       _len = 0;
       strlcpy_append(msg, sizeof(msg), &_len, label);
       strlcpy_append(msg, sizeof(msg), &_len, "\n");
-      strlcpy_append(msg, sizeof(msg), &_len, str);
+      strlcpy_append(msg, sizeof(msg), &_len, (str && *str) ? str : " ");
       materialui_render_messagebox(mui,
             p_disp,
             userdata, video_width, video_height,
-            video_height / 4, msg,
+            video_height / 4, msg, true,
             &mymat);
 
       /* Draw onscreen keyboard */
       {
-         input_driver_state_t *input_st = input_state_get_ptr();
          gfx_display_draw_keyboard(
                p_disp,
                userdata,
@@ -8479,7 +8546,7 @@ static void materialui_frame(void *data, video_frame_info_t *video_info)
       materialui_render_messagebox(mui,
             p_disp,
             userdata, video_width, video_height,
-            video_height / 2, mui->msgbox,
+            video_height / 2, mui->msgbox, false,
             &mymat);
       mui->msgbox[0] = '\0';
 

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -7151,6 +7151,7 @@ static void ozone_draw_osk(
 {
    char message[2048];
    gfx_display_t *p_disp          = (gfx_display_t*)disp_userdata;
+   input_driver_state_t *input_st = input_state_get_ptr();
    const char *text               = str;
    unsigned text_color            = 0xffffffff;
    float ozone_osk_backdrop[16] = {
@@ -7168,6 +7169,8 @@ static void ozone_draw_osk(
    unsigned bottom_end            = video_height / 2;
    unsigned y_offset              = 0;
    bool draw_placeholder          = !str || !*str;
+   unsigned cursor_line           = 0;
+   int cursor_x                   = -2;
    retro_time_t current_time      = menu_driver_get_current_time();
    const char *line               = NULL;
    const char *next               = NULL;
@@ -7265,6 +7268,32 @@ static void ozone_draw_osk(
       text_color  = ozone_theme_light.text_sublabel_rgba;
    }
 
+   if (!draw_placeholder && input_st->keyboard_line.buffer)
+   {
+      char cursor_message[2048];
+      size_t ptr = input_st->keyboard_line.ptr;
+
+      if (ptr > input_st->keyboard_line.size)
+         ptr = input_st->keyboard_line.size;
+      if (ptr >= sizeof(cursor_message))
+         ptr = sizeof(cursor_message) - 1;
+
+      memcpy(cursor_message, input_st->keyboard_line.buffer, ptr);
+      cursor_message[ptr] = '\0';
+      (ozone->word_wrap)(cursor_message,
+            sizeof(cursor_message),
+            cursor_message,
+            strlen(cursor_message),
+            (video_width - (margin * 2) - (padding * 2)) / ozone->fonts.entries_label.glyph_width,
+            ozone->fonts.entries_label.wideglyph_width,
+            0);
+
+      cursor_line = string_count_occurrences_single_character(cursor_message, '\n');
+      line        = strrchr(cursor_message, '\n');
+      line        = line ? line + 1 : cursor_message;
+      cursor_x    = font_driver_get_message_width(ozone->fonts.entries_label.font, line, strlen(line), 1.0f);
+   }
+
    (ozone->word_wrap)(message,
          sizeof(message),
          text,
@@ -7275,6 +7304,8 @@ static void ozone_draw_osk(
 
    list_size = string_count_occurrences_single_character(message, '\n');
    list_size = (list_size) ? list_size : 1;
+   if (cursor_line >= list_size)
+      cursor_line = list_size - 1;
 
    for (line = message; line; line = next ? next + 1 : NULL)
    {
@@ -7312,37 +7343,29 @@ static void ozone_draw_osk(
             false);
 
       /* Cursor/caret */
-      if (i == list_size - 1)
-      {
-         if (ozone->flags & OZONE_FLAG_OSK_CURSOR)
-         {
-            int cursor_x = draw_placeholder
-                  ? -2
-                  : font_driver_get_message_width(ozone->fonts.entries_label.font, line_buf, _len, 1.0f);
+      if ((i == cursor_line) && (ozone->flags & OZONE_FLAG_OSK_CURSOR))
+         gfx_display_draw_quad(
+               p_disp,
+               userdata,
+               video_width,
+               video_height,
+               margin
+                     + (padding * 2)
+                     + cursor_x,
+               margin
+                     + padding
+                     + y_offset
+                     + ozone->fonts.entries_label.line_height
+                     - ozone->fonts.entries_label.line_ascender
+                     + ozone->dimensions.spacer_3px,
+               ozone->dimensions.spacer_1px,
+               ozone->fonts.entries_label.line_ascender,
+               video_width,
+               video_height,
+               ozone->pure_white,
+               NULL);
 
-            gfx_display_draw_quad(
-                  p_disp,
-                  userdata,
-                  video_width,
-                  video_height,
-                  margin
-                        + (padding * 2)
-                        + cursor_x,
-                  margin
-                        + padding
-                        + y_offset
-                        + ozone->fonts.entries_label.line_height
-                        - ozone->fonts.entries_label.line_ascender
-                        + ozone->dimensions.spacer_3px,
-                  ozone->dimensions.spacer_1px,
-                  ozone->fonts.entries_label.line_ascender,
-                  video_width,
-                  video_height,
-                  ozone->pure_white,
-                  NULL);
-         }
-      }
-      else
+      if (i != list_size - 1)
          y_offset += (ozone->fonts.entries_label.line_height * 2) * scale_factor;
 
       i++;
@@ -7350,7 +7373,6 @@ static void ozone_draw_osk(
 
    /* Keyboard */
    {
-      input_driver_state_t *input_st = input_state_get_ptr();
       gfx_display_draw_keyboard(
             p_disp,
             userdata,

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5018,13 +5018,40 @@ static void rgui_render_osk(
    {
       int input_str_x, input_str_y;
       int text_cursor_x;
-      unsigned input_str_char_offset = 0;
-      unsigned input_str_length      = (unsigned)utf8len(input_str);
-      const char *input_str_visible  = NULL;
+      unsigned input_str_char_offset        = 0;
+      unsigned input_str_length             = (unsigned)utf8len(input_str);
+      unsigned input_str_cursor             = input_str_length;
+      static const char *last_cursor_buffer = NULL;
+      static size_t last_cursor_ptr         = 0;
+      static retro_time_t last_cursor_time  = 0;
+      retro_time_t current_time             = menu_driver_get_current_time();
+      size_t cursor_ptr                     = input_str_cursor;
+      const char *input_str_visible         = NULL;
+
+      if (input_str && input_st->keyboard_line.buffer)
+      {
+         size_t ptr         = input_st->keyboard_line.ptr;
+         const char *cursor = input_st->keyboard_line.buffer;
+         const char *end;
+
+         input_str_cursor   = 0;
+
+         if (ptr > input_st->keyboard_line.size)
+            ptr = input_st->keyboard_line.size;
+         cursor_ptr = ptr;
+         end = cursor + ptr;
+
+         while (cursor < end && *cursor)
+         {
+            utf8_walk(&cursor);
+            input_str_cursor++;
+         }
+      }
 
       if (input_str_length > input_str_max_length)
       {
-         input_str_char_offset       = input_str_length - input_str_max_length;
+         input_str_char_offset       = (input_str_cursor > input_str_max_length)
+            ? input_str_cursor - input_str_max_length : 0;
          input_str_length            = input_str_max_length;
       }
 
@@ -5038,10 +5065,19 @@ static void rgui_render_osk(
 
       /* Draw text cursor */
       text_cursor_x                  = osk_x + input_offset_x
-                                       + (input_str_length * rgui->font_width_stride);
+                                       + ((input_str_cursor - input_str_char_offset)
+                                             * rgui->font_width_stride);
 
-      rgui_blit_symbol(rgui, fb_width, text_cursor_x, input_str_y, RGUI_SYMBOL_TEXT_CURSOR,
-            rgui->colors.normal_color, rgui->colors.shadow_color);
+      if ((last_cursor_buffer != input_st->keyboard_line.buffer) || (last_cursor_ptr != cursor_ptr))
+      {
+         last_cursor_buffer = input_st->keyboard_line.buffer;
+         last_cursor_ptr    = cursor_ptr;
+         last_cursor_time   = current_time;
+      }
+
+      if (!(((current_time - last_cursor_time) / 500000) & 1))
+         rgui_blit_symbol(rgui, fb_width, text_cursor_x, input_str_y, RGUI_SYMBOL_TEXT_CURSOR,
+               rgui->colors.normal_color, rgui->colors.shadow_color);
    }
 
    /* Draw keyboard 'keys' */

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -1169,6 +1169,7 @@ static void xmb_render_messagebox_internal(
       unsigned video_height,
       xmb_handle_t *xmb,
       const char *message,
+      bool draw_caret,
       math_matrix_4x4 *mymat)
 {
    unsigned i, line_count              = 0;
@@ -1181,6 +1182,8 @@ static void xmb_render_messagebox_internal(
    int slice_y                         = 0;
    int slice_w                         = 0;
    int slice_h                         = 0;
+   unsigned cursor_line                = 0;
+   int cursor_x                        = 0;
    struct menu_state *menu_st          = menu_state_get_ptr();
    bool confirm_dialog                 = (menu_st->dialog_st.confirm_cmd) ? true : false;
    bool input_dialog_display_kb        = false;
@@ -1237,6 +1240,53 @@ static void xmb_render_messagebox_internal(
    /* Narrow font can make the box too narrow for Back & OK */
    if (confirm_dialog && longest_width < (int)video_width / 4)
       longest_width = video_width / 4;
+
+   if (draw_caret)
+   {
+      input_driver_state_t *input_st = input_state_get_ptr();
+      input_keyboard_line_t *line    = &input_st->keyboard_line;
+      const char *input              = strchr(message, '\n');
+
+      draw_caret = false;
+
+      if (input && line->buffer
+            && ((menu_driver_get_current_time() / 500000) & 1))
+      {
+         char cursor_message[MENU_LABEL_MAX_LENGTH];
+         size_t len = (size_t)(input - message + 1);
+         size_t ptr = line->ptr;
+
+         if (ptr > line->size)
+            ptr = line->size;
+         if (len < sizeof(cursor_message))
+         {
+            if (ptr >= sizeof(cursor_message) - len)
+               ptr = sizeof(cursor_message) - len - 1;
+
+            memcpy(cursor_message, message, len);
+            memcpy(cursor_message + len, line->buffer, ptr);
+            cursor_message[len + ptr] = '\0';
+
+            (xmb->word_wrap)(
+                  cursor_message, sizeof(cursor_message),
+                  cursor_message, strlen(cursor_message),
+                  usable_width / (xmb->font_size * 0.85f),
+                  xmb->wideglyph_width, 0);
+
+            input = cursor_message;
+            while ((input = strchr(input, '\n')))
+            {
+               cursor_line++;
+               input++;
+            }
+            input    = strrchr(cursor_message, '\n');
+            input    = input ? input + 1 : cursor_message;
+            cursor_x = font_driver_get_message_width(xmb->font, input, strlen(input), 1.0f);
+
+            draw_caret = true;
+         }
+      }
+   }
 
    slice_x                 = x - (longest_width / 2) - xmb->margins_dialog;
    slice_y                 = y + xmb->margins_slice - xmb->margins_dialog;
@@ -1310,6 +1360,30 @@ static void xmb_render_messagebox_internal(
                y + ((i + 0.85) * line_height),
                video_width, video_height, 0x444444ff,
                TEXT_ALIGN_LEFT, 1.0f, false, 0.0f, false);
+   }
+
+   if (draw_caret && (cursor_line < line_count))
+   {
+      float caret_color[16] = {
+            0.27f, 0.27f, 0.27f, 1.0f,
+            0.27f, 0.27f, 0.27f, 1.0f,
+            0.27f, 0.27f, 0.27f, 1.0f,
+            0.27f, 0.27f, 0.27f, 1.0f,
+      };
+
+      gfx_display_draw_quad(
+            p_disp,
+            userdata,
+            video_width,
+            video_height,
+            x - (longest_width / 2.0) + cursor_x,
+            y + ((cursor_line + 0.85) * line_height) - xmb->font->size,
+            2,
+            xmb->font->size,
+            video_width,
+            video_height,
+            caret_color,
+            NULL);
    }
 
    if (input_dialog_display_kb)
@@ -8641,6 +8715,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    file_list_t *selection_buf          = MENU_LIST_GET_SELECTION(menu_list, 0);
    bool input_dialog_display_kb        = menu_input_dialog_get_display_kb();
    bool render_background              = false;
+   bool draw_caret                     = false;
    bool icon_thumbnail_drawn           = false;
 
    if (!xmb)
@@ -9780,9 +9855,10 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       msg[  _len]                 = '\n';
       msg[++_len]                 = '\0';
       strlcpy(msg       + _len,
-            str,
+            (str && *str) ? str : " ",
             sizeof(msg) - _len);
       render_background           = true;
+      draw_caret                  = true;
    }
 
    if (xmb->box_message && *xmb->box_message)
@@ -9791,6 +9867,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
       free(xmb->box_message);
       xmb->box_message  = NULL;
       render_background = true;
+      draw_caret        = false;
    }
 
    if (render_background)
@@ -9803,7 +9880,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
          xmb_render_messagebox_internal(userdata, p_disp,
                dispctx,
                video_width, video_height,
-               xmb, msg, &mymat);
+               xmb, msg, draw_caret, &mymat);
    }
 
    /* Cursor image */


### PR DESCRIPTION
## Description

In the current RA master, when selecting the "Rename" submenu option for any given playlist entry, the resulting text box is always blank (despite the entry necessarily having a name/title beforehand).

Moreover, if the desired text change is minimal compared to the original, users still have to re-type the whole entry name from scratch and cannot selectively edit just some parts of it, or move the cursor with the keyboard from one part of the text to another.

An example of how it looks right now with the Ozone menu driver (no text at all, no caret):

<img width="773" height="553" alt="image" src="https://github.com/user-attachments/assets/3150628c-555b-4c07-9de7-5dad28b314e9" />

This PR improves the playlist entry "Rename" functionality as follows:

- When selecting the "Rename" option, the existing entry name will be parsed automatically onto the editing text box.
- A cursor/caret is now shown, indicating where the text will be typed/inserted.
- When using a keyboard, the arrow buttons allow free movement of the cursor/caret, making selective editing of the entry name text significantly easier.
- When using a controller, instead, functionality is left identical to how it was before (as in, the D-Pad moves the cursor over the predefined virtual keyboard buttons).

An example of how ti looks after this PR with the Ozone menu driver (with the entry name copied automatically and the caret at the end of the string):

<img width="775" height="555" alt="image" src="https://github.com/user-attachments/assets/7316b5e2-6495-4a8c-b509-5ecf56dd2ead" />

## Reviewers

@LibretroAdmin 
