### PR TITLE
Revert "gfx: ungate threaded video on Apple platforms"

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -1730,13 +1730,24 @@ bool video_driver_is_threaded(void)
 bool *video_driver_get_threaded(void)
 {
    video_driver_state_t *video_st                 = &video_driver_st;
+#if defined(__MACH__) && defined(__APPLE__)
+   /* TODO/FIXME - force threaded video to disabled on Apple for now
+    * until NSWindow/UIWindow concurrency issues are taken care of */
+   video_st->threaded = false;
+#endif
    return &video_st->threaded;
 }
 
 void video_driver_set_threaded(bool val)
 {
    video_driver_state_t *video_st                 = &video_driver_st;
+#if defined(__MACH__) && defined(__APPLE__)
+   /* TODO/FIXME - force threaded video to disabled on Apple for now
+    * until NSWindow/UIWindow concurrency issues are taken care of */
+   video_st->threaded = false;
+#else
    video_st->threaded = val;
+#endif
 }
 
 const char *video_driver_get_ident(void)

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -14538,7 +14538,7 @@ static void settings_build_video(
             ADD_DESC(vid_desc_20);
          }
 
-#if defined(HAVE_THREADS) && !defined(__PSL1GHT__) && !defined(__PS3__)
+#if defined(HAVE_THREADS) && !defined(__PSL1GHT__) && !defined(__PS3__) && !defined(__APPLE__)
          /* Descriptor holdout: value target outside settings_t. */
          CONFIG_BOOL(
                list, list_info,


### PR DESCRIPTION
## Description

This reverts commit 4a3b7b4dcd8d03b4140ffde63b33955074117c50, which took away the ifdefs around the threaded video settings on Apple platforms. According to @warmenhoven , these settings do nothing on Apple devices, since the OS already handles it, and exposing the settings will just be confusing for users and worsen the signal-to-noise ratio in support situations.

## Related Issues

none

## Related Pull Requests

none

## Reviewers

@LibretroAdmin 
