### PR TITLE
Playlists: Fix state_slot in runtime logs being saved to entry_slot (ex.: in the History playlist)

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -14566,6 +14566,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                bool savestates_enabled     = core_info_current_supports_savestate();
                playlist_t *playlist        = playlist_get_cached();
                runloop_state_t *runloop_st = runloop_state_get_ptr();
+               int state_slot              = settings->ints.state_slot;
 
                /* Load the core for getting the final state path for thumbnails */
                if (playlist && !(runloop_st->flags & RUNLOOP_FLAG_CORE_RUNNING))
@@ -14578,6 +14579,8 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
 
                   if (entry && *entry->path)
                   {
+                     runtime_log_t *runtime_log = NULL;
+
                      path_set(RARCH_PATH_CORE, entry->core_path);
                      command_event(CMD_EVENT_LOAD_CORE, NULL);
                      runloop_set_current_core_type(CORE_TYPE_PLAIN, true);
@@ -14585,8 +14588,23 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                      /* Reinit runtime log and read current state slot */
                      savestates_enabled = core_info_current_supports_savestate();
                      if (savestates_enabled)
+                     {
                         runtime_update_playlist(playlist,
                               menu_st->driver_data->rpl_entry_selection_ptr);
+
+                        runtime_log = runtime_log_init(entry->path,
+                              entry->core_path,
+                              settings->paths.directory_runtime_log,
+                              settings->paths.directory_playlist,
+                              true);
+
+                        if (runtime_log)
+                        {
+                           if (path_is_valid(runtime_log->path) && runtime_log->state_slot < 1000)
+                              state_slot = runtime_log->state_slot;
+                           free(runtime_log);
+                        }
+                     }
                   }
                }
 
@@ -14618,7 +14636,7 @@ bool menu_displaylist_ctl(enum menu_displaylist_ctl_state type,
                   }
 
                   /* Pre-select last slot from the runtime log */
-                  menu_st->selection_ptr = runloop_st->entry_state_slot + 1;
+                  menu_st->selection_ptr = state_slot + 1;
                }
 
                menu_displaylist_no_entries_fallback(info->list, count, FILE_TYPE_NONE);

--- a/runloop.c
+++ b/runloop.c
@@ -737,6 +737,11 @@ void runloop_runtime_log_deinit(
          sizeof(runloop_st->runtime_content_path));
    memset(runloop_st->runtime_core_path, 0,
          sizeof(runloop_st->runtime_core_path));
+
+   /* Reset entry state slot, to prevent any possibility
+    * of a stale slot leaking into subsequently loaded
+    * content */
+   runloop_st->entry_state_slot = -1;
 }
 
 static bool runloop_clear_all_thread_waits(
@@ -4568,12 +4573,24 @@ static void runloop_runtime_log_init(runloop_state_t *runloop_st)
 
    if (     (content_path && *content_path)
          && (core_path && *core_path))
-      runtime_log_init(
+   {
+      runtime_log_t *runtime_log = runtime_log_init(
             runloop_st->runtime_content_path,
             runloop_st->runtime_core_path,
             settings->paths.directory_runtime_log,
             settings->paths.directory_playlist,
             true);
+
+      if (runtime_log)
+      {
+         if (     runloop_st->entry_state_slot < 0
+               && path_is_valid(runtime_log->path)
+               && runtime_log->state_slot < 1000)
+            configuration_set_int(settings, settings->ints.state_slot, runtime_log->state_slot);
+
+         free(runtime_log);
+      }
+   }
 }
 
 void runloop_set_frame_limit(

--- a/runtime_file.c
+++ b/runtime_file.c
@@ -286,13 +286,6 @@ parsed:
       state_slot = (unsigned)val;
    }
 
-   if (     state_slot >= 0
-         && state_slot < 1000)
-   {
-      runloop_state_t *runloop_st  = runloop_state_get_ptr();
-      runloop_st->entry_state_slot = state_slot;
-   }
-
    /* If we reach this point then all is well
     * > Assign values to runtime_log object */
    runtime_log->runtime.hours      = runtime_hours;


### PR DESCRIPTION
## Description

In the current RA master, an issue was observed recently (and also discussed on Discord) where playlist entries for which savestates were created could get saved to the History playlist with the `entry_slot` line appended at the end, even when the original entry didn't have any `entry_slot` line at all.

The `entry_line` makes it so that, anytime any such entry is loaded from History, the content will be launched while also automatically loading its latest savestate from the chosen savestate slot.

What seems to be happening is the following:

- The runtime log files store the last-selected savestate slot into the `state_slot` variable. This way, the UI can pre-select the last chosen savestate slot for any given piece of content.
- The issue is that the `state_slot` value was being automatically copied into `runloop_st->entry_state_slot` as well.
- This made it so that the History playlist would inherit the `state_slot` value automatically as `entry_slot`, and assign an undesired auto-loading state to its entries.

This PR addresses the problem by separating the two things:

- The `state_slot` value in runtime logs is now restored directly into `settings->ints.state_slot`. It does not get written to `entry_state_slot`.
- `entry_slot` is used, just like before, as an appended suffix line in playlist entries and serves to determine whether to auto-load the state found in a user-defined slot from 1 to 999. Its value gets copied into `runloop_st->entry_state_slot`. 
- If a playlist entry does have its `entry_slot` line already, and is consequently loaded with it, that entry will be coherently saved in the History with its `entry_slot` line appended too. The difference is that now the `entry_slot` line will not be created from scratch anymore just based on the `state_slot` value found in the runtime logs.
- All other behavior is left unchanged.

## Reviewers

@sonninnos 
@LibretroAdmin 
