### PR TITLE
android: remove x86 from play store variant / update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,8 @@ wiiu/wut/elf2rpl/elf2rpl
 /pkg/android/phoenix/.externalNativeBuild
 /pkg/android/phoenix/build
 /pkg/android/phoenix-legacy/.project
+/pkg/android/phoenix-jelly-bean/.gradle/
+/pkg/android/phoenix-jelly-bean/.cxx/
 
 # Cloned by libretro-fetch.sh
 /media/assets/

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -87,6 +87,10 @@ android {
       buildConfigField "boolean", "PLAY_STORE_BUILD", "true"
 
       dimension "variant"
+
+      ndk {
+        abiFilters 'arm64-v8a', 'x86_64', 'armeabi-v7a'
+      }
     }
     playStorePlus {
       minSdkVersion 21
@@ -99,6 +103,10 @@ android {
       buildConfigField "boolean", "PLAY_STORE_BUILD", "true"
 
       dimension "variant"
+
+      ndk {
+        abiFilters 'arm64-v8a', 'x86_64', 'armeabi-v7a'
+      }
     }
   }
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Remove x86 from play store (< 0.5% of market), due to out of memory issue bundling the APK
Update gitignore to remove legacy phoenix/jelly bean temp files.

## Related Issues

## Related Pull Requests

## Reviewers

