### PR TITLE
Android: Disable native heap pointer tagging for core compatibility

### DIFF
--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -16,7 +16,8 @@
     <!-- Android 6-12 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
-    <application android:allowNativeHeapPointerTagging="false"
+    <application
+	android:allowNativeHeapPointerTagging="false"
         android:name="com.retroarch.playcore.RetroArchApplication"
         android:allowAudioPlaybackCapture="true"
         android:allowBackup="true"

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <!-- Android 6-12 -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
-    <application
+    <application android:allowNativeHeapPointerTagging="false"
         android:name="com.retroarch.playcore.RetroArchApplication"
         android:allowAudioPlaybackCapture="true"
         android:allowBackup="true"


### PR DESCRIPTION
## Description

Targeting Android API 30 or higher enables native heap pointer tagging for the RetroArch process, causing Flycast's ARM64 native code to crash when launching content. Setting allowNativeHeapPointerTagging to false resolves the crash.

Tested on a pixel 6 with android 17. I was not able to reproduce the issue on any other device. 

## Related Issues

Should resolve https://github.com/libretro/RetroArch/issues/18026 https://github.com/libretro/RetroArch/issues/19187 There have been a few other strange issues with cores, such as ppsspp, on android recently. It's possible this could resolve those issues, but it's untested.

## Related Pull Requests

When bisecting, I wasn't able to reproduce unless I was on https://github.com/libretro/RetroArch/commit/53021d40b11bb8a7e397b40802aeaf96e59f770e or newer.

## Reviewers

I looked into this on the recommendation of @i30817 
