### PR TITLE
android: set 16kb size for play store variants

### DIFF
--- a/pkg/android/phoenix-common/jni/Android.mk
+++ b/pkg/android/phoenix-common/jni/Android.mk
@@ -254,4 +254,15 @@ ifneq ($(SANITIZER),)
    LOCAL_LDFLAGS  += -fsanitize=$(SANITIZER)
 endif
 
+# Android 6 and above, play store variant
+ifeq ($(PLAY_STORE_BUILD),1)
+   ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+      LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+   endif
+
+   ifeq ($(TARGET_ARCH_ABI),x86_64)
+      LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+   endif
+endif
+
 include $(BUILD_SHARED_LIBRARY)

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -91,6 +91,12 @@ android {
       ndk {
         abiFilters 'arm64-v8a', 'x86_64', 'armeabi-v7a'
       }
+
+      externalNativeBuild {
+        ndkBuild {
+          arguments "-j${Runtime.runtime.availableProcessors()}", "PLAY_STORE_BUILD=1"
+        }
+      }
     }
     playStorePlus {
       minSdkVersion 21
@@ -106,6 +112,12 @@ android {
 
       ndk {
         abiFilters 'arm64-v8a', 'x86_64', 'armeabi-v7a'
+      }
+
+      externalNativeBuild {
+        ndkBuild {
+          arguments "-j${Runtime.runtime.availableProcessors()}", "PLAY_STORE_BUILD=1"
+        }
       }
     }
   }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

another 2026 requirement - 16kb page size. only affects play store variant not downloaded.

## Related Issues

## Related Pull Requests


## Reviewers
