### PR TITLE
android: remove MANAGE_EXTERNAL_STORAGE as unused anyway in play version

### DIFF
--- a/pkg/android/phoenix/src/playStoreNormal/AndroidManifest.xml
+++ b/pkg/android/phoenix/src/playStoreNormal/AndroidManifest.xml
@@ -2,5 +2,6 @@
           xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:node="remove"/>
     <application tools:remove="requestLegacyExternalStorage"/>
 </manifest>

--- a/pkg/android/phoenix/src/playStorePlus/AndroidManifest.xml
+++ b/pkg/android/phoenix/src/playStorePlus/AndroidManifest.xml
@@ -2,5 +2,6 @@
           xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:node="remove"/>
     <application tools:remove="requestLegacyExternalStorage"/>
 </manifest>


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This code isn't even used, but the permission is still requested. Should do no harm and meets google's requirements.

## Related Issues


## Related Pull Requests


## Reviewers

