### PR TITLE
gl1, gl2: drop the LUT stream the font shader has no attribute for

### DIFF
--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -774,9 +774,7 @@ static void gl1_raster_font_render_line(gl1_t *gl,
    GLfloat font_vertex[2 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat font_color[4 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat color_block[4 * 6];
-   GLfloat lut_block[2 * 6];
    int n;
-   GLfloat font_lut_tex_coord[2 * 6 * MAX_MSG_LEN_CHUNK];
    const char* msg_end  = msg + msg_len;
    int x                = pre_x;
    int y                = roundf(pos_y * gl->vp.height);
@@ -816,8 +814,6 @@ static void gl1_raster_font_render_line(gl1_t *gl,
       color_block[4 * n + 1] = color[1];
       color_block[4 * n + 2] = color[2];
       color_block[4 * n + 3] = color[3];
-      lut_block[2 * n + 0]   = gl->coords.lut_tex_coord[0];
-      lut_block[2 * n + 1]   = gl->coords.lut_tex_coord[1];
    }
 
    while (msg < msg_end)
@@ -851,8 +847,6 @@ static void gl1_raster_font_render_line(gl1_t *gl,
 
          memcpy(&font_color[4 * 6 * i], color_block,
                sizeof(color_block));
-         memcpy(&font_lut_tex_coord[2 * 6 * i], lut_block,
-               sizeof(lut_block));
 
          i++;
 
@@ -864,7 +858,7 @@ static void gl1_raster_font_render_line(gl1_t *gl,
       coords.vertex        = font_vertex;
       coords.color         = font_color;
       coords.vertices      = i * 6;
-      coords.lut_tex_coord = font_lut_tex_coord;
+      coords.lut_tex_coord = NULL;
 
       if (font->block)
          video_coord_array_append(&font->block->carr, &coords, coords.vertices);

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -1004,9 +1004,7 @@ static void gl2_raster_font_render_line(gl2_t *gl,
    GLfloat font_tex_coords[2 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat font_vertex[2 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat font_color[4 * 6 * MAX_MSG_LEN_CHUNK];
-   GLfloat font_lut_tex_coord[2 * 6 * MAX_MSG_LEN_CHUNK];
    GLfloat color_block[4 * 6];
-   GLfloat lut_block[2 * 6];
    int n;
    const char* msg_end  = msg + msg_len;
    int x                = roundf(pos_x * gl->vp.width);
@@ -1053,8 +1051,6 @@ static void gl2_raster_font_render_line(gl2_t *gl,
       color_block[4 * n + 1] = color[1];
       color_block[4 * n + 2] = color[2];
       color_block[4 * n + 3] = color[3];
-      lut_block[2 * n + 0]   = gl->coords.lut_tex_coord[0];
-      lut_block[2 * n + 1]   = gl->coords.lut_tex_coord[1];
    }
 
    while (msg < msg_end)
@@ -1088,8 +1084,6 @@ static void gl2_raster_font_render_line(gl2_t *gl,
 
          memcpy(&font_color[4 * 6 * i], color_block,
                sizeof(color_block));
-         memcpy(&font_lut_tex_coord[2 * 6 * i], lut_block,
-               sizeof(lut_block));
 
          i++;
 
@@ -1101,7 +1095,7 @@ static void gl2_raster_font_render_line(gl2_t *gl,
       coords.vertex        = font_vertex;
       coords.color         = font_color;
       coords.vertices      = i * 6;
-      coords.lut_tex_coord = font_lut_tex_coord;
+      coords.lut_tex_coord = NULL;
 
       if (font->block)
          video_coord_array_append(&font->block->carr,


### PR DESCRIPTION
Split from #19284. Both raster font renderers filled and copied a LUT texcoord array that nothing reads: font drawing runs under the stock blend shader, which declares no `LUTTexCoord`, so the backend never binds the stream. Removes a 48-byte memcpy per glyph each way (of 240) and 3072 bytes of stack per line-render call. Verified by rendering: XMB captured on llvmpipe under Xvfb before and after is pixel-identical across the deterministic region of the frame. The remaining constant stream (Color) is declared by the shader and needs a shader-vtable entry to eliminate, so it stays.