### PR TITLE
webOS: enlarge Running-on log buffer for snprintf

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -8431,7 +8431,7 @@ bool retroarch_main_init(int argc, char *argv[])
       }
 #elif defined(WEBOS)
       {
-         char str_output[128];
+         char str_output[256];
          char osbuf[128];
          int major = 0, minor = 0;
          frontend_state_t *frontend_st = frontend_state_get_ptr();


### PR DESCRIPTION
## Summary
- Enlarge the webOS `Running on:` startup log buffer from 128 to 256 bytes so `snprintf` no longer triggers `-Wformat-truncation` when formatting `osbuf` plus the arch suffix.

## Test plan
- [ ] `make -f Makefile.webos` (or IPK build) no longer warns at `retroarch.c` `Running on: %s%s`
- [ ] Confirm webOS startup log still prints the OS / bitness line