### PR TITLE
[Wayland] Don't create wp_tearing_control_v1 for Vulkan

### DIFF
--- a/gfx/common/wayland_common.c
+++ b/gfx/common/wayland_common.c
@@ -1182,17 +1182,6 @@ bool gfx_ctx_wl_init_common(
       wp_content_type_v1_set_content_type(wl->content_type, WP_CONTENT_TYPE_V1_TYPE_GAME);
    }
 
-   if (wl->tearing_control_manager)
-   {
-      bool video_vsync = settings->bools.video_vsync;
-      wl->tearing_control = wp_tearing_control_manager_v1_get_tearing_control(
-         wl->tearing_control_manager, wl->surface);
-      wp_tearing_control_v1_set_presentation_hint(wl->tearing_control,
-                                                  video_vsync
-                                                  ? WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC
-                                                  : WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC);
-   }
-
    wl_surface_add_listener(wl->surface, &wl_surface_listener, wl);
 
 #ifdef HAVE_LIBDECOR_H

--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -243,6 +243,17 @@ static void *gfx_ctx_wl_init(void *data)
    if (!gfx_ctx_wl_egl_init_context(wl))
       goto error;
 #endif
+   if (wl->tearing_control_manager)
+   {
+      settings_t *settings = config_get_ptr();
+      bool video_vsync     = settings->bools.video_vsync;
+      wl->tearing_control  = wp_tearing_control_manager_v1_get_tearing_control(
+         wl->tearing_control_manager, wl->surface);
+      wp_tearing_control_v1_set_presentation_hint(wl->tearing_control,
+                                                  video_vsync
+                                                  ? WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC
+                                                  : WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC);
+   }
    return wl;
 error:
    gfx_ctx_wl_destroy_resources(wl);


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Vulkan manage the buffer queue and commits of a `wl_surface` itself, and it's WSI layer (e.g. Mesa) internally
bind `wp_tearing_control_v1` during surface creation. EGL WSI does not internally bind `wp_tearing_control_v1`, so it is
safe to create it.

## Related Issues

https://github.com/libretro/RetroArch/issues/19241

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
