### PR TITLE
webOS: let remote D-pad navigate the on-screen keyboard

### DIFF
--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -847,12 +847,6 @@ void wl_keyboard_handle_key_webos(void *data,
       case KEY_WAYLAND_WEBOS_BLUE:
          keysym = KEY_A;
          break;
-      case KEY_ENTER:
-         /* When in menu and in virtual keyboard entry,
-          * map magic remote wheel button click to LCTRL for character selection */
-         if (input_st && (input_st->flags & INP_FLAG_KB_MAPPING_BLOCKED))
-            keysym = KEY_LEFTCTRL;
-         break;
       case KEY_OK:
       case KEY_SELECT:
          keysym = KEY_ENTER;
@@ -868,6 +862,23 @@ void wl_keyboard_handle_key_webos(void *data,
       BIT_SET(wl->input.key_state, keysym);
    else if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
       BIT_CLEAR(wl->input.key_state, keysym);
+
+   /* OSK: D-pad / Enter navigate and confirm the grid; do not inject
+    * text-cursor moves or '\n' line submission from those keys. */
+   if (input_st && (input_st->flags & INP_FLAG_KB_MAPPING_BLOCKED))
+   {
+      switch (keysym)
+      {
+         case KEY_UP:
+         case KEY_DOWN:
+         case KEY_LEFT:
+         case KEY_RIGHT:
+         case KEY_ENTER:
+            return;
+         default:
+            break;
+      }
+   }
 
 #ifdef HAVE_XKBCOMMON
    if (handle_xkb(keysym, value) == 0)

--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -69,10 +69,26 @@ enum sdl_webos_special_key
 {
    sdl_webos_spkey_back,
    sdl_webos_spkey_return,
+   sdl_webos_spkey_up,
+   sdl_webos_spkey_down,
+   sdl_webos_spkey_left,
+   sdl_webos_spkey_right,
    sdl_webos_spkey_size,
 };
 
 static uint8_t sdl_webos_special_keymap[sdl_webos_spkey_size] = {0};
+
+/* One-shot sticky keys: webOS often delivers KEYDOWN+KEYUP in the same
+ * poll, so SDL_GetKeyboardState is already clear when the menu reads input. */
+static bool sdl_webos_sticky_pressed(enum sdl_webos_special_key slot)
+{
+   if (sdl_webos_special_keymap[slot])
+   {
+      sdl_webos_special_keymap[slot] = 0;
+      return true;
+   }
+   return false;
+}
 #endif
 
 static void *sdl_input_init(const char *joypad_driver)
@@ -101,20 +117,26 @@ static bool sdl_key_pressed(int key)
       return false;
 
 #ifdef WEBOS
-   if ((key == RETROK_BACKSPACE)
-      && sdl_webos_special_keymap[sdl_webos_spkey_back])
-   {
-      /* Reset to unpressed state */
-      sdl_webos_special_keymap[sdl_webos_spkey_back] = 0;
+   if (key == RETROK_BACKSPACE
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_back))
       return true;
-   }
-   if ((key == RETROK_LCTRL)
-      && sdl_webos_special_keymap[sdl_webos_spkey_return])
-   {
-      /* Reset to unpressed state */
-      sdl_webos_special_keymap[sdl_webos_spkey_return] = 0;
+   /* Return must stay RETROK_RETURN so display_kb can map it to menu OK
+    * (OSK character select). Mapping it to LCTRL selected nothing. */
+   if (key == RETROK_RETURN
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_return))
       return true;
-   }
+   if (key == RETROK_UP
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_up))
+      return true;
+   if (key == RETROK_DOWN
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_down))
+      return true;
+   if (key == RETROK_LEFT
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_left))
+      return true;
+   if (key == RETROK_RIGHT
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_right))
+      return true;
    if (key == RETROK_F1 && keymap[SDL_WEBOS_SCANCODE_EXIT])
       return true;
    if (key == RETROK_x && keymap[SDL_WEBOS_SCANCODE_RED])
@@ -500,16 +522,30 @@ static void sdl_input_poll(void *data)
             case SDL_WEBOS_SCANCODE_EXIT:
                code = RETROK_F1;
                break;
-            case SDL_SCANCODE_RIGHT:
-            case SDL_SCANCODE_LEFT:
-            case SDL_SCANCODE_DOWN:
             case SDL_SCANCODE_UP:
-               /* navigation only, skip text insertion */
+            case SDL_SCANCODE_DOWN:
+            case SDL_SCANCODE_LEFT:
+            case SDL_SCANCODE_RIGHT:
+               /* OSK: navigate the grid, do not move the text cursor. */
                if (osk_active)
+               {
+                  if (event.type == SDL_KEYDOWN)
+                  {
+                     if (event.key.keysym.scancode == SDL_SCANCODE_UP)
+                        sdl_webos_special_keymap[sdl_webos_spkey_up] = 1;
+                     else if (event.key.keysym.scancode == SDL_SCANCODE_DOWN)
+                        sdl_webos_special_keymap[sdl_webos_spkey_down] = 1;
+                     else if (event.key.keysym.scancode == SDL_SCANCODE_LEFT)
+                        sdl_webos_special_keymap[sdl_webos_spkey_left] = 1;
+                     else
+                        sdl_webos_special_keymap[sdl_webos_spkey_right] = 1;
+                  }
                   continue;
+               }
                break;
             case SDL_SCANCODE_RETURN:
-               // remap wheel click to confirm selection in virtual keyboard
+               /* OSK: remote OK selects the highlighted character (via
+                * RETROK_RETURN → menu OK), do not submit the line as '\n'. */
                if (osk_active)
                {
                   if (event.type == SDL_KEYDOWN)

--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -67,12 +67,64 @@ static const char *sdl_joypad_name(unsigned pad)
 #endif
 }
 
+#ifdef HAVE_SDL2
+/* Build a hat bitmask from GameController DPAD buttons. */
+static uint8_t sdl_pad_dpad_hat_from_buttons(sdl_joypad_t *pad)
+{
+   uint8_t dir = 0;
+
+   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_UP))
+      dir |= SDL_HAT_UP;
+   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_DOWN))
+      dir |= SDL_HAT_DOWN;
+   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_LEFT))
+      dir |= SDL_HAT_LEFT;
+   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_RIGHT))
+      dir |= SDL_HAT_RIGHT;
+
+   return dir;
+}
+#endif
+
 static uint8_t sdl_pad_get_button(sdl_joypad_t *pad, unsigned button)
 {
 #ifdef HAVE_SDL2
    /* TODO: see if a LUT like xinput_joypad.c's button_index_to_bitmap_code is needed. */
    if (pad->controller)
-      return SDL_GameControllerGetButton(pad->controller, (SDL_GameControllerButton)button);
+   {
+      uint8_t pressed = SDL_GameControllerGetButton(
+            pad->controller, (SDL_GameControllerButton)button);
+
+      if (pressed)
+         return pressed;
+
+      /* Some mappings (common with Nintendo pads on webOS SDL) leave the
+       * DPAD buttons unbound while the physical pad still reports a hat.
+       * Fall back so default binds for buttons 11-14 keep working. */
+      if (     button >= SDL_CONTROLLER_BUTTON_DPAD_UP
+            && button <= SDL_CONTROLLER_BUTTON_DPAD_RIGHT
+            && pad->joypad
+            && SDL_JoystickNumHats(pad->joypad) > 0)
+      {
+         uint8_t hat = SDL_JoystickGetHat(pad->joypad, 0);
+
+         switch (button)
+         {
+            case SDL_CONTROLLER_BUTTON_DPAD_UP:
+               return (hat & SDL_HAT_UP)    ? 1 : 0;
+            case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+               return (hat & SDL_HAT_DOWN)  ? 1 : 0;
+            case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+               return (hat & SDL_HAT_LEFT)  ? 1 : 0;
+            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+               return (hat & SDL_HAT_RIGHT) ? 1 : 0;
+            default:
+               break;
+         }
+      }
+
+      return 0;
+   }
 #endif
    return SDL_JoystickGetButton(pad->joypad, button);
 }
@@ -81,7 +133,19 @@ static uint8_t sdl_pad_get_hat(sdl_joypad_t *pad, unsigned hat)
 {
 #ifdef HAVE_SDL2
    if (pad->controller)
-      return sdl_pad_get_button(pad, hat);
+   {
+      /* GameController has no real hats; expose hat 0 from DPAD buttons
+       * (and joystick hat fallback) so autoconfigs that bind h0up/... work. */
+      uint8_t dir;
+
+      if (hat != 0)
+         return 0;
+
+      dir = sdl_pad_dpad_hat_from_buttons(pad);
+      if (!dir && pad->joypad && SDL_JoystickNumHats(pad->joypad) > 0)
+         dir = SDL_JoystickGetHat(pad->joypad, 0);
+      return dir;
+   }
 #endif
    return SDL_JoystickGetHat(pad->joypad, hat);
 }
@@ -187,7 +251,7 @@ static void sdl_pad_connect(unsigned id)
        */
       pad->num_axes    = SDL_CONTROLLER_AXIS_MAX;
       pad->num_buttons = SDL_CONTROLLER_BUTTON_MAX;
-      pad->num_hats    = 0;
+      pad->num_hats    = 1;
       pad->num_balls   = 0;
 
       /* SDL Device supports Game Controller API. */

--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -67,64 +67,12 @@ static const char *sdl_joypad_name(unsigned pad)
 #endif
 }
 
-#ifdef HAVE_SDL2
-/* Build a hat bitmask from GameController DPAD buttons. */
-static uint8_t sdl_pad_dpad_hat_from_buttons(sdl_joypad_t *pad)
-{
-   uint8_t dir = 0;
-
-   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_UP))
-      dir |= SDL_HAT_UP;
-   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_DOWN))
-      dir |= SDL_HAT_DOWN;
-   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_LEFT))
-      dir |= SDL_HAT_LEFT;
-   if (SDL_GameControllerGetButton(pad->controller, SDL_CONTROLLER_BUTTON_DPAD_RIGHT))
-      dir |= SDL_HAT_RIGHT;
-
-   return dir;
-}
-#endif
-
 static uint8_t sdl_pad_get_button(sdl_joypad_t *pad, unsigned button)
 {
 #ifdef HAVE_SDL2
    /* TODO: see if a LUT like xinput_joypad.c's button_index_to_bitmap_code is needed. */
    if (pad->controller)
-   {
-      uint8_t pressed = SDL_GameControllerGetButton(
-            pad->controller, (SDL_GameControllerButton)button);
-
-      if (pressed)
-         return pressed;
-
-      /* Some mappings (common with Nintendo pads on webOS SDL) leave the
-       * DPAD buttons unbound while the physical pad still reports a hat.
-       * Fall back so default binds for buttons 11-14 keep working. */
-      if (     button >= SDL_CONTROLLER_BUTTON_DPAD_UP
-            && button <= SDL_CONTROLLER_BUTTON_DPAD_RIGHT
-            && pad->joypad
-            && SDL_JoystickNumHats(pad->joypad) > 0)
-      {
-         uint8_t hat = SDL_JoystickGetHat(pad->joypad, 0);
-
-         switch (button)
-         {
-            case SDL_CONTROLLER_BUTTON_DPAD_UP:
-               return (hat & SDL_HAT_UP)    ? 1 : 0;
-            case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-               return (hat & SDL_HAT_DOWN)  ? 1 : 0;
-            case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-               return (hat & SDL_HAT_LEFT)  ? 1 : 0;
-            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-               return (hat & SDL_HAT_RIGHT) ? 1 : 0;
-            default:
-               break;
-         }
-      }
-
-      return 0;
-   }
+      return SDL_GameControllerGetButton(pad->controller, (SDL_GameControllerButton)button);
 #endif
    return SDL_JoystickGetButton(pad->joypad, button);
 }
@@ -133,19 +81,7 @@ static uint8_t sdl_pad_get_hat(sdl_joypad_t *pad, unsigned hat)
 {
 #ifdef HAVE_SDL2
    if (pad->controller)
-   {
-      /* GameController has no real hats; expose hat 0 from DPAD buttons
-       * (and joystick hat fallback) so autoconfigs that bind h0up/... work. */
-      uint8_t dir;
-
-      if (hat != 0)
-         return 0;
-
-      dir = sdl_pad_dpad_hat_from_buttons(pad);
-      if (!dir && pad->joypad && SDL_JoystickNumHats(pad->joypad) > 0)
-         dir = SDL_JoystickGetHat(pad->joypad, 0);
-      return dir;
-   }
+      return sdl_pad_get_button(pad, hat);
 #endif
    return SDL_JoystickGetHat(pad->joypad, hat);
 }
@@ -251,7 +187,7 @@ static void sdl_pad_connect(unsigned id)
        */
       pad->num_axes    = SDL_CONTROLLER_AXIS_MAX;
       pad->num_buttons = SDL_CONTROLLER_BUTTON_MAX;
-      pad->num_hats    = 1;
+      pad->num_hats    = 0;
       pad->num_balls   = 0;
 
       /* SDL Device supports Game Controller API. */

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -8162,20 +8162,29 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
       }
       else if (display_kb && input && input->input_state)
       {
-         /* Allow character map switches, 
-          * and set RetroPad Select bit when pressing Escape
-          * in order to clear the input window and close it. */
+         /* OSK grid navigation from keyboard / TV remote D-pad, plus
+          * page switches and Escape to clear/close. Return confirms the
+          * highlighted OSK character (same as menu OK). */
          unsigned i;
+         bool swap_ok_cancel_buttons = settings->bools.input_menu_swap_ok_cancel_buttons;
          unsigned ids[][2] =
          {
+            {RETROK_RETURN,    RETRO_DEVICE_ID_JOYPAD_A      },
+            {RETROK_UP,        RETRO_DEVICE_ID_JOYPAD_UP     },
+            {RETROK_DOWN,      RETRO_DEVICE_ID_JOYPAD_DOWN   },
+            {RETROK_LEFT,      RETRO_DEVICE_ID_JOYPAD_LEFT   },
+            {RETROK_RIGHT,     RETRO_DEVICE_ID_JOYPAD_RIGHT  },
             {RETROK_PAGEUP,    RETRO_DEVICE_ID_JOYPAD_L      },
             {RETROK_PAGEDOWN,  RETRO_DEVICE_ID_JOYPAD_R      },
             {RETROK_ESCAPE,    RETRO_DEVICE_ID_JOYPAD_SELECT },
          };
 
+         if (swap_ok_cancel_buttons)
+            ids[0][1] = RETRO_DEVICE_ID_JOYPAD_B;
+
          for (i = 0; i < ARRAY_SIZE(ids); i++)
          {
-            if (input->input_state(
+            if (ids[i][0] && input->input_state(
                      input_st->current_data,
                      joypad,
                      sec_joypad,


### PR DESCRIPTION
## Summary
- While the on-screen keyboard is open on webOS, map Magic Remote / gamepad D-pad and Enter to sticky keyboard arrows/Return so Ozone OSK navigation works.
- Skip injecting Wayland text events for those remote keys during OSK (they were arriving as useless LCTRL / no menu focus).

## Test plan
- [x] Open OSK on a string setting with Magic Remote; D-pad moves the caret/focus among keys
- [x] Remote Enter/center selects the focused OSK key
- [ ] Confirm BT keyboard typing still works with OSK open
- [ ] Confirm gamepad menu navigation still works when OSK is closed