### PR TITLE
Fix ZIP member selection

### DIFF
--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -39,6 +39,39 @@
 #include <sys/stat.h>
 #endif
 
+static bool file_archive_path_is_appledouble_metadata(const char *path)
+{
+   static const char macosx_dir[] = "__MACOSX";
+   const char *base    = path;
+   const char *cursor  = path;
+   const char *segment = path;
+
+   if (!path || !*path)
+      return false;
+
+   for (;;)
+   {
+      if (*cursor == '/' || *cursor == '\\' || *cursor == '\0')
+      {
+         if ((size_t)(cursor - segment) == sizeof(macosx_dir) - 1
+               && strncmp(segment, macosx_dir, sizeof(macosx_dir) - 1) == 0)
+            return true;
+
+         if (*cursor == '\0')
+         {
+            base = segment;
+            break;
+         }
+
+         segment = cursor + 1;
+      }
+
+      cursor++;
+   }
+
+   return string_starts_with(base, "._");
+}
+
 static int file_archive_get_file_list_cb(
       const char *path,
       const char *valid_exts,
@@ -50,7 +83,11 @@ static int file_archive_get_file_list_cb(
       struct archive_extract_userdata *userdata)
 {
    union string_list_elem_attr attr;
-   attr.i = RARCH_COMPRESSED_FILE_IN_ARCHIVE;
+
+   if (file_archive_get_file_backend(userdata->archive_path)
+            == file_archive_get_zlib_file_backend()
+         && file_archive_path_is_appledouble_metadata(path))
+      return 1;
 
    if (valid_exts)
    {
@@ -85,6 +122,7 @@ static int file_archive_get_file_list_cb(
       string_list_deinitialize(&ext_list);
    }
 
+   attr.i = RARCH_COMPRESSED_FILE_IN_ARCHIVE;
    return string_list_append(userdata->list, path, attr);
 }
 
@@ -221,7 +259,10 @@ int file_archive_parse_file_iterate(
             state->type = ARCHIVE_TRANSFER_ITERATE;
          }
          else
+         {
             state->type = ARCHIVE_TRANSFER_DEINIT_ERROR;
+            goto deinit_error;
+         }
          break;
       case ARCHIVE_TRANSFER_ITERATE:
          if (state->backend)
@@ -296,7 +337,9 @@ int file_archive_parse_file_iterate(
          }
          return -1;
       case ARCHIVE_TRANSFER_DEINIT_ERROR:
-         *returnerr = false;
+deinit_error:
+         if (returnerr)
+            *returnerr = false;
       case ARCHIVE_TRANSFER_DEINIT:
          if (state->context)
          {

--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -39,39 +39,6 @@
 #include <sys/stat.h>
 #endif
 
-static bool file_archive_path_is_appledouble_metadata(const char *path)
-{
-   static const char macosx_dir[] = "__MACOSX";
-   const char *base    = path;
-   const char *cursor  = path;
-   const char *segment = path;
-
-   if (!path || !*path)
-      return false;
-
-   for (;;)
-   {
-      if (*cursor == '/' || *cursor == '\\' || *cursor == '\0')
-      {
-         if ((size_t)(cursor - segment) == sizeof(macosx_dir) - 1
-               && strncmp(segment, macosx_dir, sizeof(macosx_dir) - 1) == 0)
-            return true;
-
-         if (*cursor == '\0')
-         {
-            base = segment;
-            break;
-         }
-
-         segment = cursor + 1;
-      }
-
-      cursor++;
-   }
-
-   return string_starts_with(base, "._");
-}
-
 static int file_archive_get_file_list_cb(
       const char *path,
       const char *valid_exts,
@@ -83,11 +50,6 @@ static int file_archive_get_file_list_cb(
       struct archive_extract_userdata *userdata)
 {
    union string_list_elem_attr attr;
-
-   if (file_archive_get_file_backend(userdata->archive_path)
-            == file_archive_get_zlib_file_backend()
-         && file_archive_path_is_appledouble_metadata(path))
-      return 1;
 
    if (valid_exts)
    {

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -29,6 +29,7 @@
 #include <retro_inline.h>
 #include <retro_miscellaneous.h>
 #include <encodings/crc32.h>
+#include <string/stdstring.h>
 
 /* The ZIP DEFLATE backend can be built against zlib or against the
  * clean-room inflate implementation in encodings/deflate.h.  Define
@@ -500,7 +501,7 @@ static int zip_file_decompressed(
    if (last_char == '/' || last_char == '\\')
       return 1;
 
-   if (strstr(name, decomp_state->needle))
+   if (string_is_equal(name, decomp_state->needle))
    {
       file_archive_file_handle_t handle = {0};
 
@@ -558,12 +559,10 @@ static int64_t zip_file_read(
    if (optional_outfile)
       decomp.opt_file        = strdup(optional_outfile);
 
-   /* NULL-check strdups: zip_file_decompressed (line ~396)
-    * calls strstr(name, decomp_state->needle) which NULL-derefs
-    * if needle was requested but strdup failed.  Bail out of
-    * the extraction; caller treats -1 as 'not found / failed'.
-    * Free whatever strdup succeeded to avoid a leak on
-    * partial-success OOM. */
+   /* NULL-check strdups so allocation failure cannot be mistaken for
+    * an omitted member or output path.  Bail out of the extraction;
+    * caller treats -1 as 'not found / failed'.  Free whatever strdup
+    * succeeded to avoid a leak on partial-success OOM. */
    if ((needle && !decomp.needle) ||
        (optional_outfile && !decomp.opt_file))
    {
@@ -813,7 +812,7 @@ static int file_archive_entry_source_capture(
       return 1;
    if (name[name_len - 1] == '/' || name[name_len - 1] == '\\')
       return 1;
-   if (!strstr(name, s->needle))
+   if (!string_is_equal(name, s->needle))
       return 1;
    /* the local-header hop, both arms, mirroring the extract init */
    {

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -692,14 +692,42 @@ static int zip_parse_file_init(file_archive_transfer_t *state,
    return 0;
 }
 
+/* macOS Archive Utility writes a resource-fork sidecar for every member
+ * it stores, parked under a top-level "__MACOSX" directory and named
+ * after the member with a "._" prefix.  These are never content, and
+ * they sort ahead of the real file, so anything picking the first entry
+ * out of a Mac-made archive picks the sidecar.
+ *
+ * The central-directory name length is already in hand at the only call
+ * site, so this needs neither strlen nor a scan of the whole entry name
+ * to find the basename. */
+static int zip_entry_is_appledouble(const uint8_t *name, uint32_t len)
+{
+   uint32_t i;
+
+   if (     len >= 8
+         && memcmp(name, "__MACOSX", 8) == 0
+         && (len == 8 || name[8] == '/' || name[8] == '\\'))
+      return 1;
+
+   i = len;
+   while (i > 0 && name[i - 1] != '/' && name[i - 1] != '\\')
+      i--;
+
+   return (len - i >= 2 && name[i] == '.' && name[i + 1] == '_');
+}
+
 static int zip_parse_file_iterate_step_internal(
       zip_context_t * zip_context, char *filename,
       const uint8_t **cdata,
       unsigned *cmode, uint32_t *size, uint32_t *csize,
       uint32_t *checksum, unsigned *payback)
 {
-   uint8_t *entry = zip_context->directory_entry;
+   uint8_t *entry;
    uint32_t signature, namelength, extralength, commentlength, offset;
+
+again:
+   entry = zip_context->directory_entry;
 
    if (entry < zip_context->directory || entry >= zip_context->directory_end)
       return 0;
@@ -733,6 +761,23 @@ static int zip_parse_file_iterate_step_internal(
    if ((size_t)(zip_context->directory_end - entry)
          < (size_t)46 + namelength + extralength + commentlength)
       return -1;
+
+   /* Drop AppleDouble sidecars before the name is even copied out.
+    * Doing it here rather than in the listing callback covers every
+    * consumer of the walk - listing, extraction and the incremental
+    * entry source alike - and keeps the whole check off the callback
+    * hot path.  The end-of-central-directory record counted these
+    * entries, so take them back out of the progress denominator. */
+   if (zip_entry_is_appledouble(zip_context->directory_entry + 46, namelength))
+   {
+      zip_context->directory_entry += 46 + namelength
+         + extralength + commentlength;
+
+      if (zip_context->state && zip_context->state->step_total > 0)
+         zip_context->state->step_total--;
+
+      goto again;
+   }
 
    memcpy(filename, zip_context->directory_entry + 46, namelength); /* file name */
    filename[namelength] = '\0';

--- a/libretro-common/samples/file/archive_file/Makefile
+++ b/libretro-common/samples/file/archive_file/Makefile
@@ -25,12 +25,18 @@ SOURCES := \
 
 OBJS := $(SOURCES:.c=.o)
 
-CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
+override CPPFLAGS += -DHAVE_COMPRESSION -I$(LIBRETRO_COMM_DIR)/include
+CFLAGS            += -Wall -pedantic -std=gnu99 -g
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
 
 all: $(TARGET)
 
-%.o: %.c
-	$(CC) -c -o $@ $< $(CFLAGS)
+%.o: %.c Makefile
+	$(CC) -c -o $@ $< $(CPPFLAGS) $(CFLAGS)
 
 $(TARGET): $(OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS)

--- a/libretro-common/samples/file/archive_file/archive_zip_test.c
+++ b/libretro-common/samples/file/archive_file/archive_zip_test.c
@@ -56,7 +56,7 @@
  * All bytes are crafted in C rather than committed as binary fixtures.
  *
  * Build with AddressSanitizer for full coverage:
- *   make CFLAGS='-fsanitize=address -g -O0' LDFLAGS='-fsanitize=address'
+ *   make SANITIZER=address
  */
 
 #include <stdio.h>
@@ -125,6 +125,94 @@ static size_t write_minimal_lfh(uint8_t *dst, const char *name)
    if (namelen > 0)
       memcpy(dst + 30, name, namelen);
    return 30 + namelen;
+}
+
+static size_t write_stored_lfh(uint8_t *dst, const char *name,
+      const uint8_t *payload, size_t payload_len, uint32_t crc32)
+{
+   size_t namelen = name ? strlen(name) : 0;
+   put_u32(dst + 0,  LFH_SIG);
+   put_u16(dst + 4,  20);        /* version needed to extract          */
+   put_u16(dst + 6,  0);         /* flags                              */
+   put_u16(dst + 8,  0);         /* method = STORED                    */
+   put_u16(dst + 10, 0);         /* mtime                              */
+   put_u16(dst + 12, 0);         /* mdate                              */
+   put_u32(dst + 14, crc32);
+   put_u32(dst + 18, (uint32_t)payload_len);
+   put_u32(dst + 22, (uint32_t)payload_len);
+   put_u16(dst + 26, (uint16_t)namelen);
+   put_u16(dst + 28, 0);         /* extra length                       */
+   if (namelen > 0)
+      memcpy(dst + 30, name, namelen);
+   if (payload_len > 0)
+      memcpy(dst + 30 + namelen, payload, payload_len);
+   return 30 + namelen + payload_len;
+}
+
+static size_t write_stored_cfh(uint8_t *dst, const char *name,
+      size_t payload_len, uint32_t crc32, uint32_t lfh_offset)
+{
+   size_t namelen = name ? strlen(name) : 0;
+   put_u32(dst + 0,  CFH_SIG);
+   put_u16(dst + 4,  20);        /* version made by                    */
+   put_u16(dst + 6,  20);        /* version needed to extract          */
+   put_u16(dst + 8,  0);         /* flags                              */
+   put_u16(dst + 10, 0);         /* method = STORED                    */
+   put_u16(dst + 12, 0);         /* mtime                              */
+   put_u16(dst + 14, 0);         /* mdate                              */
+   put_u32(dst + 16, crc32);
+   put_u32(dst + 20, (uint32_t)payload_len);
+   put_u32(dst + 24, (uint32_t)payload_len);
+   put_u16(dst + 28, (uint16_t)namelen);
+   put_u16(dst + 30, 0);         /* extra length                       */
+   put_u16(dst + 32, 0);         /* comment length                     */
+   put_u16(dst + 34, 0);         /* disk number start                  */
+   put_u16(dst + 36, 0);         /* internal attributes                */
+   put_u32(dst + 38, 0);         /* external attributes                */
+   put_u32(dst + 42, lfh_offset);
+   if (namelen > 0)
+      memcpy(dst + 46, name, namelen);
+   return 46 + namelen;
+}
+
+static size_t write_appledouble_collision_zip(uint8_t *dst)
+{
+   static const char *names[]        = {
+      "__MACOSX/regular.nes",
+      "folder/._sidecar.nes",
+      "folder\\._backslash.nes",
+      "__MACOSX/._game.nes",
+      "game.nes"
+   };
+   static const char metadata[]      = "METADATA";
+   static const char rom[]           = "ROMDATA";
+   uint32_t lfh_offsets[5]           = {0};
+   uint32_t cdir_offset              = 0;
+   uint32_t cdir_size                = 0;
+   size_t len                        = 0;
+   size_t i;
+
+   for (i = 0; i < 4; i++)
+   {
+      lfh_offsets[i] = (uint32_t)len;
+      len += write_stored_lfh(dst + len, names[i],
+            (const uint8_t*)metadata, sizeof(metadata) - 1, 0x8927a858u);
+   }
+
+   lfh_offsets[4] = (uint32_t)len;
+   len += write_stored_lfh(dst + len, names[4],
+         (const uint8_t*)rom, sizeof(rom) - 1, 0xcd69c26au);
+
+   cdir_offset = (uint32_t)len;
+   for (i = 0; i < 4; i++)
+      len += write_stored_cfh(dst + len, names[i],
+            sizeof(metadata) - 1, 0x8927a858u, lfh_offsets[i]);
+   len += write_stored_cfh(dst + len, names[4],
+         sizeof(rom) - 1, 0xcd69c26au, lfh_offsets[4]);
+   cdir_size = (uint32_t)len - cdir_offset;
+
+   len += write_eocd(dst + len, 5, cdir_size, cdir_offset);
+   return len;
 }
 
 /* --- test harness -------------------------------------------------- */
@@ -342,6 +430,183 @@ static void test_directory_size_overflow(void)
          buf, len);
 }
 
+/* ================================================================== */
+/* Case F: macOS AppleDouble metadata before the real content file.
+ * The archive list must skip the metadata entry, and explicit member
+ * reads must match "game.nes" exactly instead of substring-matching
+ * "__MACOSX/._game.nes".                                             */
+/* ================================================================== */
+static void test_appledouble_exact_member_selection(void)
+{
+   uint8_t  zip_bytes[1024];
+   uint8_t  source_bytes[16];
+   int      failures_before           = failures;
+   size_t   len                       = 0;
+   void    *read_buf                  = NULL;
+   int64_t  read_len                  = 0;
+   int64_t  source_size               = 0;
+   int64_t  source_read               = 0;
+   char     archive_path[128];
+   const char *tmp_path               = "rarch_zip_regression_test.zip";
+   const char *member_path            = "rarch_zip_regression_test.zip#game.nes";
+   const char *rom_name               = "game.nes";
+   const char *rom_payload            = "ROMDATA";
+   struct string_list *list           = NULL;
+   file_archive_entry_source_t *src   = NULL;
+   const struct file_archive_file_backend *zip_backend =
+         file_archive_get_zlib_file_backend();
+
+   memset(zip_bytes, 0, sizeof(zip_bytes));
+   memset(source_bytes, 0, sizeof(source_bytes));
+
+   len = write_appledouble_collision_zip(zip_bytes);
+   write_file(tmp_path, zip_bytes, len);
+
+   if (!zip_backend)
+   {
+      printf("[FAIL] AppleDouble regression requires the ZIP backend\n");
+      failures++;
+   }
+   else if (file_archive_get_file_backend(tmp_path) != zip_backend)
+   {
+      printf("[FAIL] AppleDouble regression did not select the ZIP backend\n");
+      failures++;
+   }
+
+   list = file_archive_get_file_list(tmp_path, "nes");
+   if (!list)
+   {
+      printf("[FAIL] AppleDouble archive produced no file list\n");
+      failures++;
+   }
+   else if (list->size != 1
+         || strcmp(list->elems[0].data, rom_name) != 0)
+   {
+      const char *selected = list->size ? list->elems[0].data : "<empty>";
+      printf("[FAIL] AppleDouble archive selected \"%s\" instead of \"%s\"\n",
+            selected, rom_name);
+      failures++;
+   }
+   if (list)
+      string_list_free(list);
+   list = NULL;
+
+   list = file_archive_get_file_list(tmp_path, NULL);
+   if (!list)
+   {
+      printf("[FAIL] Unfiltered AppleDouble archive produced no file list\n");
+      failures++;
+   }
+   else if (list->size != 1
+         || strcmp(list->elems[0].data, rom_name) != 0)
+   {
+      const char *selected = list->size ? list->elems[0].data : "<empty>";
+      printf("[FAIL] Unfiltered AppleDouble archive selected \"%s\" instead of \"%s\"\n",
+            selected, rom_name);
+      failures++;
+   }
+   if (list)
+      string_list_free(list);
+   list = NULL;
+
+   if (!file_archive_compressed_read(member_path, &read_buf, NULL, &read_len)
+         || read_len != (int64_t)strlen(rom_payload)
+         || memcmp(read_buf, rom_payload, (size_t)read_len) != 0)
+   {
+      printf("[FAIL] compressed read did not select exact ZIP member\n");
+      failures++;
+   }
+
+   snprintf(archive_path, sizeof(archive_path), "%s", member_path);
+   src = file_archive_entry_source_open(archive_path, &source_size);
+   if (!src || source_size != (int64_t)strlen(rom_payload))
+   {
+      printf("[FAIL] entry source did not open exact ZIP member\n");
+      failures++;
+   }
+   else
+   {
+      source_read = file_archive_entry_source_read(src,
+            source_bytes, sizeof(source_bytes));
+      if (source_read != (int64_t)strlen(rom_payload)
+            || memcmp(source_bytes, rom_payload, (size_t)source_read) != 0)
+      {
+         printf("[FAIL] entry source did not read exact ZIP member\n");
+         failures++;
+      }
+   }
+
+   if (failures == failures_before)
+      printf("[SUCCESS] AppleDouble metadata ignored during ZIP member selection\n");
+
+   if (src)
+      file_archive_entry_source_close(src);
+   if (read_buf)
+      free(read_buf);
+   remove(tmp_path);
+}
+
+static void test_init_failure_cleanup(void)
+{
+   uint8_t buf[22];
+   int failures_before = failures;
+   bool returnerr = true;
+   const char *tmp_path = "rarch_zip_regression_test.zip";
+   file_archive_transfer_t state;
+   struct archive_extract_userdata userdata;
+
+   memset(buf, 0, sizeof(buf));
+   write_eocd(buf, 0, 20, 20);
+   write_file(tmp_path, buf, sizeof(buf));
+
+   memset(&state, 0, sizeof(state));
+   memset(&userdata, 0, sizeof(userdata));
+   state.type        = ARCHIVE_TRANSFER_INIT;
+   userdata.transfer = &state;
+
+   if (file_archive_parse_file_iterate(&state, &returnerr,
+            tmp_path, NULL, NULL, &userdata) != -1
+         || returnerr
+         || state.type != ARCHIVE_TRANSFER_DEINIT_ERROR
+         || state.archive_file
+         || state.context
+         || userdata.transfer)
+   {
+      printf("[FAIL] archive init failure did not clean up immediately\n");
+      failures++;
+   }
+#ifdef HAVE_MMAP
+   if (state.archive_mmap_data || state.archive_mmap_fd != 0)
+   {
+      printf("[FAIL] archive init failure retained mmap ownership\n");
+      failures++;
+   }
+#endif
+
+   if (state.archive_file)
+      file_archive_parse_file_iterate_stop(&state);
+
+   memset(&state, 0, sizeof(state));
+   state.type = ARCHIVE_TRANSFER_INIT;
+
+   if (file_archive_parse_file_iterate(&state, NULL,
+            tmp_path, NULL, NULL, NULL) != -1
+         || state.archive_file
+         || state.context)
+   {
+      printf("[FAIL] archive init cleanup requires an error-result pointer\n");
+      failures++;
+   }
+
+   if (state.archive_file)
+      file_archive_parse_file_iterate_stop(&state);
+
+   remove(tmp_path);
+
+   if (failures == failures_before)
+      printf("[SUCCESS] archive init failure cleaned up immediately\n");
+}
+
 int main(void)
 {
    test_truncated_entry();
@@ -349,6 +614,8 @@ int main(void)
    test_empty_filename();
    test_combined_offset_size_overflow();
    test_directory_size_overflow();
+   test_appledouble_exact_member_selection();
+   test_init_failure_cleanup();
 
    if (failures)
    {


### PR DESCRIPTION
## Description

ZIP file lists can expose macOS AppleDouble metadata before the actual content file. Explicit ZIP member reads also use substring matching, so a request for `game.nes` can select `__MACOSX/._game.nes`.

This change ignores `__MACOSX` and `._` metadata entries during ZIP-compatible archive listing. Buffered and incremental `zip#member` reads now require the complete entry name, consistent with the 7z backend.

Malformed archives that fail backend initialization now pass through the existing error cleanup before returning. This closes the opened archive stream and clears transfer ownership without changing the iterator's failure result.

The archive sample generates its ZIP inputs and verifies malformed archives, filtered and unfiltered listings, buffered reads, incremental entry-source reads, and initialization-failure cleanup without adding binary fixtures.

## Testing

Windows:

- `make clean all`
- `archive_zip_test.exe`
- MinGW `Makefile.win` build with `-std=gnu89`
- `retroarch-cleanup-test.exe --version`

CI:

- `Build and run libretro-common/samples` with ASan/UBSan

## Related Issues

Fixes #19242.

## Related Pull Requests

None.

## Reviewers
