### PR TITLE
android: set core package as per 2026 spec

### DIFF
--- a/pkg/android/phoenix/module_template/AndroidManifest.xml
+++ b/pkg/android/phoenix/module_template/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:dist="http://schemas.android.com/apk/distribution"
-    package="com.retroarch.modules.%CORE_NAME%">
+    xmlns:dist="http://schemas.android.com/apk/distribution">
 
     <dist:module dist:title="@string/%CORE_NAME%">
         <dist:delivery>

--- a/pkg/android/phoenix/module_template/build.gradle
+++ b/pkg/android/phoenix/module_template/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.dynamic-feature'
 
 android {
-  namespace "com.retroarch.%CORE_NAME%"
+  namespace "com.retroarch.modules.%CORE_NAME%"
 
   compileSdkVersion 36
   buildToolsVersion "36.0.0"


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This throws an error in 2026.

## Related Issues

## Related Pull Requests

## Reviewers
