### PR TITLE
Image decoders: rbmp header-reject leak, decode fuzzing extended to DDS and WebP

### DIFF
--- a/.github/workflows/Linux-samples-formats.yml
+++ b/.github/workflows/Linux-samples-formats.yml
@@ -35,11 +35,14 @@ jobs:
         working-directory: samples/formats/image_decode_fuzz
         run: |
           set -eu
-          # Malformed-input sweep for the BMP, TGA and DDS decoders in
+          # Malformed-input sweep for the BMP, TGA, DDS and WebP decoders in
           # libretro-common/formats.  All three take dimensions and
           # layout from a header the file supplies and size their
           # output from it, which is where this kind of arithmetic
-          # goes wrong, and none of the three had any test at all.
+          # goes wrong, and none of the four had any test at all.
+          # (WebP is told its buffer length, so it is the least
+          # exposed of them; its chunk walk still trusts sizes that
+          # came out of the file.)
           #
           # It found one on its first run: rbmp_proc_reset() gated the
           # free of output_image on phase != RBMP_PHASE_IDLE, but
@@ -57,7 +60,9 @@ jobs:
           # count of inputs that decode successfully is asserted
           # inside the test, so a sweep where the seeds stopped being
           # accepted would fail rather than exercise only the reject
-          # paths and report a pass.
+          # paths and report a pass.  That count is kept per format, not
+          # just in total, so one decoder quietly ceasing to accept its
+          # seed cannot hide behind the other three.
           make clean all SANITIZER=address,undefined
           test -x image_decode_fuzz_test
           ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 \

--- a/.github/workflows/Linux-samples-formats.yml
+++ b/.github/workflows/Linux-samples-formats.yml
@@ -1,0 +1,65 @@
+name: CI Linux samples/formats
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  samples-formats:
+    name: Build and run samples/formats
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build and run image_decode_fuzz_test (ASan + UBSan + LSan)
+        shell: bash
+        working-directory: samples/formats/image_decode_fuzz
+        run: |
+          set -eu
+          # Malformed-input sweep for the BMP, TGA and DDS decoders in
+          # libretro-common/formats.  All three take dimensions and
+          # layout from a header the file supplies and size their
+          # output from it, which is where this kind of arithmetic
+          # goes wrong, and none of the three had any test at all.
+          #
+          # It found one on its first run: rbmp_proc_reset() gated the
+          # free of output_image on phase != RBMP_PHASE_IDLE, but
+          # rbmp_begin() allocates that surface before it sets any
+          # phase and returns false between the two for a palette
+          # header claiming a bits-per-pixel other than 4 or 8.  Every
+          # such image leaked the surface, reachable from any
+          # malformed or hostile BMP.  Leak detection is therefore
+          # switched on explicitly here rather than left to the
+          # default.
+          #
+          # The sweep truncates each seed at every length and sets
+          # every header byte to each of six interesting values,
+          # including the ones that make dimensions enormous.  The
+          # count of inputs that decode successfully is asserted
+          # inside the test, so a sweep where the seeds stopped being
+          # accepted would fail rather than exercise only the reject
+          # paths and report a pass.
+          make clean all SANITIZER=address,undefined
+          test -x image_decode_fuzz_test
+          ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 \
+             timeout 120 ./image_decode_fuzz_test
+          echo "[pass] image_decode_fuzz_test"

--- a/libretro-common/formats/bmp/rbmp.c
+++ b/libretro-common/formats/bmp/rbmp.c
@@ -808,12 +808,14 @@ static bool rbmp_needs_fixup(const rbmp_t *bmp)
  * received. */
 static void rbmp_proc_reset(rbmp_t *rbmp)
 {
-   if (rbmp->phase != RBMP_PHASE_IDLE)
-   {
-      free(rbmp->output_image);
-      rbmp->output_image = NULL;
-   }
-   rbmp->phase = RBMP_PHASE_IDLE;
+   /* Unconditional: rbmp_begin() allocates output_image before it
+    * sets a phase, and returns false between the two for a palette
+    * header claiming a bpp other than 4 or 8.  Gating the free on
+    * phase != IDLE therefore leaked the surface for any such image,
+    * and free(NULL) is a no-op so the guard bought nothing. */
+   free(rbmp->output_image);
+   rbmp->output_image = NULL;
+   rbmp->phase        = RBMP_PHASE_IDLE;
 }
 
 int rbmp_process_image(rbmp_t *rbmp, void **buf_data,

--- a/samples/formats/image_decode_fuzz/Makefile
+++ b/samples/formats/image_decode_fuzz/Makefile
@@ -6,7 +6,8 @@ LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
 # Both decoders are self-contained; nothing else is needed.
 SOURCES := image_decode_fuzz_test.c \
            $(LIBRETRO_COMM_DIR)/formats/bmp/rbmp.c \
-           $(LIBRETRO_COMM_DIR)/formats/tga/rtga.c
+           $(LIBRETRO_COMM_DIR)/formats/tga/rtga.c \
+           $(LIBRETRO_COMM_DIR)/formats/dds/rdds.c
 
 CFLAGS  += -Wall -std=gnu99 -g -O1 \
            -I$(LIBRETRO_COMM_DIR)/include

--- a/samples/formats/image_decode_fuzz/Makefile
+++ b/samples/formats/image_decode_fuzz/Makefile
@@ -1,0 +1,40 @@
+TARGET := image_decode_fuzz_test
+
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+# Both decoders are self-contained; nothing else is needed.
+SOURCES := image_decode_fuzz_test.c \
+           $(LIBRETRO_COMM_DIR)/formats/bmp/rbmp.c \
+           $(LIBRETRO_COMM_DIR)/formats/tga/rtga.c
+
+CFLAGS  += -Wall -std=gnu99 -g -O1 \
+           -I$(LIBRETRO_COMM_DIR)/include
+
+CFLAGS += $(EXTRA_CFLAGS)
+
+OBJS := $(SOURCES:.c=.o)
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+sweep:
+	$(MAKE) clean && $(MAKE) SANITIZER=address,undefined && \
+	   ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 \
+	   ./$(TARGET)
+	@echo "sweep clean"
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: all sweep clean

--- a/samples/formats/image_decode_fuzz/Makefile
+++ b/samples/formats/image_decode_fuzz/Makefile
@@ -7,7 +7,9 @@ LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
 SOURCES := image_decode_fuzz_test.c \
            $(LIBRETRO_COMM_DIR)/formats/bmp/rbmp.c \
            $(LIBRETRO_COMM_DIR)/formats/tga/rtga.c \
-           $(LIBRETRO_COMM_DIR)/formats/dds/rdds.c
+           $(LIBRETRO_COMM_DIR)/formats/dds/rdds.c \
+           $(LIBRETRO_COMM_DIR)/formats/webp/rwebp.c \
+           $(LIBRETRO_COMM_DIR)/formats/vp8/rvp8.c
 
 CFLAGS  += -Wall -std=gnu99 -g -O1 \
            -I$(LIBRETRO_COMM_DIR)/include

--- a/samples/formats/image_decode_fuzz/image_decode_fuzz_test.c
+++ b/samples/formats/image_decode_fuzz/image_decode_fuzz_test.c
@@ -29,9 +29,21 @@
 #include <formats/rbmp.h>
 #include <formats/rtga.h>
 #include <formats/rdds.h>
+#include <formats/rwebp.h>
 
-static long decoded_ok;
+/* Per format, not just in total: a cumulative count hides a decoder
+ * whose seed stopped being accepted, which would leave that format
+ * exercising only its reject paths while the sweep still reported a
+ * pass. */
+enum { FMT_BMP = 0, FMT_TGA, FMT_DDS, FMT_WEBP, FMT_COUNT };
+
+static const char *const fmt_name[FMT_COUNT] =
+{ "bmp", "tga", "dds", "webp" };
+
+static long decoded_ok[FMT_COUNT];
+static long attempted[FMT_COUNT];
 static long attempts;
+static int  cur_fmt;
 
 /* Smallest well-formed 24-bit BMP: 2x2 pixels. */
 static const unsigned char bmp_seed[] =
@@ -98,6 +110,7 @@ static void try_dds(const unsigned char *buf, size_t len)
    unsigned w = 0, h = 0;
 
    attempts++;
+   attempted[cur_fmt]++;
 
    if (!rdds)
       return;
@@ -109,12 +122,57 @@ static void try_dds(const unsigned char *buf, size_t len)
             == IMAGE_PROCESS_NEXT)
          ;
       if (ret == IMAGE_PROCESS_END)
-         decoded_ok++;
+         decoded_ok[cur_fmt]++;
    }
 
    if (out)
       free(out);
    rdds_free(rdds);
+}
+
+
+/* A 2x2 lossy WebP, as produced by a real encoder: RIFF container,
+ * "WEBP" form type, one "VP8 " chunk holding a keyframe. */
+static const unsigned char webp_seed[] =
+{
+   0x52, 0x49, 0x46, 0x46, 0x3a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+   0x56, 0x50, 0x38, 0x20, 0x2e, 0x00, 0x00, 0x00, 0x90, 0x01, 0x00, 0x9d,
+   0x01, 0x2a, 0x02, 0x00, 0x02, 0x00, 0x01, 0x40, 0x26, 0x25, 0xa4, 0x00,
+   0x02, 0xe7, 0x59, 0xb6, 0x00, 0x00, 0xfe, 0xf6, 0x7f, 0xff, 0x9c, 0x0e,
+   0x21, 0x2d, 0xfc, 0xab, 0xff, 0xfb, 0x46, 0x3f, 0x3c, 0xb5, 0xef, 0x75,
+   0x7a, 0x26, 0x1e, 0x00, 0x00, 0x00
+};
+
+static void try_webp(const unsigned char *buf, size_t len)
+{
+   rwebp_t *rwebp = rwebp_alloc();
+   void    *out   = NULL;
+   unsigned w = 0, h = 0;
+
+   attempts++;
+   attempted[cur_fmt]++;
+
+   if (!rwebp)
+      return;
+
+   /* Unlike the other three, rwebp_set_buf_ptr() is told the length,
+    * so the decoder is not relying on the header alone to stay in
+    * bounds.  Worth exercising anyway: the still-ready probe and the
+    * chunk walk still trust sizes that came out of the file. */
+   if (rwebp_set_buf_ptr(rwebp, (void*)buf, len))
+   {
+      int ret;
+      (void)rwebp_still_ready(buf, len);
+      while ((ret = rwebp_process_image(rwebp, &out, len, &w, &h, true))
+            == IMAGE_PROCESS_NEXT)
+         ;
+      if (ret == IMAGE_PROCESS_END)
+         decoded_ok[cur_fmt]++;
+   }
+
+   if (out)
+      free(out);
+   rwebp_free(rwebp);
 }
 
 static void try_bmp(const unsigned char *buf, size_t len)
@@ -124,6 +182,7 @@ static void try_bmp(const unsigned char *buf, size_t len)
    unsigned w = 0, h = 0;
 
    attempts++;
+   attempted[cur_fmt]++;
 
    if (!rbmp)
       return;
@@ -138,7 +197,7 @@ static void try_bmp(const unsigned char *buf, size_t len)
             == IMAGE_PROCESS_NEXT)
          ;
       if (ret == IMAGE_PROCESS_END)
-         decoded_ok++;
+         decoded_ok[cur_fmt]++;
    }
 
    if (out)
@@ -153,6 +212,7 @@ static void try_tga(const unsigned char *buf, size_t len)
    unsigned w = 0, h = 0;
 
    attempts++;
+   attempted[cur_fmt]++;
 
    if (!rtga)
       return;
@@ -164,7 +224,7 @@ static void try_tga(const unsigned char *buf, size_t len)
             == IMAGE_PROCESS_NEXT)
          ;
       if (ret == IMAGE_PROCESS_END)
-         decoded_ok++;
+         decoded_ok[cur_fmt]++;
    }
 
    if (out)
@@ -174,9 +234,11 @@ static void try_tga(const unsigned char *buf, size_t len)
 
 /* Every single-byte value at every offset of the header, on a copy
  * sized exactly to the seed so a read past the end is a report. */
-static void sweep(const unsigned char *seed, size_t seed_len,
+static void sweep(int fmt, const unsigned char *seed, size_t seed_len,
       void (*fn)(const unsigned char*, size_t), size_t header_len)
 {
+   cur_fmt = fmt;
+
    size_t off;
    int    v;
    size_t trunc;
@@ -225,19 +287,33 @@ int main(void)
 {
    dds_seed_init();
 
-   sweep(bmp_seed, sizeof(bmp_seed), try_bmp, 54);
-   sweep(tga_seed, sizeof(tga_seed), try_tga, 18);
-   sweep(dds_seed, sizeof(dds_seed), try_dds, 128);
+   sweep(FMT_BMP,  bmp_seed,  sizeof(bmp_seed),  try_bmp,  54);
+   sweep(FMT_TGA,  tga_seed,  sizeof(tga_seed),  try_tga,  18);
+   sweep(FMT_DDS,  dds_seed,  sizeof(dds_seed),  try_dds,  128);
+   sweep(FMT_WEBP, webp_seed, sizeof(webp_seed), try_webp, 32);
 
-   printf("attempts=%ld decoded=%ld\n", attempts, decoded_ok);
-
-   if (decoded_ok < 3)
    {
-      fputs("FAIL: not every seed decoded; the sweep proved nothing\n",
-            stderr);
-      return 1;
+      int i, bad = 0;
+
+      for (i = 0; i < FMT_COUNT; i++)
+      {
+         printf("%-5s attempts=%-6ld decoded=%ld\n",
+               fmt_name[i], attempted[i], decoded_ok[i]);
+
+         if (decoded_ok[i] < 1)
+         {
+            fprintf(stderr,
+                  "FAIL: no %s input decoded; that format exercised"
+                  " only its reject paths\n", fmt_name[i]);
+            bad++;
+         }
+      }
+
+      if (bad)
+         return 1;
    }
 
+   printf("total attempts=%ld\n", attempts);
    puts("ALL OK");
    return 0;
 }

--- a/samples/formats/image_decode_fuzz/image_decode_fuzz_test.c
+++ b/samples/formats/image_decode_fuzz/image_decode_fuzz_test.c
@@ -1,0 +1,183 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (image_decode_fuzz_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <formats/image.h>
+#include <formats/rbmp.h>
+#include <formats/rtga.h>
+
+static long decoded_ok;
+static long attempts;
+
+/* Smallest well-formed 24-bit BMP: 2x2 pixels. */
+static const unsigned char bmp_seed[] =
+{
+   'B','M', 70,0,0,0, 0,0, 0,0, 54,0,0,0,        /* file header */
+   40,0,0,0, 2,0,0,0, 2,0,0,0, 1,0, 24,0,        /* info header */
+   0,0,0,0, 16,0,0,0, 0,0,0,0, 0,0,0,0,
+   0,0,0,0, 0,0,0,0,
+   /* pixel data, bottom-up, 4-byte aligned rows */
+   0xff,0x00,0x00, 0x00,0xff,0x00, 0,0,
+   0x00,0x00,0xff, 0xff,0xff,0xff, 0,0
+};
+
+/* Smallest well-formed uncompressed 24-bit TGA: 2x2. */
+static const unsigned char tga_seed[] =
+{
+   0,          /* id length */
+   0,          /* colour map type */
+   2,          /* image type: uncompressed true-colour */
+   0,0, 0,0, 0,/* colour map spec */
+   0,0, 0,0,   /* x/y origin */
+   2,0,        /* width  */
+   2,0,        /* height */
+   24,         /* bits per pixel */
+   0,          /* descriptor */
+   0xff,0x00,0x00, 0x00,0xff,0x00,
+   0x00,0x00,0xff, 0xff,0xff,0xff
+};
+
+static void try_bmp(const unsigned char *buf, size_t len)
+{
+   rbmp_t *rbmp = rbmp_alloc();
+   void   *out  = NULL;
+   unsigned w = 0, h = 0;
+
+   attempts++;
+
+   if (!rbmp)
+      return;
+
+   /* rbmp_set_buf_ptr takes the buffer; it does not take the length,
+    * which is itself worth knowing -- the decoder trusts the header
+    * to stay inside whatever it was handed. */
+   if (rbmp_set_buf_ptr(rbmp, (void*)buf))
+   {
+      int ret;
+      while ((ret = rbmp_process_image(rbmp, &out, len, &w, &h, true))
+            == IMAGE_PROCESS_NEXT)
+         ;
+      if (ret == IMAGE_PROCESS_END)
+         decoded_ok++;
+   }
+
+   if (out)
+      free(out);
+   rbmp_free(rbmp);
+}
+
+static void try_tga(const unsigned char *buf, size_t len)
+{
+   rtga_t *rtga = rtga_alloc();
+   void   *out  = NULL;
+   unsigned w = 0, h = 0;
+
+   attempts++;
+
+   if (!rtga)
+      return;
+
+   if (rtga_set_buf_ptr(rtga, (void*)buf))
+   {
+      int ret;
+      while ((ret = rtga_process_image(rtga, &out, len, &w, &h, true))
+            == IMAGE_PROCESS_NEXT)
+         ;
+      if (ret == IMAGE_PROCESS_END)
+         decoded_ok++;
+   }
+
+   if (out)
+      free(out);
+   rtga_free(rtga);
+}
+
+/* Every single-byte value at every offset of the header, on a copy
+ * sized exactly to the seed so a read past the end is a report. */
+static void sweep(const unsigned char *seed, size_t seed_len,
+      void (*fn)(const unsigned char*, size_t), size_t header_len)
+{
+   size_t off;
+   int    v;
+   size_t trunc;
+
+   /* Well-formed first, so a decoder that rejects everything is
+    * visible in the decoded_ok count. */
+   {
+      unsigned char *copy = (unsigned char*)malloc(seed_len);
+      if (!copy)
+         return;
+      memcpy(copy, seed, seed_len);
+      fn(copy, seed_len);
+      free(copy);
+   }
+
+   /* Truncated at every length. */
+   for (trunc = 0; trunc < seed_len; trunc++)
+   {
+      unsigned char *copy = (unsigned char*)malloc(trunc ? trunc : 1);
+      if (!copy)
+         return;
+      memcpy(copy, seed, trunc);
+      fn(copy, trunc);
+      free(copy);
+   }
+
+   /* Each header byte set to each of a handful of interesting
+    * values, including the ones that make dimensions enormous. */
+   for (off = 0; off < header_len && off < seed_len; off++)
+   {
+      static const int vals[] = { 0x00, 0x01, 0x7f, 0x80, 0xfe, 0xff };
+      for (v = 0; v < (int)(sizeof(vals) / sizeof(vals[0])); v++)
+      {
+         unsigned char *copy = (unsigned char*)malloc(seed_len);
+         if (!copy)
+            return;
+         memcpy(copy, seed, seed_len);
+         copy[off] = (unsigned char)vals[v];
+         fn(copy, seed_len);
+         free(copy);
+      }
+   }
+}
+
+int main(void)
+{
+   sweep(bmp_seed, sizeof(bmp_seed), try_bmp, 54);
+   sweep(tga_seed, sizeof(tga_seed), try_tga, 18);
+
+   printf("attempts=%ld decoded=%ld\n", attempts, decoded_ok);
+
+   if (decoded_ok < 2)
+   {
+      fputs("FAIL: neither seed decoded; the sweep proved nothing\n",
+            stderr);
+      return 1;
+   }
+
+   puts("ALL OK");
+   return 0;
+}

--- a/samples/formats/image_decode_fuzz/image_decode_fuzz_test.c
+++ b/samples/formats/image_decode_fuzz/image_decode_fuzz_test.c
@@ -28,6 +28,7 @@
 #include <formats/image.h>
 #include <formats/rbmp.h>
 #include <formats/rtga.h>
+#include <formats/rdds.h>
 
 static long decoded_ok;
 static long attempts;
@@ -59,6 +60,62 @@ static const unsigned char tga_seed[] =
    0xff,0x00,0x00, 0x00,0xff,0x00,
    0x00,0x00,0xff, 0xff,0xff,0xff
 };
+
+
+/* Minimal well-formed uncompressed 32-bit BGRA DDS: 2x2.
+ * 4-byte magic, 124-byte header, then pixels. */
+static unsigned char dds_seed[128 + 16];
+
+static void dds_seed_init(void)
+{
+   unsigned char *h = dds_seed;
+
+   memset(dds_seed, 0, sizeof(dds_seed));
+   memcpy(h, "DDS ", 4);
+   h[4]  = 124;                        /* dwSize                */
+   h[8]  = 0x07; h[9] = 0x10;          /* CAPS|HEIGHT|WIDTH|PIXELFORMAT */
+   h[12] = 2;                          /* dwHeight              */
+   h[16] = 2;                          /* dwWidth               */
+   h[20] = 8;                          /* dwPitchOrLinearSize   */
+   h[28] = 1;                          /* dwMipMapCount         */
+   h[76] = 32;                         /* ddspf.dwSize          */
+   h[80] = 0x41;                       /* ALPHAPIXELS | RGB     */
+   h[88] = 32;                         /* dwRGBBitCount         */
+   h[92]  = 0x00; h[93]  = 0x00; h[94]  = 0xff; /* R mask       */
+   h[96]  = 0x00; h[97]  = 0xff;                /* G mask       */
+   h[100] = 0xff;                               /* B mask       */
+   h[107] = 0xff;                               /* A mask       */
+   h[109] = 0x10;                      /* dwCaps: TEXTURE       */
+
+   /* 2x2 BGRA pixels */
+   memset(dds_seed + 128, 0x7f, 16);
+}
+
+static void try_dds(const unsigned char *buf, size_t len)
+{
+   rdds_t *rdds = rdds_alloc();
+   void   *out  = NULL;
+   unsigned w = 0, h = 0;
+
+   attempts++;
+
+   if (!rdds)
+      return;
+
+   if (rdds_set_buf_ptr(rdds, (void*)buf))
+   {
+      int ret;
+      while ((ret = rdds_process_image(rdds, &out, len, &w, &h, true))
+            == IMAGE_PROCESS_NEXT)
+         ;
+      if (ret == IMAGE_PROCESS_END)
+         decoded_ok++;
+   }
+
+   if (out)
+      free(out);
+   rdds_free(rdds);
+}
 
 static void try_bmp(const unsigned char *buf, size_t len)
 {
@@ -166,14 +223,17 @@ static void sweep(const unsigned char *seed, size_t seed_len,
 
 int main(void)
 {
+   dds_seed_init();
+
    sweep(bmp_seed, sizeof(bmp_seed), try_bmp, 54);
    sweep(tga_seed, sizeof(tga_seed), try_tga, 18);
+   sweep(dds_seed, sizeof(dds_seed), try_dds, 128);
 
    printf("attempts=%ld decoded=%ld\n", attempts, decoded_ok);
 
-   if (decoded_ok < 2)
+   if (decoded_ok < 3)
    {
-      fputs("FAIL: neither seed decoded; the sweep proved nothing\n",
+      fputs("FAIL: not every seed decoded; the sweep proved nothing\n",
             stderr);
       return 1;
    }


### PR DESCRIPTION
Split from #19284.

- **rbmp**: free the surface when the header is rejected after it was allocated.
- **image_decode_fuzz**: coverage extended to DDS and WebP with per-format decode counting, so a format whose decoder is never reached fails the run instead of silently contributing nothing. Runs in CI via `Linux-samples-formats.yml` under ASan+UBSan+LSan.