### PR TITLE
android: default to 16kb with ndk 29, set to 4kb for non play store b…

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     - name: Compile RA

--- a/pkg/android/phoenix-common/jni/Android.mk
+++ b/pkg/android/phoenix-common/jni/Android.mk
@@ -254,14 +254,13 @@ ifneq ($(SANITIZER),)
    LOCAL_LDFLAGS  += -fsanitize=$(SANITIZER)
 endif
 
-# Android 6 and above, play store variant
-ifeq ($(PLAY_STORE_BUILD),1)
+ifneq ($(PLAY_STORE_BUILD),1)
    ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
-      LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+      LOCAL_LDFLAGS += -Wl,-z,max-page-size=4096
    endif
 
    ifeq ($(TARGET_ARCH_ABI),x86_64)
-      LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+      LOCAL_LDFLAGS += -Wl,-z,max-page-size=4096
    endif
 endif
 

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -34,7 +34,7 @@ android {
     buildConfig true
   }
 
-  ndkVersion "27.3.13750724"
+  ndkVersion "29.0.14206865"
 
   flavorDimensions "variant"
 


### PR DESCRIPTION
…uild

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Play store now requires 16kb alignment. This is set for the play store variant only.

Update to NDK 29 as this is what cores must now use for automatic 16kb alignment.

Android 5 support is now dropped from the play store version.

## Related Issues

## Related Pull Requests


## Reviewers
