### PR TITLE
webOS: restore absolute mouse coords for menu/OSK hit-testing

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -266,9 +266,13 @@ static int16_t sdl_input_state(
                   return sdl->mouse_wd;
 #endif
                case RETRO_DEVICE_ID_MOUSE_X:
-                  return sdl->mouse_x;
+                  /* MOUSE_SCREEN must be absolute (menu/OSK hit-test);
+                   * RETRO_DEVICE_MOUSE stays relative for cores. */
+                  return (device == RARCH_DEVICE_MOUSE_SCREEN)
+                        ? sdl->mouse_abs_x : sdl->mouse_x;
                case RETRO_DEVICE_ID_MOUSE_Y:
-                  return sdl->mouse_y;
+                  return (device == RARCH_DEVICE_MOUSE_SCREEN)
+                        ? sdl->mouse_abs_y : sdl->mouse_y;
                case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                   return sdl->mouse_m;
                case RETRO_DEVICE_ID_MOUSE_BUTTON_4:


### PR DESCRIPTION
## Summary
- `#18432` made SDL mouse X/Y always relative on webOS so cores receive deltas.
- Menu / OSK use `RARCH_DEVICE_MOUSE_SCREEN` and need absolute coordinates for key hit-testing, so Magic Remote pointer clicks on the OSK missed.
- Keep relative for `RETRO_DEVICE_MOUSE` and absolute for `MOUSE_SCREEN` (same split as other input drivers).

## Test plan
- [ ] webOS: open OSK, move Magic Remote cursor over keys — highlight follows cursor
- [ ] webOS: click a key with Magic Remote pointer — character is entered
- [ ] webOS: mouse-using core (e.g. ScummVM) still gets relative mouse movement