### PR TITLE
android: attempt fix play delivery of cores

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
     package="com.retroarch"
-    android:versionCode="1597175267"
+    android:versionCode="1597175271"
     android:versionName="1.22.2"
     android:installLocation="internalOnly">
     <uses-feature android:glEsVersion="0x00020000" />
@@ -16,8 +16,6 @@
     <!-- Android 6-12 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
-    <!-- Android 11+ -->
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <application
         android:name="com.retroarch.playcore.RetroArchApplication"
         android:allowAudioPlaybackCapture="true"

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -50,6 +50,14 @@ android {
     versionName "${getManifestAttribute("versionName")}_GIT"
   }
 
+  android {
+    packagingOptions {
+      jniLibs {
+        useLegacyPackaging = true
+      }
+    }
+  }
+
   productFlavors {
     normal {
       resValue "string", "app_name", "RetroArch"

--- a/pkg/android/play-core-impl/com/retroarch/playcore/PlayCoreManager.java
+++ b/pkg/android/play-core-impl/com/retroarch/playcore/PlayCoreManager.java
@@ -1,5 +1,6 @@
 package com.retroarch.playcore;
 
+import com.google.android.play.core.splitinstall.SplitInstallHelper;
 import com.google.android.play.core.splitinstall.SplitInstallManager;
 import com.google.android.play.core.splitinstall.SplitInstallManagerFactory;
 import com.google.android.play.core.splitinstall.SplitInstallRequest;
@@ -43,6 +44,8 @@ public class PlayCoreManager {
                     activity.coreInstallStatusChanged(coreNames, INSTALL_STATUS_INSTALLING, state.bytesDownloaded(), state.totalBytesToDownload());
                     break;
                 case SplitInstallSessionStatus.INSTALLED:
+                    SplitInstallHelper.updateAppInfo(activity);
+
                     activity.updateSymlinks();
 
                     activity.coreInstallStatusChanged(coreNames, INSTALL_STATUS_INSTALLED, state.bytesDownloaded(), state.totalBytesToDownload());


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Attempt to fix new android play method of distributing the cores.

MANAGE_EXTERNAL_STORAGE was duplicate so that is also removed.

## Related Issues

## Related Pull Requests


## Reviewers

