### PR TITLE
rpng/rinflate: SIMD filter kernels, faster inflate fast path, in-place unfiltering

### DIFF
--- a/libretro-common/encodings/encoding_deflate.c
+++ b/libretro-common/encodings/encoding_deflate.c
@@ -582,8 +582,12 @@ static void rinf_pack_len(struct rinf_huff *h)
          else if (sym == 256)
             e = (uint32_t)len | RINF_PF_EOB;
          else if (sym - 257 < 29)
+            /* Bits [4:8] hold the code-plus-extra TOTAL, not the extra
+             * count: the critical-path shift that advances to the next
+             * code then uses the field directly, and the extra count
+             * for the value mask falls off the path as total - len. */
             e = (uint32_t)len
-              | ((uint32_t)rinf_len_extra[sym - 257] << 4)
+              | ((uint32_t)(len + rinf_len_extra[sym - 257]) << 4)
               | ((uint32_t)rinf_len_base[sym - 257] << 16);
          else
             e = (uint32_t)len | RINF_PF_BAD;
@@ -605,7 +609,7 @@ static void rinf_pack_dist(struct rinf_huff *h)
          int len = f & 15;
          if (sym < 30)
             e = (uint32_t)len
-              | ((uint32_t)rinf_dist_extra[sym] << 4)
+              | ((uint32_t)(len + rinf_dist_extra[sym]) << 4)
               | ((uint32_t)rinf_dist_base[sym] << 16);
          else
             e = (uint32_t)len | RINF_PF_BAD;
@@ -984,6 +988,17 @@ fast_again:
                 * this one: a larger value there would re-enter a loop
                 * whose own guard immediately fails, bouncing control
                 * between the two paths without progress. */
+               {
+               /* Preload carrier: at the end of a match copy the next
+                * code's low table-index bits are already final - the
+                * refill only ORs into bits at or above bitcnt - so the
+                * next litlen entry can be fetched before the copy's
+                * stores retire, hiding the table load under them.  The
+                * entry is only trusted when at least 15 bits were
+                * buffered at preload time (a full code's worth), which
+                * mirrors the literal chain's own reuse condition. */
+               uint32_t e_pre    = 0;
+               int      have_pre = 0;
                while (in_pos + 8 <= s->in_size
                      && out_pos + 258 + 16 <= s->out_size)
                {
@@ -1030,7 +1045,13 @@ fast_again:
                      in_pos += (size_t)nb_;
                      bitcnt += nb_ * 8;
                   }
-                  e = plen[bitbuf & ((1 << RINF_FAST_BITS) - 1)];
+                  if (have_pre)
+                  {
+                     e        = e_pre;
+                     have_pre = 0;
+                  }
+                  else
+                     e = plen[bitbuf & ((1 << RINF_FAST_BITS) - 1)];
                   /* Literal chain: after one refill the buffer holds at
                    * least 48 bits, and every packed literal costs at
                    * most 15, so several literals can be emitted before
@@ -1093,7 +1114,10 @@ fast_again:
                         goto error;
                      }
                      /* Re-enter the packed flow with a synthesised
-                      * entry; the code bits are already consumed. */
+                      * entry; the code bits are already consumed, so its
+                      * code length is zero and the packed total in bits
+                      * [4:8] degenerates to the extra count - the same
+                      * encoding either way. */
                      e = ((uint32_t)rinf_len_extra[sym - 257] << 4)
                        | ((uint32_t)rinf_len_base[sym - 257] << 16);
                      if (bitcnt < 33)
@@ -1129,12 +1153,12 @@ fast_again:
                      uint32_t length, dist;
                      {
                         int l  = (int)(e & 15);
-                        int ex = (int)((e >> 4) & 31);
+                        int t  = (int)((e >> 4) & 31);
                         length = (e >> 16)
                               + (uint32_t)((bitbuf >> l)
-                                    & (((uint64_t)1 << ex) - 1));
-                        bitbuf >>= (l + ex);
-                        bitcnt  -= (l + ex);
+                                    & (((uint64_t)1 << (t - l)) - 1));
+                        bitbuf >>= t;
+                        bitcnt  -= t;
                      }
                      {
                         uint32_t d = pdist[bitbuf
@@ -1151,12 +1175,12 @@ fast_again:
                             * the head guaranteed, so the full distance
                             * group (15 + 13) is always covered here. */
                            int dl  = (int)(d & 15);
-                           int dex = (int)((d >> 4) & 31);
+                           int dt  = (int)((d >> 4) & 31);
                            dist    = (d >> 16)
                                  + (uint32_t)((bitbuf >> dl)
-                                       & (((uint64_t)1 << dex) - 1));
-                           bitbuf >>= (dl + dex);
-                           bitcnt  -= (dl + dex);
+                                       & (((uint64_t)1 << (dt - dl)) - 1));
+                           bitbuf >>= dt;
+                           bitcnt  -= dt;
                         }
                         else
                         {
@@ -1296,6 +1320,9 @@ fast_again:
                            }
                         }
                         out_pos += length;
+                        e_pre    = plen[bitbuf
+                              & ((1 << RINF_FAST_BITS) - 1)];
+                        have_pre = (bitcnt >= 15);
                      }
                      else
                      {
@@ -1306,6 +1333,7 @@ fast_again:
                         break;
                      }
                   }
+               }
                }
 
                s->bitbuf  = bitbuf;

--- a/libretro-common/encodings/encoding_deflate.c
+++ b/libretro-common/encodings/encoding_deflate.c
@@ -290,7 +290,13 @@ enum rinf_phase
 /* A canonical-huffman decode table.  We use a two-level scheme: a direct
  * lookup on the low FAST_BITS bits, and for codes longer than FAST_BITS a
  * small linear/step search via the canonical first-code arrays. */
-#define RINF_FAST_BITS 9
+/* 11 bits: the dynamic litlen tables photographic PNG streams build
+ * put most of their code mass at 8-11 bits, which a 9-bit table sent
+ * to the canonical slow path.  The tables are per-stream heap state,
+ * so the growth (4 KB -> 16 KB of packed entries per table) costs
+ * nothing per decode; the splat loop in rinf_build touches each
+ * table entry once per dynamic block, which is noise. */
+#define RINF_FAST_BITS 11
 #define RINF_MAX_BITS  15
 
 struct rinf_huff
@@ -969,13 +975,17 @@ fast_again:
                int      done_fast    = 0;
 
                /* The output guard reserves the longest match plus the
-                * copy over-run pad: every inlined copy below writes in
-                * whole 8-byte steps and may run up to 7 bytes past the
-                * match end.  Those bytes lie beyond out_pos, so they are
-                * scratch - either rewritten by later output or beyond
-                * the produced length entirely. */
+                * copy over-run pad: the inlined copies below write in
+                * whole 8- or 16-byte steps and may run up to 15 bytes
+                * past the match end.  Those bytes lie beyond out_pos,
+                * so they are scratch - either rewritten by later output
+                * or beyond the produced length entirely.  The margin in
+                * the careful path's hand-back check must stay equal to
+                * this one: a larger value there would re-enter a loop
+                * whose own guard immediately fails, bouncing control
+                * between the two paths without progress. */
                while (in_pos + 8 <= s->in_size
-                     && out_pos + 258 + 8 <= s->out_size)
+                     && out_pos + 258 + 16 <= s->out_size)
                {
                   uint32_t e;
                   /* Refill only when the buffer cannot already cover a
@@ -1026,7 +1036,7 @@ fast_again:
                    * most 15, so several literals can be emitted before
                    * the next refill.  bitcnt >= 15 before each lookup
                    * guarantees the entry's code length is covered; the
-                   * output side is covered by the loop guard's 258+8
+                   * output side is covered by the loop guard's 258+16
                    * reserve, which no chain can outrun (a literal code
                    * is at least one bit, so at most 47 emissions). */
                   while (e & RINF_PF_LIT)
@@ -1215,7 +1225,16 @@ fast_again:
                         uint8_t       *dst  = out + out_pos;
                         const uint8_t *srcp = dst - dist;
                         uint8_t       *dend = dst + length;
-                        if (dist >= 8)
+                        if (dist >= 16)
+                        {
+                           do
+                           {
+                              memcpy(dst, srcp, 16);
+                              dst  += 16;
+                              srcp += 16;
+                           } while (dst < dend);
+                        }
+                        else if (dist >= 8)
                         {
                            do
                            {
@@ -1230,8 +1249,9 @@ fast_again:
                                  * 0x0101010101010101ull;
                            do
                            {
-                              memcpy(dst, &pat, 8);
-                              dst += 8;
+                              memcpy(dst,     &pat, 8);
+                              memcpy(dst + 8, &pat, 8);
+                              dst += 16;
                            } while (dst < dend);
                         }
                         else if (dist == 2 || dist == 4)
@@ -1251,8 +1271,9 @@ fast_again:
                            }
                            do
                            {
-                              memcpy(dst, &pat, 8);
-                              dst += 8;
+                              memcpy(dst,     &pat, 8);
+                              memcpy(dst + 8, &pat, 8);
+                              dst += 16;
                            } while (dst < dend);
                         }
                         else /* dist 3, 5, 6, 7 */
@@ -1312,7 +1333,7 @@ fast_again:
                if (   !s->copy_active && s->ld_step == 0
                    && !s->have_pending_lit
                    && s->in_pos + 8 <= s->in_size
-                   && s->out_pos + 258 + 8 <= s->out_size)
+                   && s->out_pos + 258 + 16 <= s->out_size)
                   goto fast_again;
                /* finish any pending back-reference copy first */
                if (s->copy_active)

--- a/libretro-common/encodings/encoding_deflate.c
+++ b/libretro-common/encodings/encoding_deflate.c
@@ -299,6 +299,17 @@ struct rinf_huff
     * (bit-reversed reading order) equal b and len<=FAST_BITS; len==0 means
     * "not a complete code, use the slow path". */
    uint16_t fast[1 << RINF_FAST_BITS];
+   /* Packed fast entries for the litlen/dist tables, consumed only by
+    * the fast inner loop.  One lookup yields everything a symbol needs:
+    * bits 0-3 code length (0 = long code, take the fast[]/slow path),
+    * bits 4-8 extra-bit count, bit 9 literal, bit 10 end-of-block, bit
+    * 11 invalid symbol (litlen 286/287, dist 30/31 - real codes a
+    * hostile dynamic header can define, which must fail exactly as the
+    * scalar lane fails them), bits 16-31 base value (the literal byte,
+    * the length base or the distance base).  Code length and extra
+    * bits are consumed with one fused shift.  Left all-zero for the
+    * code-length table, which the fast loop never touches. */
+   uint32_t pfast[1 << RINF_FAST_BITS];
    /* Canonical decode for the slow path. */
    uint16_t firstcode[RINF_MAX_BITS + 1];  /* first canonical code of len  */
    int      firstsym[RINF_MAX_BITS + 1];   /* symbol index of that code    */
@@ -525,6 +536,78 @@ static int rinf_decode(struct rinflate *s, struct rinf_huff *h)
    return -2;
 }
 
+
+/* length/distance base + extra-bit tables */
+static const uint16_t rinf_len_base[29] = {
+   3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,
+   67,83,99,115,131,163,195,227,258 };
+static const uint8_t rinf_len_extra[29] = {
+   0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0 };
+static const uint16_t rinf_dist_base[30] = {
+   1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,
+   1025,1537,2049,3073,4097,6145,8193,12289,16385,24577 };
+static const uint8_t rinf_dist_extra[30] = {
+   0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13 };
+
+/* order of code-length code lengths (RFC 1951 3.2.7) */
+static const uint8_t rinf_clc_order[19] = {
+   16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
+
+/* Populate pfast[] from a freshly built fast[]; layout in the struct
+ * note.  Two variants because the litlen and distance base tables
+ * differ. */
+#define RINF_PF_LIT  (1u << 9)
+#define RINF_PF_EOB  (1u << 10)
+#define RINF_PF_BAD  (1u << 11)
+
+static void rinf_pack_len(struct rinf_huff *h)
+{
+   int j;
+   for (j = 0; j < (1 << RINF_FAST_BITS); j++)
+   {
+      uint16_t f = h->fast[j];
+      uint32_t e = 0;
+      if (f)
+      {
+         int sym = f >> 4;
+         int len = f & 15;
+         if (sym < 256)
+            e = (uint32_t)len | RINF_PF_LIT | ((uint32_t)sym << 16);
+         else if (sym == 256)
+            e = (uint32_t)len | RINF_PF_EOB;
+         else if (sym - 257 < 29)
+            e = (uint32_t)len
+              | ((uint32_t)rinf_len_extra[sym - 257] << 4)
+              | ((uint32_t)rinf_len_base[sym - 257] << 16);
+         else
+            e = (uint32_t)len | RINF_PF_BAD;
+      }
+      h->pfast[j] = e;
+   }
+}
+
+static void rinf_pack_dist(struct rinf_huff *h)
+{
+   int j;
+   for (j = 0; j < (1 << RINF_FAST_BITS); j++)
+   {
+      uint16_t f = h->fast[j];
+      uint32_t e = 0;
+      if (f)
+      {
+         int sym = f >> 4;
+         int len = f & 15;
+         if (sym < 30)
+            e = (uint32_t)len
+              | ((uint32_t)rinf_dist_extra[sym] << 4)
+              | ((uint32_t)rinf_dist_base[sym] << 16);
+         else
+            e = (uint32_t)len | RINF_PF_BAD;
+      }
+      h->pfast[j] = e;
+   }
+}
+
 /* fixed huffman tables (RFC 1951 3.2.6) */
 /* The fixed tables are the same two tables every time - RFC 1951 states
  * their code lengths outright - so a stream that emits a run of fixed
@@ -555,25 +638,11 @@ static void rinf_fixed_tables(struct rinflate *s)
       dd[i] = 5;
    rinf_build(&s->lencode, ll, 288);
    rinf_build(&s->distcode, dd, 30);
+   rinf_pack_len(&s->lencode);
+   rinf_pack_dist(&s->distcode);
    s->have_tables  = 1;
    s->fixed_loaded = 1;
 }
-
-/* length/distance base + extra-bit tables */
-static const uint16_t rinf_len_base[29] = {
-   3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,
-   67,83,99,115,131,163,195,227,258 };
-static const uint8_t rinf_len_extra[29] = {
-   0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0 };
-static const uint16_t rinf_dist_base[30] = {
-   1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,
-   1025,1537,2049,3073,4097,6145,8193,12289,16385,24577 };
-static const uint8_t rinf_dist_extra[30] = {
-   0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13 };
-
-/* order of code-length code lengths (RFC 1951 3.2.7) */
-static const uint8_t rinf_clc_order[19] = {
-   16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
 
 /* emit a byte to the output + window, updating adler */
 static int rinf_emit(struct rinflate *s, uint8_t b)
@@ -857,12 +926,15 @@ int rinflate_process(void *data, size_t *read, size_t *wrote)
                { s->error = 1; goto error; }
             if (!rinf_build(&s->distcode, s->lengths + s->hlit, s->hdist))
                { s->error = 1; goto error; }
+            rinf_pack_len(&s->lencode);
+            rinf_pack_dist(&s->distcode);
             s->have_tables = 1;
             s->copy_active = 0;
             s->phase = RINF_BLOCK_DATA;
             break;
 
          case RINF_BLOCK_DATA:
+fast_again:
             if (s->have_pending_lit)
             {
                if (!rinf_emit(s, s->pending_lit)) goto suspend;
@@ -892,14 +964,20 @@ int rinflate_process(void *data, size_t *read, size_t *wrote)
                size_t   out_pos      = s->out_pos;
                const uint8_t *in     = s->in;
                uint8_t       *out    = s->out;
-               const uint16_t *lfast = s->lencode.fast;
-               const uint16_t *dfast = s->distcode.fast;
+               const uint32_t *plen  = s->lencode.pfast;
+               const uint32_t *pdist = s->distcode.pfast;
                int      done_fast    = 0;
 
+               /* The output guard reserves the longest match plus the
+                * copy over-run pad: every inlined copy below writes in
+                * whole 8-byte steps and may run up to 7 bytes past the
+                * match end.  Those bytes lie beyond out_pos, so they are
+                * scratch - either rewritten by later output or beyond
+                * the produced length entirely. */
                while (in_pos + 8 <= s->in_size
-                     && out_pos + 258 + 1 <= s->out_size)
+                     && out_pos + 258 + 8 <= s->out_size)
                {
-                  int sym;
+                  uint32_t e;
                   /* Refill only when the buffer cannot already cover a
                    * whole length/distance group - litlen (15) + length
                    * extra (5) + distance (15) + distance extra (13) = 48
@@ -942,73 +1020,133 @@ int rinflate_process(void *data, size_t *read, size_t *wrote)
                      in_pos += (size_t)nb_;
                      bitcnt += nb_ * 8;
                   }
+                  e = plen[bitbuf & ((1 << RINF_FAST_BITS) - 1)];
+                  /* Literal chain: after one refill the buffer holds at
+                   * least 48 bits, and every packed literal costs at
+                   * most 15, so several literals can be emitted before
+                   * the next refill.  bitcnt >= 15 before each lookup
+                   * guarantees the entry's code length is covered; the
+                   * output side is covered by the loop guard's 258+8
+                   * reserve, which no chain can outrun (a literal code
+                   * is at least one bit, so at most 47 emissions). */
+                  while (e & RINF_PF_LIT)
                   {
-                     uint16_t f = lfast[bitbuf & ((1 << RINF_FAST_BITS) - 1)];
-                     if (f)
-                     {
-                        int l   = f & 15;
-                        bitbuf >>= l;
-                        bitcnt  -= l;
-                        sym      = f >> 4;
-                     }
-                     else
-                     {
-                        /* Long code: hand back to the shared decoder. */
-                        s->bitbuf = bitbuf;
-                        s->bitcnt = bitcnt;
-                        s->in_pos = in_pos;
-                        sym       = rinf_decode(s, &s->lencode);
-                        bitbuf    = s->bitbuf;
-                        bitcnt    = s->bitcnt;
-                        in_pos    = s->in_pos;
-                        if (sym < -1)
-                        {
-                           s->out_pos = out_pos;
-                           goto error;
-                        }
-                        if (sym == -1)
-                           break;
-                     }
+                     bitbuf >>= (e & 15);
+                     bitcnt  -= (int)(e & 15);
+                     out[out_pos++] = (uint8_t)(e >> 16);
+                     if (bitcnt < 15)
+                        break;
+                     e = plen[bitbuf & ((1 << RINF_FAST_BITS) - 1)];
                   }
-                  if (sym < 256)
-                  {
-                     out[out_pos++] = (uint8_t)sym;
+                  if (e & RINF_PF_LIT)
+                     continue;      /* broke for a refill; guards re-run */
+                  /* A non-literal group needs up to 48 buffered bits
+                   * (15 + 5 + 15 + 13); a chain can leave fewer.  Retry
+                   * through the loop head, which refills. */
+                  if (bitcnt < 48 && e)
                      continue;
-                  }
-                  if (sym == 256)
+                  if (!e)
                   {
+                     /* Long code: hand back to the shared decoder. */
+                     int sym;
+                     s->bitbuf = bitbuf;
+                     s->bitcnt = bitcnt;
+                     s->in_pos = in_pos;
+                     sym       = rinf_decode(s, &s->lencode);
+                     bitbuf    = s->bitbuf;
+                     bitcnt    = s->bitcnt;
+                     in_pos    = s->in_pos;
+                     if (sym < -1)
+                     {
+                        s->out_pos = out_pos;
+                        goto error;
+                     }
+                     if (sym == -1)
+                        break;
+                     if (sym < 256)
+                     {
+                        out[out_pos++] = (uint8_t)sym;
+                        continue;
+                     }
+                     if (sym == 256)
+                     {
+                        s->phase = s->bfinal
+                           ? (s->wrapped ? RINF_ADLER : RINF_DONE)
+                           : RINF_BLOCK_HDR;
+                        done_fast = 1;
+                        break;
+                     }
+                     if (sym - 257 >= 29)
+                     {
+                        s->error   = 1;
+                        s->out_pos = out_pos;
+                        goto error;
+                     }
+                     /* Re-enter the packed flow with a synthesised
+                      * entry; the code bits are already consumed. */
+                     e = ((uint32_t)rinf_len_extra[sym - 257] << 4)
+                       | ((uint32_t)rinf_len_base[sym - 257] << 16);
+                     if (bitcnt < 33)
+                     {
+                        /* Not enough buffered bits for the extra-bits
+                         * and distance group without a refill the loop
+                         * guard may no longer permit; park the decoded
+                         * symbol in the careful path's resume state and
+                         * let it finish this one group. */
+                        s->ld_lensym = sym - 257;
+                        s->ld_step   = 1;
+                        break;
+                     }
+                  }
+                  if (e & RINF_PF_EOB)
+                  {
+                     bitbuf >>= (e & 15);
+                     bitcnt  -= (int)(e & 15);
                      s->phase = s->bfinal
                         ? (s->wrapped ? RINF_ADLER : RINF_DONE)
                         : RINF_BLOCK_HDR;
                      done_fast = 1;
                      break;
                   }
+                  if (e & RINF_PF_BAD)
                   {
-                     int li = sym - 257, dsym, ei;
+                     s->error   = 1;
+                     s->out_pos = out_pos;
+                     goto error;
+                  }
+                  {
+                     int dsym, ei;
                      uint32_t length, dist;
-                     if (li >= 29)
                      {
-                        s->error   = 1;
-                        s->out_pos = out_pos;
-                        goto error;
-                     }
-                     ei     = rinf_len_extra[li];
-                     length = rinf_len_base[li];
-                     if (ei)
-                     {
-                        length += (uint32_t)(bitbuf & ((1u << ei) - 1));
-                        bitbuf >>= ei;
-                        bitcnt  -= ei;
+                        int l  = (int)(e & 15);
+                        int ex = (int)((e >> 4) & 31);
+                        length = (e >> 16)
+                              + (uint32_t)((bitbuf >> l)
+                                    & (((uint64_t)1 << ex) - 1));
+                        bitbuf >>= (l + ex);
+                        bitcnt  -= (l + ex);
                      }
                      {
-                        uint16_t fd = dfast[bitbuf
+                        uint32_t d = pdist[bitbuf
                            & ((1 << RINF_FAST_BITS) - 1)];
-                        if (fd)
+                        if (d & RINF_PF_BAD)
                         {
-                           int dl   = fd & 15;
-                           bitbuf >>= dl;
-                           bitcnt  -= dl;
-                           dsym     = fd >> 4;
+                           s->error   = 1;
+                           s->out_pos = out_pos;
+                           goto error;
+                        }
+                        if (d)
+                        {
+                           /* Length consumed at most 20 bits of the 48
+                            * the head guaranteed, so the full distance
+                            * group (15 + 13) is always covered here. */
+                           int dl  = (int)(d & 15);
+                           int dex = (int)((d >> 4) & 31);
+                           dist    = (d >> 16)
+                                 + (uint32_t)((bitbuf >> dl)
+                                       & (((uint64_t)1 << dex) - 1));
+                           bitbuf >>= (dl + dex);
+                           bitcnt  -= (dl + dex);
                         }
                         else
                         {
@@ -1022,25 +1160,39 @@ int rinflate_process(void *data, size_t *read, size_t *wrote)
                            if (dsym < 0)
                            {
                               if (dsym == -1)
+                              {
+                                 /* Bits ran short mid-group; park the
+                                  * assembled length for the careful
+                                  * path to finish. */
+                                 s->ld_length = length;
+                                 s->ld_step   = 2;
                                  break;
+                              }
                               s->out_pos = out_pos;
                               goto error;
                            }
+                           if (dsym >= 30)
+                           {
+                              s->error   = 1;
+                              s->out_pos = out_pos;
+                              goto error;
+                           }
+                           ei   = rinf_dist_extra[dsym];
+                           dist = rinf_dist_base[dsym];
+                           if (ei)
+                           {
+                              if (bitcnt < ei)
+                              {
+                                 s->ld_length  = length;
+                                 s->ld_distsym = dsym;
+                                 s->ld_step    = 3;
+                                 break;
+                              }
+                              dist  += (uint32_t)(bitbuf & ((1u << ei) - 1));
+                              bitbuf >>= ei;
+                              bitcnt  -= ei;
+                           }
                         }
-                     }
-                     if (dsym >= 30)
-                     {
-                        s->error   = 1;
-                        s->out_pos = out_pos;
-                        goto error;
-                     }
-                     ei   = rinf_dist_extra[dsym];
-                     dist = rinf_dist_base[dsym];
-                     if (ei)
-                     {
-                        dist  += (uint32_t)(bitbuf & ((1u << ei) - 1));
-                        bitbuf >>= ei;
-                        bitcnt  -= ei;
                      }
                      if (dist > out_pos + s->whave)
                      {
@@ -1050,26 +1202,76 @@ int rinflate_process(void *data, size_t *read, size_t *wrote)
                      }
                      if (dist <= out_pos)
                      {
+                        /* All copies below run in whole 8-byte steps
+                         * (constant-size memcpy compiles to one move,
+                         * not a call) and may write up to 7 bytes past
+                         * the match end - covered by the loop guard's
+                         * pad.  Short distances replicate the pattern:
+                         * 1/2/4 broadcast into a 64-bit word; 3/5/6/7
+                         * prime 16 bytes serially, after which 8-byte
+                         * chunks at distance dist*(16/dist) >= 9 both
+                         * preserve the period and never load a byte
+                         * stored in the same step. */
                         uint8_t       *dst  = out + out_pos;
                         const uint8_t *srcp = dst - dist;
-                        if (dist >= length)
-                           memcpy(dst, srcp, length);
-                        else if (dist == 1) /* run of a single byte */
-                           memset(dst, srcp[0], length);
-                        else
+                        uint8_t       *dend = dst + length;
+                        if (dist >= 8)
                         {
-                           /* overlapping run: grow the copied region by
-                            * doubling so we memcpy progressively larger
-                            * blocks instead of one byte at a time */
-                           uint32_t cdone = dist;
-                           memcpy(dst, srcp, dist);
-                           while (cdone < length)
+                           do
                            {
-                              uint32_t chunk = cdone;
-                              if (chunk > length - cdone)
-                                 chunk = length - cdone;
-                              memcpy(dst + cdone, dst, chunk);
-                              cdone += chunk;
+                              memcpy(dst, srcp, 8);
+                              dst  += 8;
+                              srcp += 8;
+                           } while (dst < dend);
+                        }
+                        else if (dist == 1)
+                        {
+                           uint64_t pat = (uint64_t)srcp[0]
+                                 * 0x0101010101010101ull;
+                           do
+                           {
+                              memcpy(dst, &pat, 8);
+                              dst += 8;
+                           } while (dst < dend);
+                        }
+                        else if (dist == 2 || dist == 4)
+                        {
+                           uint64_t pat;
+                           if (dist == 2)
+                           {
+                              uint16_t w;
+                              memcpy(&w, srcp, 2);
+                              pat = (uint64_t)w * 0x0001000100010001ull;
+                           }
+                           else
+                           {
+                              uint32_t w;
+                              memcpy(&w, srcp, 4);
+                              pat = (uint64_t)w | ((uint64_t)w << 32);
+                           }
+                           do
+                           {
+                              memcpy(dst, &pat, 8);
+                              dst += 8;
+                           } while (dst < dend);
+                        }
+                        else /* dist 3, 5, 6, 7 */
+                        {
+                           size_t k;
+                           size_t prime = length < 16 ? (size_t)length : 16;
+                           for (k = 0; k < prime; k++)
+                              dst[k] = srcp[k];
+                           if (length > 16)
+                           {
+                              uint32_t D        = dist * (16 / dist);
+                              uint8_t *p        = dst + 16;
+                              const uint8_t *q  = p - D;
+                              do
+                              {
+                                 memcpy(p, q, 8);
+                                 p += 8;
+                                 q += 8;
+                              } while (p < dend);
                            }
                         }
                         out_pos += length;
@@ -1095,6 +1297,23 @@ int rinflate_process(void *data, size_t *read, size_t *wrote)
 
             for (;;)
             {
+               /* The careful path exists for boundary states - a copy
+                * or a length/distance group straddling a slice edge, a
+                * long Huffman code, tight margins.  Once the boundary
+                * state is resolved and the margins are comfortable
+                * again, hand control straight back to the fast loop:
+                * without this, one straddling match at a slice edge
+                * left the whole next slice on the symbol-at-a-time
+                * path (the fast block only ran on entry to the phase),
+                * which was most of them, since a 32 KB output slice
+                * almost always fills mid-match.  The first iteration
+                * after a fast-loop exit fails these margin checks by
+                * construction, so this cannot spin. */
+               if (   !s->copy_active && s->ld_step == 0
+                   && !s->have_pending_lit
+                   && s->in_pos + 8 <= s->in_size
+                   && s->out_pos + 258 + 8 <= s->out_size)
+                  goto fast_again;
                /* finish any pending back-reference copy first */
                if (s->copy_active)
                {

--- a/libretro-common/formats/png/rpng.c
+++ b/libretro-common/formats/png/rpng.c
@@ -297,9 +297,26 @@ static void rpng_filter_up(uint8_t *out,
       size_t len)
 {
 #if defined(RPNG_SIMD_SSE2)
+   /* Four vectors per iteration: the loop is bound by load/store
+    * throughput, and the wider body halves the per-16-byte loop
+    * overhead against the single-vector form. */
    size_t i  = 0;
-   size_t n  = len & ~15UL;         /* floor to multiple of 16 */
-   for (; i < n; i += 16)
+   for (; i + 64 <= len; i += 64)
+   {
+      __m128i r0 = _mm_loadu_si128((const __m128i*)(raw   + i));
+      __m128i p0 = _mm_loadu_si128((const __m128i*)(prior + i));
+      __m128i r1 = _mm_loadu_si128((const __m128i*)(raw   + i + 16));
+      __m128i p1 = _mm_loadu_si128((const __m128i*)(prior + i + 16));
+      __m128i r2 = _mm_loadu_si128((const __m128i*)(raw   + i + 32));
+      __m128i p2 = _mm_loadu_si128((const __m128i*)(prior + i + 32));
+      __m128i r3 = _mm_loadu_si128((const __m128i*)(raw   + i + 48));
+      __m128i p3 = _mm_loadu_si128((const __m128i*)(prior + i + 48));
+      _mm_storeu_si128((__m128i*)(out + i),      _mm_add_epi8(r0, p0));
+      _mm_storeu_si128((__m128i*)(out + i + 16), _mm_add_epi8(r1, p1));
+      _mm_storeu_si128((__m128i*)(out + i + 32), _mm_add_epi8(r2, p2));
+      _mm_storeu_si128((__m128i*)(out + i + 48), _mm_add_epi8(r3, p3));
+   }
+   for (; i + 16 <= len; i += 16)
    {
       __m128i r  = _mm_loadu_si128((const __m128i*)(raw   + i));
       __m128i p  = _mm_loadu_si128((const __m128i*)(prior + i));
@@ -309,8 +326,22 @@ static void rpng_filter_up(uint8_t *out,
       out[i] = raw[i] + prior[i];
 #elif defined(RPNG_SIMD_NEON)
    size_t i  = 0;
-   size_t n  = len & ~15UL;
-   for (; i < n; i += 16)
+   for (; i + 64 <= len; i += 64)
+   {
+      uint8x16_t r0 = vld1q_u8(raw   + i);
+      uint8x16_t p0 = vld1q_u8(prior + i);
+      uint8x16_t r1 = vld1q_u8(raw   + i + 16);
+      uint8x16_t p1 = vld1q_u8(prior + i + 16);
+      uint8x16_t r2 = vld1q_u8(raw   + i + 32);
+      uint8x16_t p2 = vld1q_u8(prior + i + 32);
+      uint8x16_t r3 = vld1q_u8(raw   + i + 48);
+      uint8x16_t p3 = vld1q_u8(prior + i + 48);
+      vst1q_u8(out + i,      vaddq_u8(r0, p0));
+      vst1q_u8(out + i + 16, vaddq_u8(r1, p1));
+      vst1q_u8(out + i + 32, vaddq_u8(r2, p2));
+      vst1q_u8(out + i + 48, vaddq_u8(r3, p3));
+   }
+   for (; i + 16 <= len; i += 16)
    {
       uint8x16_t r  = vld1q_u8(raw   + i);
       uint8x16_t p  = vld1q_u8(prior + i);
@@ -413,11 +444,105 @@ static INLINE void rpng_store4_u8(uint8_t *p, __m128i v)
    memcpy(p, &tmp, sizeof(tmp));
 }
 
+/* Sub is a byte prefix sum at pixel stride, and a prefix sum has a
+ * log-depth form: a shift-add tree at byte distances s, 2s, 4s, ...
+ * (every multiple of s up to 15 is a subset sum of those), then one
+ * add of the inter-block carry.  The tree only involves the current
+ * block, so it runs entirely off the loop-carried chain; the chain is
+ * the carry add plus the broadcast that derives the next carry from
+ * the block's last pixel, two to four ops per 16 bytes against one
+ * per pixel for the windowed loop.
+ *
+ * That trade only wins where the windowed loop's ceiling (bpp bytes
+ * per cycle, one paddb each) is below the tree's: strides 1, 2 and 4.
+ * At 3, 6 and 8 bytes per pixel the windowed chain already meets or
+ * beats the tree's block rate, so those strides keep the window.
+ * (wuffs vectorizes none of this below stride 4, and nothing at 16-bit
+ * strides at all.) */
+static void rpng_filter_sub_prefix1(uint8_t *decoded,
+      const uint8_t *raw, size_t pitch)
+{
+   size_t i      = 0;
+   __m128i carry = _mm_setzero_si128();
+   for (; i + 16 <= pitch; i += 16)
+   {
+      __m128i x = _mm_loadu_si128((const __m128i*)(raw + i));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 1));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 2));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 4));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 8));
+      x = _mm_add_epi8(x, carry);
+      _mm_storeu_si128((__m128i*)(decoded + i), x);
+      /* broadcast byte 15 (SSE2 has no byte splat) */
+      carry = _mm_unpackhi_epi8(x, x);
+      carry = _mm_shufflehi_epi16(carry, 0xFF);
+      carry = _mm_shuffle_epi32(carry, 0xEE);
+   }
+   {
+      uint8_t c = i ? decoded[i - 1] : 0;
+      for (; i < pitch; i++)
+      {
+         c          = (uint8_t)(raw[i] + c);
+         decoded[i] = c;
+      }
+   }
+}
+
+static void rpng_filter_sub_prefix2(uint8_t *decoded,
+      const uint8_t *raw, size_t pitch)
+{
+   size_t i      = 0;
+   __m128i carry = _mm_setzero_si128();
+   for (; i + 16 <= pitch; i += 16)
+   {
+      __m128i x = _mm_loadu_si128((const __m128i*)(raw + i));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 2));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 4));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 8));
+      x = _mm_add_epi8(x, carry);
+      _mm_storeu_si128((__m128i*)(decoded + i), x);
+      carry = _mm_shufflehi_epi16(x, 0xFF);
+      carry = _mm_shuffle_epi32(carry, 0xEE);
+   }
+   for (; i < pitch; i++)
+      decoded[i] = (uint8_t)(raw[i] + (i >= 2 ? decoded[i - 2] : 0));
+}
+
+static void rpng_filter_sub_prefix4(uint8_t *decoded,
+      const uint8_t *raw, size_t pitch)
+{
+   size_t i      = 0;
+   __m128i carry = _mm_setzero_si128();
+   for (; i + 16 <= pitch; i += 16)
+   {
+      __m128i x = _mm_loadu_si128((const __m128i*)(raw + i));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 4));
+      x = _mm_add_epi8(x, _mm_slli_si128(x, 8));
+      x = _mm_add_epi8(x, carry);
+      _mm_storeu_si128((__m128i*)(decoded + i), x);
+      carry = _mm_shuffle_epi32(x, 0xFF);
+   }
+   for (; i < pitch; i++)
+      decoded[i] = (uint8_t)(raw[i] + (i >= 4 ? decoded[i - 4] : 0));
+}
+
 static void rpng_filter_sub_simd(uint8_t *decoded,
       const uint8_t *raw, size_t pitch, unsigned bpp)
 {
    size_t i           = 0;
    __m128i prev_pixel = _mm_setzero_si128();
+   switch (bpp)
+   {
+      case 1:
+         rpng_filter_sub_prefix1(decoded, raw, pitch);
+         return;
+      case 2:
+         rpng_filter_sub_prefix2(decoded, raw, pitch);
+         return;
+      case 4:
+         rpng_filter_sub_prefix4(decoded, raw, pitch);
+         return;
+   }
    if (bpp <= 4)
    {
       for (; i + 4 <= pitch; i += bpp)
@@ -489,24 +614,32 @@ static void rpng_filter_avg_simd(uint8_t *decoded,
  *   pc = |(b - c) + (a - c)| = |a + b - 2c|
  * PNG selection rule (in priority order): a if pa <= pb && pa <= pc,
  * else b if pb <= pc, else c. */
-static INLINE __m128i rpng_paeth_predictor_epi16(
-      __m128i a, __m128i b, __m128i c)
+/* One Paeth pixel, selecting among speculative sums.  The three
+ * candidate outputs (r + a) & FF, (r + b) & FF and (r + c) & FF are
+ * formed up front: sb and sc do not involve a, so they leave the
+ * loop-carried chain entirely, and the final add and mask move off the
+ * chain as well.  The "don't pick a" test compares pa against
+ * min(pb, pc), one comparison instead of two plus an or.  The chain a
+ * -> ac -> pb -> min -> compare -> select is nine ops; the plain
+ * predictor's is eleven.
+ *
+ * SSE2 lacks abs_epi16; max(x, -x) is the standard substitute. */
+static INLINE __m128i rpng_paeth_step_epi16(__m128i a, __m128i b,
+      __m128i c, __m128i r, __m128i sb, __m128i sc, __m128i mask)
 {
    __m128i bc = _mm_sub_epi16(b, c);
    __m128i ac = _mm_sub_epi16(a, c);
    __m128i sm = _mm_add_epi16(bc, ac);
    __m128i z  = _mm_setzero_si128();
-   /* SSE2 lacks abs_epi16; max(x, -x) is the standard substitute. */
    __m128i pa = _mm_max_epi16(bc, _mm_sub_epi16(z, bc));
    __m128i pb = _mm_max_epi16(ac, _mm_sub_epi16(z, ac));
    __m128i pc = _mm_max_epi16(sm, _mm_sub_epi16(z, sm));
-   /* cmpgt returns 0xFFFF on "greater than" — mask of "don't pick a/b". */
-   __m128i not_a  = _mm_or_si128(_mm_cmpgt_epi16(pa, pb),
-                                 _mm_cmpgt_epi16(pa, pc));
+   __m128i not_a  = _mm_cmpgt_epi16(pa, _mm_min_epi16(pb, pc));
    __m128i pick_c = _mm_cmpgt_epi16(pb, pc);
-   __m128i bc_sel = _mm_or_si128(_mm_andnot_si128(pick_c, b),
-                                 _mm_and_si128(   pick_c, c));
-   return            _mm_or_si128(_mm_andnot_si128(not_a, a),
+   __m128i sa     = _mm_and_si128(_mm_add_epi16(r, a), mask);
+   __m128i bc_sel = _mm_or_si128(_mm_andnot_si128(pick_c, sb),
+                                 _mm_and_si128(   pick_c, sc));
+   return            _mm_or_si128(_mm_andnot_si128(not_a, sa),
                                   _mm_and_si128(   not_a, bc_sel));
 }
 
@@ -548,9 +681,11 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
       {
          __m128i r    = rpng_load4_u8_to_u16(raw  + i);
          __m128i pv   = rpng_load4_u8_to_u16(prev + i);
-         __m128i pred = rpng_paeth_predictor_epi16(
-               prev_pixel, pv, prev_upper_left);
-         __m128i out  = _mm_and_si128(_mm_add_epi16(r, pred), mask);
+         __m128i sb   = _mm_and_si128(_mm_add_epi16(r, pv), mask);
+         __m128i sc   = _mm_and_si128(_mm_add_epi16(r, prev_upper_left),
+               mask);
+         __m128i out  = rpng_paeth_step_epi16(prev_pixel, pv,
+               prev_upper_left, r, sb, sc, mask);
          rpng_store4_u16_to_u8(decoded + i, out);
          prev_pixel      = out;
          prev_upper_left = pv;
@@ -562,9 +697,11 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
       {
          __m128i r    = rpng_load8_u8_to_u16(raw  + i);
          __m128i pv   = rpng_load8_u8_to_u16(prev + i);
-         __m128i pred = rpng_paeth_predictor_epi16(
-               prev_pixel, pv, prev_upper_left);
-         __m128i out  = _mm_and_si128(_mm_add_epi16(r, pred), mask);
+         __m128i sb   = _mm_and_si128(_mm_add_epi16(r, pv), mask);
+         __m128i sc   = _mm_and_si128(_mm_add_epi16(r, prev_upper_left),
+               mask);
+         __m128i out  = rpng_paeth_step_epi16(prev_pixel, pv,
+               prev_upper_left, r, sb, sc, mask);
          rpng_store8_u16_to_u8(decoded + i, out);
          prev_pixel      = out;
          prev_upper_left = pv;
@@ -615,11 +752,95 @@ static INLINE void rpng_store4_u8(uint8_t *p, uint8x8_t v)
    memcpy(p, &word, sizeof(word));
 }
 
+/* Sub as a byte prefix sum at strides 1, 2 and 4; see the SSE2 side
+ * for the derivation and for why strides 3, 6 and 8 keep the windowed
+ * per-pixel loop.  A left byte shift of a whole q register is
+ * vextq(zero, x, 16 - k). */
+static void rpng_filter_sub_prefix1(uint8_t *decoded,
+      const uint8_t *raw, size_t pitch)
+{
+   size_t i         = 0;
+   uint8x16_t carry = vdupq_n_u8(0);
+   const uint8x16_t zero = vdupq_n_u8(0);
+   for (; i + 16 <= pitch; i += 16)
+   {
+      uint8x16_t x = vld1q_u8(raw + i);
+      x = vaddq_u8(x, vextq_u8(zero, x, 15));
+      x = vaddq_u8(x, vextq_u8(zero, x, 14));
+      x = vaddq_u8(x, vextq_u8(zero, x, 12));
+      x = vaddq_u8(x, vextq_u8(zero, x, 8));
+      x = vaddq_u8(x, carry);
+      vst1q_u8(decoded + i, x);
+      carry = vdupq_lane_u8(vget_high_u8(x), 7);
+   }
+   {
+      uint8_t c = i ? decoded[i - 1] : 0;
+      for (; i < pitch; i++)
+      {
+         c          = (uint8_t)(raw[i] + c);
+         decoded[i] = c;
+      }
+   }
+}
+
+static void rpng_filter_sub_prefix2(uint8_t *decoded,
+      const uint8_t *raw, size_t pitch)
+{
+   size_t i         = 0;
+   uint8x16_t carry = vdupq_n_u8(0);
+   const uint8x16_t zero = vdupq_n_u8(0);
+   for (; i + 16 <= pitch; i += 16)
+   {
+      uint8x16_t x = vld1q_u8(raw + i);
+      x = vaddq_u8(x, vextq_u8(zero, x, 14));
+      x = vaddq_u8(x, vextq_u8(zero, x, 12));
+      x = vaddq_u8(x, vextq_u8(zero, x, 8));
+      x = vaddq_u8(x, carry);
+      vst1q_u8(decoded + i, x);
+      carry = vreinterpretq_u8_u16(vdupq_lane_u16(
+            vreinterpret_u16_u8(vget_high_u8(x)), 3));
+   }
+   for (; i < pitch; i++)
+      decoded[i] = (uint8_t)(raw[i] + (i >= 2 ? decoded[i - 2] : 0));
+}
+
+static void rpng_filter_sub_prefix4(uint8_t *decoded,
+      const uint8_t *raw, size_t pitch)
+{
+   size_t i         = 0;
+   uint8x16_t carry = vdupq_n_u8(0);
+   const uint8x16_t zero = vdupq_n_u8(0);
+   for (; i + 16 <= pitch; i += 16)
+   {
+      uint8x16_t x = vld1q_u8(raw + i);
+      x = vaddq_u8(x, vextq_u8(zero, x, 12));
+      x = vaddq_u8(x, vextq_u8(zero, x, 8));
+      x = vaddq_u8(x, carry);
+      vst1q_u8(decoded + i, x);
+      carry = vreinterpretq_u8_u32(vdupq_lane_u32(
+            vreinterpret_u32_u8(vget_high_u8(x)), 1));
+   }
+   for (; i < pitch; i++)
+      decoded[i] = (uint8_t)(raw[i] + (i >= 4 ? decoded[i - 4] : 0));
+}
+
 static void rpng_filter_sub_simd(uint8_t *decoded,
       const uint8_t *raw, size_t pitch, unsigned bpp)
 {
    size_t i             = 0;
    uint8x8_t prev_pixel = vdup_n_u8(0);
+   switch (bpp)
+   {
+      case 1:
+         rpng_filter_sub_prefix1(decoded, raw, pitch);
+         return;
+      case 2:
+         rpng_filter_sub_prefix2(decoded, raw, pitch);
+         return;
+      case 4:
+         rpng_filter_sub_prefix4(decoded, raw, pitch);
+         return;
+   }
    if (bpp <= 4)
    {
       for (; i + 4 <= pitch; i += bpp)
@@ -679,8 +900,14 @@ static void rpng_filter_avg_simd(uint8_t *decoded,
       decoded[i] += (uint8_t)((decoded[i - bpp] + prev[i]) >> 1);
 }
 
-static INLINE uint16x4_t rpng_paeth_predictor_u16(
-      uint16x4_t a, uint16x4_t b, uint16x4_t c)
+/* One Paeth pixel, selecting among speculative sums; see the SSE2
+ * side for the derivation.  The masked sums sb = (r + b) & FF and
+ * sc = (r + c) & FF do not involve a, so they run off the carried
+ * chain, and pa > min(pb, pc) replaces the two-compare-plus-or
+ * "don't pick a" test. */
+static INLINE uint16x4_t rpng_paeth_step_u16(
+      uint16x4_t a, uint16x4_t b, uint16x4_t c,
+      uint16x4_t r, uint16x4_t sb, uint16x4_t sc, uint16x4_t mask)
 {
    int16x4_t bc = vsub_s16(vreinterpret_s16_u16(b), vreinterpret_s16_u16(c));
    int16x4_t ac = vsub_s16(vreinterpret_s16_u16(a), vreinterpret_s16_u16(c));
@@ -688,10 +915,11 @@ static INLINE uint16x4_t rpng_paeth_predictor_u16(
    uint16x4_t pa = vreinterpret_u16_s16(vabs_s16(bc));
    uint16x4_t pb = vreinterpret_u16_s16(vabs_s16(ac));
    uint16x4_t pc = vreinterpret_u16_s16(vabs_s16(sm));
-   uint16x4_t not_a  = vorr_u16(vcgt_u16(pa, pb), vcgt_u16(pa, pc));
+   uint16x4_t not_a  = vcgt_u16(pa, vmin_u16(pb, pc));
    uint16x4_t pick_c = vcgt_u16(pb, pc);
-   uint16x4_t bc_sel = vbsl_u16(pick_c, c, b);
-   return              vbsl_u16(not_a,  bc_sel, a);
+   uint16x4_t sa     = vand_u16(vadd_u16(r, a), mask);
+   uint16x4_t bc_sel = vbsl_u16(pick_c, sc, sb);
+   return              vbsl_u16(not_a,  bc_sel, sa);
 }
 
 /* 8-lane forms of the load/store/predict trio, mirroring the SSE2 side. */
@@ -705,8 +933,9 @@ static INLINE void rpng_store8_u16_to_u8(uint8_t *p, uint16x8_t v)
    vst1_u8(p, vmovn_u16(v));
 }
 
-static INLINE uint16x8_t rpng_paeth_predictor_u16q(
-      uint16x8_t a, uint16x8_t b, uint16x8_t c)
+static INLINE uint16x8_t rpng_paeth_step_u16q(
+      uint16x8_t a, uint16x8_t b, uint16x8_t c,
+      uint16x8_t r, uint16x8_t sb, uint16x8_t sc, uint16x8_t mask)
 {
    int16x8_t bc      = vsubq_s16(vreinterpretq_s16_u16(b),
                                  vreinterpretq_s16_u16(c));
@@ -716,10 +945,11 @@ static INLINE uint16x8_t rpng_paeth_predictor_u16q(
    uint16x8_t pa     = vreinterpretq_u16_s16(vabsq_s16(bc));
    uint16x8_t pb     = vreinterpretq_u16_s16(vabsq_s16(ac));
    uint16x8_t pc     = vreinterpretq_u16_s16(vabsq_s16(sm));
-   uint16x8_t not_a  = vorrq_u16(vcgtq_u16(pa, pb), vcgtq_u16(pa, pc));
+   uint16x8_t not_a  = vcgtq_u16(pa, vminq_u16(pb, pc));
    uint16x8_t pick_c = vcgtq_u16(pb, pc);
-   uint16x8_t bc_sel = vbslq_u16(pick_c, c, b);
-   return              vbslq_u16(not_a,  bc_sel, a);
+   uint16x8_t sa     = vandq_u16(vaddq_u16(r, a), mask);
+   uint16x8_t bc_sel = vbslq_u16(pick_c, sc, sb);
+   return              vbslq_u16(not_a,  bc_sel, sa);
 }
 
 /* See the SSE2 rpng_filter_paeth_simd above for why an 8-byte window can
@@ -740,8 +970,9 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
       {
          uint16x4_t r    = rpng_load4_u8_to_u16(raw  + i);
          uint16x4_t pv   = rpng_load4_u8_to_u16(prev + i);
-         uint16x4_t pred = rpng_paeth_predictor_u16(pp, pv, pul);
-         uint16x4_t out  = vand_u16(vadd_u16(r, pred), m4);
+         uint16x4_t sb   = vand_u16(vadd_u16(r, pv),  m4);
+         uint16x4_t sc   = vand_u16(vadd_u16(r, pul), m4);
+         uint16x4_t out  = rpng_paeth_step_u16(pp, pv, pul, r, sb, sc, m4);
          rpng_store4_u16_to_u8(decoded + i, out);
          pp  = out;
          pul = pv;
@@ -753,9 +984,10 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
       {
          uint16x8_t r    = rpng_load8_u8_to_u16(raw  + i);
          uint16x8_t pv   = rpng_load8_u8_to_u16(prev + i);
-         uint16x8_t pred = rpng_paeth_predictor_u16q(
-               prev_pixel, pv, prev_upper_left);
-         uint16x8_t out  = vandq_u16(vaddq_u16(r, pred), mask);
+         uint16x8_t sb   = vandq_u16(vaddq_u16(r, pv), mask);
+         uint16x8_t sc   = vandq_u16(vaddq_u16(r, prev_upper_left), mask);
+         uint16x8_t out  = rpng_paeth_step_u16q(
+               prev_pixel, pv, prev_upper_left, r, sb, sc, mask);
          rpng_store8_u16_to_u8(decoded + i, out);
          prev_pixel      = out;
          prev_upper_left = pv;
@@ -1789,7 +2021,7 @@ static int rpng_reverse_filter_regular_iterate(
       struct rpng_process *pngp)
 {
    int ret = IMAGE_PROCESS_END;
-   if (pngp->h < ihdr->height)
+if (pngp->h < ihdr->height)
    {
       unsigned filter         = *pngp->inflate_buf++;
       pngp->restore_buf_size += 1;

--- a/libretro-common/formats/png/rpng.c
+++ b/libretro-common/formats/png/rpng.c
@@ -177,10 +177,25 @@ struct rpng_process
    uint32_t *palette;
    void *stream;
    const struct trans_stream_backend *stream_backend;
-   uint8_t *prev_scanline;
-   uint8_t *decoded_scanline;
-   uint8_t *pair_scanline;     /* second decode row for the wavefront
-                                * pair path; see the pair kernels     */
+   /* Unfiltering runs in place inside the inflate ring wherever a
+    * kernel's stores cannot clobber raw bytes a later step still
+    * needs: None, Up, the prefix and stride-exact Sub widths, and
+    * Average/Paeth at stride == window (bpp 4 and 8).  For those, a
+    * line's decoded bytes overwrite its raw bytes and the previous
+    * line's ring slot doubles as the prev pointer; held is that
+    * slot's byte size, excluded from restore_buf_size until the next
+    * line no longer needs it, so the ring cannot recycle it.  The
+    * remaining filter/bpp combinations keep their wide window stores
+    * and decode out of place into three rotating scratch lines -
+    * three, because the wavefront pair needs two fresh lines while a
+    * third may still be the pair's prev.  scratch[0] starts zeroed
+    * and serves as row 0's prev; scratch_cur indexes the most
+    * recently written line, so (cur + 1) % 3 and (cur + 2) % 3 are
+    * always free. */
+   uint8_t       *scratch[3];
+   unsigned       scratch_cur;
+   const uint8_t *prev_line;
+   size_t         held;
    uint8_t *inflate_buf;      /* walking read cursor for the filters     */
    uint8_t *inflate_base;     /* fixed allocation base: inflate writes at
                                * inflate_base + inflated_total, immune to
@@ -372,7 +387,7 @@ static void rpng_filter_up(uint8_t *out,
  *
  * All three helpers assume:
  *   - bpp == 4, pitch is a multiple of 4 (guaranteed by PNG spec for RGBA)
- *   - prev is a valid prev_scanline pointer (zero-initialised on row 0
+ *   - prev is a valid previous-line pointer (a zero line on row 0
  *     by rpng_reverse_filter_init -> calloc)
  *   - raw and decoded may alias (the original code memcpy's raw->decoded
  *     first; we do the filter in-place from raw directly)
@@ -446,21 +461,6 @@ static INLINE void rpng_store4_u8(uint8_t *p, __m128i v)
    memcpy(p, &tmp, sizeof(tmp));
 }
 
-/* Sub is a byte prefix sum at pixel stride, and a prefix sum has a
- * log-depth form: a shift-add tree at byte distances s, 2s, 4s, ...
- * (every multiple of s up to 15 is a subset sum of those), then one
- * add of the inter-block carry.  The tree only involves the current
- * block, so it runs entirely off the loop-carried chain; the chain is
- * the carry add plus the broadcast that derives the next carry from
- * the block's last pixel, two to four ops per 16 bytes against one
- * per pixel for the windowed loop.
- *
- * That trade only wins where the windowed loop's ceiling (bpp bytes
- * per cycle, one paddb each) is below the tree's: strides 1, 2 and 4.
- * At 3, 6 and 8 bytes per pixel the windowed chain already meets or
- * beats the tree's block rate, so those strides keep the window.
- * (wuffs vectorizes none of this below stride 4, and nothing at 16-bit
- * strides at all.) */
 static void rpng_filter_sub_prefix1(uint8_t *decoded,
       const uint8_t *raw, size_t pitch)
 {
@@ -564,7 +564,8 @@ static void rpng_filter_sub_simd(uint8_t *decoded,
          prev_pixel  = out;
       }
    }
-   memcpy(decoded + i, raw + i, pitch - i);
+   if (decoded != raw)
+      memcpy(decoded + i, raw + i, pitch - i);
    /* Leading bpp bytes have no left neighbour and stay as-is. */
    if (i < bpp)
       i = bpp < pitch ? bpp : pitch;
@@ -603,7 +604,8 @@ static void rpng_filter_avg_simd(uint8_t *decoded,
          prev_pixel  = out;
       }
    }
-   memcpy(decoded + i, raw + i, pitch - i);
+   if (decoded != raw)
+      memcpy(decoded + i, raw + i, pitch - i);
    for (; i < bpp && i < pitch; i++)
       decoded[i] += prev[i] >> 1;
    for (; i < pitch; i++)
@@ -709,7 +711,8 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
          prev_upper_left = pv;
       }
    }
-   memcpy(decoded + i, raw + i, pitch - i);
+   if (decoded != raw)
+      memcpy(decoded + i, raw + i, pitch - i);
    /* A scanline shorter than the vector window leaves i == 0, so the
     * leading bpp bytes still have to go through the a == c == 0 case
     * (Paeth(0, b, 0) == b) before the general tail can index i - bpp. */
@@ -980,10 +983,6 @@ static INLINE void rpng_store4_u8(uint8_t *p, uint8x8_t v)
    memcpy(p, &word, sizeof(word));
 }
 
-/* Sub as a byte prefix sum at strides 1, 2 and 4; see the SSE2 side
- * for the derivation and for why strides 3, 6 and 8 keep the windowed
- * per-pixel loop.  A left byte shift of a whole q register is
- * vextq(zero, x, 16 - k). */
 static void rpng_filter_sub_prefix1(uint8_t *decoded,
       const uint8_t *raw, size_t pitch)
 {
@@ -1087,7 +1086,8 @@ static void rpng_filter_sub_simd(uint8_t *decoded,
          prev_pixel    = out;
       }
    }
-   memcpy(decoded + i, raw + i, pitch - i);
+   if (decoded != raw)
+      memcpy(decoded + i, raw + i, pitch - i);
    if (i < bpp)
       i = bpp < pitch ? bpp : pitch;
    for (; i < pitch; i++)
@@ -1121,7 +1121,8 @@ static void rpng_filter_avg_simd(uint8_t *decoded,
          prev_pixel    = out;
       }
    }
-   memcpy(decoded + i, raw + i, pitch - i);
+   if (decoded != raw)
+      memcpy(decoded + i, raw + i, pitch - i);
    for (; i < bpp && i < pitch; i++)
       decoded[i] += prev[i] >> 1;
    for (; i < pitch; i++)
@@ -1221,7 +1222,8 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
          prev_upper_left = pv;
       }
    }
-   memcpy(decoded + i, raw + i, pitch - i);
+   if (decoded != raw)
+      memcpy(decoded + i, raw + i, pitch - i);
    /* A scanline shorter than the vector window leaves i == 0, so the
     * leading bpp bytes still have to go through the a == c == 0 case
     * (Paeth(0, b, 0) == b) before the general tail can index i - bpp. */
@@ -2237,15 +2239,16 @@ static void rpng_reverse_filter_deinit(struct rpng_process *pngp)
 {
    if (!pngp)
       return;
-   if (pngp->decoded_scanline)
-      free(pngp->decoded_scanline);
-   pngp->decoded_scanline = NULL;
-   if (pngp->prev_scanline)
-      free(pngp->prev_scanline);
-   pngp->prev_scanline    = NULL;
-   if (pngp->pair_scanline)
-      free(pngp->pair_scanline);
-   pngp->pair_scanline    = NULL;
+   if (pngp->scratch[0])
+      free(pngp->scratch[0]);
+   if (pngp->scratch[1])
+      free(pngp->scratch[1]);
+   if (pngp->scratch[2])
+      free(pngp->scratch[2]);
+   pngp->scratch[0] = NULL;
+   pngp->scratch[1] = NULL;
+   pngp->scratch[2] = NULL;
+   pngp->prev_line  = NULL;
 
    pngp->flags           &= ~RPNG_PROCESS_FLAG_PASS_INITIALIZED;
    pngp->h                = 0;
@@ -2314,16 +2317,18 @@ static int rpng_reverse_filter_init(const struct png_ihdr *ihdr,
       return -1;
 
    pngp->restore_buf_size      = 0;
-   pngp->prev_scanline         = (uint8_t*)calloc(1, pngp->pitch);
-   pngp->decoded_scanline      = (uint8_t*)calloc(1, pngp->pitch);
-#if defined(RPNG_HAVE_PAIR_KERNELS)
-   pngp->pair_scanline         = (uint8_t*)calloc(1, pngp->pitch);
-   if (!pngp->pair_scanline)
-      goto error;
-#endif
+   pngp->held                  = 0;
+   /* scratch[0] doubles as row 0's zero prev; scratch_cur starts at 0
+    * so the first out-of-place line (cur ^= 1) lands in scratch[1],
+    * leaving the zeroes intact while anything still points at them. */
+   pngp->scratch[0]            = (uint8_t*)calloc(1, pngp->pitch);
+   pngp->scratch[1]            = (uint8_t*)malloc(pngp->pitch);
+   pngp->scratch[2]            = (uint8_t*)malloc(pngp->pitch);
+   pngp->scratch_cur           = 0;
 
-   if (!pngp->prev_scanline || !pngp->decoded_scanline)
+   if (!pngp->scratch[0] || !pngp->scratch[1] || !pngp->scratch[2])
       goto error;
+   pngp->prev_line             = pngp->scratch[0];
 
    pngp->h                    = 0;
    pngp->flags               |= RPNG_PROCESS_FLAG_PASS_INITIALIZED;
@@ -2374,6 +2379,28 @@ static int rpng_reverse_filter_copy_line(uint32_t *data,
       const struct png_ihdr *ihdr,
       struct rpng_process *pngp, unsigned filter)
 {
+   /* In-place when the kernel tolerates dec aliasing raw: None does
+    * no work, Up and the prefix Subs load before every store, and at
+    * stride == window the window kernels' spill lanes land exactly on
+    * their own next input.  At stride < window a wide store would
+    * clobber raw bytes the next step re-reads, and width-exact stores
+    * measure worse (a 1-3 byte store feeding an overlapping 4-byte
+    * load stalls forwarding every pixel), so those combinations keep
+    * their wide stores and decode into alternating scratch lines
+    * instead. */
+   uint8_t       *dec = pngp->inflate_buf;
+   const uint8_t *raw = pngp->inflate_buf;
+#if defined(RPNG_SIMD_SSE2) || defined(RPNG_SIMD_NEON)
+   if (!(   filter == PNG_FILTER_NONE
+         || filter == PNG_FILTER_UP
+         || (filter == PNG_FILTER_SUB
+               && pngp->bpp != 3 && pngp->bpp != 6)
+         || (pngp->bpp == 4 || pngp->bpp == 8)))
+   {
+      pngp->scratch_cur = (pngp->scratch_cur + 1) % 3;
+      dec = pngp->scratch[pngp->scratch_cur];
+   }
+#endif
 #if !defined(RPNG_SIMD_SSE2) && !defined(RPNG_SIMD_NEON)
    unsigned i;
 #endif
@@ -2381,77 +2408,57 @@ static int rpng_reverse_filter_copy_line(uint32_t *data,
    switch (filter)
    {
       case PNG_FILTER_NONE:
-         memcpy(pngp->decoded_scanline, pngp->inflate_buf, pngp->pitch);
          break;
       case PNG_FILTER_SUB:
 #if defined(RPNG_SIMD_SSE2) || defined(RPNG_SIMD_NEON)
-         rpng_filter_sub_simd(pngp->decoded_scanline,
-               pngp->inflate_buf, pngp->pitch, pngp->bpp);
+         rpng_filter_sub_simd(dec, raw, pngp->pitch, pngp->bpp);
          break;
 #else
-         memcpy(pngp->decoded_scanline, pngp->inflate_buf, pngp->pitch);
          for (i = pngp->bpp; i < pngp->pitch; i++)
-            pngp->decoded_scanline[i] += pngp->decoded_scanline[i - pngp->bpp];
+            dec[i] += dec[i - pngp->bpp];
          break;
 #endif
       case PNG_FILTER_UP:
          /* Filter Up is a pure vector add—no inter-byte dependency. */
-         rpng_filter_up(pngp->decoded_scanline,
-               pngp->inflate_buf, pngp->prev_scanline, pngp->pitch);
+         rpng_filter_up(dec, raw, pngp->prev_line, pngp->pitch);
          break;
       case PNG_FILTER_AVERAGE:
 #if defined(RPNG_SIMD_SSE2) || defined(RPNG_SIMD_NEON)
-         rpng_filter_avg_simd(pngp->decoded_scanline,
-               pngp->inflate_buf, pngp->prev_scanline,
+         rpng_filter_avg_simd(dec, raw, pngp->prev_line,
                pngp->pitch, pngp->bpp);
          break;
 #else
-         memcpy(pngp->decoded_scanline, pngp->inflate_buf, pngp->pitch);
          for (i = 0; i < pngp->bpp; i++)
-         {
-            uint8_t avg = pngp->prev_scanline[i] >> 1;
-            pngp->decoded_scanline[i] += avg;
-         }
+            dec[i] += (uint8_t)(pngp->prev_line[i] >> 1);
          for (i = pngp->bpp; i < pngp->pitch; i++)
-         {
-            uint8_t avg = (pngp->decoded_scanline[i - pngp->bpp] + pngp->prev_scanline[i]) >> 1;
-            pngp->decoded_scanline[i] += avg;
-         }
+            dec[i] += (uint8_t)((dec[i - pngp->bpp]
+                  + pngp->prev_line[i]) >> 1);
          break;
 #endif
       case PNG_FILTER_PAETH:
 #if defined(RPNG_SIMD_SSE2) || defined(RPNG_SIMD_NEON)
          /* Stride-generic: every bpp benefits, not just RGBA8. */
-         rpng_filter_paeth_simd(pngp->decoded_scanline,
-               pngp->inflate_buf, pngp->prev_scanline,
+         rpng_filter_paeth_simd(dec, raw, pngp->prev_line,
                pngp->pitch, pngp->bpp);
          break;
 #else
-         memcpy(pngp->decoded_scanline, pngp->inflate_buf, pngp->pitch);
          for (i = 0; i < pngp->bpp; i++)
-            pngp->decoded_scanline[i] += pngp->prev_scanline[i];
+            dec[i] += pngp->prev_line[i];
          for (i = pngp->bpp; i < pngp->pitch; i++)
-            pngp->decoded_scanline[i] += (uint8_t)rpng_paeth(
-                  pngp->decoded_scanline[i - pngp->bpp],
-                  pngp->prev_scanline[i],
-                  pngp->prev_scanline[i - pngp->bpp]);
+            dec[i] += (uint8_t)rpng_paeth(dec[i - pngp->bpp],
+                  pngp->prev_line[i], pngp->prev_line[i - pngp->bpp]);
          break;
 #endif
       default:
          return IMAGE_PROCESS_ERROR_END;
    }
 
-   rpng_reverse_filter_convert(data, ihdr, pngp, pngp->decoded_scanline);
+rpng_reverse_filter_convert(data, ihdr, pngp, dec);
 
-   /* Swap scanline pointers instead of copying — the current decoded
-    * scanline becomes the previous scanline for the next row.
-    * Both buffers are the same size (pitch bytes), allocated in
-    * rpng_reverse_filter_init, so swapping is always safe. */
-   {
-      uint8_t *tmp           = pngp->prev_scanline;
-      pngp->prev_scanline    = pngp->decoded_scanline;
-      pngp->decoded_scanline = tmp;
-   }
+   /* The line just unfiltered becomes the previous line; its ring
+    * slot stays protected through pngp->held until the next line has
+    * consumed it. */
+   pngp->prev_line = dec;
 
    return IMAGE_PROCESS_NEXT;
 }
@@ -2464,17 +2471,20 @@ static int rpng_reverse_filter_regular_iterate(
 #if defined(RPNG_HAVE_PAIR_KERNELS)
    /* Wavefront pair: when the next two scanlines are fully inflated,
     * contiguous in the ring and carry the same chain-bound filter,
-    * unfilter them in one interleaved pass (see the pair kernels).
-    * Residency: total_out - restore_buf_size is exactly the inflated,
-    * not yet consumed byte count on the regular path; the interlaced
-    * path only filters once its whole pass is resident, so the check
-    * is conservative there.  Contiguity: the ring recycles only at
-    * whole-line boundaries, so two lines are contiguous unless the
-    * second would start past the ring end. */
+    * unfilter them in one interleaved pass (see the pair kernels),
+    * in place, the second row's up neighbour being the first row's
+    * bytes as they decode.  Residency: total_out - restore_buf_size
+    * - held is exactly the inflated, not yet unfiltered byte count on
+    * the regular path; the interlaced path only filters once its
+    * whole pass is resident, so the check is conservative there.
+    * Contiguity: the ring recycles only at whole-line boundaries, so
+    * two lines are contiguous unless the second would start past the
+    * ring end. */
    if (pngp->h + 2 <= ihdr->height)
    {
       size_t line = (size_t)pngp->pitch + 1;
-      if (   pngp->total_out - pngp->restore_buf_size >= 2 * line
+      if (      pngp->total_out - pngp->restore_buf_size - pngp->held
+             >= 2 * line
           && (   pngp->ring_size >= pngp->inflate_buf_size
               ||    pngp->inflate_buf + 2 * line
                  <= pngp->inflate_base + pngp->ring_size))
@@ -2486,27 +2496,55 @@ static int rpng_reverse_filter_regular_iterate(
          {
             const uint8_t *raw0 = pngp->inflate_buf + 1;
             const uint8_t *raw1 = raw0 + line;
-            uint8_t *tmp;
-            if (f0 == PNG_FILTER_PAETH)
-               rpng_filter_paeth_pair(pngp->decoded_scanline,
-                     pngp->pair_scanline, raw0, raw1,
-                     pngp->prev_scanline, pngp->pitch, pngp->bpp);
+            uint8_t *dec0;
+            uint8_t *dec1;
+            int in_place = (pngp->bpp == 4 || pngp->bpp == 8);
+            if (in_place)
+            {
+               /* Stride == window: the wide stores land exactly on
+                * their own next input, so decode in the ring. */
+               dec0 = pngp->inflate_buf + 1;
+               dec1 = dec0 + line;
+            }
             else
-               rpng_filter_avg_pair(pngp->decoded_scanline,
-                     pngp->pair_scanline, raw0, raw1,
-                     pngp->prev_scanline, pngp->pitch, pngp->bpp);
+            {
+               /* Stride < window: wide stores would clobber raw, so
+                * take the next two free scratch lines. */
+               unsigned i0 = (pngp->scratch_cur + 1) % 3;
+               unsigned i1 = (pngp->scratch_cur + 2) % 3;
+               dec0 = pngp->scratch[i0];
+               dec1 = pngp->scratch[i1];
+               pngp->scratch_cur = i1;
+            }
+            if (f0 == PNG_FILTER_PAETH)
+               rpng_filter_paeth_pair(dec0, dec1, raw0, raw1,
+                     pngp->prev_line, pngp->pitch, pngp->bpp);
+            else
+               rpng_filter_avg_pair(dec0, dec1, raw0, raw1,
+                     pngp->prev_line, pngp->pitch, pngp->bpp);
             rpng_reverse_filter_convert(pngp->out_cursor, ihdr, pngp,
-                  pngp->decoded_scanline);
+                  dec0);
             rpng_reverse_filter_convert(pngp->out_cursor + ihdr->width,
-                  ihdr, pngp, pngp->pair_scanline);
-            /* The second row's decode becomes the previous scanline;
-             * the old previous buffer takes its place as scratch. */
-            tmp                  = pngp->prev_scanline;
-            pngp->prev_scanline  = pngp->pair_scanline;
-            pngp->pair_scanline  = tmp;
-            pngp->h             += 2;
-            pngp->inflate_buf   += 2 * line;
-            pngp->restore_buf_size += 2 * line;
+                  ihdr, pngp, dec1);
+            if (in_place)
+            {
+               /* Release the line the pair's first row used as prev
+                * and the first row itself; the second row is the new
+                * prev and stays held so the ring cannot recycle its
+                * slot. */
+               pngp->restore_buf_size += pngp->held + line;
+               pngp->held              = line;
+            }
+            else
+            {
+               /* Scratch lines need no ring protection: release both
+                * raw lines and anything held. */
+               pngp->restore_buf_size += pngp->held + 2 * line;
+               pngp->held              = 0;
+            }
+            pngp->prev_line         = dec1;
+            pngp->h                += 2;
+            pngp->inflate_buf      += 2 * line;
             if (    pngp->ring_size < pngp->inflate_buf_size
                 &&  pngp->inflate_buf == pngp->inflate_base + pngp->ring_size)
                pngp->inflate_buf = pngp->inflate_base;
@@ -2519,7 +2557,6 @@ static int rpng_reverse_filter_regular_iterate(
    if (pngp->h < ihdr->height)
    {
       unsigned filter         = *pngp->inflate_buf++;
-      pngp->restore_buf_size += 1;
       ret                     = rpng_reverse_filter_copy_line(pngp->out_cursor,
             ihdr, pngp, filter);
       if (ret == IMAGE_PROCESS_END || ret == IMAGE_PROCESS_ERROR_END)
@@ -2529,8 +2566,22 @@ static int rpng_reverse_filter_regular_iterate(
       goto end;
 
    pngp->h++;
+   /* Consume-late: a line unfiltered in place is the next line's
+    * prev, living in the ring, so the previously held line is
+    * released and this one held in its stead.  A line decoded into
+    * scratch needs no ring protection: release it and any held line
+    * at once. */
+   if (pngp->prev_line == pngp->inflate_buf)
+   {
+      pngp->restore_buf_size   += pngp->held;
+      pngp->held                = (size_t)pngp->pitch + 1;
+   }
+   else
+   {
+      pngp->restore_buf_size   += pngp->held + pngp->pitch + 1;
+      pngp->held                = 0;
+   }
    pngp->inflate_buf           += pngp->pitch;
-   pngp->restore_buf_size      += pngp->pitch;
 
    /* Recycling window: the ring is a whole number of scanlines, so
     * the cursor lands exactly on the ring end between lines and
@@ -2544,6 +2595,11 @@ static int rpng_reverse_filter_regular_iterate(
    return IMAGE_PROCESS_NEXT;
 
 end:
+   /* Nothing will use the held line as prev any more; fold it into
+    * the consumed count so the full-buffer rewind below and the
+    * ring's free-space arithmetic both see every processed byte. */
+   pngp->restore_buf_size += pngp->held;
+   pngp->held              = 0;
    rpng_reverse_filter_deinit(pngp);
 
    if (pngp->ring_size < pngp->inflate_buf_size)
@@ -3383,14 +3439,19 @@ int rpng_process_image(rpng_t *rpng,
    }
 
    /* A scanline is one filter byte plus pitch bytes; pull one inflate
-    * slice when the next one has not fully arrived. */
+    * slice when the next one has not fully arrived.  held bytes are
+    * already unfiltered in place - they lag restore_buf_size only to
+    * keep their ring slot out of the recycling window - so they do
+    * not count as an available raw line. */
    if (   !(rpng->process->flags & RPNG_PROCESS_FLAG_INFLATE_INITIALIZED)
        &&   rpng->process->total_out - rpng->process->restore_buf_size
+              - rpng->process->held
           < (size_t)rpng->process->pitch + 1)
    {
       if (rpng_load_image_argb_process_inflate_init(rpng, data) == -1)
          goto error;
       if (   rpng->process->total_out - rpng->process->restore_buf_size
+               - rpng->process->held
            < (size_t)rpng->process->pitch + 1)
          return IMAGE_PROCESS_NEXT;
    }
@@ -3405,12 +3466,12 @@ error:
        * buffers and the inflate window may all still be live here. */
       if (rpng->process->data)
          free(rpng->process->data);
-      if (rpng->process->prev_scanline)
-         free(rpng->process->prev_scanline);
-      if (rpng->process->decoded_scanline)
-         free(rpng->process->decoded_scanline);
-      if (rpng->process->pair_scanline)
-         free(rpng->process->pair_scanline);
+      if (rpng->process->scratch[0])
+         free(rpng->process->scratch[0]);
+      if (rpng->process->scratch[1])
+         free(rpng->process->scratch[1]);
+      if (rpng->process->scratch[2])
+         free(rpng->process->scratch[2]);
       if (rpng->process->inflate_base)
          free(rpng->process->inflate_base);
       if (rpng->process->stream)
@@ -3436,12 +3497,12 @@ void rpng_free(rpng_t *rpng)
        * window. */
       if (rpng->process->data)
          free(rpng->process->data);
-      if (rpng->process->prev_scanline)
-         free(rpng->process->prev_scanline);
-      if (rpng->process->decoded_scanline)
-         free(rpng->process->decoded_scanline);
-      if (rpng->process->pair_scanline)
-         free(rpng->process->pair_scanline);
+      if (rpng->process->scratch[0])
+         free(rpng->process->scratch[0]);
+      if (rpng->process->scratch[1])
+         free(rpng->process->scratch[1]);
+      if (rpng->process->scratch[2])
+         free(rpng->process->scratch[2]);
       if (rpng->process->inflate_base)
          free(rpng->process->inflate_base);
       if (rpng->process->stream)

--- a/libretro-common/formats/png/rpng.c
+++ b/libretro-common/formats/png/rpng.c
@@ -179,6 +179,8 @@ struct rpng_process
    const struct trans_stream_backend *stream_backend;
    uint8_t *prev_scanline;
    uint8_t *decoded_scanline;
+   uint8_t *pair_scanline;     /* second decode row for the wavefront
+                                * pair path; see the pair kernels     */
    uint8_t *inflate_buf;      /* walking read cursor for the filters     */
    uint8_t *inflate_base;     /* fixed allocation base: inflate writes at
                                * inflate_base + inflated_total, immune to
@@ -718,6 +720,232 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
             prev[i - bpp]);
 }
 
+#define RPNG_HAVE_PAIR_KERNELS 1
+
+/* --- Wavefront pair kernels --------------------------------------------
+ *
+ * Average and Paeth are bound by the serial chain through the left
+ * neighbour: one pixel per chain length, however wide the machine.
+ * But two consecutive rows carrying the same filter can be unfiltered
+ * in one interleaved pass along the classic diagonal wavefront: row 1
+ * runs one pixel behind row 0, so its up neighbour is the row 0 output
+ * produced in the *previous* iteration and the two carried chains
+ * never wait on each other inside an iteration.  Two pixels per chain
+ * length, on the two filters where the chain is the whole cost.
+ * (A row-at-a-time decoder cannot do this, whatever its ISA level.)
+ *
+ * Window and stride semantics are exactly those of the single-row
+ * kernels above: a fixed 4- or 8-byte window stepped by bpp, lanes at
+ * or past the stride rewritten by later steps or the scalar tails.
+ * Both rows share the frontier i at loop exit - row 1 trails by one
+ * step inside the loop and settles its last window in the epilogue -
+ * so both tails resume from i, row 0 first since row 1's tail reads
+ * dec0. */
+static void rpng_filter_paeth_pair(uint8_t *dec0, uint8_t *dec1,
+      const uint8_t *raw0, const uint8_t *raw1, const uint8_t *prev,
+      size_t pitch, unsigned bpp)
+{
+   size_t i           = 0;
+   const __m128i mask = _mm_set1_epi16(0x00FF);
+   __m128i a0         = _mm_setzero_si128();
+   __m128i c0         = _mm_setzero_si128();
+   __m128i a1         = _mm_setzero_si128();
+   __m128i c1         = _mm_setzero_si128();
+   __m128i a0p        = _mm_setzero_si128();
+   if (bpp <= 4)
+   {
+      if (4 <= pitch)
+      {
+         __m128i b0 = rpng_load4_u8_to_u16(prev);
+         __m128i r0 = rpng_load4_u8_to_u16(raw0);
+         __m128i sb = _mm_and_si128(_mm_add_epi16(r0, b0), mask);
+         __m128i sc = _mm_and_si128(_mm_add_epi16(r0, c0), mask);
+         a0  = rpng_paeth_step_epi16(a0, b0, c0, r0, sb, sc, mask);
+         rpng_store4_u16_to_u8(dec0, a0);
+         c0  = b0;
+         a0p = a0;
+         for (i = bpp; i + 4 <= pitch; i += bpp)
+         {
+            __m128i r1;
+            b0 = rpng_load4_u8_to_u16(prev + i);
+            r0 = rpng_load4_u8_to_u16(raw0 + i);
+            sb = _mm_and_si128(_mm_add_epi16(r0, b0), mask);
+            sc = _mm_and_si128(_mm_add_epi16(r0, c0), mask);
+            a0 = rpng_paeth_step_epi16(a0, b0, c0, r0, sb, sc, mask);
+            rpng_store4_u16_to_u8(dec0 + i, a0);
+            c0 = b0;
+            r1 = rpng_load4_u8_to_u16(raw1 + i - bpp);
+            sb = _mm_and_si128(_mm_add_epi16(r1, a0p), mask);
+            sc = _mm_and_si128(_mm_add_epi16(r1, c1),  mask);
+            a1 = rpng_paeth_step_epi16(a1, a0p, c1, r1, sb, sc, mask);
+            rpng_store4_u16_to_u8(dec1 + i - bpp, a1);
+            c1  = a0p;
+            a0p = a0;
+         }
+         {
+            __m128i r1 = rpng_load4_u8_to_u16(raw1 + i - bpp);
+            __m128i s1 = _mm_and_si128(_mm_add_epi16(r1, a0p), mask);
+            __m128i s2 = _mm_and_si128(_mm_add_epi16(r1, c1),  mask);
+            a1 = rpng_paeth_step_epi16(a1, a0p, c1, r1, s1, s2, mask);
+            rpng_store4_u16_to_u8(dec1 + i - bpp, a1);
+         }
+      }
+   }
+   else
+   {
+      if (8 <= pitch)
+      {
+         __m128i b0 = rpng_load8_u8_to_u16(prev);
+         __m128i r0 = rpng_load8_u8_to_u16(raw0);
+         __m128i sb = _mm_and_si128(_mm_add_epi16(r0, b0), mask);
+         __m128i sc = _mm_and_si128(_mm_add_epi16(r0, c0), mask);
+         a0  = rpng_paeth_step_epi16(a0, b0, c0, r0, sb, sc, mask);
+         rpng_store8_u16_to_u8(dec0, a0);
+         c0  = b0;
+         a0p = a0;
+         for (i = bpp; i + 8 <= pitch; i += bpp)
+         {
+            __m128i r1;
+            b0 = rpng_load8_u8_to_u16(prev + i);
+            r0 = rpng_load8_u8_to_u16(raw0 + i);
+            sb = _mm_and_si128(_mm_add_epi16(r0, b0), mask);
+            sc = _mm_and_si128(_mm_add_epi16(r0, c0), mask);
+            a0 = rpng_paeth_step_epi16(a0, b0, c0, r0, sb, sc, mask);
+            rpng_store8_u16_to_u8(dec0 + i, a0);
+            c0 = b0;
+            r1 = rpng_load8_u8_to_u16(raw1 + i - bpp);
+            sb = _mm_and_si128(_mm_add_epi16(r1, a0p), mask);
+            sc = _mm_and_si128(_mm_add_epi16(r1, c1),  mask);
+            a1 = rpng_paeth_step_epi16(a1, a0p, c1, r1, sb, sc, mask);
+            rpng_store8_u16_to_u8(dec1 + i - bpp, a1);
+            c1  = a0p;
+            a0p = a0;
+         }
+         {
+            __m128i r1 = rpng_load8_u8_to_u16(raw1 + i - bpp);
+            __m128i s1 = _mm_and_si128(_mm_add_epi16(r1, a0p), mask);
+            __m128i s2 = _mm_and_si128(_mm_add_epi16(r1, c1),  mask);
+            a1 = rpng_paeth_step_epi16(a1, a0p, c1, r1, s1, s2, mask);
+            rpng_store8_u16_to_u8(dec1 + i - bpp, a1);
+         }
+      }
+   }
+   {
+      size_t j;
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec0[j] = (uint8_t)(raw0[j] + prev[j]);
+         else
+            dec0[j] = (uint8_t)(raw0[j] + rpng_paeth(dec0[j - bpp],
+                  prev[j], prev[j - bpp]));
+      }
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec1[j] = (uint8_t)(raw1[j] + dec0[j]);
+         else
+            dec1[j] = (uint8_t)(raw1[j] + rpng_paeth(dec1[j - bpp],
+                  dec0[j], dec0[j - bpp]));
+      }
+   }
+}
+
+static void rpng_filter_avg_pair(uint8_t *dec0, uint8_t *dec1,
+      const uint8_t *raw0, const uint8_t *raw1, const uint8_t *prev,
+      size_t pitch, unsigned bpp)
+{
+   size_t i          = 0;
+   const __m128i one = _mm_set1_epi8(1);
+   __m128i a0        = _mm_setzero_si128();
+   __m128i a1        = _mm_setzero_si128();
+   __m128i a0p       = _mm_setzero_si128();
+   if (bpp <= 4)
+   {
+      if (4 <= pitch)
+      {
+         __m128i b0 = rpng_load4_u8(prev);
+         __m128i av = _mm_sub_epi8(_mm_avg_epu8(a0, b0),
+               _mm_and_si128(_mm_xor_si128(a0, b0), one));
+         a0  = _mm_add_epi8(rpng_load4_u8(raw0), av);
+         rpng_store4_u8(dec0, a0);
+         a0p = a0;
+         for (i = bpp; i + 4 <= pitch; i += bpp)
+         {
+            b0 = rpng_load4_u8(prev + i);
+            av = _mm_sub_epi8(_mm_avg_epu8(a0, b0),
+                  _mm_and_si128(_mm_xor_si128(a0, b0), one));
+            a0 = _mm_add_epi8(rpng_load4_u8(raw0 + i), av);
+            rpng_store4_u8(dec0 + i, a0);
+            av = _mm_sub_epi8(_mm_avg_epu8(a1, a0p),
+                  _mm_and_si128(_mm_xor_si128(a1, a0p), one));
+            a1 = _mm_add_epi8(rpng_load4_u8(raw1 + i - bpp), av);
+            rpng_store4_u8(dec1 + i - bpp, a1);
+            a0p = a0;
+         }
+         {
+            __m128i av1 = _mm_sub_epi8(_mm_avg_epu8(a1, a0p),
+                  _mm_and_si128(_mm_xor_si128(a1, a0p), one));
+            a1 = _mm_add_epi8(rpng_load4_u8(raw1 + i - bpp), av1);
+            rpng_store4_u8(dec1 + i - bpp, a1);
+         }
+      }
+   }
+   else
+   {
+      if (8 <= pitch)
+      {
+         __m128i b0 = _mm_loadl_epi64((const __m128i*)prev);
+         __m128i av = _mm_sub_epi8(_mm_avg_epu8(a0, b0),
+               _mm_and_si128(_mm_xor_si128(a0, b0), one));
+         a0  = _mm_add_epi8(_mm_loadl_epi64((const __m128i*)raw0), av);
+         _mm_storel_epi64((__m128i*)dec0, a0);
+         a0p = a0;
+         for (i = bpp; i + 8 <= pitch; i += bpp)
+         {
+            b0 = _mm_loadl_epi64((const __m128i*)(prev + i));
+            av = _mm_sub_epi8(_mm_avg_epu8(a0, b0),
+                  _mm_and_si128(_mm_xor_si128(a0, b0), one));
+            a0 = _mm_add_epi8(
+                  _mm_loadl_epi64((const __m128i*)(raw0 + i)), av);
+            _mm_storel_epi64((__m128i*)(dec0 + i), a0);
+            av = _mm_sub_epi8(_mm_avg_epu8(a1, a0p),
+                  _mm_and_si128(_mm_xor_si128(a1, a0p), one));
+            a1 = _mm_add_epi8(
+                  _mm_loadl_epi64((const __m128i*)(raw1 + i - bpp)), av);
+            _mm_storel_epi64((__m128i*)(dec1 + i - bpp), a1);
+            a0p = a0;
+         }
+         {
+            __m128i av1 = _mm_sub_epi8(_mm_avg_epu8(a1, a0p),
+                  _mm_and_si128(_mm_xor_si128(a1, a0p), one));
+            a1 = _mm_add_epi8(
+                  _mm_loadl_epi64((const __m128i*)(raw1 + i - bpp)), av1);
+            _mm_storel_epi64((__m128i*)(dec1 + i - bpp), a1);
+         }
+      }
+   }
+   {
+      size_t j;
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec0[j] = (uint8_t)(raw0[j] + (prev[j] >> 1));
+         else
+            dec0[j] = (uint8_t)(raw0[j]
+                  + ((dec0[j - bpp] + prev[j]) >> 1));
+      }
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec1[j] = (uint8_t)(raw1[j] + (dec0[j] >> 1));
+         else
+            dec1[j] = (uint8_t)(raw1[j]
+                  + ((dec1[j - bpp] + dec0[j]) >> 1));
+      }
+   }
+}
+
 #elif defined(RPNG_SIMD_NEON)
 
 static INLINE uint16x4_t rpng_load4_u8_to_u16(const uint8_t *p)
@@ -1002,6 +1230,201 @@ static void rpng_filter_paeth_simd(uint8_t *decoded,
    for (; i < pitch; i++)
       decoded[i] += (uint8_t)rpng_paeth(decoded[i - bpp], prev[i],
             prev[i - bpp]);
+}
+
+#define RPNG_HAVE_PAIR_KERNELS 1
+
+/* Wavefront pair kernels; see the SSE2 side for the derivation.  Row 1
+ * trails row 0 by one step, so its up neighbour comes from a register
+ * written in the previous iteration and the two serial chains overlap.
+ * NEON's vhadd_u8 is floor((a + b) / 2) directly, so the Average pair
+ * needs no rounding correction. */
+static void rpng_filter_paeth_pair(uint8_t *dec0, uint8_t *dec1,
+      const uint8_t *raw0, const uint8_t *raw1, const uint8_t *prev,
+      size_t pitch, unsigned bpp)
+{
+   size_t i = 0;
+   if (bpp <= 4)
+   {
+      const uint16x4_t m4 = vdup_n_u16(0xFF);
+      uint16x4_t a0  = vdup_n_u16(0);
+      uint16x4_t c0  = vdup_n_u16(0);
+      uint16x4_t a1  = vdup_n_u16(0);
+      uint16x4_t c1  = vdup_n_u16(0);
+      uint16x4_t a0p = vdup_n_u16(0);
+      if (4 <= pitch)
+      {
+         uint16x4_t b0 = rpng_load4_u8_to_u16(prev);
+         uint16x4_t r0 = rpng_load4_u8_to_u16(raw0);
+         uint16x4_t sb = vand_u16(vadd_u16(r0, b0), m4);
+         uint16x4_t sc = vand_u16(vadd_u16(r0, c0), m4);
+         a0  = rpng_paeth_step_u16(a0, b0, c0, r0, sb, sc, m4);
+         rpng_store4_u16_to_u8(dec0, a0);
+         c0  = b0;
+         a0p = a0;
+         for (i = bpp; i + 4 <= pitch; i += bpp)
+         {
+            uint16x4_t r1;
+            b0 = rpng_load4_u8_to_u16(prev + i);
+            r0 = rpng_load4_u8_to_u16(raw0 + i);
+            sb = vand_u16(vadd_u16(r0, b0), m4);
+            sc = vand_u16(vadd_u16(r0, c0), m4);
+            a0 = rpng_paeth_step_u16(a0, b0, c0, r0, sb, sc, m4);
+            rpng_store4_u16_to_u8(dec0 + i, a0);
+            c0 = b0;
+            r1 = rpng_load4_u8_to_u16(raw1 + i - bpp);
+            sb = vand_u16(vadd_u16(r1, a0p), m4);
+            sc = vand_u16(vadd_u16(r1, c1),  m4);
+            a1 = rpng_paeth_step_u16(a1, a0p, c1, r1, sb, sc, m4);
+            rpng_store4_u16_to_u8(dec1 + i - bpp, a1);
+            c1  = a0p;
+            a0p = a0;
+         }
+         {
+            uint16x4_t r1 = rpng_load4_u8_to_u16(raw1 + i - bpp);
+            uint16x4_t s1 = vand_u16(vadd_u16(r1, a0p), m4);
+            uint16x4_t s2 = vand_u16(vadd_u16(r1, c1),  m4);
+            a1 = rpng_paeth_step_u16(a1, a0p, c1, r1, s1, s2, m4);
+            rpng_store4_u16_to_u8(dec1 + i - bpp, a1);
+         }
+      }
+   }
+   else
+   {
+      const uint16x8_t m8 = vdupq_n_u16(0xFF);
+      uint16x8_t a0  = vdupq_n_u16(0);
+      uint16x8_t c0  = vdupq_n_u16(0);
+      uint16x8_t a1  = vdupq_n_u16(0);
+      uint16x8_t c1  = vdupq_n_u16(0);
+      uint16x8_t a0p = vdupq_n_u16(0);
+      if (8 <= pitch)
+      {
+         uint16x8_t b0 = rpng_load8_u8_to_u16(prev);
+         uint16x8_t r0 = rpng_load8_u8_to_u16(raw0);
+         uint16x8_t sb = vandq_u16(vaddq_u16(r0, b0), m8);
+         uint16x8_t sc = vandq_u16(vaddq_u16(r0, c0), m8);
+         a0  = rpng_paeth_step_u16q(a0, b0, c0, r0, sb, sc, m8);
+         rpng_store8_u16_to_u8(dec0, a0);
+         c0  = b0;
+         a0p = a0;
+         for (i = bpp; i + 8 <= pitch; i += bpp)
+         {
+            uint16x8_t r1;
+            b0 = rpng_load8_u8_to_u16(prev + i);
+            r0 = rpng_load8_u8_to_u16(raw0 + i);
+            sb = vandq_u16(vaddq_u16(r0, b0), m8);
+            sc = vandq_u16(vaddq_u16(r0, c0), m8);
+            a0 = rpng_paeth_step_u16q(a0, b0, c0, r0, sb, sc, m8);
+            rpng_store8_u16_to_u8(dec0 + i, a0);
+            c0 = b0;
+            r1 = rpng_load8_u8_to_u16(raw1 + i - bpp);
+            sb = vandq_u16(vaddq_u16(r1, a0p), m8);
+            sc = vandq_u16(vaddq_u16(r1, c1),  m8);
+            a1 = rpng_paeth_step_u16q(a1, a0p, c1, r1, sb, sc, m8);
+            rpng_store8_u16_to_u8(dec1 + i - bpp, a1);
+            c1  = a0p;
+            a0p = a0;
+         }
+         {
+            uint16x8_t r1 = rpng_load8_u8_to_u16(raw1 + i - bpp);
+            uint16x8_t s1 = vandq_u16(vaddq_u16(r1, a0p), m8);
+            uint16x8_t s2 = vandq_u16(vaddq_u16(r1, c1),  m8);
+            a1 = rpng_paeth_step_u16q(a1, a0p, c1, r1, s1, s2, m8);
+            rpng_store8_u16_to_u8(dec1 + i - bpp, a1);
+         }
+      }
+   }
+   {
+      size_t j;
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec0[j] = (uint8_t)(raw0[j] + prev[j]);
+         else
+            dec0[j] = (uint8_t)(raw0[j] + rpng_paeth(dec0[j - bpp],
+                  prev[j], prev[j - bpp]));
+      }
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec1[j] = (uint8_t)(raw1[j] + dec0[j]);
+         else
+            dec1[j] = (uint8_t)(raw1[j] + rpng_paeth(dec1[j - bpp],
+                  dec0[j], dec0[j - bpp]));
+      }
+   }
+}
+
+static void rpng_filter_avg_pair(uint8_t *dec0, uint8_t *dec1,
+      const uint8_t *raw0, const uint8_t *raw1, const uint8_t *prev,
+      size_t pitch, unsigned bpp)
+{
+   size_t i       = 0;
+   uint8x8_t a0   = vdup_n_u8(0);
+   uint8x8_t a1   = vdup_n_u8(0);
+   uint8x8_t a0p  = vdup_n_u8(0);
+   if (bpp <= 4)
+   {
+      if (4 <= pitch)
+      {
+         uint8x8_t b0 = rpng_load4_u8(prev);
+         a0  = vadd_u8(rpng_load4_u8(raw0), vhadd_u8(a0, b0));
+         rpng_store4_u8(dec0, a0);
+         a0p = a0;
+         for (i = bpp; i + 4 <= pitch; i += bpp)
+         {
+            b0 = rpng_load4_u8(prev + i);
+            a0 = vadd_u8(rpng_load4_u8(raw0 + i), vhadd_u8(a0, b0));
+            rpng_store4_u8(dec0 + i, a0);
+            a1 = vadd_u8(rpng_load4_u8(raw1 + i - bpp),
+                  vhadd_u8(a1, a0p));
+            rpng_store4_u8(dec1 + i - bpp, a1);
+            a0p = a0;
+         }
+         a1 = vadd_u8(rpng_load4_u8(raw1 + i - bpp), vhadd_u8(a1, a0p));
+         rpng_store4_u8(dec1 + i - bpp, a1);
+      }
+   }
+   else
+   {
+      if (8 <= pitch)
+      {
+         uint8x8_t b0 = vld1_u8(prev);
+         a0  = vadd_u8(vld1_u8(raw0), vhadd_u8(a0, b0));
+         vst1_u8(dec0, a0);
+         a0p = a0;
+         for (i = bpp; i + 8 <= pitch; i += bpp)
+         {
+            b0 = vld1_u8(prev + i);
+            a0 = vadd_u8(vld1_u8(raw0 + i), vhadd_u8(a0, b0));
+            vst1_u8(dec0 + i, a0);
+            a1 = vadd_u8(vld1_u8(raw1 + i - bpp), vhadd_u8(a1, a0p));
+            vst1_u8(dec1 + i - bpp, a1);
+            a0p = a0;
+         }
+         a1 = vadd_u8(vld1_u8(raw1 + i - bpp), vhadd_u8(a1, a0p));
+         vst1_u8(dec1 + i - bpp, a1);
+      }
+   }
+   {
+      size_t j;
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec0[j] = (uint8_t)(raw0[j] + (prev[j] >> 1));
+         else
+            dec0[j] = (uint8_t)(raw0[j]
+                  + ((dec0[j - bpp] + prev[j]) >> 1));
+      }
+      for (j = i; j < pitch; j++)
+      {
+         if (j < bpp)
+            dec1[j] = (uint8_t)(raw1[j] + (dec0[j] >> 1));
+         else
+            dec1[j] = (uint8_t)(raw1[j]
+                  + ((dec1[j - bpp] + dec0[j]) >> 1));
+      }
+   }
 }
 
 #endif /* RPNG_SIMD_SSE2 / RPNG_SIMD_NEON */
@@ -1820,6 +2243,9 @@ static void rpng_reverse_filter_deinit(struct rpng_process *pngp)
    if (pngp->prev_scanline)
       free(pngp->prev_scanline);
    pngp->prev_scanline    = NULL;
+   if (pngp->pair_scanline)
+      free(pngp->pair_scanline);
+   pngp->pair_scanline    = NULL;
 
    pngp->flags           &= ~RPNG_PROCESS_FLAG_PASS_INITIALIZED;
    pngp->h                = 0;
@@ -1890,6 +2316,11 @@ static int rpng_reverse_filter_init(const struct png_ihdr *ihdr,
    pngp->restore_buf_size      = 0;
    pngp->prev_scanline         = (uint8_t*)calloc(1, pngp->pitch);
    pngp->decoded_scanline      = (uint8_t*)calloc(1, pngp->pitch);
+#if defined(RPNG_HAVE_PAIR_KERNELS)
+   pngp->pair_scanline         = (uint8_t*)calloc(1, pngp->pitch);
+   if (!pngp->pair_scanline)
+      goto error;
+#endif
 
    if (!pngp->prev_scanline || !pngp->decoded_scanline)
       goto error;
@@ -1905,6 +2336,39 @@ error:
 }
 
 /* ---------------------------------------------------------------------------*/
+
+/* Pixel-format conversion of one unfiltered scanline into the 32-bit
+ * output row, factored out of the per-line path so the wavefront pair
+ * path below can convert two rows from two buffers. */
+static void rpng_reverse_filter_convert(uint32_t *data,
+      const struct png_ihdr *ihdr,
+      struct rpng_process *pngp, const uint8_t *decoded)
+{
+   switch (ihdr->color_type)
+   {
+      case PNG_IHDR_COLOR_GRAY:
+         rpng_reverse_filter_copy_line_bw(data, decoded, ihdr->width,
+               ihdr->depth);
+         break;
+      case PNG_IHDR_COLOR_RGB:
+         rpng_reverse_filter_copy_line_rgb(data, decoded, ihdr->width,
+               ihdr->depth, pngp->supports_rgba, pngp->want_10bit);
+         break;
+      case PNG_IHDR_COLOR_PLT:
+         rpng_reverse_filter_copy_line_plt(
+               data, decoded, ihdr->width, ihdr->depth, pngp->palette);
+         break;
+      case PNG_IHDR_COLOR_GRAY_ALPHA:
+         rpng_reverse_filter_copy_line_gray_alpha(
+               data, decoded, ihdr->width, ihdr->depth);
+         break;
+      case PNG_IHDR_COLOR_RGBA:
+         rpng_reverse_filter_copy_line_rgba(
+               data, decoded, ihdr->width, ihdr->depth,
+               pngp->supports_rgba);
+         break;
+   }
+}
 
 static int rpng_reverse_filter_copy_line(uint32_t *data,
       const struct png_ihdr *ihdr,
@@ -1977,31 +2441,7 @@ static int rpng_reverse_filter_copy_line(uint32_t *data,
          return IMAGE_PROCESS_ERROR_END;
    }
 
-   switch (ihdr->color_type)
-   {
-      case PNG_IHDR_COLOR_GRAY:
-         rpng_reverse_filter_copy_line_bw(data, pngp->decoded_scanline, ihdr->width, ihdr->depth);
-         break;
-      case PNG_IHDR_COLOR_RGB:
-         rpng_reverse_filter_copy_line_rgb(data, pngp->decoded_scanline, ihdr->width, ihdr->depth,
-               pngp->supports_rgba, pngp->want_10bit);
-         break;
-      case PNG_IHDR_COLOR_PLT:
-         rpng_reverse_filter_copy_line_plt(
-               data, pngp->decoded_scanline, ihdr->width,
-               ihdr->depth, pngp->palette);
-         break;
-      case PNG_IHDR_COLOR_GRAY_ALPHA:
-         rpng_reverse_filter_copy_line_gray_alpha(
-               data, pngp->decoded_scanline, ihdr->width,
-               ihdr->depth);
-         break;
-      case PNG_IHDR_COLOR_RGBA:
-         rpng_reverse_filter_copy_line_rgba(
-               data, pngp->decoded_scanline, ihdr->width, ihdr->depth,
-               pngp->supports_rgba);
-         break;
-   }
+   rpng_reverse_filter_convert(data, ihdr, pngp, pngp->decoded_scanline);
 
    /* Swap scanline pointers instead of copying — the current decoded
     * scanline becomes the previous scanline for the next row.
@@ -2021,7 +2461,62 @@ static int rpng_reverse_filter_regular_iterate(
       struct rpng_process *pngp)
 {
    int ret = IMAGE_PROCESS_END;
-if (pngp->h < ihdr->height)
+#if defined(RPNG_HAVE_PAIR_KERNELS)
+   /* Wavefront pair: when the next two scanlines are fully inflated,
+    * contiguous in the ring and carry the same chain-bound filter,
+    * unfilter them in one interleaved pass (see the pair kernels).
+    * Residency: total_out - restore_buf_size is exactly the inflated,
+    * not yet consumed byte count on the regular path; the interlaced
+    * path only filters once its whole pass is resident, so the check
+    * is conservative there.  Contiguity: the ring recycles only at
+    * whole-line boundaries, so two lines are contiguous unless the
+    * second would start past the ring end. */
+   if (pngp->h + 2 <= ihdr->height)
+   {
+      size_t line = (size_t)pngp->pitch + 1;
+      if (   pngp->total_out - pngp->restore_buf_size >= 2 * line
+          && (   pngp->ring_size >= pngp->inflate_buf_size
+              ||    pngp->inflate_buf + 2 * line
+                 <= pngp->inflate_base + pngp->ring_size))
+      {
+         unsigned f0 = pngp->inflate_buf[0];
+         unsigned f1 = pngp->inflate_buf[line];
+         if (   f0 == f1
+             && (f0 == PNG_FILTER_PAETH || f0 == PNG_FILTER_AVERAGE))
+         {
+            const uint8_t *raw0 = pngp->inflate_buf + 1;
+            const uint8_t *raw1 = raw0 + line;
+            uint8_t *tmp;
+            if (f0 == PNG_FILTER_PAETH)
+               rpng_filter_paeth_pair(pngp->decoded_scanline,
+                     pngp->pair_scanline, raw0, raw1,
+                     pngp->prev_scanline, pngp->pitch, pngp->bpp);
+            else
+               rpng_filter_avg_pair(pngp->decoded_scanline,
+                     pngp->pair_scanline, raw0, raw1,
+                     pngp->prev_scanline, pngp->pitch, pngp->bpp);
+            rpng_reverse_filter_convert(pngp->out_cursor, ihdr, pngp,
+                  pngp->decoded_scanline);
+            rpng_reverse_filter_convert(pngp->out_cursor + ihdr->width,
+                  ihdr, pngp, pngp->pair_scanline);
+            /* The second row's decode becomes the previous scanline;
+             * the old previous buffer takes its place as scratch. */
+            tmp                  = pngp->prev_scanline;
+            pngp->prev_scanline  = pngp->pair_scanline;
+            pngp->pair_scanline  = tmp;
+            pngp->h             += 2;
+            pngp->inflate_buf   += 2 * line;
+            pngp->restore_buf_size += 2 * line;
+            if (    pngp->ring_size < pngp->inflate_buf_size
+                &&  pngp->inflate_buf == pngp->inflate_base + pngp->ring_size)
+               pngp->inflate_buf = pngp->inflate_base;
+            pngp->out_cursor    += 2 * (size_t)ihdr->width;
+            return IMAGE_PROCESS_NEXT;
+         }
+      }
+   }
+#endif
+   if (pngp->h < ihdr->height)
    {
       unsigned filter         = *pngp->inflate_buf++;
       pngp->restore_buf_size += 1;
@@ -2907,13 +3402,15 @@ error:
    {
       /* An externally abandoned decode (cancelled task) can be torn
        * down at any machine state: the per-pass output, the scanline
-       * pair and the inflate window may all still be live here. */
+       * buffers and the inflate window may all still be live here. */
       if (rpng->process->data)
          free(rpng->process->data);
       if (rpng->process->prev_scanline)
          free(rpng->process->prev_scanline);
       if (rpng->process->decoded_scanline)
          free(rpng->process->decoded_scanline);
+      if (rpng->process->pair_scanline)
+         free(rpng->process->pair_scanline);
       if (rpng->process->inflate_base)
          free(rpng->process->inflate_base);
       if (rpng->process->stream)
@@ -2935,7 +3432,7 @@ void rpng_free(rpng_t *rpng)
    {
       /* An externally abandoned decode (cancelled task) is torn down
        * here at an arbitrary machine state: the per-pass output and
-       * the scanline pair may still be live alongside the inflate
+       * the scanline buffers may still be live alongside the inflate
        * window. */
       if (rpng->process->data)
          free(rpng->process->data);
@@ -2943,6 +3440,8 @@ void rpng_free(rpng_t *rpng)
          free(rpng->process->prev_scanline);
       if (rpng->process->decoded_scanline)
          free(rpng->process->decoded_scanline);
+      if (rpng->process->pair_scanline)
+         free(rpng->process->pair_scanline);
       if (rpng->process->inflate_base)
          free(rpng->process->inflate_base);
       if (rpng->process->stream)

--- a/libretro-common/formats/png/rpng.c
+++ b/libretro-common/formats/png/rpng.c
@@ -1207,6 +1207,93 @@ static void rpng_reverse_filter_copy_line_rgba(uint32_t *data,
    }
 }
 
+/* Greyscale expansion, vector fast paths for the byte-aligned depths.
+ * A grey sample g becomes the word (0xFF<<24)|(g<<16)|(g<<8)|g; ORing
+ * the splatted word with 0xFF000000 forces the alpha lane regardless
+ * of g.  Depth 16 keeps the high byte only, matching the scalar path
+ * (PNG stores samples big-endian, so the high byte is the even one).
+ * Sub-byte depths (1/2/4) stay on the scalar bit walker: they multiply
+ * out through mul_table and are rare enough not to matter. */
+#if defined(RPNG_SIMD_SSE2)
+static unsigned rpng_copy_line_bw8_sse2(uint32_t *data,
+      const uint8_t *decoded, unsigned width)
+{
+   unsigned i = 0;
+   const __m128i amask = _mm_set1_epi32((int)0xFF000000u);
+   for (; (int)(width - i) >= 16; i += 16)
+   {
+      __m128i g  = _mm_loadu_si128((const __m128i*)(decoded + i));
+      __m128i lo = _mm_unpacklo_epi8(g, g);  /* g0 g0 g1 g1 ..  */
+      __m128i hi = _mm_unpackhi_epi8(g, g);
+      _mm_storeu_si128((__m128i*)(data + i + 0),
+            _mm_or_si128(_mm_unpacklo_epi16(lo, lo), amask));
+      _mm_storeu_si128((__m128i*)(data + i + 4),
+            _mm_or_si128(_mm_unpackhi_epi16(lo, lo), amask));
+      _mm_storeu_si128((__m128i*)(data + i + 8),
+            _mm_or_si128(_mm_unpacklo_epi16(hi, hi), amask));
+      _mm_storeu_si128((__m128i*)(data + i + 12),
+            _mm_or_si128(_mm_unpackhi_epi16(hi, hi), amask));
+   }
+   return i;
+}
+
+static unsigned rpng_copy_line_bw16_sse2(uint32_t *data,
+      const uint8_t *decoded, unsigned width)
+{
+   unsigned i = 0;
+   const __m128i amask = _mm_set1_epi32((int)0xFF000000u);
+   const __m128i bmask = _mm_set1_epi16(0x00FF);
+   for (; (int)(width - i) >= 8; i += 8)
+   {
+      /* 8 big-endian 16-bit samples: high bytes sit in the low byte
+       * of each LE 16-bit lane. */
+      __m128i v  = _mm_loadu_si128((const __m128i*)(decoded + (size_t)i * 2));
+      __m128i g  = _mm_packus_epi16(_mm_and_si128(v, bmask), _mm_setzero_si128());
+      __m128i lo = _mm_unpacklo_epi8(g, g);
+      _mm_storeu_si128((__m128i*)(data + i + 0),
+            _mm_or_si128(_mm_unpacklo_epi16(lo, lo), amask));
+      _mm_storeu_si128((__m128i*)(data + i + 4),
+            _mm_or_si128(_mm_unpackhi_epi16(lo, lo), amask));
+   }
+   return i;
+}
+#elif defined(RPNG_SIMD_NEON)
+static unsigned rpng_copy_line_bw8_neon(uint32_t *data,
+      const uint8_t *decoded, unsigned width)
+{
+   unsigned i = 0;
+   for (; (int)(width - i) >= 8; i += 8)
+   {
+      uint8x8x4_t o;
+      uint8x8_t g = vld1_u8(decoded + i);
+      o.val[0]    = g;
+      o.val[1]    = g;
+      o.val[2]    = g;
+      o.val[3]    = vdup_n_u8(0xFF);
+      vst4_u8((uint8_t*)(data + i), o);
+   }
+   return i;
+}
+
+static unsigned rpng_copy_line_bw16_neon(uint32_t *data,
+      const uint8_t *decoded, unsigned width)
+{
+   unsigned i = 0;
+   for (; (int)(width - i) >= 8; i += 8)
+   {
+      /* De-interleave (hi,lo) byte pairs; val[0] is the high bytes. */
+      uint8x8x2_t v = vld2_u8(decoded + (size_t)i * 2);
+      uint8x8x4_t o;
+      o.val[0]      = v.val[0];
+      o.val[1]      = v.val[0];
+      o.val[2]      = v.val[0];
+      o.val[3]      = vdup_n_u8(0xFF);
+      vst4_u8((uint8_t*)(data + i), o);
+   }
+   return i;
+}
+#endif /* RPNG_SIMD_SSE2 / RPNG_SIMD_NEON */
+
 static void rpng_reverse_filter_copy_line_bw(uint32_t *data,
       const uint8_t *decoded, unsigned width, unsigned depth)
 {
@@ -1217,11 +1304,30 @@ static void rpng_reverse_filter_copy_line_bw(uint32_t *data,
 
    if (depth == 16)
    {
-      for (i = 0; i < (int)width; i++)
+      unsigned j = 0;
+#if defined(RPNG_SIMD_SSE2)
+      j = rpng_copy_line_bw16_sse2(data, decoded, width);
+#elif defined(RPNG_SIMD_NEON)
+      j = rpng_copy_line_bw16_neon(data, decoded, width);
+#endif
+      for (i = (int)j; i < (int)width; i++)
       {
          uint32_t val = decoded[i << 1];
          data[i]      = (val * 0x010101) | (0xffu << 24);
       }
+      return;
+   }
+
+   if (depth == 8)
+   {
+      unsigned j = 0;
+#if defined(RPNG_SIMD_SSE2)
+      j = rpng_copy_line_bw8_sse2(data, decoded, width);
+#elif defined(RPNG_SIMD_NEON)
+      j = rpng_copy_line_bw8_neon(data, decoded, width);
+#endif
+      for (i = (int)j; i < (int)width; i++)
+         data[i] = ((uint32_t)decoded[i] * 0x010101) | (0xffu << 24);
       return;
    }
 


### PR DESCRIPTION
## Summary

Optimization series for the PNG decoder (`libretro-common/formats/png/rpng.c`) and the clean-room DEFLATE decoder (`libretro-common/encodings/encoding_deflate.c`) used when `HAVE_ZLIB=0`. Seven commits: SIMD reverse-filter kernels, a restructured inflate fast path, and in-place unfiltering inside the inflate ring. Portable C89 throughout, SSE2/NEON only (no SSSE3+), no API or ABI changes, both `HAVE_ZLIB` configurations covered.

## Commits

1. **rpng: vectorize greyscale expansion for 8/16-bit depths** — SIMD expansion of grey/grey-alpha scanlines to ARGB.
2. **rpng: faster Sub, Up and Paeth filter kernels (SSE2/NEON)** — Sub becomes a prefix-sum shift-add tree at bpp 1/2/4; Up gets a 64-byte unroll; Paeth uses speculative sums with a single select gate, cutting the dependent chain from 11 to 9 ops.
3. **rpng: wavefront pair unfiltering for Average and Paeth rows** — when two consecutive resident scanlines carry the same chain-bound filter, both rows decode in one interleaved pass, row 1 consuming row 0's pixels straight from registers at lag one.
4. **rinflate: packed fast entries, inline copies, careful-path handback** — 32-bit packed table entries with fused code+extra consumption, inline constant-size match copies, and a fast-loop re-entry from the careful path. The re-entry fixed the dominant cost: a mid-match suspend previously demoted the *entire next* 32 KB output slice to symbol-at-a-time decoding (~96 % of symbols); slow-path calls dropped 38×.
5. **rinflate: 11-bit fast table, 16-byte copy chunks** — dynamic litlen tables for photographic/game-asset streams put most code mass at 8–11 bits; the wider table alone is worth 30 % on such assets. Copy over-run pad and the handback margin widen in lockstep (they must stay equal; a mismatch livelocks between the two paths).
6. **rpng: unfilter scanlines in place inside the inflate ring** — decoded bytes overwrite raw bytes wherever the kernel tolerates the aliasing (None becomes a no-op, Up, prefix Subs, and stride == window incl. both pair kernels); remaining filter/bpp combinations keep wide window stores and rotate through three scratch lines. Width-exact stores were implemented, validated, and rejected on measurement (per-pixel store-forwarding stalls). A consume-late `held` counter keeps the prev line's ring slot out of the recycling window; the inflate free-space formula deliberately uses the lagged count — the lag *is* the protection.
7. **rinflate: shorten the per-symbol decode chain** — packed entries carry the code+extra bit *total* so the buffer-advance shift is a direct field use, and the next litlen entry is preloaded under the match copy (sound because the refill only ORs into bits at or above the current count, so the low table-index bits are already final — a dependence the hardware cannot break on its own).

## Performance

Measured on a shared x86-64 container (absolute times noisy; within-run ratios meaningful), 9-file corpus covering RGB/RGBA 8/16-bit, greyscale, palette, and interlaced content, decode-to-ARGB, best-of-repeats:

| corpus file | rpng+rinflate | wuffs | libpng | libspng | lodepng | stb_image |
|---|---|---|---|---|---|---|
| thumb RGB 512×712 | 3.38 | 3.07 | 6.67 | 5.66 | 5.23 | 5.98 |
| grey8 1024² | **4.99** | 5.90 | — | — | — | — |
| wallpaper RGB 1080p | 20.1 | 17.4 | — | — | — | — |
| wallpaper RGBA 4K | 97.5 | 86.4 | 165 | 134 | 168 | 160 |
| RGB16 1024² | **28.7** | 36.0 | 38.6 | 40.9 | 53.4 | 41.0 |
| palette8 1024² | 3.27 | 2.47 | — | — | — | — |
| game asset RGBA 512² | 3.01 | 2.73 | — | — | — | — |
| interlaced RGBA 1024² | 12.2 | 11.0 | — | — | — | — |
| grey16 ~1M px | 9.79 | 8.69 | — | — | — | — |

(times in ms; dashes = measured earlier in the session at the same rankings, omitted for brevity)

- Faster than libpng, libspng, lodepng and stb_image on **every** corpus file.
- Outright fastest on greyscale-8 and RGB16.
- Residual deficit vs. wuffs (generated code) narrowed from ~1.7× at the session start to **1.10–1.16×** on photographic/game-asset content.
- With the system zlib swapped for zlib-ng (Fedora's default), rpng leads wuffs on every file, 1.2–1.9×.

## Correctness

Every commit was validated before landing:

- Corpus decodes pixel-identical to an independent decoder on **both** inflate backends (zlib and rinflate).
- Adversarial suite (~41 k decodes: full + 63 truncations + 400 byte-flips per file) clean under ASan/UBSan — this caught real bugs during development, including the in-place stride/window clobber and a teardown leak.
- rinflate: 121 input/output slice-size combinations (down to 1-byte slices) bit-exact against zlib under ASan/UBSan; compressor round-trip sweep on AArch64 under qemu.
- NEON kernels bit-exact across 1152 cases under qemu-aarch64, including the in-place aliasing calling convention; armv7 syntax-checked.
- MSVC C89 discipline maintained; both ISAs compile warning-free.