### PR TITLE
Video filters: OOB reads/writes, undefined shifts, and the 2xSaI family running horizontal-only

### DIFF
--- a/gfx/video_filters/2xsai.c
+++ b/gfx/video_filters/2xsai.c
@@ -115,23 +115,27 @@ static void twoxsai_generic_destroy(void *data)
 
 #define twoxsai_result(A, B, C, D) (((A) != (C) || (A) != (D)) - ((B) != (C) || (B) != (D)));
 
-#define twoxsai_declare_variables(typename_t, in, nextline) \
+/* prevline/nextline/nextline2 are row offsets already clamped against
+ * the top and bottom of the frame, and xm1/xp1/xp2 are column offsets
+ * clamped against its left and right edge, so the 4x4 neighbourhood
+ * never reaches outside the source. */
+#define twoxsai_declare_variables(typename_t, in, prevline, nextline, nextline2, xm1, xp1, xp2) \
          typename_t product, product1, product2; \
-         typename_t colorI = *(in - nextline - 1); \
-         typename_t colorE = *(in - nextline + 0); \
-         typename_t colorF = *(in - nextline + 1); \
-         typename_t colorJ = *(in - nextline + 2); \
-         typename_t colorG = *(in - 1); \
-         typename_t colorA = *(in + 0); \
-         typename_t colorB = *(in + 1); \
-         typename_t colorK = *(in + 2); \
-         typename_t colorH = *(in + nextline - 1); \
-         typename_t colorC = *(in + nextline + 0); \
-         typename_t colorD = *(in + nextline + 1); \
-         typename_t colorL = *(in + nextline + 2); \
-         typename_t colorM = *(in + nextline + nextline - 1); \
-         typename_t colorN = *(in + nextline + nextline + 0); \
-         typename_t colorO = *(in + nextline + nextline + 1);
+         typename_t colorI = *(in - prevline + xm1); \
+         typename_t colorE = *(in - prevline); \
+         typename_t colorF = *(in - prevline + xp1); \
+         typename_t colorJ = *(in - prevline + xp2); \
+         typename_t colorG = *(in + xm1); \
+         typename_t colorA = *(in); \
+         typename_t colorB = *(in + xp1); \
+         typename_t colorK = *(in + xp2); \
+         typename_t colorH = *(in + nextline + xm1); \
+         typename_t colorC = *(in + nextline); \
+         typename_t colorD = *(in + nextline + xp1); \
+         typename_t colorL = *(in + nextline + xp2); \
+         typename_t colorM = *(in + nextline2 + xm1); \
+         typename_t colorN = *(in + nextline2); \
+         typename_t colorO = *(in + nextline2 + xp1);
 
 #ifndef twoxsai_function
 #define twoxsai_function(result_cb, interpolate_cb, interpolate2_cb) \
@@ -212,16 +216,29 @@ static void twoxsai_generic_xrgb8888(unsigned width, unsigned height,
       unsigned src_stride, uint32_t *dst, unsigned dst_stride)
 {
    unsigned finish;
-   unsigned nextline = (last) ? 0 : src_stride;
+   unsigned row = 0;
 
-   for (; height; height--)
+   for (; height; height--, row++)
    {
-      uint32_t *in  = (uint32_t*)src;
-      uint32_t *out = (uint32_t*)dst;
+      uint32_t *in            = (uint32_t*)src;
+      uint32_t *out           = (uint32_t*)dst;
+      /* Rows above are only unavailable on the frame's very first row;
+       * a worker that does not start at the top can always read back
+       * into the preceding slice. */
+      unsigned prevline   = (first == 0 && row == 0) ? 0 : src_stride;
+      unsigned nextline   = (last && height <= 1) ? 0 : src_stride;
+      unsigned nextline2  = (last && height <= 2) ? nextline : 2 * src_stride;
 
       for (finish = width; finish; finish -= 1)
       {
-         twoxsai_declare_variables(uint32_t, in, nextline);
+         /* finish counts down from width, so it doubles as the distance
+          * to the right edge. */
+         int xm1 = (finish < width) ? -1 : 0;
+         int xp1 = (finish > 1) ? 1 : 0;
+         int xp2 = (finish > 2) ? 2 : (int)finish - 1;
+
+         twoxsai_declare_variables(uint32_t, in, prevline, nextline, nextline2,
+               xm1, xp1, xp2);
 
          /*
           * Map of the pixels:           I|E F|J
@@ -244,16 +261,29 @@ static void twoxsai_generic_rgb565(unsigned width, unsigned height,
       unsigned src_stride, uint16_t *dst, unsigned dst_stride)
 {
    unsigned finish;
-   unsigned nextline = (last) ? 0 : src_stride;
+   unsigned row = 0;
 
-   for (; height; height--)
+   for (; height; height--, row++)
    {
-      uint16_t *in  = (uint16_t*)src;
-      uint16_t *out = (uint16_t*)dst;
+      uint16_t *in            = (uint16_t*)src;
+      uint16_t *out           = (uint16_t*)dst;
+      /* Rows above are only unavailable on the frame's very first row;
+       * a worker that does not start at the top can always read back
+       * into the preceding slice. */
+      unsigned prevline   = (first == 0 && row == 0) ? 0 : src_stride;
+      unsigned nextline   = (last && height <= 1) ? 0 : src_stride;
+      unsigned nextline2  = (last && height <= 2) ? nextline : 2 * src_stride;
 
       for (finish = width; finish; finish -= 1)
       {
-         twoxsai_declare_variables(uint16_t, in, nextline);
+         /* finish counts down from width, so it doubles as the distance
+          * to the right edge. */
+         int xm1 = (finish < width) ? -1 : 0;
+         int xp1 = (finish > 1) ? 1 : 0;
+         int xp2 = (finish > 2) ? 2 : (int)finish - 1;
+
+         twoxsai_declare_variables(uint16_t, in, prevline, nextline, nextline2,
+               xm1, xp1, xp2);
 
          /*
           * Map of the pixels:           I|E F|J

--- a/gfx/video_filters/epx.c
+++ b/gfx/video_filters/epx.c
@@ -107,7 +107,7 @@ static void epx_generic_rgb565 (unsigned width, unsigned height,
       int first, int lsat, uint16_t *src,
       unsigned src_stride, uint16_t *dst, unsigned dst_stride)
 {
-   uint16_t colorA;
+   uint32_t colorA;
    int w;
 
    for (; height; height--)
@@ -119,10 +119,10 @@ static void epx_generic_rgb565 (unsigned width, unsigned height,
       uint32_t *dP2   = (uint32_t *) (dst + dst_stride);
 
       /* left edge */
-      uint16_t colorX = *sP;
-      uint16_t colorC = *++sP;
-      uint16_t colorB = *lP++;
-      uint16_t colorD = *uP++;
+      uint32_t colorX = *sP;
+      uint32_t colorC = *++sP;
+      uint32_t colorB = *lP++;
+      uint32_t colorD = *uP++;
 
       if ((colorX != colorC) && (colorB != colorD))
       {

--- a/gfx/video_filters/epx.c
+++ b/gfx/video_filters/epx.c
@@ -109,12 +109,39 @@ static void epx_generic_rgb565 (unsigned width, unsigned height,
 {
    uint32_t colorA;
    int w;
+   unsigned row = 0;
 
-   for (; height; height--)
+   /* The peeled left and right edges below assume there is a pixel on
+    * either side of the run between them. */
+   if (width < 2)
    {
+      for (; height; height--)
+      {
+         unsigned x;
+         uint32_t *dP1 = (uint32_t *) dst;
+         uint32_t *dP2 = (uint32_t *) (dst + dst_stride);
+         for (x = 0; x < width; x++)
+         {
+            uint32_t colorX = src[x];
+            dP1[x] = dP2[x] = (colorX << 16) + colorX;
+         }
+         src += src_stride;
+         dst += dst_stride << 1;
+      }
+      return;
+   }
+
+   for (; height; height--, row++)
+   {
+      /* uP and lP are the rows either side.  Outside the frame they are
+       * clamped onto this row; first counts from the top of the frame,
+       * not of this worker's slice, so a worker that does not start at
+       * the top can still read back into the preceding rows. */
+      unsigned prevline = (first + row >= 1) ? src_stride : 0;
+      unsigned nextline = (lsat && height <= 1) ? 0 : src_stride;
       uint16_t *sP    = (uint16_t *) src;
-      uint16_t *uP    = (uint16_t *) (src - src_stride);
-      uint16_t *lP    = (uint16_t *) (src + src_stride);
+      uint16_t *uP    = (uint16_t *) (src - prevline);
+      uint16_t *lP    = (uint16_t *) (src + nextline);
       uint32_t *dP1   = (uint32_t *) dst;
       uint32_t *dP2   = (uint32_t *) (dst + dst_stride);
 

--- a/gfx/video_filters/ntsc.c
+++ b/gfx/video_filters/ntsc.c
@@ -21,6 +21,14 @@
 
 typedef struct { int Y, I, Q; } yiq_t;
 
+/* Scratch for one worker: four line buffers plus the YIQ cache.  Held
+ * per thread rather than on the stack - as locals these came to 45264
+ * bytes of frame in the work callback, against the 64 KB thread stack
+ * rthreads asks for on Vita. */
+#define NTSC_SCRATCH_INTS  (4 * NTSC_MAX_WIDTH * 2)
+#define NTSC_SCRATCH_BYTES (NTSC_SCRATCH_INTS * sizeof(int) \
+      + NTSC_MAX_WIDTH * sizeof(yiq_t))
+
 struct softfilter_thread_data {
    void       *out_data;
    const void *in_data;
@@ -29,6 +37,12 @@ struct softfilter_thread_data {
    unsigned    width;
    unsigned    height;
    int         first;
+   void       *scratch;
+   int        *cbuf;
+   int        *lineI;
+   int        *lineQ;
+   int        *lineY;
+   yiq_t      *yiq_cache;
 };
 
 struct filter_data {
@@ -134,14 +148,15 @@ static void ntsc_process_line(const struct filter_data *filt,
    }
 }
 
+static void ntsc_destroy(void *data);
+
 static void ntsc_work_cb(void *data, void *thread_data) {
    struct filter_data *filt = (struct filter_data*)data;
    struct softfilter_thread_data *thr = (struct softfilter_thread_data*)thread_data;
-   int cbuf[NTSC_MAX_WIDTH * 2], lineI[NTSC_MAX_WIDTH * 2], lineQ[NTSC_MAX_WIDTH * 2], lineY[NTSC_MAX_WIDTH * 2];
-   yiq_t yiq_cache[NTSC_MAX_WIDTH];
    for (unsigned y = 0; y < thr->height; y++) {
       void *dst = (uint8_t*)thr->out_data + (y * thr->out_pitch);
-      ntsc_process_line(filt, thr, y, cbuf, lineI, lineQ, lineY, yiq_cache, dst);
+      ntsc_process_line(filt, thr, y, thr->cbuf, thr->lineI, thr->lineQ,
+            thr->lineY, thr->yiq_cache, dst);
    }
 }
 
@@ -183,6 +198,24 @@ static void *ntsc_create(const struct softfilter_config *config,
    }
    filt->threads = threads;
    filt->workers = (struct softfilter_thread_data*)calloc(threads, sizeof(struct softfilter_thread_data));
+   if (!filt->workers) {
+      free(filt);
+      return NULL;
+   }
+   for (unsigned i = 0; i < threads; i++) {
+      struct softfilter_thread_data *thr = &filt->workers[i];
+      /* one block per worker, so the four line buffers and the YIQ
+       * cache stay adjacent rather than landing in five allocations */
+      if (!(thr->scratch = calloc(1, NTSC_SCRATCH_BYTES))) {
+         ntsc_destroy(filt);
+         return NULL;
+      }
+      thr->cbuf      = (int*)thr->scratch;
+      thr->lineI     = thr->cbuf  + NTSC_MAX_WIDTH * 2;
+      thr->lineQ     = thr->lineI + NTSC_MAX_WIDTH * 2;
+      thr->lineY     = thr->lineQ + NTSC_MAX_WIDTH * 2;
+      thr->yiq_cache = (yiq_t*)(void*)(thr->lineY + NTSC_MAX_WIDTH * 2);
+   }
    return filt;
 }
 
@@ -197,16 +230,24 @@ static void ntsc_packets(void *data, struct softfilter_work_packet *packets,
       thr->in_data = (const uint8_t*)input + y_start * input_stride;
       thr->out_data = (uint8_t*)output + y_start * output_stride;
       thr->in_pitch = input_stride; thr->out_pitch = output_stride;
-      thr->width = width; thr->height = y_end - y_start;
+      thr->width = (width > NTSC_MAX_WIDTH) ? NTSC_MAX_WIDTH : width;
+      thr->height = y_end - y_start;
       thr->first = (int)y_start;
       packets[i].work = ntsc_work_cb;
       packets[i].thread_data = thr;
    }
 }
 
-static void ntsc_destroy(void *data) { 
-   struct filter_data *f = (struct filter_data*)data; 
-   if (f) { free(f->workers); free(f); }
+static void ntsc_destroy(void *data) {
+   struct filter_data *f = (struct filter_data*)data;
+   if (!f)
+      return;
+   if (f->workers) {
+      for (unsigned i = 0; i < f->threads; i++)
+         free(f->workers[i].scratch);
+      free(f->workers);
+   }
+   free(f);
 }
 
 static void ntsc_output(void *data, unsigned *ow, unsigned *oh, unsigned w, unsigned h) { *ow = w*2; *oh = h; }

--- a/gfx/video_filters/ntsc.c
+++ b/gfx/video_filters/ntsc.c
@@ -120,8 +120,8 @@ static void ntsc_process_line(const struct filter_data *filt,
       
       // Notch filter optimized for system-specific bandwidth
       int notchedY = (filt->c64_mode) ? 
-         (cbuf[i_m1] + (cbuf[x] << 1) + cbuf[i_p1]) >> 2 :
-         (cbuf[i_m2] + (cbuf[i_m1] << 2) + (cbuf[x] * 6) + (cbuf[i_p1] << 2) + cbuf[i_p2]) >> 4;
+         (cbuf[i_m1] + (cbuf[x] * 2) + cbuf[i_p1]) >> 2 :
+         (cbuf[i_m2] + (cbuf[i_m1] * 4) + (cbuf[x] * 6) + (cbuf[i_p1] * 4) + cbuf[i_p2]) >> 4;
 
       lineY[x] = ((notchedY * (256 - filt->artifacts)) + (cbuf[x] * filt->artifacts)) >> 8;
    }

--- a/gfx/video_filters/super2xsai.c
+++ b/gfx/video_filters/super2xsai.c
@@ -114,24 +114,28 @@ static void supertwoxsai_generic_destroy(void *data)
 #define supertwoxsai_result(A, B, C, D) (((A) != (C) || (A) != (D)) - ((B) != (C) || (B) != (D)))
 
 #ifndef supertwoxsai_declare_variables
-#define supertwoxsai_declare_variables(typename_t, in, nextline) \
+/* prevline/nextline/nextline2 are row offsets already clamped against
+ * the top and bottom of the frame, and xm1/xp1/xp2 are column offsets
+ * clamped against its left and right edge, so the sampled
+ * neighbourhood never reaches outside the source. */
+#define supertwoxsai_declare_variables(typename_t, in, prevline, nextline, nextline2, xm1, xp1, xp2) \
          typename_t product1a, product1b, product2a, product2b; \
-         const typename_t colorB0 = *(in - nextline - 1); \
-         const typename_t colorB1 = *(in - nextline + 0); \
-         const typename_t colorB2 = *(in - nextline + 1); \
-         const typename_t colorB3 = *(in - nextline + 2); \
-         const typename_t color4  = *(in - 1); \
-         const typename_t color5  = *(in + 0); \
-         const typename_t color6  = *(in + 1); \
-         const typename_t colorS2 = *(in + 2); \
-         const typename_t color1  = *(in + nextline - 1); \
-         const typename_t color2  = *(in + nextline + 0); \
-         const typename_t color3  = *(in + nextline + 1); \
-         const typename_t colorS1 = *(in + nextline + 2); \
-         const typename_t colorA0 = *(in + nextline + nextline - 1); \
-         const typename_t colorA1 = *(in + nextline + nextline + 0); \
-         const typename_t colorA2 = *(in + nextline + nextline + 1); \
-         const typename_t colorA3 = *(in + nextline + nextline + 2)
+         const typename_t colorB0 = *(in - prevline + xm1); \
+         const typename_t colorB1 = *(in - prevline); \
+         const typename_t colorB2 = *(in - prevline + xp1); \
+         const typename_t colorB3 = *(in - prevline + xp2); \
+         const typename_t color4  = *(in + xm1); \
+         const typename_t color5  = *(in); \
+         const typename_t color6  = *(in + xp1); \
+         const typename_t colorS2 = *(in + xp2); \
+         const typename_t color1  = *(in + nextline + xm1); \
+         const typename_t color2  = *(in + nextline); \
+         const typename_t color3  = *(in + nextline + xp1); \
+         const typename_t colorS1 = *(in + nextline + xp2); \
+         const typename_t colorA0 = *(in + nextline2 + xm1); \
+         const typename_t colorA1 = *(in + nextline2); \
+         const typename_t colorA2 = *(in + nextline2 + xp1); \
+         const typename_t colorA3 = *(in + nextline2 + xp2)
 #endif
 
 #ifndef supertwoxsai_function
@@ -202,16 +206,29 @@ static void supertwoxsai_generic_xrgb8888(unsigned width, unsigned height,
       unsigned src_stride, uint32_t *dst, unsigned dst_stride)
 {
    unsigned finish;
-   unsigned nextline = (last) ? 0 : src_stride;
+   unsigned row = 0;
 
-   for (; height; height--)
+   for (; height; height--, row++)
    {
-      uint32_t *in  = (uint32_t*)src;
-      uint32_t *out = (uint32_t*)dst;
+      uint32_t *in             = (uint32_t*)src;
+      uint32_t *out            = (uint32_t*)dst;
+      /* Rows above are only unavailable on the frame's very first row;
+       * a worker that does not start at the top can always read back
+       * into the preceding slice. */
+      unsigned prevline  = (first == 0 && row == 0) ? 0 : src_stride;
+      unsigned nextline  = (last && height <= 1) ? 0 : src_stride;
+      unsigned nextline2 = (last && height <= 2) ? nextline : 2 * src_stride;
 
       for (finish = width; finish; finish -= 1)
       {
-         supertwoxsai_declare_variables(uint32_t, in, nextline);
+         /* finish counts down from width, so it doubles as the distance
+          * to the right edge. */
+         int xm1 = (finish < width) ? -1 : 0;
+         int xp1 = (finish > 1) ? 1 : 0;
+         int xp2 = (finish > 2) ? 2 : (int)finish - 1;
+
+         supertwoxsai_declare_variables(uint32_t, in, prevline, nextline, nextline2,
+               xm1, xp1, xp2);
 
          /*---------------------------    B1 B2
           *                             4  5  6 S2
@@ -233,16 +250,29 @@ static void supertwoxsai_generic_rgb565(unsigned width, unsigned height,
       unsigned src_stride, uint16_t *dst, unsigned dst_stride)
 {
    unsigned finish;
-   unsigned nextline = (last) ? 0 : src_stride;
+   unsigned row = 0;
 
-   for (; height; height--)
+   for (; height; height--, row++)
    {
-      uint16_t *in  = (uint16_t*)src;
-      uint16_t *out = (uint16_t*)dst;
+      uint16_t *in             = (uint16_t*)src;
+      uint16_t *out            = (uint16_t*)dst;
+      /* Rows above are only unavailable on the frame's very first row;
+       * a worker that does not start at the top can always read back
+       * into the preceding slice. */
+      unsigned prevline  = (first == 0 && row == 0) ? 0 : src_stride;
+      unsigned nextline  = (last && height <= 1) ? 0 : src_stride;
+      unsigned nextline2 = (last && height <= 2) ? nextline : 2 * src_stride;
 
       for (finish = width; finish; finish -= 1)
       {
-         supertwoxsai_declare_variables(uint16_t, in, nextline);
+         /* finish counts down from width, so it doubles as the distance
+          * to the right edge. */
+         int xm1 = (finish < width) ? -1 : 0;
+         int xp1 = (finish > 1) ? 1 : 0;
+         int xp2 = (finish > 2) ? 2 : (int)finish - 1;
+
+         supertwoxsai_declare_variables(uint16_t, in, prevline, nextline, nextline2,
+               xm1, xp1, xp2);
 
          /*---------------------------    B1 B2
           *                             4  5  6 S2

--- a/gfx/video_filters/supereagle.c
+++ b/gfx/video_filters/supereagle.c
@@ -109,20 +109,24 @@ static void supereagle_generic_destroy(void *data)
 
 #define supereagle_result(A, B, C, D) (((A) != (C) || (A) != (D)) - ((B) != (C) || (B) != (D)));
 
-#define supereagle_declare_variables(typename_t, in, nextline) \
+/* prevline/nextline/nextline2 are row offsets already clamped against
+ * the top and bottom of the frame, and xm1/xp1/xp2 are column offsets
+ * clamped against its left and right edge, so the sampled
+ * neighbourhood never reaches outside the source. */
+#define supereagle_declare_variables(typename_t, in, prevline, nextline, nextline2, xm1, xp1, xp2) \
          typename_t product1a, product1b, product2a, product2b; \
-         const typename_t colorB1 = *(in - nextline + 0); \
-         const typename_t colorB2 = *(in - nextline + 1); \
-         const typename_t color4  = *(in - 1); \
-         const typename_t color5  = *(in + 0); \
-         const typename_t color6  = *(in + 1); \
-         const typename_t colorS2 = *(in + 2); \
-         const typename_t color1  = *(in + nextline - 1); \
-         const typename_t color2  = *(in + nextline + 0); \
-         const typename_t color3  = *(in + nextline + 1); \
-         const typename_t colorS1 = *(in + nextline + 2); \
-         const typename_t colorA1 = *(in + nextline + nextline + 0); \
-         const typename_t colorA2 = *(in + nextline + nextline + 1)
+         const typename_t colorB1 = *(in - prevline); \
+         const typename_t colorB2 = *(in - prevline + xp1); \
+         const typename_t color4  = *(in + xm1); \
+         const typename_t color5  = *(in); \
+         const typename_t color6  = *(in + xp1); \
+         const typename_t colorS2 = *(in + xp2); \
+         const typename_t color1  = *(in + nextline + xm1); \
+         const typename_t color2  = *(in + nextline); \
+         const typename_t color3  = *(in + nextline + xp1); \
+         const typename_t colorS1 = *(in + nextline + xp2); \
+         const typename_t colorA1 = *(in + nextline2); \
+         const typename_t colorA2 = *(in + nextline2 + xp1)
 
 #ifndef supereagle_function
 #define supereagle_function(result_cb, interpolate_cb, interpolate2_cb) \
@@ -215,16 +219,29 @@ static void supereagle_generic_xrgb8888(unsigned width, unsigned height,
       unsigned src_stride, uint32_t *dst, unsigned dst_stride)
 {
    unsigned finish;
-   unsigned nextline = (last) ? 0 : src_stride;
+   unsigned row = 0;
 
-   for (; height; height--)
+   for (; height; height--, row++)
    {
-      uint32_t *in  = (uint32_t*)src;
-      uint32_t *out = (uint32_t*)dst;
+      uint32_t *in             = (uint32_t*)src;
+      uint32_t *out            = (uint32_t*)dst;
+      /* Rows above are only unavailable on the frame's very first row;
+       * a worker that does not start at the top can always read back
+       * into the preceding slice. */
+      unsigned prevline  = (first == 0 && row == 0) ? 0 : src_stride;
+      unsigned nextline  = (last && height <= 1) ? 0 : src_stride;
+      unsigned nextline2 = (last && height <= 2) ? nextline : 2 * src_stride;
 
       for (finish = width; finish; finish -= 1)
       {
-         supereagle_declare_variables(uint32_t, in, nextline);
+         /* finish counts down from width, so it doubles as the distance
+          * to the right edge. */
+         int xm1 = (finish < width) ? -1 : 0;
+         int xp1 = (finish > 1) ? 1 : 0;
+         int xp2 = (finish > 2) ? 2 : (int)finish - 1;
+
+         supereagle_declare_variables(uint32_t, in, prevline, nextline, nextline2,
+               xm1, xp1, xp2);
          supereagle_function(supereagle_result, supereagle_interpolate_xrgb8888, supereagle_interpolate2_xrgb8888);
       }
 
@@ -238,16 +255,29 @@ static void supereagle_generic_rgb565(unsigned width, unsigned height,
       unsigned src_stride, uint16_t *dst, unsigned dst_stride)
 {
    unsigned finish;
-   unsigned nextline = (last) ? 0 : src_stride;
+   unsigned row = 0;
 
-   for (; height; height--)
+   for (; height; height--, row++)
    {
-      uint16_t *in  = (uint16_t*)src;
-      uint16_t *out = (uint16_t*)dst;
+      uint16_t *in             = (uint16_t*)src;
+      uint16_t *out            = (uint16_t*)dst;
+      /* Rows above are only unavailable on the frame's very first row;
+       * a worker that does not start at the top can always read back
+       * into the preceding slice. */
+      unsigned prevline  = (first == 0 && row == 0) ? 0 : src_stride;
+      unsigned nextline  = (last && height <= 1) ? 0 : src_stride;
+      unsigned nextline2 = (last && height <= 2) ? nextline : 2 * src_stride;
 
       for (finish = width; finish; finish -= 1)
       {
-         supereagle_declare_variables(uint16_t, in, nextline);
+         /* finish counts down from width, so it doubles as the distance
+          * to the right edge. */
+         int xm1 = (finish < width) ? -1 : 0;
+         int xp1 = (finish > 1) ? 1 : 0;
+         int xp2 = (finish > 2) ? 2 : (int)finish - 1;
+
+         supereagle_declare_variables(uint16_t, in, prevline, nextline, nextline2,
+               xm1, xp1, xp2);
          supereagle_function(supereagle_result, supereagle_interpolate_rgb565, supereagle_interpolate2_rgb565);
       }
 


### PR DESCRIPTION
Split from #19284. Every filter in `gfx/video_filters` was driven through the real softfilter entry points under the sanitizers; these are the findings.

- **ntsc**: out-of-bounds write for any core wider than `NTSC_MAX_WIDTH` (buffers sized for 1024, width unbounded — reproduced under ASan at 1200); 45 KB of scratch moved off the thread stack, which was 69% of a Vita-sized 64 KB thread stack before the line function was even entered. Frame drops 45264 → 56 bytes.
- **2xsai / super2xsai / supereagle**: the whole family forces one thread, so `nextline = last ? 0 : src_stride` was 0 for every row of every frame — the vertical half of the sampling neighbourhood collapsed onto the current row and all three filters have been running horizontal-only. Also unclamped horizontal edges reading `in[-1]` and `in[+2]` straight out of the core's unpadded framebuffer on every frame. Output necessarily changes: the filters were not computing what they were supposed to. Demonstrated on alternating one-pixel bands (0 → 7875/15625 interior pixels differing from plain doubling).
- **epx**: same vertical clamp problem plus a `width - 2` loop that turns width 1 into a near-infinite loop; edge rows previously composed against whatever followed the framebuffer. 58 of 60 sweep cases byte-identical (the two that differ are the previously-OOB edge rows). Cost free within noise.
- **undefined shifts** in epx (`uint16_t << 16` promoting into the sign bit, eight sites, trips on ordinary content) and ntsc (signed chroma shifted left); byte-identical output verified via dlopen'd before/after builds through the real softfilter API.

All clean under ASan, LSan, UBSan and TSan across geometry sweeps from 1x1 to 1200x240, both pixel formats, 1/2/4 threads. Costs measured and stated per commit. 2xbr has the same two defects and is deliberately not included — its distance function needs separate treatment.