### PR TITLE
webOS: fix file browser hang when opening filesystem root

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2532,23 +2532,58 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
    }
 
 #elif defined(WEBOS)
-   if (path_is_directory("/media/developer/temp"))
-      menu_entries_append(list, "/media/developer/temp",
-         MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
-         enum_idx,
-         FILE_TYPE_DIRECTORY, 0, 0, NULL);
+   /* Prefer real storage paths. Do not list jail root "/" — readdir on
+    * /proc and /sys under jailer can stall the UI for a long time. */
+   {
+      char app_dir[PATH_MAX_LENGTH];
+      char app_config[PATH_MAX_LENGTH];
+      size_t wi;
+      static const char *const webos_storage[] = {
+         "/media/developer/temp",
+         "/media/developer",
+         "/media/internal/downloads",
+         "/media/internal",
+         "/tmp/usb",
+         "/tmp",
+         NULL
+      };
 
-   if (path_is_directory("/media/internal"))
-      menu_entries_append(list, "/media/internal",
-            MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
-            enum_idx,
-            FILE_TYPE_DIRECTORY, 0, 0, NULL);
+      /* Application package, config tree, and downloads (common content). */
+      app_dir[0] = '\0';
+      fill_pathname_application_dir(app_dir, sizeof(app_dir));
+      if (!string_is_empty(app_dir) && path_is_directory(app_dir))
+      {
+         menu_entries_append(list, app_dir,
+               MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
+               enum_idx,
+               FILE_TYPE_DIRECTORY, 0, 0, NULL);
 
-   if (path_is_directory("/tmp/usb"))
-      menu_entries_append(list, "/tmp/usb",
-            MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
-            enum_idx,
-            FILE_TYPE_DIRECTORY, 0, 0, NULL);
+         fill_pathname_join_special(app_config, app_dir, ".config/retroarch",
+               sizeof(app_config));
+         if (path_is_directory(app_config))
+            menu_entries_append(list, app_config,
+                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
+                  enum_idx,
+                  FILE_TYPE_DIRECTORY, 0, 0, NULL);
+
+         fill_pathname_join_special(app_config, app_dir,
+               ".config/retroarch/downloads", sizeof(app_config));
+         if (path_is_directory(app_config))
+            menu_entries_append(list, app_config,
+                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
+                  enum_idx,
+                  FILE_TYPE_DIRECTORY, 0, 0, NULL);
+      }
+
+      for (wi = 0; webos_storage[wi]; wi++)
+      {
+         if (path_is_directory(webos_storage[wi]))
+            menu_entries_append(list, webos_storage[wi],
+                  MENU_ENUM_LABEL_FILE_DETECT_CORE_LIST_PUSH_DIR_STR,
+                  enum_idx,
+                  FILE_TYPE_DIRECTORY, 0, 0, NULL);
+      }
+   }
 #else
    char base_path[PATH_MAX] = {0};
    char udisks_media_path[PATH_MAX] = {0};
@@ -2618,7 +2653,8 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
    }
 #endif
 
-#ifdef ANDROID
+#if !defined(WEBOS)
+#if defined(ANDROID)
    if (!g_android->is_play_store_build)
 #else
    if (1)
@@ -2629,6 +2665,7 @@ static int frontend_unix_parse_drive_list(void *data, bool load_content)
             enum_idx,
             FILE_TYPE_DIRECTORY, 0, 0, NULL);
    }
+#endif
 
 #if defined(ANDROID) && defined(HAVE_SAF)
    if (g_android->have_saf)

--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -35,6 +35,7 @@
 #include <file/file_path.h>
 
 #include <compat/strl.h>
+#include <string/stdstring.h>
 #include <retro_dirent.h>
 
 #include <retro_miscellaneous.h>

--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -229,6 +229,17 @@ static int dir_list_read(const char *dir,
 
       fill_pathname_join_special(file_path, dir, name, sizeof(file_path));
 
+#if defined(WEBOS)
+      /* Skip virtual / dangerous FS nodes under jail root — readdir+stat
+       * on /proc or /sys can stall the main thread for a long time. */
+      if (   (string_is_equal(dir, "/") || string_is_equal(dir, "//"))
+          && (   string_is_equal(name, "proc")
+              || string_is_equal(name, "sys")
+              || string_is_equal(name, "dev")
+              || string_is_equal(name, "run")))
+         continue;
+#endif
+
       if (retro_dirent_is_dir(entry, NULL))
       {
          /* Exclude this frequent hidden dir on platforms which can not handle hidden attribute */

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -272,6 +272,20 @@ static int filebrowser_parse(
             || !strcmp(label, "cursor_manager_list"))
          allow_parent_directory = false;
 
+#if defined(WEBOS)
+      /* Parent-directory navigation can still reach "/". Re-show the
+       * platform drive list instead of readdir() on jail root, which
+       * freezes the UI when /proc or /sys is scanned. */
+      if (string_is_equal(full_path, "/") || string_is_equal(full_path, "//"))
+      {
+         frontend_driver_parse_drive_list(info_list, true);
+         allow_parent_directory = false;
+         count = 1; /* info_list already has drives; avoid "No items" */
+         ret   = true;
+         goto end;
+      }
+#endif
+
       if (filebrowser_type == FILEBROWSER_SELECT_FILE_SUBSYSTEM)
       {
          runloop_state_t    *runloop_st = runloop_state_get_ptr();


### PR DESCRIPTION
## Summary

On webOS, RetroArch runs under **jailer**. Opening **Load Content** and selecting filesystem root (`/`), or navigating Parent Directory up to `/`, can **freeze the UI**. Under the jail, directory enumeration touches virtual filesystems such as `/proc` and `/sys`, which stalls the main thread.

This change keeps the file browser on **safe storage locations** and refuses to treat `/` as a normal browsable directory on webOS.

### Changes
1. **`frontend/drivers/platform_unix.c`** — Safe webOS drive list (app package, media, USB, temp); do not offer `/`
2. **`menu/menu_displaylist.c`** — If path is `/`, re-show drive list instead of `readdir` on jail root
3. **`libretro-common/lists/dir_list.c`** — Skip `proc`/`sys`/`dev`/`run` when listing `/`

## Test plan
- [ ] webOS TV (jailer): Load Content opens without hang
- [ ] Opening or navigating to `/` does not freeze; safe drives shown
- [ ] Can still open `/media/internal`, `/media/developer`, app directory
- [ ] Non-webOS platforms unchanged

## Notes
Companion PR for Load Content visibility (empty file list / wrong start dir) stacks on this branch.

Previously opened against the wrong fork (webosbrew/RetroArch#14); reopening here per maintainer guidance.