### PR TITLE
vulkan: preserve cached frames behind menu

### DIFF
--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -7446,6 +7446,17 @@ static bool vulkan_get_current_sw_framebuffer(void *data,
    if (chain->texture.width != framebuffer->width ||
          chain->texture.height != framebuffer->height)
    {
+      /* vulkan_create_texture() synchronously unmaps (and, unless the
+       * allocation is pilfered, frees) the old memory. If the core
+       * rendered the previous frame through this callback, the cached
+       * frame still points at that mapping: evict it first, under the
+       * lifetime lock, so a concurrent reader cannot be left mid-read
+       * of dying memory and a later cached re-render cannot pick up a
+       * stale pointer (the pilfer path can even remap the same
+       * VkDeviceMemory at the same host address, making a stale
+       * pointer look dereferenceable with the wrong geometry). */
+      video_driver_cached_frame_invalidate_if(
+            vk, vulkan_cached_frame_uses_swapchain_texture);
       chain->texture   = vulkan_create_texture(vk, &chain->texture,
             framebuffer->width, framebuffer->height, chain->texture.format,
             NULL, NULL, VULKAN_TEXTURE_STREAMED);

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -3996,17 +3996,27 @@ static void vulkan_init_textures(vk_t *vk)
          &zero, NULL, VULKAN_TEXTURE_STATIC);
 }
 
+static bool vulkan_cached_frame_uses_swapchain_texture(
+      void *userdata, const void *data)
+{
+   vk_t *vk = (vk_t*)userdata;
+   int i;
+
+   for (i = 0; i < (int)vk->num_swapchain_images; i++)
+      if (data == vk->swapchain[i].texture.mapped)
+         return true;
+
+   return false;
+}
+
 static void vulkan_deinit_textures(vk_t *vk)
 {
    int i;
-   /* Invalidate the cached frame unconditionally before destroying
-    * the swapchain textures.  The new API's lifetime lock blocks
-    * here if an off-thread consumer is mid-read of pixels that
-    * may live in one of those mapped textures, so the destroy
-    * below cannot race a reader.  Cheaper and simpler than the
-    * previous conditional check (which only covered the
-    * synchronous case via a pointer-in-mapped-range test). */
-   video_driver_cached_frame_invalidate();
+   /* Keep cached core-owned pixels across swapchain recreation. If the
+    * cache points into a mapped swapchain texture, invalidate it under
+    * the lifetime lock before unmapping that texture. */
+   video_driver_cached_frame_invalidate_if(
+         vk, vulkan_cached_frame_uses_swapchain_texture);
 
    vkDestroySampler(vk->context->device, vk->samplers.nearest,        NULL);
    vkDestroySampler(vk->context->device, vk->samplers.linear,         NULL);

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -3443,6 +3443,30 @@ void video_driver_cached_frame_invalidate(void)
    cached_frame_lock_release();
 }
 
+bool video_driver_cached_frame_invalidate_if(
+      void *userdata,
+      bool (*predicate)(void *userdata, const void *data))
+{
+   bool invalidated = false;
+
+   if (!predicate)
+      return false;
+
+   cached_frame_lock_acquire();
+   if (     frame_cache_data
+         && predicate(userdata, frame_cache_data))
+   {
+      frame_cache_data   = NULL;
+      frame_cache_width  = 0;
+      frame_cache_height = 0;
+      frame_cache_pitch  = 0;
+      invalidated        = true;
+   }
+   cached_frame_lock_release();
+
+   return invalidated;
+}
+
 bool video_driver_has_focus(void)
 {
    video_driver_state_t *video_st = &video_driver_st;

--- a/gfx/video_driver.h
+++ b/gfx/video_driver.h
@@ -1071,6 +1071,18 @@ void video_driver_cached_frame_publish(
  */
 void video_driver_cached_frame_invalidate(void);
 
+/**
+ * video_driver_cached_frame_invalidate_if:
+ *
+ * Conditionally invalidates the cached frame while holding its lifetime
+ * lock. The predicate must not call another cached-frame API.
+ *
+ * Returns true when the cached frame was invalidated.
+ */
+bool video_driver_cached_frame_invalidate_if(
+      void *userdata,
+      bool (*predicate)(void *userdata, const void *data));
+
 bool video_driver_is_hw_context(void);
 
 /* True when the active video driver's render context can only be driven


### PR DESCRIPTION
## Problem

Game content behind an open menu could go blank or flash after a Vulkan swapchain rebuild, such as background/resume or integer-scale changes.

Vulkan invalidated RetroArch’s cached frame every time swapchain textures were destroyed and recreated. This is necessary when the cache points into a mapped swapchain texture that is about to be unmapped, but it also cleared core-owned cached pixels that remain valid.

## Fix

Add a conditional cached-frame invalidation helper that holds the existing cache lifetime lock while checking the cached data pointer.

The Vulkan driver now invalidates the cache only when it points to one of its mapped swapchain textures. Core-owned cached frames remain valid across swapchain rebuilds, while swapchain-owned frames are still cleared before their backing texture is destroyed.

## Validation

Tested on Android 14 / Mali with Vulkan:

- Background and resume with a shader and menu open.
- Toggle integer scale and switch overscale/underscale with the menu open.
- Load, unload, and reapply shader presets.
- Close the menu after each scenario and confirm normal gameplay.

Cached game content remained visible behind the menu across the tested rebuild paths.
