### PR TITLE
scaler/pixconv: SSE2 paths for the two heaviest spill sites (1.4x, 2.0x measured)

### DIFF
--- a/libretro-common/gfx/scaler/pixconv.c
+++ b/libretro-common/gfx/scaler/pixconv.c
@@ -438,7 +438,18 @@ void conv_rgba4444_argb8888(void *output_, const void *input_,
    const uint16_t *input = (const uint16_t*)input_;
    uint32_t *output      = (uint32_t*)output_;
 
-#if defined(__MMX__)
+#if defined(__SSE2__)
+   const __m128i pix_mask_r = _mm_set1_epi16(0xf << 10);
+   const __m128i pix_mask_g = _mm_set1_epi16(0xf << 8);
+   const __m128i pix_mask_b = _mm_set1_epi16(0xf << 8);
+   const __m128i pix_mask_a = _mm_set1_epi16(0x000f);
+   const __m128i mul16_r    = _mm_set1_epi16(0x0440);
+   const __m128i mul16_g    = _mm_set1_epi16(0x1100);
+   const __m128i mul16_b    = _mm_set1_epi16(0x1100);
+   const __m128i mul_a      = _mm_set1_epi16(0x0011);
+
+   int max_width            = width - 7;
+#elif defined(__MMX__)
    const __m64 pix_mask_r = _mm_set1_pi16(0xf << 10);
    const __m64 pix_mask_g = _mm_set1_pi16(0xf << 8);
    const __m64 pix_mask_b = _mm_set1_pi16(0xf << 8);
@@ -455,7 +466,40 @@ void conv_rgba4444_argb8888(void *output_, const void *input_,
          h++, output += out_stride >> 2, input += in_stride >> 1)
    {
       int w = 0;
-#if defined(__MMX__)
+#if defined(__SSE2__)
+      for (; w < max_width; w += 8)
+      {
+         __m128i res_lo, res_hi;
+         __m128i res_lo_bg, res_hi_bg, res_lo_ra, res_hi_ra;
+         const __m128i in = _mm_loadu_si128(
+               (const __m128i*)(const void*)(input + w));
+         __m128i         r = _mm_and_si128(_mm_srli_epi16(in, 2), pix_mask_r);
+         __m128i         g = _mm_and_si128(in, pix_mask_g);
+         __m128i         b = _mm_and_si128(_mm_slli_epi16(in, 4), pix_mask_b);
+         /* Source is rgba4444 -- alpha is the low nibble of each 16-bit
+          * input word.  Expand 4-bit -> 8-bit via a*0x11 (== a<<4 | a),
+          * matching the scalar fallback. */
+         __m128i         a = _mm_and_si128(in, pix_mask_a);
+
+         r                 = _mm_mulhi_epi16(r, mul16_r);
+         g                 = _mm_mulhi_epi16(g, mul16_g);
+         b                 = _mm_mulhi_epi16(b, mul16_b);
+         a                 = _mm_mullo_epi16(a, mul_a);
+
+         res_lo_bg         = _mm_unpacklo_epi8(b, g);
+         res_hi_bg         = _mm_unpackhi_epi8(b, g);
+         res_lo_ra         = _mm_unpacklo_epi8(r, a);
+         res_hi_ra         = _mm_unpackhi_epi8(r, a);
+
+         res_lo            = _mm_or_si128(res_lo_bg,
+               _mm_slli_si128(res_lo_ra, 2));
+         res_hi            = _mm_or_si128(res_hi_bg,
+               _mm_slli_si128(res_hi_ra, 2));
+
+         _mm_storeu_si128((__m128i*)(void*)(output + w + 0), res_lo);
+         _mm_storeu_si128((__m128i*)(void*)(output + w + 4), res_hi);
+      }
+#elif defined(__MMX__)
       for (; w < max_width; w += 4)
       {
          __m64 res_lo, res_hi;

--- a/libretro-common/gfx/scaler/scaler_int.c
+++ b/libretro-common/gfx/scaler/scaler_int.c
@@ -291,20 +291,121 @@ static INLINE uint16_t clamp_10bit(int val)
    return (uint16_t)val;
 }
 
-/* The horizontal pass stays scalar deliberately.  Vectorising it needs
- * a per-pixel _mm_set_epi16 of three shifted-and-masked fields, where
- * the 8-bit path gets its four channels from one _mm_unpacklo_epi8;
- * measured, that lane assembly costs more than the multiply it feeds,
- * and 1080p -> 960x540 sinc went from 55 ms scalar to 65 ms.  The
- * vertical pass below reads the 16-bit intermediate directly, has no
- * such unpack, and is worth vectorising - the same case runs at 43 ms
- * with it. */
+/* Vectorised across taps, not across output pixels.
+ *
+ * Going across pixels needs a per-pixel _mm_set_epi16 of three
+ * shifted-and-masked fields, and that lane assembly costs more than the
+ * multiply it feeds - measured, it loses.  Going across taps needs no
+ * lane assembly at all: eight consecutive taps are eight consecutive
+ * input pixels, so the three 10-bit fields fall out of shifts and masks
+ * on packed dwords, and (r * coeff) >> 16 is exactly _mm_mulhi_epi16.
+ *
+ * The per-pixel reduction has to stay in registers.  Spilling the
+ * accumulators to a scratch array and summing them scalar-side gives
+ * back more than the vector loop wins, because sinc runs only 8 or 16
+ * taps and the reduction is then most of the work. */
 void scaler_xrgb2101010_horiz(const struct scaler_ctx *ctx,
       const void *input_, int stride)
 {
    int h, w, x;
    const uint32_t *input = (const uint32_t*)input_;
    uint64_t *output      = ctx->scaled.frame;
+
+#if defined(__SSE2__)
+   /* Sinc runs 8 or 16 taps; bilinear runs 2 and point runs 1.  The
+    * choice is made out here rather than inside the pixel loop so the
+    * short-filter path keeps exactly the code it had - a per-pixel
+    * branch on filter_len costs bilinear about 7%. */
+   if (ctx->horiz.filter_len >= 8)
+   {
+      const int filter_len = ctx->horiz.filter_len;
+      const __m128i mask10 = _mm_set1_epi32(0x3ff);
+      const __m128i ones   = _mm_set1_epi16(1);
+
+      for (h = 0; h < ctx->scaled.height; h++, input += stride >> 2,
+            output += ctx->scaled.stride >> 3)
+      {
+         const int16_t *filter_horiz = ctx->horiz.filter;
+
+         for (w = 0; w < ctx->scaled.width; w++,
+               filter_horiz += ctx->horiz.filter_stride)
+         {
+            const uint32_t *input_base_x = input + ctx->horiz.filter_pos[w];
+            __m128i acc_r = _mm_setzero_si128();
+            __m128i acc_g = _mm_setzero_si128();
+            __m128i acc_b = _mm_setzero_si128();
+            __m128i sum;
+            int16_t res_r, res_g, res_b;
+
+            for (x = 0; x + 8 <= filter_len; x += 8)
+            {
+               __m128i p0 = _mm_loadu_si128(
+                     (const __m128i*)(const void*)(input_base_x + x));
+               __m128i p1 = _mm_loadu_si128(
+                     (const __m128i*)(const void*)(input_base_x + x + 4));
+               __m128i c  = _mm_loadu_si128(
+                     (const __m128i*)(const void*)(filter_horiz + x));
+               /* every field is below 1024 << 5, so packs_epi32 never
+                * saturates and the int16 view is exact */
+               __m128i r  = _mm_packs_epi32(
+                     _mm_slli_epi32(_mm_and_si128(
+                           _mm_srli_epi32(p0, 20), mask10), 5),
+                     _mm_slli_epi32(_mm_and_si128(
+                           _mm_srli_epi32(p1, 20), mask10), 5));
+               __m128i g  = _mm_packs_epi32(
+                     _mm_slli_epi32(_mm_and_si128(
+                           _mm_srli_epi32(p0, 10), mask10), 5),
+                     _mm_slli_epi32(_mm_and_si128(
+                           _mm_srli_epi32(p1, 10), mask10), 5));
+               __m128i b  = _mm_packs_epi32(
+                     _mm_slli_epi32(_mm_and_si128(p0, mask10), 5),
+                     _mm_slli_epi32(_mm_and_si128(p1, mask10), 5));
+
+               /* mulhi_epi16 is exactly (a * b) >> 16 for signed 16-bit */
+               acc_r = _mm_add_epi16(acc_r, _mm_mulhi_epi16(r, c));
+               acc_g = _mm_add_epi16(acc_g, _mm_mulhi_epi16(g, c));
+               acc_b = _mm_add_epi16(acc_b, _mm_mulhi_epi16(b, c));
+            }
+
+            /* summing the lanes in 32-bit and truncating leaves the same
+             * low 16 bits as the scalar accumulator's wrapping adds */
+            sum   = _mm_madd_epi16(acc_r, ones);
+            sum   = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4e));
+            sum   = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xb1));
+            res_r = (int16_t)_mm_cvtsi128_si32(sum);
+
+            sum   = _mm_madd_epi16(acc_g, ones);
+            sum   = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4e));
+            sum   = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xb1));
+            res_g = (int16_t)_mm_cvtsi128_si32(sum);
+
+            sum   = _mm_madd_epi16(acc_b, ones);
+            sum   = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0x4e));
+            sum   = _mm_add_epi32(sum, _mm_shuffle_epi32(sum, 0xb1));
+            res_b = (int16_t)_mm_cvtsi128_si32(sum);
+
+            for (; x < filter_len; x++)
+            {
+               uint32_t col   = input_base_x[x];
+               int16_t r      = (int16_t)(((col >> 20) & 0x3ff) << 5);
+               int16_t g      = (int16_t)(((col >> 10) & 0x3ff) << 5);
+               int16_t b      = (int16_t)(( col        & 0x3ff) << 5);
+               int16_t coeff  = filter_horiz[x];
+               res_r         += (r * coeff) >> 16;
+               res_g         += (g * coeff) >> 16;
+               res_b         += (b * coeff) >> 16;
+            }
+
+            output[w]         = (
+                  (uint64_t)0     << 48)  |
+                  ((uint64_t)(uint16_t)res_r << 32)  |
+                  ((uint64_t)(uint16_t)res_g << 16)  |
+                  ((uint64_t)(uint16_t)res_b << 0);
+         }
+      }
+      return;
+   }
+#endif
 
    for (h = 0; h < ctx->scaled.height; h++, input += stride >> 2,
          output += ctx->scaled.stride >> 3)


### PR DESCRIPTION
Split from #19284. The two heaviest register-spill sites in the scaler and converter, measured by block-frequency-weighted reload cost, given the SSE2 paths every neighbouring kernel already has.

- **scaler**: `scaler_xrgb2101010_horiz` vectorised across taps rather than output pixels — the direction the old "tried it, lost" comment did not cover. 1.38–1.41× measured across resolutions, byte-identical to scalar over 36 cases spanning taps, widths and both scaling directions. Thumbnail/wallpaper scaling on a task thread, not the frame path.
- **pixconv**: `conv_rgba4444_argb8888` was the last converter still shipping MMX as its best path on x86-64. Direct SSE2 widening, MMX kept for pre-SSE2 x86, scalar tail untouched. 1.99× measured; byte-identical against both the MMX and scalar builds including an exhaustive pass over all 65536 source values.

Both build clean under gcc x86-64 (with and without SIMD), mingw-w64, aarch64 and armhf at `-std=c89 -pedantic`.