### PR TITLE
rgui_config_directory: Rename 'Configuration files' label to `Configurations` and add `Configuration Files, Overrides, and Manage Core Options` to the sub-label

### DIFF
--- a/settings/settings_def_dir_core.h
+++ b/settings/settings_def_dir_core.h
@@ -66,8 +66,10 @@ S_DIR(directory_menu_content, RGUI_BROWSER_DIRECTORY,
 S_DIR(directory_menu_config, RGUI_CONFIG_DIRECTORY,
       "rgui_config_directory",
       g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], DIRECTORY_DEFAULT, SD_FLAG_NONE, 0, directory_action_start_generic,
-      "Configuration files",
-      "Default configuration file is stored in this directory.")
+      "Configurations",
+      "This directory stores files managed by menu items located in "
+      "Configuration Files, Overrides, and—for core overrides on "
+      "supported cores—Manage Core Options sub-menus.")
 #endif
 /* config key "libretro_directory" differs from the label string; the
  * configuration.c row stays literal for this setting. */

--- a/settings/settings_def_dir_core.h
+++ b/settings/settings_def_dir_core.h
@@ -67,7 +67,7 @@ S_DIR(directory_menu_config, RGUI_CONFIG_DIRECTORY,
       "rgui_config_directory",
       g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], DIRECTORY_DEFAULT, SD_FLAG_NONE, 0, directory_action_start_generic,
       "Configurations",
-      "This directory stores configuration files managed by Configuration Files,"
+      "This directory stores configuration files managed by Configuration File,"
       "Overrides, and Manage Core Options menu items."
 #endif
 /* config key "libretro_directory" differs from the label string; the

--- a/settings/settings_def_dir_core.h
+++ b/settings/settings_def_dir_core.h
@@ -67,8 +67,8 @@ S_DIR(directory_menu_config, RGUI_CONFIG_DIRECTORY,
       "rgui_config_directory",
       g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], DIRECTORY_DEFAULT, SD_FLAG_NONE, 0, directory_action_start_generic,
       "Configurations",
-      "This directory stores configuration files for general settings, "
-      "core options, and overrides."
+      "This directory stores configuration files managed by Configuration Files,"
+      "Overrides, and Manage Core Options menu items."
 #endif
 /* config key "libretro_directory" differs from the label string; the
  * configuration.c row stays literal for this setting. */

--- a/settings/settings_def_dir_core.h
+++ b/settings/settings_def_dir_core.h
@@ -68,7 +68,7 @@ S_DIR(directory_menu_config, RGUI_CONFIG_DIRECTORY,
       g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], DIRECTORY_DEFAULT, SD_FLAG_NONE, 0, directory_action_start_generic,
       "Configurations",
       "This directory stores configuration files managed by Configuration File,"
-      "Overrides, and Manage Core Options menu items."
+      "Overrides, and Manage Core Options sub-menus."
 #endif
 /* config key "libretro_directory" differs from the label string; the
  * configuration.c row stays literal for this setting. */

--- a/settings/settings_def_dir_core.h
+++ b/settings/settings_def_dir_core.h
@@ -67,9 +67,8 @@ S_DIR(directory_menu_config, RGUI_CONFIG_DIRECTORY,
       "rgui_config_directory",
       g_defaults.dirs[DEFAULT_DIR_MENU_CONFIG], DIRECTORY_DEFAULT, SD_FLAG_NONE, 0, directory_action_start_generic,
       "Configurations",
-      "This directory stores files managed by menu items located in "
-      "Configuration Files, Overrides, and—for core overrides on "
-      "supported cores—Manage Core Options sub-menus.")
+      "This directory stores configuration files for general settings, "
+      "core options, and overrides."
 #endif
 /* config key "libretro_directory" differs from the label string; the
  * configuration.c row stays literal for this setting. */


### PR DESCRIPTION
## Description

**Replace:**

> Configuration files
> Default configuration file is stored in this directory.

**With:**

> Configurations
> This directory stores files managed by menu items located in Configuration Files, Overrides, and—for core overrides on supported cores—Manage Core Options sub-menus.

**Rationale:**
* Label:
   - Add: `Configurations`. Matches the default `config` destination directory used by the `rgui_config_directory` variable.
   - Remove `Configuration files`: Lowercase initial words are non-standard for labels; standardizing "Configuration Files" to capital "F" risks confusing users into thinking it only affects items under `Main Menu → Configuration Files`, whereas it is also used for saving overrides (e.g., `Quick Menu → Overrides → Save Core Overrides` and `Quick Menu → Core Options → Save Game Options`).
   - Avoid: Adding `Overrides` to the label to prevent confusion that it is limited exclusively to `Quick Menu → Overrides` (capital "O"), given that it also handles other items like `Quick Menu → Core Options`. Additionally, since overrides are inherently configurations, using the simpler term `Configurations` keeps the label concise and all-encompassing.
* Sub-label
   - Added
     - `Configuration Files, Overrides, and Manage Core Options`, along with detailed explanations of their functions.
       - This aligns with how other labels and sub-labels reference each other rather than using general descriptions. Note the capital 'File Browser' used specifically as a reference here: under Settings → User Interface → File Browser, the option Filter by current Core has the sub-label: 'Filter files being shown in File Browser by current core.'
       - This clarifies what isn't included for `rgui_config_directory`. For instance, `Manage Remap Files` (for loaded content) is [often mistakenly assumed](https://github.com/libretro/RetroArch/issues/19200#issuecomment-4958458428) to be part of this feature, even though it has its own separate `Input Remaps` directory (`input_remapping_directory`).
     - ` sub-menus`: Indicating that these settings are nested within those submenus.
   - Remove `Default configuration file is stored in this directory.`:
     - Context from Issue #19211: _The "Save Main Configuration" is the only menu item under `Main Menu → Configuration File` that does not save to the `Settings → Directory → Configuration files` directory._
     - Even if this behavior is updated in the future, the primary file will remain associated with the configuration files section, which is explicitly covered by `Configuration Files` in the the new sub-label.

## Related Issues

* https://github.com/libretro/RetroArch/issues/19200

## Reviewers

@hizzlekizzle @Ryunam 