### PR TITLE
Content Scan: Fix file extension filter when scanning single files

### DIFF
--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -145,6 +145,15 @@ size_t manual_content_scan_get_file_exts_custom_size(void)
    return sizeof(scan_file_exts_custom);
 }
 
+/* Returns custom extensions,
+ * falling back to core-supported extensions */
+const char *manual_content_scan_get_file_exts(void)
+{
+   if (*scan_file_exts_custom)
+      return scan_file_exts_custom;
+   return scan_file_exts_core;
+}
+
 /* Returns a pointer to the internal
  * 'dat_file_path' string */
 char *manual_content_scan_get_dat_file_path_ptr(void)

--- a/manual_content_scan.h
+++ b/manual_content_scan.h
@@ -165,6 +165,10 @@ char *manual_content_scan_get_file_exts_custom_ptr(void);
  * 'file_exts_custom' string */
 size_t manual_content_scan_get_file_exts_custom_size(void);
 
+/* Returns custom extensions,
+ * falling back to core-supported extensions */
+const char *manual_content_scan_get_file_exts(void);
+
 /* Returns a pointer to the internal
  * 'dat_file_path' string */
 char *manual_content_scan_get_dat_file_path_ptr(void);

--- a/menu/cbs/menu_cbs_deferred_push.c
+++ b/menu/cbs/menu_cbs_deferred_push.c
@@ -33,6 +33,7 @@
 #include "../../configuration.h"
 #include "../../core.h"
 #include "../../core_info.h"
+#include "../../manual_content_scan.h"
 #include "../../verbosity.h"
 #include "../../msg_hash_lbl_str.h"
 
@@ -458,6 +459,13 @@ static int general_push(menu_displaylist_info_t *info,
       }
    }
 #endif
+
+   if (     string_is_equal(info->label, MENU_ENUM_LABEL_MANUAL_CONTENT_SCAN_DIR_STR)
+         && manual_content_scan_get_scan_method_enum() == MANUAL_CONTENT_SCAN_METHOD_CUSTOM)
+   {
+      strlcpy(ext_filter, manual_content_scan_get_file_exts(), sizeof(ext_filter));
+      string_replace_all_chars(ext_filter, ' ', '|');
+   }
 
    if (*ext_filter)
    {


### PR DESCRIPTION
## Description

In the current RA master, there is an issue with the Content Scan process: when scanning single files (by first setting the scan method to Custom, then disabling "Scan Recursively" and finally enabling "Scan Single Files"), the content scan filebrowser will continue to only show **folders and/or .zip files**, irrespective of the preferences defined in the "Default Core" and "File Extensions" settings.

_This is with no File Extensions filter and Default Core set to "Unspecified":_
<img alt="image" src="https://github.com/user-attachments/assets/32db0287-5642-420d-a508-2ce25785eb87" />

This PR fixes the file extension reporting for the single-file content scan, by properly exposing the chosen extension filter(s) to the scan filebrowser.

_This is with this PR, using the same folder, with no File Extensions filter and Default Core set to "Unspecified":_
<img alt="image" src="https://github.com/user-attachments/assets/c77d3705-223c-4a11-8b8f-e105a52ce8d1" />

## Reviewers

@LibretroAdmin 
