### PR TITLE
[Wayland]Add support for tearing-control-v1 protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,8 @@ gfx/common/wayland/webos-shell.c
 gfx/common/wayland/webos-shell.h
 gfx/common/wayland/webos-surface-group.c
 gfx/common/wayland/webos-surface-group.h
+gfx/common/wayland/tearing-control-v1.h
+gfx/common/wayland/tearing-control-v1.c
 
 # libretro-common samples
 libretro-common/samples/streams/rzip/rzip

--- a/Makefile.common
+++ b/Makefile.common
@@ -1321,7 +1321,8 @@ ifeq ($(HAVE_WAYLAND), 1)
         gfx/common/wayland/cursor-shape-v1.o \
         gfx/common/wayland/tablet-unstable-v2.o \
         gfx/common/wayland/content-type-v1.o \
-        gfx/common/wayland/single-pixel-buffer-v1.o
+        gfx/common/wayland/single-pixel-buffer-v1.o \
+        gfx/common/wayland/tearing-control-v1.o
 
    ifeq ($(HAVE_VULKAN), 1)
       OBJ += gfx/drivers_context/wayland_vk_ctx.o

--- a/deps/wayland-protocols/staging/tearing-control/README
+++ b/deps/wayland-protocols/staging/tearing-control/README
@@ -1,0 +1,4 @@
+Tearing control protocol
+
+Maintainers:
+Xaver Hugl <xaver.hugl@gmail.com> (@Zamundaaa)

--- a/deps/wayland-protocols/staging/tearing-control/tearing-control-v1.xml
+++ b/deps/wayland-protocols/staging/tearing-control/tearing-control-v1.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="tearing_control_v1">
+  <copyright>
+    Copyright © 2021 Xaver Hugl
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_tearing_control_manager_v1" version="1">
+    <description summary="protocol for tearing control">
+      For some use cases like games or drawing tablets it can make sense to
+      reduce latency by accepting tearing with the use of asynchronous page
+      flips. This global is a factory interface, allowing clients to inform
+      which type of presentation the content of their surfaces is suitable for.
+
+      Graphics APIs like EGL or Vulkan, that manage the buffer queue and commits
+      of a wl_surface themselves, are likely to be using this extension
+      internally. If a client is using such an API for a wl_surface, it should
+      not directly use this extension on that surface, to avoid raising a
+      tearing_control_exists protocol error.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy tearing control factory object">
+        Destroy this tearing control factory object. Other objects, including
+        wp_tearing_control_v1 objects created by this factory, are not affected
+        by this request.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="tearing_control_exists" value="0"
+             summary="the surface already has a tearing object associated"/>
+    </enum>
+
+    <request name="get_tearing_control">
+      <description summary="extend surface interface for tearing control">
+        Instantiate an interface extension for the given wl_surface to request
+        asynchronous page flips for presentation.
+
+        If the given wl_surface already has a wp_tearing_control_v1 object
+        associated, the tearing_control_exists protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_tearing_control_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_tearing_control_v1" version="1">
+    <description summary="per-surface tearing control interface">
+      An additional interface to a wl_surface object, which allows the client
+      to hint to the compositor if the content on the surface is suitable for
+      presentation with tearing.
+      The default presentation hint is vsync. See presentation_hint for more
+      details.
+
+      If the associated wl_surface is destroyed, this object becomes inert and
+      should be destroyed.
+    </description>
+
+    <enum name="presentation_hint">
+      <description summary="presentation hint values">
+        This enum provides information for if submitted frames from the client
+        may be presented with tearing.
+      </description>
+      <entry name="vsync" value="0">
+        <description summary="tearing-free presentation">
+          The content of this surface is meant to be synchronized to the
+          vertical blanking period. This should not result in visible tearing
+          and may result in a delay before a surface commit is presented.
+        </description>
+      </entry>
+      <entry name="async" value="1">
+        <description summary="asynchronous presentation">
+          The content of this surface is meant to be presented with minimal
+          latency and tearing is acceptable.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_presentation_hint">
+      <description summary="set presentation hint">
+        Set the presentation hint for the associated wl_surface. This state is
+        double-buffered, see wl_surface.commit.
+
+        The compositor is free to dynamically respect or ignore this hint based
+        on various conditions like hardware capabilities, surface state and
+        user preferences.
+      </description>
+      <arg name="hint" type="uint" enum="presentation_hint"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy tearing control object">
+        Destroy this surface tearing object and revert the presentation hint to
+        vsync. The change will be applied on the next wl_surface.commit.
+      </description>
+    </request>
+  </interface>
+
+</protocol>

--- a/gfx/common/wayland/generate_wayland_protos.sh
+++ b/gfx/common/wayland/generate_wayland_protos.sh
@@ -81,6 +81,7 @@ generate_source 'staging/cursor-shape' 'cursor-shape-v1'
 generate_source 'unstable/tablet' 'tablet-unstable-v2'
 generate_source 'staging/content-type' 'content-type-v1'
 generate_source 'staging/single-pixel-buffer' 'single-pixel-buffer-v1'
+generate_source 'staging/tearing-control' 'tearing-control-v1'
 generate_source 'staging/xdg-toplevel-icon' 'xdg-toplevel-icon-v1'
 generate_source 'staging/xdg-toplevel-tag' 'xdg-toplevel-tag-v1'
 

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -446,6 +446,8 @@ void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
       wp_viewport_destroy(wl->viewport);
    if (wl->fractional_scale)
       wp_fractional_scale_v1_destroy(wl->fractional_scale);
+   if (wl->tearing_control)
+      wp_tearing_control_v1_destroy(wl->tearing_control);
    if (wl->idle_inhibitor)
       zwp_idle_inhibitor_v1_destroy(wl->idle_inhibitor);
    if (wl->deco)
@@ -467,6 +469,8 @@ void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
       xdg_toplevel_tag_manager_v1_destroy(wl->xdg_toplevel_tag_manager);
    if (wl->idle_inhibit_manager)
       zwp_idle_inhibit_manager_v1_destroy(wl->idle_inhibit_manager);
+   if (wl->tearing_control_manager)
+      wp_tearing_control_manager_v1_destroy(wl->tearing_control_manager);
    else
    {
 #ifdef HAVE_DBUS
@@ -542,6 +546,8 @@ void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
    wl->idle_inhibit_manager      = NULL;
    wl->deco_manager              = NULL;
    wl->single_pixel_manager      = NULL;
+   wl->tearing_control_manager   = NULL;
+   wl->tearing_control           = NULL;
    wl->surface                   = NULL;
    wl->xdg_surface               = NULL;
    wl->xdg_toplevel              = NULL;
@@ -978,6 +984,11 @@ bool gfx_ctx_wl_init_common(
       RARCH_LOG("[Wayland] Compositor doesn't support the %s protocol.\n", xdg_toplevel_tag_manager_v1_interface.name);
    }
 
+   if (!wl->tearing_control_manager)
+   {
+      RARCH_LOG("[Wayland] Compositor doesn't support the %s protocol.\n", wp_tearing_control_manager_v1_interface.name);
+   }
+
    wl->surface = wl_compositor_create_surface(wl->compositor);
    if (wl->viewporter)
       wl->viewport = wp_viewporter_get_viewport(wl->viewporter, wl->surface);
@@ -993,6 +1004,17 @@ bool gfx_ctx_wl_init_common(
    {
       wl->content_type = wp_content_type_manager_v1_get_surface_content_type(wl->content_type_manager, wl->surface);
       wp_content_type_v1_set_content_type(wl->content_type, WP_CONTENT_TYPE_V1_TYPE_GAME);
+   }
+
+   if (wl->tearing_control_manager)
+   {
+      bool video_vsync = settings->bools.video_vsync;
+      wl->tearing_control = wp_tearing_control_manager_v1_get_tearing_control(
+         wl->tearing_control_manager, wl->surface);
+      wp_tearing_control_v1_set_presentation_hint(wl->tearing_control,
+                                                  video_vsync
+                                                  ? WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC
+                                                  : WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC);
    }
 
    wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);

--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -469,8 +469,6 @@ void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
       xdg_toplevel_tag_manager_v1_destroy(wl->xdg_toplevel_tag_manager);
    if (wl->idle_inhibit_manager)
       zwp_idle_inhibit_manager_v1_destroy(wl->idle_inhibit_manager);
-   if (wl->tearing_control_manager)
-      wp_tearing_control_manager_v1_destroy(wl->tearing_control_manager);
    else
    {
 #ifdef HAVE_DBUS
@@ -478,6 +476,8 @@ void gfx_ctx_wl_destroy_resources_common(gfx_ctx_wayland_data_t *wl)
       dbus_close_connection();
 #endif
    }
+   if (wl->tearing_control_manager)
+      wp_tearing_control_manager_v1_destroy(wl->tearing_control_manager);
    if (wl->pointer_constraints)
       zwp_pointer_constraints_v1_destroy(wl->pointer_constraints);
    if (wl->relative_pointer_manager)

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -345,6 +345,14 @@ static void gfx_ctx_wl_set_swap_interval(void *data, int swap_interval)
 #ifdef HAVE_EGL
    egl_set_swap_interval(&wl->egl, swap_interval);
 #endif
+
+   if (wl->tearing_control)
+   {
+      wp_tearing_control_v1_set_presentation_hint(wl->tearing_control,
+                                                  swap_interval == 0
+                                                  ? WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC
+                                                  : WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC);
+   }
 }
 
 static bool gfx_ctx_wl_set_video_mode(void *data,

--- a/gfx/drivers_context/wayland_vk_ctx.c
+++ b/gfx/drivers_context/wayland_vk_ctx.c
@@ -141,6 +141,14 @@ static void gfx_ctx_wl_set_swap_interval(void *data, int swap_interval)
       if (wl->vk.swapchain)
          wl->vk.flags  |= VK_DATA_FLAG_NEED_NEW_SWAPCHAIN;
    }
+
+   if (wl->tearing_control)
+   {
+      wp_tearing_control_v1_set_presentation_hint(wl->tearing_control,
+                                                  swap_interval == 0
+                                                  ? WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC
+                                                  : WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC);
+   }
 }
 
 static bool gfx_ctx_wl_set_video_mode(void *data,

--- a/input/common/wayland_common.c
+++ b/input/common/wayland_common.c
@@ -837,6 +837,10 @@ static void wl_registry_handle_global(void *data, struct wl_registry *reg,
       wl->xdg_toplevel_tag_manager = (struct xdg_toplevel_tag_manager_v1*)
          wl_registry_bind(
             reg, id, &xdg_toplevel_tag_manager_v1_interface, MIN(version, 1));
+   else if (string_is_equal(interface, wp_tearing_control_manager_v1_interface.name) && found++)
+      wl->tearing_control_manager = (struct wp_tearing_control_manager_v1*)
+         wl_registry_bind(
+            reg, id, &wp_tearing_control_manager_v1_interface, MIN(version, 1));
 
    if (found > 1)
    RARCH_LOG("[Wayland] Registered interface %s at version %u.\n",

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -46,6 +46,7 @@
 #include "../../gfx/common/wayland/pointer-constraints-unstable-v1.h"
 #include "../../gfx/common/wayland/relative-pointer-unstable-v1.h"
 #include "../../gfx/common/wayland/single-pixel-buffer-v1.h"
+#include "../../gfx/common/wayland/tearing-control-v1.h"
 #include "../../gfx/common/wayland/viewporter.h"
 #include "../../gfx/common/wayland/xdg-decoration-unstable-v1.h"
 #include "../../gfx/common/wayland/xdg-shell.h"
@@ -181,6 +182,8 @@ typedef struct gfx_ctx_wayland_data
    struct xdg_toplevel_icon_v1 *xdg_toplevel_icon;
    struct xdg_toplevel_icon_manager_v1 *xdg_toplevel_icon_manager;
    struct xdg_toplevel_tag_manager_v1 *xdg_toplevel_tag_manager;
+   struct wp_tearing_control_manager_v1 *tearing_control_manager;
+   struct wp_tearing_control_v1 *tearing_control;
    struct wl_keyboard *wl_keyboard;
    struct wl_pointer  *wl_pointer;
    struct zwp_relative_pointer_v1 *wl_relative_pointer;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This protocol sends hint to the compositor to allow async page flips via DRM_MODE_PAGE_FLIP_ASYNC. It's tied to Vsync state so when Vsync is off - RetroArch will send async hint and compositor will guarantee that tearing is allowed and non blocked. The protocol allows tearing both for fullscreen and non-fullscreen surfaces, but I don't know if is any of compositors allowing tearing for non-fullscreen surfaces. Tested in KDE Plasma 6.3.5.

Supersedes https://github.com/libretro/RetroArch/pull/19209

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
