### PR TITLE
android: special case for permissions on Android 10

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <!-- Android 6-12 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <application
         android:name="com.retroarch.playcore.RetroArchApplication"
         android:allowAudioPlaybackCapture="true"

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -58,6 +58,7 @@ public final class MainMenuActivity extends PreferenceActivity
 
 	public void checkRuntimePermissions()
 	{
+		// The SDK on the user's device >= 30 (Android 11)
 		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
 		{
 			if (!Environment.isExternalStorageManager())
@@ -89,6 +90,7 @@ public final class MainMenuActivity extends PreferenceActivity
 					});
 			}
 		}
+		// The SDK on the user's device >= 23 (Android 6)
 		else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M)
 		{
 			// Android 6.0+ needs runtime permission checks
@@ -213,6 +215,7 @@ public final class MainMenuActivity extends PreferenceActivity
 				break;
 		}
 
+		// The SDK on the user's device < 30 (Android 11)
 		if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.R)
 		{
 			boolean allGranted = true;


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Android 10 is a special case of "in between" storage permission changes.

This works on Android 10 as android:requestLegacyExternalStorage="true" is still applied.

## Related Issues


## Related Pull Requests


## Reviewers
