### PR TITLE
Fix incorrect VIDEO_FLAG_USE_RGBA bitmask in image viewer

### DIFF
--- a/cores/libretro-imageviewer/image_core.c
+++ b/cores/libretro-imageviewer/image_core.c
@@ -35,8 +35,7 @@
 
 #ifdef RARCH_INTERNAL
 #include "internal_cores.h"
-extern uint32_t video_driver_get_disp_flags(void);
-#define VIDEO_FLAG_USE_RGBA (1 << 3)
+#include "../../gfx/video_driver.h"
 #define IMAGE_CORE_PREFIX(s) libretro_imageviewer_##s
 #else
 #define IMAGE_CORE_PREFIX(s) s


### PR DESCRIPTION
## Description

Remove the local forward declaration and hardcoded VIDEO_FLAG_USE_RGBA definition from cores/libretro-imageviewer/image_core.c. Include gfx/video_driver.h directly so the core uses the canonical display flag definitions provided by the video driver API.

The local definition assigned VIDEO_FLAG_USE_RGBA to (1 << 3), which did not match the canonical value defined in video_driver.h. As a result, video_driver_get_disp_flags() & VIDEO_FLAG_USE_RGBA evaluated incorrectly, preventing the core from correctly detecting RGBA support. Because Android and other platforms build RetroArch as a single unified translation unit (griffin.c, which includes core and driver source files sequentially), this incorrect local definition was not confined to image_core.c. It had no matching #undef, so it silently overrode the correct value for every file included afterward in the same build, including gl2.c, gfx_display.c, gfx_thumbnail.c, and the menu drivers, which all check this flag by including video_driver.h normally and rely on it already being defined correctly.

On desktop drivers (Direct3D and OpenGL), the incorrect path generally produced the expected output because 32-bit textures were accepted in the fallback byte order. On OpenGL ES, however, textures are expected in RGBA order. The incorrect flag forced the asset loader down its BGRA fallback path, swapping the red and blue channels and causing menu icons, thumbnails, and RetroAchievements badges to appear blue on Android. The same corrupted flag also affected gameplay output on software-rendered cores, which route the core's framebuffer through the same pixel conversion utility. GL and Vulkan gameplay rendering were unaffected, since the core's framebuffer is uploaded through a separate format-negotiation path that does not consult this flag.

Using the canonical flag definition ensures supports_rgba correctly reflects the active video driver's capabilities across desktop and mobile platforms, and removes the conflicting definition that was affecting unrelated files compiled later in the same unified build. Also update the include path to ../../gfx/video_driver.h so the header resolves correctly during unified Griffin (griffin.c) builds.

## Related Issues

This resolves https://github.com/libretro/RetroArch/issues/19148. After doing a bisect, this commit was the issue https://github.com/libretro/RetroArch/commit/01c66a239943108d57f42a6c24a16fa69cd64ca6. The issue was closed, but still occurred on current builds. My comments on the issue outlined several test scenarios. All test cases outlined there are solved with this change. 

## LLM Disclaimer

The bisect and testing was done by me. The change was authored by gemini. I have tested thoroughly on 3 android devices using vulkan and openGL video drivers (two with adreno GPUs and one with a Mali GPU). The issue was originally opened by a macOS user. I don't have a macOS device to test this on.