### PR TITLE
Makefile.webos: fix macOS Make/cp for webOS IPK packaging

### DIFF
--- a/Makefile.webos
+++ b/Makefile.webos
@@ -406,14 +406,15 @@ ifeq ($(SET_ELF_INTERPRETER), 1)
 	patchelf --set-interpreter $(ELF_INTERPRETER) $(TARGET)
 endif
 	echo "$$APPINFO" > webos/dist/appinfo.json
-	cp -t webos/dist -vf $(TARGET) webos/icon160.png
-	cp -t webos/dist/lib -vf $(WEBOS_USR_LIB_DIR)/libstdc++.so.6
+	# BSD cp (macOS) has no -t; put the destination last.
+	cp -vf $(TARGET) webos/icon160.png webos/dist/
+	cp -vf $(WEBOS_USR_LIB_DIR)/libstdc++.so.6 webos/dist/lib/
 ifeq ($(HAVE_XKBCOMMON), 1)
-	cp -t webos/dist/lib -vf $(WEBOS_USR_LIB_DIR)/libxkbcommon.so.0
+	cp -vf $(WEBOS_USR_LIB_DIR)/libxkbcommon.so.0 webos/dist/lib/
 endif
-	cp -t webos/dist/lib -vf $(WEBOS_LIB_DIR)/libatomic.so.1
+	cp -vf $(WEBOS_LIB_DIR)/libatomic.so.1 webos/dist/lib/
 ifeq ($(ADD_SDL2_LIB), 1)
-	cp -t webos/dist/lib -vf SDL/lib/libSDL2-2.0.so.0
+	cp -vf SDL/lib/libSDL2-2.0.so.0 webos/dist/lib/
 endif
 ifneq ($(DEBUG), 1)
 	$(STRIP) webos/dist/$(TARGET)

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -30,7 +30,7 @@ SET_BUILD_ID          ?= 0
 
 APP_PACKAGE_NAME ?= com.retroarch.webos
 ARES_PACKAGE_ARGS ?=
-IPK_VERSION := $(shell grep '#define PACKAGE_VERSION' version.all | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+IPK_VERSION := $(shell grep '\#define PACKAGE_VERSION' version.all | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
 
 WEBOS = 1
 DEBUG ?= 0


### PR DESCRIPTION
## Summary
- Escape `#` in the `IPK_VERSION` `$(shell grep …)` line so Apple GNU Make 3.81 does not treat it as a makefile comment
- Replace GNU-only `cp -t` with portable `cp sources… dest/` so IPK packaging works with BSD `cp` on macOS
- Without these, `make -f Makefile.webos` fails on macOS either at parse time (`unterminated call to function 'shell'`) or at `ipk` (`cp: illegal option -- t`)

## Test plan
- [ ] On macOS with system `/usr/bin/make` (GNU Make 3.81) and BSD `/bin/cp`: `make -f Makefile.webos ipk` gets past `IPK_VERSION` and copies files into `webos/dist/`
- [ ] On Linux CI / GNU Make 4.x + GNU cp: existing webOS workflow still builds IPKs as before