### PR TITLE
Fix SMB archive browse and load without a core

### DIFF
--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1775,6 +1775,12 @@ GAME AI
 SMB CLIENT
 ============================================================ */
 #ifdef HAVE_BUILTINSMBCLIENT
+/* libsmb2 sources expect autoconf-style unused-param marker and
+ * GNU C (typeof in alloc.c). Platforms that compile griffin as
+ * ISO C99 must pass -std=gnu99 (or equivalent) as well. */
+#ifndef _U_
+#define _U_ __attribute__((unused))
+#endif
 #include "../deps/libsmb2/lib/aes.c"
 #include "../deps/libsmb2/lib/aes_apple.c"
 #include "../deps/libsmb2/lib/aes128ccm.c"

--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -160,10 +160,16 @@ static int file_archive_parse_file_init(file_archive_transfer_t *state,
    state->archive_size = filestream_get_size(state->archive_file);
 
 #ifdef HAVE_MMAP
-   if (state->archive_size <= (256*1024*1024))
+   /* mmap needs a real host fd. Skip VFS URL schemes (smb://, cdrom://,
+    * saf://, ...) where POSIX open() cannot work, and require fd >= 0 —
+    * open() returns -1 on failure, which is truthy and previously slipped
+    * into mmap(). */
+   if (     state->archive_size > 0
+         && state->archive_size <= (256 * 1024 * 1024)
+         && !strstr(path, "://"))
    {
       state->archive_mmap_fd = open(path, O_RDONLY);
-      if (state->archive_mmap_fd)
+      if (state->archive_mmap_fd >= 0)
       {
          state->archive_mmap_data = (uint8_t*)mmap(NULL,
                (size_t)state->archive_size,

--- a/libretro-common/file/archive_file_zlib.c
+++ b/libretro-common/file/archive_file_zlib.c
@@ -319,7 +319,7 @@ static int zlib_stream_decompress_data_to_file_iterate(
          filestream_seek(state->archive_file, zip_context->fdoffset, RETRO_VFS_SEEK_POSITION_START);
          if (filestream_read(state->archive_file,
                              zip_context->decompressed_data,
-                             zip_context->usize) < 0)
+                             zip_context->usize) != (int64_t)zip_context->usize)
             return -1;
       }
 
@@ -350,6 +350,11 @@ static int zlib_stream_decompress_data_to_file_iterate(
                RETRO_VFS_SEEK_POSITION_START);
          rd = filestream_read(state->archive_file, zip_context->tmpbuf, to_read);
          if (rd < 0)
+            return -1;
+         /* Unexpected EOF before csize: returning 0 would spin forever
+          * in file_archive_walk's tight iterate loop (seen with short
+          * or stalled VFS backends such as SMB). */
+         if (rd == 0)
             return -1;
          dptr = zip_context->tmpbuf;
       }

--- a/libretro-common/file/file_path.c
+++ b/libretro-common/file/file_path.c
@@ -730,6 +730,12 @@ bool path_is_absolute(const char *path)
    {
       if (path[0] == '/')
          return true;
+      /* VFS URL schemes (smb://, cdrom://, saf://, ...) are absolute. */
+      {
+         const char *scheme = strstr(path, "://");
+         if (scheme && scheme > path)
+            return true;
+      }
 #if defined(_WIN32)
       if (path[0] == '\\' && path[1] == '\\')
          return true;

--- a/libretro-common/vfs/vfs_implementation_smb.c
+++ b/libretro-common/vfs/vfs_implementation_smb.c
@@ -352,51 +352,91 @@ bool retro_vfs_file_open_smb(libretro_vfs_implementation_file *stream,
 int64_t retro_vfs_file_read_smb(libretro_vfs_implementation_file *stream,
    void *s, uint64_t len)
 {
-   int ret;
+   uint8_t *ptr               = (uint8_t*)s;
+   uint64_t total             = 0;
    struct smb2_context *ctx;
+   struct smb2fh *fh;
 
-   if (!smb_initialized || !stream || stream->smb_fh < 0)
+   if (!smb_initialized || !stream || !s || stream->smb_fh < 0)
       return -1;
+
+   if (len == 0)
+      return 0;
 
    ctx = (struct smb2_context *)(void *)(uintptr_t)stream->smb_ctx;
    if (!ctx)
-       return -1;
+      return -1;
 
-   /* smb2_read takes uint32_t count; passing a uint64_t len that
-    * exceeds UINT32_MAX was silently truncated pre-patch.  Cap at
-    * UINT32_MAX so the caller gets back the (partial) byte count
-    * and knows to loop for more.  This matches fread-style
-    * short-read semantics already observed by VFS consumers. */
-   if (len > (uint64_t)UINT32_MAX)
-      len = UINT32_MAX;
+   fh = (struct smb2fh *)(intptr_t)stream->smb_fh;
+   if (!fh)
+      return -1;
 
-   ret = smb2_read(ctx, (struct smb2fh *)(intptr_t)stream->smb_fh, s, (uint32_t)len);
+   /* libsmb2 silently caps each smb2_read() to max_read_size / credits
+    * (often 64 KiB–1 MiB).  Archive parsers (ZIP EOCD / central directory)
+    * and other VFS callers compare against the exact requested length, so
+    * a single short read looks like I/O failure and yields an empty
+    * "Browse Archive" list.  Loop like fread() on a regular file. */
+   while (total < len)
+   {
+      uint64_t want = len - total;
+      int ret;
 
-   return ret;
+      if (want > (uint64_t)UINT32_MAX)
+         want = UINT32_MAX;
+
+      ret = smb2_read(ctx, fh, ptr + total, (uint32_t)want);
+      if (ret < 0)
+         return (total > 0) ? (int64_t)total : -1;
+      if (ret == 0)
+         break; /* EOF */
+
+      total += (uint64_t)ret;
+   }
+
+   return (int64_t)total;
 }
 
 int64_t retro_vfs_file_write_smb(libretro_vfs_implementation_file *stream,
    const void *s, uint64_t len)
 {
-   int ret;
+   const uint8_t *ptr         = (const uint8_t*)s;
+   uint64_t total             = 0;
    struct smb2_context *ctx;
+   struct smb2fh *fh;
 
-   if (!smb_initialized || !stream || stream->smb_fh < 0)
+   if (!smb_initialized || !stream || !s || stream->smb_fh < 0)
       return -1;
+
+   if (len == 0)
+      return 0;
 
    ctx = (struct smb2_context *)(void *)(uintptr_t)stream->smb_ctx;
    if (!ctx)
-       return -1;
+      return -1;
 
-   /* smb2_write takes uint32_t count; see retro_vfs_file_read_smb
-    * for the rationale.  Cap at UINT32_MAX and let the caller
-    * re-issue for remaining bytes. */
-   if (len > (uint64_t)UINT32_MAX)
-      len = UINT32_MAX;
+   fh = (struct smb2fh *)(intptr_t)stream->smb_fh;
+   if (!fh)
+      return -1;
 
-   ret = smb2_write(ctx, (struct smb2fh *)(intptr_t)stream->smb_fh, (void*)s, (uint32_t)len);
+   /* Same max_write_size / credits cap as reads — accumulate. */
+   while (total < len)
+   {
+      uint64_t want = len - total;
+      int ret;
 
-   return ret;
+      if (want > (uint64_t)UINT32_MAX)
+         want = UINT32_MAX;
+
+      ret = smb2_write(ctx, fh, ptr + total, (uint32_t)want);
+      if (ret < 0)
+         return (total > 0) ? (int64_t)total : -1;
+      if (ret == 0)
+         break;
+
+      total += (uint64_t)ret;
+   }
+
+   return (int64_t)total;
 }
 
 int64_t retro_vfs_file_seek_smb(libretro_vfs_implementation_file *stream,

--- a/menu/cbs/menu_cbs_deferred_push.c
+++ b/menu/cbs/menu_cbs_deferred_push.c
@@ -321,21 +321,30 @@ static int general_push(menu_displaylist_info_t *info,
    {
       /* Need to use the scratch buffer here */
       char tmp_str[PATH_MAX_LENGTH];
-#if IOS
+      /* scratch_buf may already be a full VFS URL (smb://...); do not
+       * join that onto the parent directory. */
       if (path_is_absolute(menu->scratch_buf))
+      {
+#if IOS
+         fill_pathname_expand_special(tmp_str, menu->scratch_buf,
+               sizeof(tmp_str));
+#else
          strlcpy(tmp_str, menu->scratch_buf, sizeof(tmp_str));
+#endif
+      }
       else
       {
+#if IOS
          char tmp_path[PATH_MAX_LENGTH];
          fill_pathname_expand_special(tmp_path,
                menu->scratch2_buf, sizeof(tmp_path));
          fill_pathname_join_special(tmp_str, tmp_path,
                menu->scratch_buf, sizeof(tmp_str));
-      }
 #else
-      fill_pathname_join_special(tmp_str, menu->scratch2_buf,
-            menu->scratch_buf, sizeof(tmp_str));
+         fill_pathname_join_special(tmp_str, menu->scratch2_buf,
+               menu->scratch_buf, sizeof(tmp_str));
 #endif
+      }
 
       if (*info->path)
          free(info->path);
@@ -354,16 +363,23 @@ static int general_push(menu_displaylist_info_t *info,
    switch (id)
    {
       case PUSH_ARCHIVE_OPEN:
+         /* Overlay picker still wants only .cfg inside the archive. */
          if (filebrowser_get_type() == FILEBROWSER_SELECT_OVERLAY)
             string_ext_list_merge_dedup(ext_filter, &_len, sizeof(ext_filter), "cfg");
          else
          {
-            struct retro_system_info *sysinfo =
-               &runloop_state_get_ptr()->system.info;
-            if (    sysinfo 
-                &&  sysinfo->valid_extensions 
-                && *sysinfo->valid_extensions)
-               string_ext_list_merge_dedup(ext_filter, &_len, sizeof(ext_filter), sysinfo->valid_extensions);
+            /* Browse Archive from Load Content uses this push (not
+             * DETECT_CORE).  Seeding only the current core's extensions
+             * — or worse, leaving the list empty so the multimedia
+             * blocks below fill it with image/audio types — hides ROM
+             * members (e.g. .smc in a zip under a nes/ folder) and
+             * presents an empty list.  List every member; core choice
+             * still happens when the user selects a file. */
+            if (info->exts)
+            {
+               free(info->exts);
+               info->exts = NULL;
+            }
          }
          break;
       case PUSH_DEFAULT:
@@ -444,8 +460,10 @@ static int general_push(menu_displaylist_info_t *info,
          break;
    }
 
+   /* Do not invent a media-only filter for Browse Archive — see
+    * PUSH_ARCHIVE_OPEN above. */
 #if defined(HAVE_FFMPEG) || defined(HAVE_MPV)
-   if (multimedia_builtin_mediaplayer_enable)
+   if (multimedia_builtin_mediaplayer_enable && id != PUSH_ARCHIVE_OPEN)
    {
       struct retro_system_info sysinfo = {0};
 #if defined(HAVE_FFMPEG)
@@ -461,7 +479,7 @@ static int general_push(menu_displaylist_info_t *info,
 #endif
 
 #ifdef HAVE_IMAGEVIEWER
-   if (multimedia_builtin_imageviewer_enable)
+   if (multimedia_builtin_imageviewer_enable && id != PUSH_ARCHIVE_OPEN)
    {
       struct retro_system_info sysinfo = {0};
       libretro_imageviewer_retro_get_system_info(&sysinfo);

--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -8231,6 +8231,9 @@ static int action_ok_state_slot_run(const char *path,
    return 0;
 }
 
+static int action_ok_load_archive_detect_core(const char *path,
+      const char *label, unsigned type, size_t idx, size_t entry_idx);
+
 static int action_ok_load_archive(const char *path,
       const char *label, unsigned type, size_t idx, size_t entry_idx)
 {
@@ -8241,6 +8244,13 @@ static int action_ok_load_archive(const char *path,
 
    if (!menu)
       return -1;
+
+   /* Load Content opens archives via ARCHIVE_ACTION (not DETECT_CORE).
+    * With no core loaded, loading "with current core" leaves a broken
+    * runloop state (or appears to hang).  Fall through to detect-core. */
+   if (path_is_empty(RARCH_PATH_CORE))
+      return action_ok_load_archive_detect_core(
+            path, label, type, idx, entry_idx);
 
    menu_path    = menu->scratch2_buf;
    content_path = menu->scratch_buf;
@@ -10180,6 +10190,22 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
                         BIND_ACTION_OK(cbs, action_ok_file_load_with_detect_core);
                      }
                      break;
+                  case MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN:
+                     /* Browse Archive (non-detect) still needs detect-core
+                      * when nothing is loaded — otherwise
+                      * action_ok_file_load pushes content with a dummy
+                      * core and core_run() jumps through a NULL
+                      * retro_run (SIGSEGV). */
+#ifdef HAVE_COMPRESSION
+                     if (type == FILE_TYPE_IN_CARCHIVE
+                           && path_is_empty(RARCH_PATH_CORE))
+                     {
+                        BIND_ACTION_OK(cbs, action_ok_file_load_with_detect_core_carchive);
+                        break;
+                     }
+#endif
+                     BIND_ACTION_OK(cbs, action_ok_file_load);
+                     break;
                   case MENU_ENUM_LABEL_DISK_IMAGE_APPEND:
                      BIND_ACTION_OK(cbs, action_ok_disk_image_append);
                      break;
@@ -10208,6 +10234,20 @@ static int menu_cbs_init_bind_ok_compare_type(menu_file_list_cbs_t *cbs,
                   {
                      BIND_ACTION_OK(cbs, action_ok_file_load_with_detect_core);
                   }
+               }
+               else if (string_is_equal(menu_label,
+                        MENU_ENUM_LABEL_DEFERRED_ARCHIVE_OPEN_STR)
+#ifdef HAVE_COMPRESSION
+                     && type == FILE_TYPE_IN_CARCHIVE
+                     && path_is_empty(RARCH_PATH_CORE)
+#endif
+                     )
+               {
+#ifdef HAVE_COMPRESSION
+                  BIND_ACTION_OK(cbs, action_ok_file_load_with_detect_core_carchive);
+#else
+                  BIND_ACTION_OK(cbs, action_ok_file_load);
+#endif
                }
                else if (string_is_equal(menu_label, MENU_ENUM_LABEL_DISK_IMAGE_APPEND_STR))
                {

--- a/runloop.c
+++ b/runloop.c
@@ -8652,7 +8652,11 @@ void core_run(void)
    else if (late_polling)
       current_core->flags &= ~RETRO_CORE_FLAG_INPUT_POLLED;
 
-   current_core->retro_run();
+   /* Content can be marked CORE_RUNNING after a failed/partial load
+    * (e.g. archive member opened with no core).  Never call through
+    * a NULL retro_run — that is an immediate SIGSEGV. */
+   if (current_core->retro_run)
+      current_core->retro_run();
 
 #ifdef HAVE_GAME_AI
    {


### PR DESCRIPTION
## Summary
- Make SMB VFS reads/writes accumulate short I/O so ZIP parsing over `smb://` does not fail on capped `smb2_read`/`smb2_write`.
- Skip archive `mmap` for VFS URL schemes; treat `scheme://` paths as absolute; stop ZIP decompress from spinning on unexpected EOF.
- Browse Archive lists all members (instead of a multimedia/core-only filter), and Load Archive / in-archive selection falls back to detect-core when no core is loaded; guard `core_run` against a NULL `retro_run`.

## Test plan
- [ ] macOS build with apple-deps `libsmb2` / `HAVE_SMBCLIENT`
- [ ] SMB Browse → open a `.zip` → **Browse Archive** shows members (e.g. `.smc` even under a `nes/` folder)
- [ ] With **No Core**, select a member → Detect Core list appears and load succeeds
- [ ] With **No Core**, **Load Archive** on the same zip → Detect Core / load works (no hang)
- [ ] Local (non-SMB) archive browse/load still works as before