### PR TITLE
sdl_input: fix Shift leaking '?' and blocking capitals in text fields

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -546,8 +546,11 @@ static void sdl_input_poll(void *data)
          if (event.key.keysym.mod & 0x8000 /*KMOD_SCROLL*/)
             mod |= RETROKMOD_SCROLLOCK;
 
-         input_keyboard_event(event.type == SDL_KEYDOWN, code, code, mod,
-               RETRO_DEVICE_KEYBOARD);
+         /* Use key+mod ASCII so Shift does not leak as '?' and capitals work. */
+         input_keyboard_event(event.type == SDL_KEYDOWN, code,
+               input_keymaps_translate_rk_to_ascii(
+                     (enum retro_key)code, (enum retro_mod)mod),
+               mod, RETRO_DEVICE_KEYBOARD);
       }
 #ifdef HAVE_SDL2
       else if (event.type == SDL_MOUSEWHEEL)


### PR DESCRIPTION
## Summary
- SDL keyboard input previously passed the raw `RETROK_*` keycode as the text character
- Modifier keys such as Shift (`RETROK_LSHIFT`/`RETROK_RSHIFT` ≥ 0x80) were turned into `'?'` by the menu line editor, and Shift+letter never produced capitals
- Resolve the printable character with `input_keymaps_translate_rk_to_ascii(code, mod)` (same approach as overlay / Android keyboard fixes)
- Fixes Bluetooth keyboard text entry on webOS (and other SDL platforms)

## Test plan
- [ ] On webOS (or any SDL build), open a menu text field
- [ ] Press Shift alone — nothing should be inserted
- [ ] Type Shift+letter — uppercase letter should appear
- [ ] Type Shift+number — shifted symbol (`!`, `@`, etc.) should appear
- [ ] Lowercase letters and Backspace/Enter still work as before