### PR TITLE
android: use scoped "media" storage folder for saves, system etc on pla…

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/debug/CoreSideloadActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/debug/CoreSideloadActivity.java
@@ -161,6 +161,7 @@ public class CoreSideloadActivity extends Activity
                 Log.d("sideload", "Running RetroArch with core " + destination.getAbsolutePath());
 
                 MainMenuActivity.startRetroActivity(
+                    ctx,
                     retro,
                     content,
                     destination.getAbsolutePath(),

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -4,6 +4,7 @@ import com.retroarch.BuildConfig;
 import com.retroarch.browser.preferences.util.UserPreferences;
 import com.retroarch.browser.retroactivity.RetroActivityFuture;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
@@ -13,6 +14,7 @@ import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 
+import java.io.File;
 import java.util.List;
 import java.util.ArrayList;
 import android.content.pm.PackageManager;
@@ -177,6 +179,7 @@ public final class MainMenuActivity extends PreferenceActivity
 			final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
 			startRetroActivity(
+					this,
 					retro,
 					null,
 					prefs.getString("libretro_path", getApplicationInfo().dataDir + "/cores/"),
@@ -237,7 +240,7 @@ public final class MainMenuActivity extends PreferenceActivity
 		finalStartup();
 	}
 
-	public static void startRetroActivity(Intent retro, String contentPath, String corePath,
+	public static void startRetroActivity(Context ctx, Intent retro, String contentPath, String corePath,
 			String configFilePath, String imePath, String dataDirPath, String dataSourcePath)
 	{
 		if (contentPath != null) {
@@ -248,8 +251,31 @@ public final class MainMenuActivity extends PreferenceActivity
 		retro.putExtra("IME", imePath);
 		retro.putExtra("DATADIR", dataDirPath);
 		retro.putExtra("APK", dataSourcePath);
-		String external = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/" + PACKAGE_NAME + "/files";
-		retro.putExtra("SDCARD", BuildConfig.PLAY_STORE_BUILD ? external : Environment.getExternalStorageDirectory().getAbsolutePath());
+
+		String external;
+		if (BuildConfig.PLAY_STORE_BUILD)
+		{
+			File[] mediaDirs = ctx.getExternalMediaDirs();
+			if (mediaDirs != null && mediaDirs.length > 0 && mediaDirs[0] != null)
+			{
+				File dir = mediaDirs[0];
+				if (!dir.exists())
+					dir.mkdirs();
+				external = dir.getAbsolutePath();
+			}
+			else
+			{
+				// Fallback: external media unavailable
+				external = Environment.getExternalStorageDirectory().getAbsolutePath()
+						+ "/Android/data/" + PACKAGE_NAME + "/files";
+			}
+		}
+		else
+		{
+			external = Environment.getExternalStorageDirectory().getAbsolutePath();
+		}
+
+		retro.putExtra("SDCARD", external);
 		retro.putExtra("EXTERNAL", external);
 	}
 


### PR DESCRIPTION
…y version

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

The play store currently writes saves, system etc. to /Android/data/com.retroarch, but this is not writeable over USB, so users cannot upload BIOS etc.

This changes those locations to /Android/media/com.retroarch which is writeable.

Folders now in media:

```
temp
system
saves
downloads
playlists
cheats
thumbnails
config
logs
screenshots
states
```

## Related Issues


## Related Pull Requests


## Reviewers

