### PR TITLE
android: recreate Vulkan surface after app resume

### DIFF
--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1403,6 +1403,23 @@ static void vulkan_destroy_swapchain(gfx_ctx_vulkan_data_t *vk)
    vk->context.num_recycled_acquire_semaphores = 0;
 }
 
+bool vulkan_surface_destroy(gfx_ctx_vulkan_data_t *vk)
+{
+   if (!vk || !vk->context.instance)
+      return false;
+
+   vulkan_destroy_swapchain(vk);
+
+   if (vk->vk_surface != VK_NULL_HANDLE)
+   {
+      vkDestroySurfaceKHR(vk->context.instance,
+            vk->vk_surface, NULL);
+      vk->vk_surface = VK_NULL_HANDLE;
+   }
+
+   return true;
+}
+
 static void vulkan_acquire_clear_fences(gfx_ctx_vulkan_data_t *vk)
 {
    unsigned i;
@@ -1696,16 +1713,48 @@ bool vulkan_surface_create(gfx_ctx_vulkan_data_t *vk,
          return false;
    }
 
-   /* Must create device after surface since we need to be able to query queues to use for presentation. */
-   if (!vulkan_context_init_device(vk))
-      return false;
+   /* Must create device after surface since we need to be able to query queues
+    * to use for presentation. When replacing a lost surface, retain the
+    * existing device and verify that its queue can present to the new one. */
+   if (vk->context.device == VK_NULL_HANDLE)
+   {
+      if (!vulkan_context_init_device(vk))
+         goto error_surface;
+   }
+   else
+   {
+      VkResult res;
+      VkBool32 supported = VK_FALSE;
+
+      res = vkGetPhysicalDeviceSurfaceSupportKHR(
+            vk->context.gpu,
+            vk->context.graphics_queue_index,
+            vk->vk_surface, &supported);
+      if (res != VK_SUCCESS || !supported)
+      {
+         RARCH_ERR("[Vulkan] Existing queue cannot present to replacement surface (err = %d).\n",
+               (int)res);
+         goto error_surface;
+      }
+   }
 
    if (!vulkan_create_swapchain(
             vk, width, height, swap_interval))
-      return false;
+      goto error_swapchain;
 
    vulkan_acquire_next_image(vk);
    return true;
+
+error_swapchain:
+   vulkan_destroy_swapchain(vk);
+error_surface:
+   if (vk->vk_surface != VK_NULL_HANDLE)
+   {
+      vkDestroySurfaceKHR(vk->context.instance,
+            vk->vk_surface, NULL);
+      vk->vk_surface = VK_NULL_HANDLE;
+   }
+   return false;
 }
 
 uint32_t vulkan_find_memory_type(

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -2636,6 +2636,10 @@ bool vulkan_create_swapchain(gfx_ctx_vulkan_data_t *vk,
    /* Force driver to reset swapchain image handles. */
    vk->context.flags                 |=  VK_CTX_FLAG_INVALID_SWAPCHAIN;
    vk->context.flags                 &= ~VK_CTX_FLAG_HAS_ACQUIRED_SWAPCHAIN;
+   /* A replacement swapchain can have fewer images than its predecessor.
+    * Do not retain an image index from the old swapchain while waiting for
+    * the first acquire from the new one. */
+   vk->context.current_swapchain_index = 0;
    vulkan_create_wait_fences(vk);
 
    if (vk->flags & VK_DATA_FLAG_EMULATING_MAILBOX)

--- a/gfx/common/vulkan_common.h
+++ b/gfx/common/vulkan_common.h
@@ -338,6 +338,8 @@ bool vulkan_surface_create(gfx_ctx_vulkan_data_t *vk,
       unsigned width, unsigned height,
       int8_t swap_interval);
 
+bool vulkan_surface_destroy(gfx_ctx_vulkan_data_t *vk);
+
 void vulkan_present(gfx_ctx_vulkan_data_t *vk, unsigned index);
 
 void vulkan_acquire_next_image(gfx_ctx_vulkan_data_t *vk);

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -5216,6 +5216,9 @@ static void *vulkan_init(const video_info_t *video,
 #endif
 
    vulkan_init_readback(vk, settings->bools.video_gpu_record);
+
+   /* Driver resources now match the context's current swapchain. */
+   vk->context->flags &= ~VK_CTX_FLAG_INVALID_SWAPCHAIN;
    return vk;
 
 error:
@@ -5347,6 +5350,25 @@ static void vulkan_check_swapchain(vk_t *vk)
           &filter_info)
       )
       RARCH_ERR("[Vulkan] Failed to update filter chain info.\n");
+}
+
+static bool vulkan_recreate_context_swapchain(vk_t *vk)
+{
+   unsigned width  = vk->context->swapchain_width;
+   unsigned height = vk->context->swapchain_height;
+
+   if (!vk->ctx_driver->set_resize)
+      return false;
+
+   /* set_resize is the context-owned recreation path. It replaces the
+    * swapchain before returning, releasing any acquired image that cannot be
+    * submitted safely by this frame. */
+   vk->context->flags |= VK_CTX_FLAG_INVALID_SWAPCHAIN;
+   if (!vk->ctx_driver->set_resize(vk->ctx_data, width, height))
+      return false;
+
+   vulkan_check_swapchain(vk);
+   return true;
 }
 
 static void vulkan_set_nonblock_state(void *data, bool state,
@@ -6360,11 +6382,26 @@ static bool vulkan_frame(void *data, const void *frame,
 #ifdef HAVE_GFX_WIDGETS
    bool widgets_active                           = video_info->widgets_active;
 #endif
-   unsigned frame_index                          =
-      vk->context->current_frame_index;
-   unsigned swapchain_index                      =
-      vk->context->current_swapchain_index;
+   unsigned frame_index;
+   unsigned swapchain_index;
    bool overlay_behind_menu                      = video_info->overlay_behind_menu;
+
+   /* The context may recreate its swapchain while acquiring the next
+    * image. Rebuild driver-owned framebuffers before recording commands
+    * against images from the new swapchain. */
+   if (vk->context->flags & VK_CTX_FLAG_INVALID_SWAPCHAIN)
+      vulkan_check_swapchain(vk);
+
+   frame_index     = vk->context->current_frame_index;
+   swapchain_index = vk->context->current_swapchain_index;
+
+   if (     frame_index     >= vk->num_swapchain_images
+         || swapchain_index >= vk->num_swapchain_images)
+   {
+      RARCH_ERR("[Vulkan] Invalid swapchain indices (frame %u, image %u, count %u).\n",
+            frame_index, swapchain_index, vk->num_swapchain_images);
+      return vulkan_recreate_context_swapchain(vk);
+   }
 
    /* Fast toggle shader filter chain logic */
    filter_chain = vk->filter_chain;
@@ -6748,8 +6785,17 @@ static bool vulkan_frame(void *data, const void *frame,
       backbuffer = &vk->offscreen_buffer;
 #endif /* VULKAN_HDR_SWAPCHAIN */
 
+   if (     (backbuffer->image != VK_NULL_HANDLE)
+         && (backbuffer->framebuffer == VK_NULL_HANDLE))
+   {
+      RARCH_ERR("[Vulkan] Swapchain image %u has no framebuffer.\n",
+            swapchain_index);
+      return vulkan_recreate_context_swapchain(vk);
+   }
+
    /* Render to backbuffer. */
    if (     (backbuffer->image != VK_NULL_HANDLE)
+         && (backbuffer->framebuffer != VK_NULL_HANDLE)
          && (vk->context->flags & VK_CTX_FLAG_HAS_ACQUIRED_SWAPCHAIN))
    {
       rp_info.sType                    = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;

--- a/gfx/drivers_context/android_vk_ctx.c
+++ b/gfx/drivers_context/android_vk_ctx.c
@@ -39,6 +39,7 @@ typedef struct
    unsigned width;
    unsigned height;
    int swap_interval;
+   bool surface_lost;
 } android_ctx_data_vk_t;
 
 /* FORWARD DECLARATION */
@@ -168,8 +169,57 @@ static bool android_gfx_ctx_vk_set_video_mode(void *data,
       RARCH_ERR("[Vulkan] Failed to create surface.\n");
       return false;
    }
+   and->surface_lost = false;
    RARCH_LOG("[Vulkan] Native window size: %ux%u.\n",
          and->width, and->height);
+   return true;
+}
+
+static bool android_gfx_ctx_vk_create_surface(void *data)
+{
+   struct android_app *android_app = (struct android_app*)g_android;
+   android_ctx_data_vk_t *and      = (android_ctx_data_vk_t*)data;
+
+   /* APP_CMD_INIT_WINDOW can remain pending after startup even though the
+    * Vulkan surface is already active. */
+   if (and && !and->surface_lost
+         && and->vk.vk_surface != VK_NULL_HANDLE)
+   {
+      RARCH_LOG("[Vulkan] Ignoring duplicate Android window initialization.\n");
+      return true;
+   }
+
+   if (!android_app || !android_app->window || !and)
+      return false;
+
+   and->width  = ANativeWindow_getWidth(android_app->window);
+   and->height = ANativeWindow_getHeight(android_app->window);
+
+   if (!vulkan_surface_create(&and->vk, VULKAN_WSI_ANDROID,
+            NULL, android_app->window,
+            and->width, and->height, and->swap_interval))
+   {
+      RARCH_ERR("[Vulkan] Failed to recreate Android surface.\n");
+      return false;
+   }
+
+   and->surface_lost = false;
+   RARCH_LOG("[Vulkan] Recreated Android surface: %ux%u.\n",
+         and->width, and->height);
+   return true;
+}
+
+static bool android_gfx_ctx_vk_destroy_surface(void *data)
+{
+   android_ctx_data_vk_t *and = (android_ctx_data_vk_t*)data;
+
+   if (!and)
+      return false;
+
+   and->surface_lost = true;
+   if (!vulkan_surface_destroy(&and->vk))
+      return false;
+
    return true;
 }
 
@@ -200,6 +250,10 @@ static bool android_gfx_ctx_vk_suppress_screensaver(void *data, bool enable) { r
 static void android_gfx_ctx_vk_swap_buffers(void *data)
 {
    android_ctx_data_vk_t *and  = (android_ctx_data_vk_t*)data;
+
+   if (!and || and->surface_lost
+         || and->vk.vk_surface == VK_NULL_HANDLE)
+      return;
 
    if (and->vk.context.flags & VK_CTX_FLAG_HAS_ACQUIRED_SWAPCHAIN)
    {
@@ -281,6 +335,6 @@ const gfx_ctx_driver_t gfx_ctx_vk_android = {
    android_gfx_ctx_vk_bind_hw_render,
    android_gfx_ctx_vk_get_context_data,
    NULL,                                     /* make_current */
-   NULL,                                     /* create_surface */
-   NULL                                      /* destroy_surface */
+   android_gfx_ctx_vk_create_surface,
+   android_gfx_ctx_vk_destroy_surface
 };

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -584,14 +584,14 @@ typedef struct gfx_ctx_driver
     * active for this thread. */
    void (*make_current)(bool release);
 
-   /* Optional. Creates and binds a new window surface, destroying the original
-    * window surface if applicable. Returns true on success and false on error.
-    * Currently only for OpenGL. */
+   /* Optional. Creates and binds a replacement window surface without
+    * reinitializing the underlying graphics context/device. Returns true on
+    * success and false on error. */
    bool (*create_surface)(void *data);
 
-   /* Optional. Destroys the current window surface. Returns true on success or
-    * or if there is no currently bound window surface and false on error.
-    * Currently only for OpenGL. */
+   /* Optional. Destroys the current window surface without reinitializing the
+    * underlying graphics context/device. Returns true on success, or if no
+    * window surface is bound, and false on error. */
    bool (*destroy_surface)(void *data);
 } gfx_ctx_driver_t;
 

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -48,6 +48,10 @@
 #include "../../runloop.h"
 #include "../input_driver.h"
 
+#ifdef HAVE_THREADS
+#include "../../gfx/video_thread_wrapper.h"
+#endif
+
 #define MAX_TOUCH 16
 #define MAX_NUM_KEYBOARDS 3
 #define DEFAULT_ASENSOR_EVENT_RATE 60
@@ -365,6 +369,20 @@ bool android_input_can_be_keyboard(void *data, int port)
     return android_input_can_be_keyboard_jni(device->id);
 }
 
+static void android_input_destroy_surface(video_driver_state_t *state)
+{
+   if (!state || !state->current_video_context.destroy_surface)
+      return;
+
+#ifdef HAVE_THREADS
+   /* The video worker may still be recording a frame that references the
+    * surface. Drain it before the context driver frees the surface. */
+   video_thread_wait_idle();
+#endif
+
+   state->current_video_context.destroy_surface(state->context_data);
+}
+
 static void android_input_poll_main_cmd(void)
 {
    int8_t cmd;
@@ -426,10 +444,14 @@ static void android_input_poll_main_cmd(void)
 
          slock_lock(android_app->mutex);
          android_app->activityState = cmd;
+         /* RESUME/START can arrive before INIT_WINDOW. In that case,
+          * wait for INIT_WINDOW rather than falling back to a full
+          * video-driver reinitialization without a native window. */
          if (  (cmd == APP_CMD_RESUME || cmd == APP_CMD_START)
              && state->current_video_context.ident
              && string_is_equal(state->current_video_context.ident,
                    "vk_android")
+             && android_app->window
              && state->current_video_context.create_surface)
             android_app->reinitRequested = 1;
          scond_broadcast(android_app->cond);
@@ -451,9 +473,8 @@ static void android_input_poll_main_cmd(void)
           * cannot wedge before APP_CMD_TERM_WINDOW is delivered. */
          if (     state->current_video_context.ident
                && string_is_equal(state->current_video_context.ident,
-                     "vk_android")
-               && state->current_video_context.destroy_surface)
-            state->current_video_context.destroy_surface(state->context_data);
+                     "vk_android"))
+            android_input_destroy_surface(state);
          break;
       }
 
@@ -462,20 +483,20 @@ static void android_input_poll_main_cmd(void)
                android_app->activity->assetManager);
          break;
       case APP_CMD_TERM_WINDOW:
+      {
+         video_driver_state_t *state = video_state_get_ptr();
+
+         android_input_destroy_surface(state);
+
          slock_lock(android_app->mutex);
 
          /* The window is being hidden or closed, clean it up. */
          /* terminate display/EGL context here */
-         {
-            video_driver_state_t *state = video_state_get_ptr();
-            if (state->current_video_context.destroy_surface != NULL)
-               state->current_video_context.destroy_surface(state->context_data);
-         }
-
          android_app->window = NULL;
          scond_broadcast(android_app->cond);
          slock_unlock(android_app->mutex);
          break;
+      }
 
       case APP_CMD_GAINED_FOCUS:
          {

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -421,12 +421,41 @@ static void android_input_poll_main_cmd(void)
       case APP_CMD_RESUME:
       case APP_CMD_START:
       case APP_CMD_PAUSE:
+      {
+         video_driver_state_t *state = video_state_get_ptr();
+
+         slock_lock(android_app->mutex);
+         android_app->activityState = cmd;
+         if (  (cmd == APP_CMD_RESUME || cmd == APP_CMD_START)
+             && state->current_video_context.ident
+             && string_is_equal(state->current_video_context.ident,
+                   "vk_android")
+             && state->current_video_context.create_surface)
+            android_app->reinitRequested = 1;
+         scond_broadcast(android_app->cond);
+         slock_unlock(android_app->mutex);
+         break;
+      }
+
       case APP_CMD_STOP:
+      {
+         video_driver_state_t *state = video_state_get_ptr();
+
          slock_lock(android_app->mutex);
          android_app->activityState = cmd;
          scond_broadcast(android_app->cond);
          slock_unlock(android_app->mutex);
+
+         /* Android may retain the same ANativeWindow while the app is
+          * backgrounded. Release Vulkan's acquired buffers anyway so BLAST
+          * cannot wedge before APP_CMD_TERM_WINDOW is delivered. */
+         if (     state->current_video_context.ident
+               && string_is_equal(state->current_video_context.ident,
+                     "vk_android")
+               && state->current_video_context.destroy_surface)
+            state->current_video_context.destroy_surface(state->context_data);
          break;
+      }
 
       case APP_CMD_CONFIG_CHANGED:
          AConfiguration_fromAssetManager(android_app->config,

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1913,11 +1913,10 @@ static void android_input_reinit(void)
 
    if (runloop_flags & RUNLOOP_FLAG_PAUSED)
    {
-      /* When using OpenGL, pausing the app (e.g. by opening the app switcher)
-       * will result in the EGL window surface being destroyed, but the actual
-       * OpenGL context will be preserved on most devices, so we may be able to
-       * get away with reinitializing only the window surface without having to
-       * do a full video driver reinitialization. */
+      /* When the app is paused (e.g. by opening the app switcher), Android may
+       * destroy the presentation surface while retaining the OpenGL context or
+       * Vulkan device. Recreate only the surface when supported before falling
+       * back to a full video driver reinitialization. */
       video_driver_state_t *state = video_state_get_ptr();
       if (state->current_video_context.create_surface == NULL || !state->current_video_context.create_surface(state->context_data))
          command_event(CMD_EVENT_REINIT, NULL);


### PR DESCRIPTION
## Problem

On Android, RetroArch could resume Vulkan rendering after the Android window lifecycle had invalidated the presentation surface or swapchain.

Android may retain the same `ANativeWindow` while the app is backgrounded, so waiting only for a later window teardown could leave Vulkan presentation resources alive too long. This could stall the presentation queue or lead to a resume crash or freeze. User may notice a black flash before game resumes.

## Fix

Handle Android Vulkan surface loss independently of the Vulkan device:

- Destroy the swapchain and `VkSurfaceKHR` when the app stops.
- Keep the Vulkan device, shader state, textures, menu state, and input state.
- Recreate the surface on resume, verify the existing graphics queue can present to it, and recreate the swapchain.
- Avoid presenting while no Android surface is available.
- Rebuild driver-owned swapchain resources before rendering after a context-side swapchain recreation.
- Validate frame/image indices and avoid beginning a render pass with a null framebuffer.
- Wait for Android to provide a new native window before attempting surface recreation.
- Drain threaded video before destroying the presentation surface, without holding the Android lifecycle mutex.
- Reset the current swapchain image index when replacing a swapchain, so an index from a larger old swapchain cannot be used with a smaller new one.

If surface recreation fails, the existing full-context recovery path remains available.

## Validation

Tested on Android with Vulkan:

- Repeated background → resume cycles with shaders enabled and disabled.
- Resume with the menu both open and closed.
- Shader disable/re-enable after resume.
- Toggled threaded video off while using Vulkan; verified recovery from the prior invalid-swapchain-index hang.
- Tested Dolphin with Vulkan hardware rendering through repeated background/resume cycles.
- Tested a software-rendered core with Vulkan, threaded video, and a shader.

No resume crash or permanent presentation stall was observed in the tested paths. Eliminates black flash before game resumes after backgrounding.
