### PR TITLE
sdl_joypad: webOS Switch Pro builtin remap via hat #0

### DIFF
--- a/input/drivers_joypad/sdl_joypad.c
+++ b/input/drivers_joypad/sdl_joypad.c
@@ -81,7 +81,14 @@ static uint8_t sdl_pad_get_hat(sdl_joypad_t *pad, unsigned hat)
 {
 #ifdef HAVE_SDL2
    if (pad->controller)
-      return sdl_pad_get_button(pad, hat);
+   {
+      /* Stock code called get_button(hat) here, which is wrong for a hat
+       * index. Read the real joystick hat so h0* autoconfigs work (webOS
+       * Switch Pro reports the D-pad as hat 0). */
+      if (hat != 0 || !pad->joypad || SDL_JoystickNumHats(pad->joypad) <= 0)
+         return 0;
+      return SDL_JoystickGetHat(pad->joypad, 0);
+   }
 #endif
    return SDL_JoystickGetHat(pad->joypad, hat);
 }
@@ -180,14 +187,14 @@ static void sdl_pad_connect(unsigned id)
        * So, we can claim to support all axes/buttons, and when we try to poll
        * an unbound ID, SDL simply returns the correct unpressed value.
        *
-       * Note that, in addition to 0 trackballs, we also have 0 hats. This is
-       * because the d-pad is in the button list, as the last 4 enum entries.
+       * Expose one hat so autoconfigs / remap that bind h0up/... work when
+       * the platform reports the D-pad as a joystick hat (webOS uhid).
        *
-       * -flibit
+       * -flibit (num_hats note updated for hat fallback)
        */
       pad->num_axes    = SDL_CONTROLLER_AXIS_MAX;
       pad->num_buttons = SDL_CONTROLLER_BUTTON_MAX;
-      pad->num_hats    = 0;
+      pad->num_hats    = 1;
       pad->num_balls   = 0;
 
       /* SDL Device supports Game Controller API. */

--- a/input/input_autodetect_builtin.c
+++ b/input/input_autodetect_builtin.c
@@ -67,6 +67,36 @@ DECL_AXIS(r_x_minus, -2) \
 DECL_AXIS(r_y_plus,  -3) \
 DECL_AXIS(r_y_minus, +3)
 
+#ifdef WEBOS
+/* Switch Pro on webOS — working physical remap. */
+#define SWITCH_PRO_SDL2_BINDS \
+DECL_BTN(a, 0) \
+DECL_BTN(b, 1) \
+DECL_BTN(x, 2) \
+DECL_BTN(y, 3) \
+DECL_BTN(select, 9) \
+DECL_BTN(start, 10) \
+DECL_BTN(up, h0up) \
+DECL_BTN(down, h0down) \
+DECL_BTN(left, h0left) \
+DECL_BTN(right, h0right) \
+DECL_BTN(l, 5) \
+DECL_BTN(r, 6) \
+DECL_BTN(l2, 7) \
+DECL_BTN(r2, 8) \
+DECL_BTN(l3, 12) \
+DECL_BTN(r3, 13) \
+DECL_AXIS(l_x_plus,  +0) \
+DECL_AXIS(l_x_minus, -0) \
+DECL_AXIS(l_y_plus,  +1) \
+DECL_AXIS(l_y_minus, -1) \
+DECL_AXIS(r_x_plus,  +2) \
+DECL_AXIS(r_x_minus, -2) \
+DECL_AXIS(r_y_plus,  -3) \
+DECL_AXIS(r_y_minus, +3) \
+DECL_MENU(11)
+#endif
+
 #define SDL3_DEFAULT_BINDS \
 DECL_BTN_EX(a,           1, "Right Face Button")   /* SDL_GAMEPAD_BUTTON_EAST           */ \
 DECL_BTN_EX(b,           0, "Bottom Face Button")  /* SDL_GAMEPAD_BUTTON_SOUTH          */ \
@@ -747,6 +777,11 @@ const char* const input_builtin_autoconfs[] =
 #endif
 #ifdef HAVE_SDL2
    DECL_AUTOCONF_DEVICE("Standard Gamepad", "sdl2", SDL2_DEFAULT_BINDS),
+#ifdef WEBOS
+   DECL_AUTOCONF_PID(0x2009, 0x057e, "sdl2", SWITCH_PRO_SDL2_BINDS),
+   DECL_AUTOCONF_PID(0x200e, 0x057e, "sdl2", SWITCH_PRO_SDL2_BINDS),
+   DECL_AUTOCONF_DEVICE("Nintendo Switch Pro Controller", "sdl2", SWITCH_PRO_SDL2_BINDS),
+#endif
 #endif
 #ifdef HAVE_SDL3
    DECL_AUTOCONF_DEVICE("Gamepad", "sdl3", SDL3_DEFAULT_BINDS),


### PR DESCRIPTION
## Summary
- webOS-only builtin Switch Pro autoconfig from a working remap:
  - D-pad: `h0up/down/left/right`
  - Home / menu toggle: button 11
  - − / +: 9 / 10
  - L1 / R1: 5 / 6
  - L2 / R2: 7 / 8 (buttons)
  - L3 / R3: 12 / 13
- Minimal `sdl_joypad` change: expose hat 0 and read the real joystick hat (stock GC path called `get_button(hat)` and set `num_hats = 0`, so `h0*` binds never worked).

## Test plan
- [ ] webOS + Switch Pro works without manual remap after deleting downloaded `*Switch*Pro*.cfg`
- [ ] Home opens quick menu, not D-pad Up
- [ ] L3/R3 stick clicks work
- [ ] Non-webOS builds unchanged