### PR TITLE
gfx_animation/thumbnail/widgets: content-reachable ticker overflow, sanitize samples, TSan stress fixes

### DIFF
--- a/.github/workflows/Linux-samples-gfx.yml
+++ b/.github/workflows/Linux-samples-gfx.yml
@@ -288,3 +288,108 @@ jobs:
           TSAN_OPTIONS=halt_on_error=1 timeout 60 \
              ./gfx_widgets_msg_queue_race_test
           echo "[pass] gfx_widgets_msg_queue_race_test"
+
+      - name: Build and run gfx_animation_sanitize_test (ASan + UBSan)
+        shell: bash
+        working-directory: samples/gfx/gfx_animation_sanitize
+        run: |
+          set -eu
+          # Regression test for the stack overflow in
+          # gfx/gfx_animation.c::gfx_animation_ticker().  Pre-fix it
+          # passed PATH_MAX_LENGTH to utf8cpy() as the destination
+          # size, in all five places it copies, regardless of what the
+          # caller had provided.  utf8cpy()'s second argument is a
+          # size in BYTES; ticker->len, which the surrounding logic
+          # uses, is a width in GLYPHS -- so the guard
+          # `str_len <= ticker->len` compared glyph counts and then
+          # copied bytes, and one glyph of CJK or emoji is three or
+          # four of them.  PATH_MAX_LENGTH is 512 and not one of the
+          # 27 call sites in tree provides that much (mostly
+          # NAME_MAX_LENGTH, 64 bytes in one RGUI case), so the
+          # function was licensed to write 511 bytes plus a
+          # terminator into any of them.  Reachable from content: RGUI
+          # sets ticker.len from term_layout.width and ticker.s to a
+          # NAME_MAX_LENGTH stack buffer, so a playlist entry with a
+          # long enough Japanese, Cyrillic or emoji title overran it.
+          # Fixed by giving the struct an s_len field carrying the
+          # destination size in bytes, mirroring the dst_str_len that
+          # gfx_animation_ticker_smooth() had all along.
+          #
+          # AddressSanitizer is the validator: the test allocates
+          # every ticker destination at exactly the length it hands
+          # over, so a single byte past the end is a report rather
+          # than a stomp on whatever followed.  It also sweeps every
+          # easing type through push/update/expire, frees animation
+          # subjects while their animation is in flight, and deinits
+          # with animations still running.  If gfx_animation.c amends
+          # the destination sizing, this goes red.
+          make clean all SANITIZER=address,undefined
+          test -x gfx_animation_sanitize_test
+          ASAN_OPTIONS=detect_leaks=1 timeout 120 \
+             ./gfx_animation_sanitize_test
+          echo "[pass] gfx_animation_sanitize_test"
+
+      - name: Build and run gfx_thumbnail_sanitize_test (ASan + UBSan)
+        shell: bash
+        working-directory: samples/gfx/gfx_thumbnail_sanitize
+        run: |
+          set -eu
+          # Sanitizer sweep of gfx/gfx_thumbnail.c: init, work,
+          # teardown; path-data reset and reuse mid-stream; the
+          # request/callback/reset cycle; repeated and idempotent
+          # frees; and the producer/consumer pairing the atomic
+          # status field exists for, across two real threads.
+          # task_push_image_load() is stubbed to record the request
+          # rather than queue it, so the test fires the callback
+          # itself on a thread of its choosing -- which is what makes
+          # that pairing reachable at all.
+          #
+          # This one pins no historical defect: the file came back
+          # clean and stays clean.  It is a tripwire for the next
+          # change rather than a regression test.  The texture load
+          # and unload counts are asserted rather than printed, so a
+          # build where the request path is never entered fails
+          # instead of reporting a clean sweep having swept nothing.
+          make clean all SANITIZER=address,undefined
+          test -x gfx_thumbnail_sanitize_test
+          ASAN_OPTIONS=detect_leaks=1 timeout 120 \
+             ./gfx_thumbnail_sanitize_test
+          echo "[pass] gfx_thumbnail_sanitize_test (ASan)"
+          make clean all SANITIZER=thread
+          TSAN_OPTIONS=halt_on_error=1 timeout 120 \
+             ./gfx_thumbnail_sanitize_test
+          echo "[pass] gfx_thumbnail_sanitize_test (TSan)"
+
+      - name: Build and run gfx_widgets_sanitize_test (ASan + UBSan)
+        shell: bash
+        working-directory: samples/gfx/gfx_widgets_sanitize
+        run: |
+          set -eu
+          # Sanitizer sweep of gfx/gfx_widgets.c, focused on the
+          # message queue: it has the same shape as the
+          # gfx_animation ticker overflow -- a caller-supplied
+          # string, internal fixed buffers, and arithmetic that has
+          # to keep glyphs and bytes apart.  Multi-byte text,
+          # over-long text, text with no break opportunity, embedded
+          # newlines and empty strings across every message/title
+          # pairing, a 256-message overflow to drive eviction and
+          # free, and eight init/deinit cycles with messages still
+          # outstanding at teardown.
+          #
+          # Like the thumbnail sweep this pins no historical defect
+          # and is a tripwire.  Two things decide whether it sweeps
+          # anything: the font metric stubs return a non-zero
+          # proportional width (a zero-width font makes every "does
+          # this fit" test succeed and the layout paths are never
+          # entered), and gfx_widgets_init() returning false makes
+          # the whole run vacuous -- hence the asserted push and
+          # frame counters.
+          make clean all SANITIZER=address,undefined
+          test -x gfx_widgets_sanitize_test
+          ASAN_OPTIONS=detect_leaks=1 timeout 120 \
+             ./gfx_widgets_sanitize_test
+          echo "[pass] gfx_widgets_sanitize_test (ASan)"
+          make clean all SANITIZER=thread
+          TSAN_OPTIONS=halt_on_error=1 timeout 120 \
+             ./gfx_widgets_sanitize_test
+          echo "[pass] gfx_widgets_sanitize_test (TSan)"

--- a/.github/workflows/Linux-samples-gfx.yml
+++ b/.github/workflows/Linux-samples-gfx.yml
@@ -236,7 +236,14 @@ jobs:
           # GFX_THUMB_STATUS_STORE / GFX_THUMB_STATUS_LOAD or the
           # .status field type, the verbatim copies in
           # gfx_thumbnail_status_atomic_test.c must follow.
-          make clean all SANITIZER=thread
+          #
+          # STRESS_ITERS is bounded here because the default of
+          # 1000000 measures ~145 s on a single core before TSan
+          # multiplies it, and this step allows 60 s.  20000 runs
+          # in ~2.4 s under TSan on one core and still routes every
+          # round trip through the instrumented release/acquire
+          # pair; the default stays at 1000000 for local soak runs.
+          make clean all SANITIZER=thread EXTRA_CFLAGS="-DSTRESS_ITERS=20000"
           test -x gfx_thumbnail_status_atomic_test
           TSAN_OPTIONS=halt_on_error=1 timeout 60 \
              ./gfx_thumbnail_status_atomic_test

--- a/gfx/gfx_animation.c
+++ b/gfx/gfx_animation.c
@@ -1114,13 +1114,20 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
    gfx_animation_t *p_anim = &anim_st;
    size_t str_len          = utf8len(ticker->str);
 
+   /* utf8cpy() computes its clamp as (len - 1), so a zero here
+    * underflows to SIZE_MAX and the clamp never fires.  A caller that
+    * forgot to set s_len gets nothing written rather than an
+    * unbounded write. */
+   if (ticker->s_len < 1)
+      return false;
+
    if (!ticker->spacer)
       ticker->spacer       = TICKER_SPACER_DEFAULT;
 
    if ((size_t)str_len <= ticker->len)
    {
       utf8cpy(ticker->s,
-            PATH_MAX_LENGTH,
+            ticker->s_len,
             ticker->str,
             ticker->len);
       return false;
@@ -1129,14 +1136,16 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
    if (!ticker->selected)
    {
       size_t _len = utf8cpy(ticker->s,
-            PATH_MAX_LENGTH, ticker->str, ticker->len - 3);
-      if (_len + 4 <= PATH_MAX_LENGTH)
+            ticker->s_len, ticker->str, ticker->len - 3);
+      if (_len + 4 <= ticker->s_len)
       {
          ticker->s[  _len] = '.';
          ticker->s[++_len] = '.';
          ticker->s[++_len] = '.';
          ticker->s[++_len] = '\0';
       }
+      else
+         ticker->s[ticker->s_len - 1] = '\0';
       return false;
    }
 
@@ -1163,7 +1172,7 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
                   offset1, width1,
                   offset2, width2,
                   offset3, width3,
-                  ticker->s, PATH_MAX_LENGTH);
+                  ticker->s, ticker->s_len);
          }
          break;
       case TICKER_TYPE_BOUNCE:
@@ -1177,7 +1186,7 @@ bool gfx_animation_ticker(gfx_animation_ctx_ticker_t *ticker)
 
             utf8cpy(
                   ticker->s,
-                  PATH_MAX_LENGTH,
+                  ticker->s_len,
                   utf8skip(ticker->str, offset),
                   str_len);
          }

--- a/gfx/gfx_animation.h
+++ b/gfx/gfx_animation.h
@@ -131,6 +131,13 @@ typedef struct gfx_animation_ctx_ticker
    char *s;
    const char *str;
    const char *spacer;
+   /* Size of the buffer @s points at, in BYTES.  Must be set; a
+    * ticker with s_len == 0 is rejected rather than guessed at.
+    * Distinct from @len below, and the distinction matters: one
+    * glyph of CJK or emoji is three or four bytes, so a string that
+    * fits @len glyphs can be several times @s_len bytes long. */
+   size_t s_len;
+   /* Width of the field to fit the string into, in GLYPHS. */
    size_t len;
    enum gfx_animation_ticker_type type_enum;
    bool selected;

--- a/gfx/widgets/gfx_widget_screenshot.c
+++ b/gfx/widgets/gfx_widget_screenshot.c
@@ -328,6 +328,7 @@ static void gfx_widget_screenshot_frame(void* data, void *user_data)
       ticker.idx        = p_anim->ticker_idx;
       ticker.len        = state->shotname_length;
       ticker.s          = shotname;
+      ticker.s_len      = sizeof(shotname);
       ticker.selected   = true;
       ticker.str        = state->shotname;
       ticker.spacer     = NULL;

--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -5044,6 +5044,7 @@ static void materialui_render_menu_entry_default(
                   entry_value_len      = entry_value_len_max;
 
                mui->ticker.s           = value_buf;
+               mui->ticker.s_len       = sizeof(value_buf);
                mui->ticker.len         = entry_value_len;
                mui->ticker.str         = entry_value;
 
@@ -5149,6 +5150,7 @@ static void materialui_render_menu_entry_default(
          {
             /* Label */
             mui->ticker.s        = label_buf;
+            mui->ticker.s_len    = sizeof(label_buf);
             mui->ticker.len      = (size_t)(label_width / mui->font_data.list.glyph_width);
             mui->ticker.str      = entry_label;
 
@@ -5375,6 +5377,7 @@ static void materialui_render_menu_entry_playlist_list(
          {
             /* Label */
             mui->ticker.s        = label_buf;
+            mui->ticker.s_len    = sizeof(label_buf);
             mui->ticker.len      = (size_t)(usable_width / mui->font_data.list.glyph_width);
             mui->ticker.str      = entry_label;
 
@@ -5557,6 +5560,7 @@ static void materialui_render_menu_entry_playlist_dual_icon(
          {
             /* Label */
             mui->ticker.s   = label_buf;
+            mui->ticker.s_len = sizeof(label_buf);
             mui->ticker.len = (size_t)(usable_width / mui->font_data.list.glyph_width);
             mui->ticker.str = entry_label;
 
@@ -5668,6 +5672,7 @@ static void materialui_render_menu_entry_playlist_desktop(
          {
             mui->ticker.selected = entry_selected;
             mui->ticker.s        = label_buf;
+            mui->ticker.s_len    = sizeof(label_buf);
             mui->ticker.len      = (size_t)(usable_width / mui->font_data.list.glyph_width);
             mui->ticker.str      = entry_label;
 
@@ -5902,6 +5907,7 @@ static void materialui_render_menu_entry_savestate_list(
                   entry_value_len      = entry_value_len_max;
 
                mui->ticker.s           = value_buf;
+               mui->ticker.s_len       = sizeof(value_buf);
                mui->ticker.len         = entry_value_len;
                mui->ticker.str         = entry_value;
 
@@ -5987,6 +5993,7 @@ static void materialui_render_menu_entry_savestate_list(
          {
             mui->ticker.selected = entry_selected;
             mui->ticker.s        = label_buf;
+            mui->ticker.s_len    = sizeof(label_buf);
             mui->ticker.len      = (size_t)(usable_width / mui->font_data.list.glyph_width);
             mui->ticker.str      = entry_label;
 
@@ -6272,6 +6279,7 @@ static void materialui_render_selected_entry_aux_playlist_desktop(
          {
             mui->ticker.selected = true;
             mui->ticker.s        = metadata_buf;
+            mui->ticker.s_len    = sizeof(metadata_buf);
             mui->ticker.len      = (size_t)(text_width / mui->font_data.hint.glyph_width);
             mui->ticker.str      = mui->status_bar.str;
 
@@ -7155,6 +7163,7 @@ MUI_NOINLINE static void materialui_render_header(
       else
       {
          mui->ticker.s        = core_title_buf;
+         mui->ticker.s_len    = sizeof(core_title_buf);
          mui->ticker.len      = (unsigned)(usable_sys_bar_width / mui->font_data.hint.glyph_width);
          mui->ticker.str      = core_title;
          mui->ticker.selected = true;
@@ -7286,6 +7295,7 @@ MUI_NOINLINE static void materialui_render_header(
    else
    {
       mui->ticker.s        = menu_title_buf;
+      mui->ticker.s_len    = sizeof(menu_title_buf);
       mui->ticker.len      = (unsigned)(usable_title_bar_width / mui->font_data.title.glyph_width) - 1;
       mui->ticker.str      = menu_title;
       mui->ticker.selected = true;

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -3765,6 +3765,7 @@ OZONE_NOINLINE static void ozone_draw_sidebar(
                   ? ticker_field_width / ozone->fonts.sidebar.glyph_width
                   : 0;
             ticker.s        = console_title;
+            ticker.s_len    = sizeof(console_title);
             ticker.selected = selected;
             ticker.str      = title;
 
@@ -3925,6 +3926,7 @@ OZONE_NOINLINE static void ozone_draw_sidebar(
                      ? ticker_field_width / ozone->fonts.sidebar.glyph_width
                      : 0;
                ticker.s        = console_title;
+               ticker.s_len    = sizeof(console_title);
                ticker.selected = selected;
                ticker.str      = node->console_name;
 
@@ -6179,6 +6181,7 @@ border_iterate:
       else
       {
          ticker.s        = rich_label;
+         ticker.s_len    = sizeof(rich_label);
          ticker.str      = entry_rich_label;
          ticker.selected = entry_selected && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
          ticker.len      = (entry_width - ozone->dimensions.entry_icon_padding * 6) / ozone->fonts.entries_label.glyph_width;
@@ -6476,6 +6479,7 @@ border_iterate:
       else
       {
          ticker.s        = entry_value_ticker;
+         ticker.s_len    = sizeof(entry_value_ticker);
          ticker.str      = entry_value;
          ticker.selected = entry_selected && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR));
          ticker.len      = (entry_width
@@ -6959,6 +6963,7 @@ static void ozone_draw_thumbnail_bar(
             ticker.selected                  = true;
             ticker.len                       = (sidebar_width - (separator_padding * 2)) / ozone->fonts.footer.glyph_width;
             ticker.s                         = ticker_buf;
+            ticker.s_len                     = sizeof(ticker_buf);
          }
       }
 
@@ -11322,6 +11327,7 @@ OZONE_NOINLINE static void ozone_draw_header(
    else
    {
       ticker.s        = title;
+      ticker.s_len    = sizeof(title);
       ticker.len      = video_width - status_row_size / ozone->fonts.title.glyph_width;
       ticker.str      = (ozone->flags2 & OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS)
             ? ozone->fullscreen_thumbnail_label
@@ -12073,6 +12079,7 @@ static void ozone_draw_footer(
             ticker.spacer               = (ozone->font_unicode) ? OZONE_TICKER_SPACER : NULL;
 
             ticker.s                    = core_title_buf;
+            ticker.s_len                = sizeof(core_title_buf);
             ticker.len                  = usable_width / ozone->fonts.footer.glyph_width;
             ticker.str                  = core_title;
             ticker.selected             = true;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5871,6 +5871,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          else
          {
             ticker.s        = thumbnail_title_buf;
+            ticker.s_len    = sizeof(thumbnail_title_buf);
             ticker.len      = rgui->term_layout.width;
             ticker.str      = thumbnail_title;
             ticker.selected = true;
@@ -6073,6 +6074,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
       else
       {
          ticker.s        = title_buf;
+         ticker.s_len    = sizeof(title_buf);
          ticker.len      = title_max_len;
          ticker.str      = rgui->menu_title;
          ticker.selected = true;
@@ -6226,6 +6228,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          else
          {
             ticker.s                  = entry_title_buf;
+            ticker.s_len              = sizeof(entry_title_buf);
             ticker.len                = entry_title_max_len;
             if (*entry.rich_label)
                ticker.str             = entry.rich_label;
@@ -6263,6 +6266,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
                else
                {
                   ticker.s                  = type_str_buf;
+                  ticker.s_len              = sizeof(type_str_buf);
                   ticker.len                = entry_value_len;
                   ticker.str                = entry_value;
 
@@ -6379,6 +6383,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          else
          {
             ticker.s                  = sublabel_buf;
+            ticker.s_len              = sizeof(sublabel_buf);
             ticker.len                = rgui->term_layout.width;
             ticker.str                = rgui->menu_sublabel;
             ticker.selected           = true;
@@ -6416,6 +6421,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          else
          {
             ticker.s                  = core_title_buf;
+            ticker.s_len              = sizeof(core_title_buf);
             ticker.len                = rgui->term_layout.width;
             ticker.str                = core_title;
             ticker.selected           = true;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -6003,6 +6003,7 @@ XMB_NOINLINE static int xmb_draw_item(
       ticker.len                = xmb->ticker_limit;
       ticker.str                = ticker_str;
       ticker.s                  = tmp;
+      ticker.s_len              = sizeof(tmp);
 
       if (ticker.str)
          gfx_animation_ticker(&ticker);
@@ -6100,6 +6101,7 @@ XMB_NOINLINE static int xmb_draw_item(
    else
    {
       ticker.s                  = tmp;
+      ticker.s_len              = sizeof(tmp);
       ticker.len                = ((xmb->use_ps3_layout) ? 40 : 26) * xmb->scale_mod[7];
       ticker.selected           = (i == current);
       ticker.str                = entry.value;
@@ -10002,6 +10004,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
 
          ticker.str                = title_truncated;
          ticker.s                  = tmp;
+         ticker.s_len              = sizeof(tmp);
          ticker.len                = (tmp_len * xmb->last_scale_factor) / font_width;
 
          if (ticker.str)

--- a/samples/gfx/gfx_animation_sanitize/Makefile
+++ b/samples/gfx/gfx_animation_sanitize/Makefile
@@ -1,0 +1,54 @@
+TARGET := gfx_animation_sanitize_test
+
+# Path back to the repo root from this sample dir.  Links the real
+# gfx/gfx_animation.c, which reaches for only sixteen symbols outside
+# itself -- fourteen from libc and libretro-common, two stubbed here.
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+SOURCES := gfx_animation_sanitize_test.c \
+           stubs_retroarch.c \
+           $(REPO_ROOT)/gfx/gfx_animation.c \
+           $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+           $(LIBRETRO_COMM_DIR)/string/stdstring.c
+
+CFLAGS  += -Wall -std=gnu99 -g -O1 \
+           -I$(REPO_ROOT) \
+           -I$(LIBRETRO_COMM_DIR)/include
+
+LDFLAGS += -lm
+
+# Extra flags for the caller; CFLAGS= on the command line would replace
+# everything set above instead of adding to it.
+CFLAGS += $(EXTRA_CFLAGS)
+
+OBJS := $(SOURCES:.c=.o)
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+# ASan and TSan are mutually exclusive, hence separate passes.
+sweep:
+	$(MAKE) clean && $(MAKE) && ./$(TARGET)
+	$(MAKE) clean && $(MAKE) SANITIZER=address,undefined && \
+	   ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+	   UBSAN_OPTIONS=print_stacktrace=1 ./$(TARGET)
+	$(MAKE) clean && $(MAKE) SANITIZER=thread && \
+	   TSAN_OPTIONS=halt_on_error=0 ./$(TARGET)
+	@echo "sweep clean"
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: all sweep clean

--- a/samples/gfx/gfx_animation_sanitize/gfx_animation_sanitize_test.c
+++ b/samples/gfx/gfx_animation_sanitize/gfx_animation_sanitize_test.c
@@ -1,0 +1,418 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (gfx_animation_sanitize_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Sanitizer sweep for gfx/gfx_animation.c.
+ *
+ * Companion to the gfx_thumbnail_sanitize sample; same idea,
+ * different file.  gfx_animation.c reaches for only sixteen
+ * symbols outside itself, so it stands up almost bare.
+ *
+ * Two areas are worth the sanitizers' attention.
+ *
+ * The tween list: entries hold a pointer to the caller's float
+ * and an optional userdata, and are killed by tag or expire on
+ * their own.  A subject that outlives its entry, or an entry
+ * that outlives its subject, is a use-after-free that a normal
+ * run will not notice because the memory is usually still there.
+ * So the test animates subjects on the heap and frees them while
+ * the animation is in flight, which is what a menu does every
+ * time a list is repopulated mid-transition.
+ *
+ * The tickers: both forms slice UTF-8 by glyph and write into a
+ * caller-supplied buffer of a caller-supplied length.  Off-by-one
+ * there is invisible until it is not.  The test feeds them
+ * multi-byte text, buffers of every length from 1 upward, and
+ * field widths from 0 up, with the destination heap-allocated
+ * and exactly sized so ASan can see a single byte over.
+ *
+ * Run it three ways:
+ *
+ *     make sweep
+ *
+ * which is plain, then address+undefined with leak detection,
+ * then thread.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <retro_miscellaneous.h>
+
+#include "gfx/gfx_animation.h"
+
+static int failures;
+
+#define CHECK(cond, msg) \
+   do { if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); failures++; } } while (0)
+
+/* Counted so a run that reaches nothing cannot report success. */
+static int cb_calls;
+static int pushes;
+static int ticker_calls;
+
+static void on_tween_done(void *userdata)
+{
+   (void)userdata;
+   cb_calls++;
+}
+
+/* ------------------------------------------------------------------
+ * 1. push / update / expire, every easing type
+ * ------------------------------------------------------------------ */
+static void test_easing_types(void)
+{
+   int e;
+
+   for (e = 0; e < EASING_LAST; e++)
+   {
+      gfx_animation_ctx_entry_t entry;
+      float subject = 0.0f;
+      int   i;
+
+      memset(&entry, 0, sizeof(entry));
+      entry.subject      = &subject;
+      entry.target_value = 100.0f;
+      entry.duration     = 16.0f;
+      entry.easing_enum  = (enum gfx_animation_easing_type)e;
+      entry.tag          = (uintptr_t)&subject;
+      entry.cb           = on_tween_done;
+
+      if (gfx_animation_push(&entry))
+         pushes++;
+
+      /* Drive it past its duration in small steps. */
+      for (i = 0; i < 32; i++)
+         gfx_animation_update(i * 1000, false, 60.0f, 1920, 1080);
+
+      gfx_animation_kill_by_tag(&entry.tag);
+   }
+
+   gfx_animation_deinit();
+}
+
+/* ------------------------------------------------------------------
+ * 2. subject freed while the animation is in flight
+ *
+ * A menu repopulating a list mid-transition does exactly this.
+ * The entry has to go with the subject, or the next update writes
+ * through a dangling float*.
+ * ------------------------------------------------------------------ */
+static void test_subject_freed_midflight(void)
+{
+   int i;
+
+   for (i = 0; i < 64; i++)
+   {
+      gfx_animation_ctx_entry_t entry;
+      float    *subject = (float*)calloc(1, sizeof(float));
+      uintptr_t tag     = (uintptr_t)subject;
+
+      if (!subject)
+         return;
+
+      memset(&entry, 0, sizeof(entry));
+      entry.subject      = subject;
+      entry.target_value = 1.0f;
+      entry.duration     = 1000.0f;   /* long: still running when killed */
+      entry.easing_enum  = EASING_LINEAR;
+      entry.tag          = tag;
+      entry.cb           = on_tween_done;
+
+      if (gfx_animation_push(&entry))
+         pushes++;
+
+      /* Part-way through. */
+      gfx_animation_update((uint64_t)i * 100, false, 60.0f, 1920, 1080);
+
+      /* Kill first, then free -- the order the caller is obliged to
+       * use.  Getting it wrong is the use-after-free this is looking
+       * for; getting it right must leave nothing behind either. */
+      gfx_animation_kill_by_tag(&tag);
+      free(subject);
+
+      /* Anything still referencing it would be caught here. */
+      gfx_animation_update((uint64_t)i * 100 + 50, false, 60.0f, 1920, 1080);
+   }
+
+   gfx_animation_deinit();
+}
+
+/* ------------------------------------------------------------------
+ * 3. deinit with animations still in flight
+ * ------------------------------------------------------------------ */
+static void test_deinit_while_running(void)
+{
+   float subjects[16];
+   int   i;
+
+   memset(subjects, 0, sizeof(subjects));
+
+   for (i = 0; i < 16; i++)
+   {
+      gfx_animation_ctx_entry_t entry;
+      memset(&entry, 0, sizeof(entry));
+      entry.subject      = &subjects[i];
+      entry.target_value = 1.0f;
+      entry.duration     = 10000.0f;
+      entry.easing_enum  = EASING_OUT_BOUNCE;
+      entry.tag          = (uintptr_t)&subjects[i];
+      entry.cb           = on_tween_done;
+      if (gfx_animation_push(&entry))
+         pushes++;
+   }
+
+   gfx_animation_update(1, false, 60.0f, 1920, 1080);
+   gfx_animation_deinit();
+
+   /* Deinit twice: the idempotent-teardown path. */
+   gfx_animation_deinit();
+}
+
+/* ------------------------------------------------------------------
+ * 4. tickers, exactly-sized destinations
+ *
+ * dst is heap-allocated at precisely the length handed to the
+ * ticker, so a single byte written past the end is an ASan report
+ * rather than a quiet stomp on the next stack slot.
+ * ------------------------------------------------------------------ */
+static const char *const ticker_inputs[] =
+{
+   "",
+   "a",
+   "short",
+   "a moderately long entry label that will not fit",
+   /* Multi-byte: the slicing is per glyph, not per byte. */
+   "\xc3\xa9\xc3\xa8\xc3\xaa\xc3\xab accented",
+   "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e \xe3\x83\x86\xe3\x82\xb9\xe3\x83\x88",
+   "mixed \xc3\xa9 and \xe6\x97\xa5 together"
+};
+
+static void test_ticker(void)
+{
+   size_t i;
+   int    t;
+   size_t len;
+   uint64_t idx;
+
+   for (i = 0; i < sizeof(ticker_inputs) / sizeof(ticker_inputs[0]); i++)
+   {
+      for (t = 0; t < TICKER_TYPE_LAST; t++)
+      {
+         for (len = 1; len <= 24; len++)
+         {
+            for (idx = 0; idx < 8; idx++)
+            {
+               gfx_animation_ctx_ticker_t ticker;
+               char *dst = (char*)malloc(len);
+
+               if (!dst)
+                  return;
+
+               /* Prefilled with a non-NUL sentinel: the ticker may
+                * legitimately write nothing (it returns false when no
+                * scrolling is needed and the caller already has the
+                * string), so a NUL found here has to have been put
+                * there by the call, not left over from malloc. */
+               memset(dst, 'X', len);
+
+               memset(&ticker, 0, sizeof(ticker));
+               ticker.s         = dst;
+               ticker.s_len     = len;
+               ticker.len       = len;
+               ticker.idx       = idx * 37;
+               ticker.str       = ticker_inputs[i];
+               ticker.spacer    = NULL;
+               ticker.selected  = (idx & 1) ? true : false;
+               ticker.type_enum = (enum gfx_animation_ticker_type)t;
+
+               gfx_animation_ticker(&ticker);
+               ticker_calls++;
+
+               /* The contract is bounded writes, not that anything is
+                * written at all.  ASan owns the bound; all that can be
+                * asserted here is that if it did write, it terminated.
+                * Anything still 'X' at the front means it declined,
+                * which is legitimate. */
+               if (dst[0] != 'X')
+                  CHECK(memchr(dst, '\0', len) != NULL,
+                        "ticker wrote an unterminated string");
+
+               free(dst);
+            }
+         }
+      }
+   }
+}
+
+static void test_ticker_smooth(void)
+{
+   size_t i;
+   int    t;
+   size_t len;
+   unsigned field;
+
+   for (i = 0; i < sizeof(ticker_inputs) / sizeof(ticker_inputs[0]); i++)
+   {
+      for (t = 0; t < TICKER_TYPE_LAST; t++)
+      {
+         for (len = 1; len <= 24; len++)
+         {
+            for (field = 0; field <= 64; field += 8)
+            {
+               gfx_animation_ctx_ticker_smooth_t ticker;
+               char    *dst       = (char*)malloc(len);
+               unsigned x_offset  = 0;
+               unsigned dst_width = 0;
+
+               if (!dst)
+                  return;
+
+               memset(dst, 'X', len);
+
+               memset(&ticker, 0, sizeof(ticker));
+               ticker.dst_str       = dst;
+               ticker.dst_str_len   = len;
+               ticker.dst_str_width = &dst_width;
+               ticker.x_offset      = &x_offset;
+               ticker.idx           = (uint64_t)field * 13;
+               ticker.src_str       = ticker_inputs[i];
+               ticker.spacer        = NULL;
+               ticker.font          = NULL;
+               ticker.glyph_width   = 8;
+               ticker.field_width   = field;
+               ticker.font_scale    = 1.0f;
+               ticker.selected      = (field & 8) ? true : false;
+               ticker.type_enum     = (enum gfx_animation_ticker_type)t;
+
+               gfx_animation_ticker_smooth(&ticker);
+               ticker_calls++;
+
+               if (dst[0] != 'X')
+                  CHECK(memchr(dst, '\0', len) != NULL,
+                        "smooth ticker wrote an unterminated string");
+
+               free(dst);
+            }
+         }
+      }
+   }
+}
+
+/* The stack overflow this sample was written to find.
+ *
+ * gfx_animation_ticker() told utf8cpy() the destination was
+ * PATH_MAX_LENGTH bytes regardless of what the caller had actually
+ * provided.  Every caller in tree provides less -- NAME_MAX_LENGTH
+ * mostly, 64 bytes in one RGUI case -- so the guard
+ * `str_len <= ticker->len`, which compares GLYPHS, let a multi-byte
+ * string through and utf8cpy wrote its BYTES past the end.
+ *
+ * RGUI's shape, with a Japanese playlist title: 100 glyphs at three
+ * bytes each into a NAME_MAX_LENGTH buffer.
+ */
+static void test_multibyte_does_not_overflow(void)
+{
+   char     dst[NAME_MAX_LENGTH];
+   char     src[512];
+   gfx_animation_ctx_ticker_t ticker;
+   unsigned i;
+
+   for (i = 0; i < 100; i++)
+      memcpy(src + i * 3, "\xe6\x97\xa5", 3);
+   src[300] = '\0';
+
+   memset(dst, 0, sizeof(dst));
+   memset(&ticker, 0, sizeof(ticker));
+   ticker.s         = dst;
+   ticker.s_len     = sizeof(dst);
+   ticker.len       = 100;              /* glyphs, and 100 <= 100 */
+   ticker.str       = src;
+   ticker.type_enum = TICKER_TYPE_BOUNCE;
+
+   gfx_animation_ticker(&ticker);
+   ticker_calls++;
+
+   CHECK(strlen(dst) < sizeof(dst),
+         "ticker overran a NAME_MAX_LENGTH buffer with multi-byte text");
+
+   /* Same again through the ellipsis branch. */
+   memset(dst, 0, sizeof(dst));
+   ticker.len      = 50;                /* 100 glyphs > 50: truncates */
+   ticker.selected = false;
+   gfx_animation_ticker(&ticker);
+   ticker_calls++;
+
+   CHECK(strlen(dst) < sizeof(dst),
+         "ticker overran the buffer on the ellipsis path");
+}
+
+/* A caller that forgot to set s_len must get nothing written, not an
+ * unbounded write: utf8cpy computes its clamp as (len - 1), so zero
+ * underflows to SIZE_MAX. */
+static void test_zero_s_len_is_rejected(void)
+{
+   char dst[16];
+   gfx_animation_ctx_ticker_t ticker;
+
+   memset(dst, 'X', sizeof(dst));
+   memset(&ticker, 0, sizeof(ticker));
+   ticker.s         = dst;
+   ticker.s_len     = 0;
+   ticker.len       = 8;
+   ticker.str       = "a string that will not fit in eight glyphs";
+   ticker.type_enum = TICKER_TYPE_BOUNCE;
+
+   gfx_animation_ticker(&ticker);
+   ticker_calls++;
+
+   CHECK(dst[0] == 'X', "a zero s_len still wrote to the destination");
+}
+
+int main(void)
+{
+   test_multibyte_does_not_overflow();
+   test_zero_s_len_is_rejected();
+   test_easing_types();
+   test_subject_freed_midflight();
+   test_deinit_while_running();
+   test_ticker();
+   test_ticker_smooth();
+
+   printf("pushes=%d callbacks=%d ticker calls=%d\n",
+         pushes, cb_calls, ticker_calls);
+
+   /* Asserted, not merely printed: a build where the animation list
+    * silently refused every push, or where the tickers were never
+    * entered, would otherwise report a clean sweep having swept
+    * nothing. */
+   CHECK(pushes > 0,       "no animation was ever pushed");
+   CHECK(ticker_calls > 0, "no ticker was ever run");
+
+   if (failures)
+   {
+      fprintf(stderr, "%d check(s) failed\n", failures);
+      return 1;
+   }
+   puts("ALL OK");
+   return 0;
+}

--- a/samples/gfx/gfx_animation_sanitize/stubs_retroarch.c
+++ b/samples/gfx/gfx_animation_sanitize/stubs_retroarch.c
@@ -1,0 +1,46 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (stubs_retroarch.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* The only two frontend symbols gfx/gfx_animation.c reaches for.
+ *
+ * The smooth ticker takes either a font_data_t or, when that is NULL,
+ * a fixed glyph_width; the test passes NULL so the width path is the
+ * one exercised and these are never entered.  They still have to
+ * resolve, and their signatures are copied from gfx/font_driver.h
+ * rather than guessed. */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <boolean.h>
+
+int font_driver_get_message_width(void *font, const char *msg,
+      size_t len, float scale)
+{
+   (void)font; (void)msg; (void)len; (void)scale;
+   return 0;
+}
+
+unsigned font_driver_get_generation(void *font)
+{
+   (void)font;
+   return 0;
+}

--- a/samples/gfx/gfx_thumbnail_sanitize/Makefile
+++ b/samples/gfx/gfx_thumbnail_sanitize/Makefile
@@ -1,0 +1,69 @@
+TARGET := gfx_thumbnail_sanitize_test
+
+# Path back to the repo root from this sample dir.  Like the
+# display_servers and vulkan_validation samples, this one links the
+# real code rather than mirroring it: the point is to put
+# gfx/gfx_thumbnail.c itself under the sanitizers.
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+# gfx_thumbnail.c reaches for 97 symbols outside itself.  Eleven of
+# them are real libretro-common sources and are linked; the rest are
+# in stubs_retroarch.c.
+SOURCES := gfx_thumbnail_sanitize_test.c \
+           stubs_retroarch.c \
+           $(REPO_ROOT)/gfx/gfx_thumbnail.c \
+           $(LIBRETRO_COMM_DIR)/file/file_path.c \
+           $(LIBRETRO_COMM_DIR)/file/file_path_io.c \
+           $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
+           $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c \
+           $(LIBRETRO_COMM_DIR)/string/stdstring.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+           $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+           $(LIBRETRO_COMM_DIR)/lists/string_list.c \
+           $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+           $(LIBRETRO_COMM_DIR)/time/rtime.c \
+           $(LIBRETRO_COMM_DIR)/features/features_cpu.c
+
+CFLAGS  += -Wall -std=gnu99 -g -O1 \
+           -DHAVE_THREADS -DHAVE_MENU -DHAVE_GFX_WIDGETS \
+           -I$(REPO_ROOT) \
+           -I$(LIBRETRO_COMM_DIR)/include
+
+LDFLAGS += -lpthread
+
+# Extra flags for the caller; passing these through CFLAGS= instead
+# would replace everything set above, -DHAVE_THREADS included, and the
+# threaded section would silently not be built.
+CFLAGS += $(EXTRA_CFLAGS)
+
+OBJS := $(SOURCES:.c=.o)
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+# The four ways this is meant to be run.  ASan and TSan are mutually
+# exclusive, hence two passes.
+sweep:
+	$(MAKE) clean && $(MAKE) && ./$(TARGET)
+	$(MAKE) clean && $(MAKE) SANITIZER=address,undefined && \
+	   ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+	   UBSAN_OPTIONS=print_stacktrace=1 ./$(TARGET)
+	$(MAKE) clean && $(MAKE) SANITIZER=thread && \
+	   TSAN_OPTIONS=halt_on_error=0 ./$(TARGET)
+	@echo "sweep clean"
+
+clean:
+	rm -f $(TARGET) $(OBJS) gfx_thumbnail_sanitize_probe.png
+
+.PHONY: all sweep clean

--- a/samples/gfx/gfx_thumbnail_sanitize/gfx_thumbnail_sanitize_test.c
+++ b/samples/gfx/gfx_thumbnail_sanitize/gfx_thumbnail_sanitize_test.c
@@ -1,0 +1,352 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (gfx_thumbnail_sanitize_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Sanitizer sweep for gfx/gfx_thumbnail.c.
+ *
+ * Links the real thing rather than mirroring it, and drives the
+ * lifecycle the sanitizers care about: init, work, teardown;
+ * path-data reset and reuse mid-stream; the
+ * request/callback/reset cycle; repeated and idempotent frees;
+ * and the producer/consumer pairing the atomic status field
+ * exists for, on two real threads so TSan has something to see.
+ *
+ * The image-load callback is fired by this file rather than by
+ * the task queue (see stubs_retroarch.c), which is what lets the
+ * upload side run on a thread of our choosing while the video
+ * side polls.
+ *
+ * Run it four ways:
+ *
+ *     make && ./gfx_thumbnail_sanitize_test
+ *     make clean && make SANITIZER=address,undefined
+ *     ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+ *         ./gfx_thumbnail_sanitize_test
+ *     make clean && make SANITIZER=thread
+ *     ./gfx_thumbnail_sanitize_test
+ *
+ * All four are clean as of writing, over five consecutive TSan
+ * runs.
+ *
+ * THREE WAYS THIS NEARLY LIED, AND WHAT STOPS IT NOW
+ *
+ * The first working version reported ALL OK with
+ * texture loads=0: it pointed at a path that did not exist,
+ * path_is_valid() rejected it, and the whole request path was
+ * skipped.  Hence make_probe_file() and the explicit assertions
+ * on the load/unload counts below -- a run that reaches nothing
+ * now fails instead of passing.
+ *
+ * The first LSan run reported 81920 bytes leaked, all of it
+ * because image_texture_free() was stubbed as a no-op and that
+ * is the function that owns the pixel buffer.  The stub now
+ * frees it like the real one, so a leak that survives is the
+ * code under test's.
+ *
+ * The first TSan run reported six races, all of them the
+ * harness's own go/stop handshake, which was a pair of volatile
+ * ints.  volatile is not a synchronisation primitive and TSan
+ * was right to say so; they are atomics now, because six
+ * harness warnings would bury one real report.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rthreads/rthreads.h>
+#include <queues/task_queue.h>
+#include <retro_timers.h>
+#include <retro_atomic.h>
+
+#define GFX_THUMB_STATUS_LOAD(p)     retro_atomic_load_acquire_int(p)
+#define GFX_THUMB_STATUS_STORE(p, v) retro_atomic_store_release_int((p), (v))
+
+#include "gfx/gfx_thumbnail.h"
+
+typedef struct
+{
+   retro_task_callback_t cb;
+   void                 *user_data;
+   uint32_t              type_hash;
+   char                  path[4096];
+   int                   pending;
+} stub_image_request_t;
+
+extern stub_image_request_t g_stub_image_req;
+extern int g_stub_texture_loads;
+extern int g_stub_texture_unloads;
+extern int g_stub_quiet;
+
+static int  failures;
+static char s_probe_path[512];
+
+/* gfx_thumbnail_request_file() calls path_is_valid() before it does
+ * anything else, so without a file on disk the whole request path is
+ * skipped and every check below passes having tested nothing.  Write
+ * one. */
+static int make_probe_file(void)
+{
+   FILE *f;
+   snprintf(s_probe_path, sizeof(s_probe_path),
+         "gfx_thumbnail_sanitize_probe.png");
+   if (!(f = fopen(s_probe_path, "wb")))
+      return 0;
+   /* Contents are never decoded -- task_push_image_load is stubbed --
+    * so a PNG signature is plenty. */
+   fwrite("\x89PNG\r\n\x1a\n", 1, 8, f);
+   fclose(f);
+   return 1;
+}
+
+#define CHECK(cond, msg) \
+   do { if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); failures++; } } while (0)
+
+/* Deliver the image-load result the way task_image_load's callback
+ * would.  A NULL task_data is the "decode failed" path, which the
+ * thumbnail code has to treat as MISSING rather than AVAILABLE. */
+static void deliver(int succeed)
+{
+   struct texture_image *img = NULL;
+
+   if (!g_stub_image_req.pending || !g_stub_image_req.cb)
+      return;
+
+   if (succeed)
+   {
+      img = (struct texture_image*)calloc(1, sizeof(*img));
+      if (img)
+      {
+         img->width  = 64;
+         img->height = 64;
+         img->pixels = (uint32_t*)calloc(64 * 64, sizeof(uint32_t));
+      }
+   }
+
+   g_stub_image_req.pending = 0;
+   g_stub_image_req.cb(NULL, img, g_stub_image_req.user_data, NULL);
+}
+
+/* ------------------------------------------------------------------
+ * 1. init -> request -> deliver -> reset -> free, repeatedly
+ * ------------------------------------------------------------------ */
+static void test_lifecycle(void)
+{
+   gfx_thumbnail_t thumb;
+   int i;
+
+   for (i = 0; i < 8; i++)
+   {
+      memset(&thumb, 0, sizeof(thumb));
+      gfx_thumbnail_init_blank(&thumb);
+
+      CHECK(GFX_THUMB_STATUS_LOAD(&thumb.status)
+            == GFX_THUMBNAIL_STATUS_UNKNOWN,
+            "a blank thumbnail should start UNKNOWN");
+
+      gfx_thumbnail_request_file(s_probe_path, &thumb, 0);
+      deliver(i & 1);
+
+      gfx_thumbnail_reset(&thumb);
+
+      CHECK(thumb.texture == 0,
+            "reset should leave no texture behind");
+   }
+}
+
+/* ------------------------------------------------------------------
+ * 2. double free / idempotent free
+ * ------------------------------------------------------------------ */
+static void test_double_reset(void)
+{
+   gfx_thumbnail_t thumb;
+
+   memset(&thumb, 0, sizeof(thumb));
+   gfx_thumbnail_init_blank(&thumb);
+   gfx_thumbnail_request_file(s_probe_path, &thumb, 0);
+   deliver(1);
+
+   gfx_thumbnail_reset(&thumb);
+   gfx_thumbnail_reset(&thumb);
+   gfx_thumbnail_reset(&thumb);
+
+   CHECK(thumb.texture == 0, "repeated reset must stay clean");
+}
+
+/* ------------------------------------------------------------------
+ * 3. path data: reset and reuse mid-stream
+ * ------------------------------------------------------------------ */
+static void test_path_data_churn(void)
+{
+   gfx_thumbnail_path_data_t *pd = gfx_thumbnail_path_init();
+   int i;
+
+   CHECK(pd != NULL, "path_init should allocate");
+   if (!pd)
+      return;
+
+   for (i = 0; i < 32; i++)
+   {
+      char label[64];
+      snprintf(label, sizeof(label), "content-%d", i);
+
+      gfx_thumbnail_set_system(pd, "SystemName", NULL);
+      gfx_thumbnail_set_content(pd, label);
+      gfx_thumbnail_update_path(pd, GFX_THUMBNAIL_RIGHT);
+      gfx_thumbnail_update_path(pd, GFX_THUMBNAIL_LEFT);
+
+      if (i & 1)
+         gfx_thumbnail_path_reset(pd);
+
+      gfx_thumbnail_set_content_image(pd, "/tmp", "image.png");
+      gfx_thumbnail_update_path(pd, GFX_THUMBNAIL_ICON);
+   }
+
+   free(pd);
+}
+
+/* ------------------------------------------------------------------
+ * 4. the producer/consumer pairing, on two real threads
+ *
+ * The upload thread publishes; the video thread polls status and,
+ * on AVAILABLE, reads the fields the publisher wrote before it.
+ * A missing release/acquire pair shows up here as a TSan report or
+ * as a torn read of width/height/texture.
+ * ------------------------------------------------------------------ */
+#define PAIR_ITERS 2000
+
+/* go/stop are atomics, not volatile ints.  volatile is not a
+ * synchronisation primitive and TSan is right to say so; leaving them
+ * plain buries any real report from gfx_thumbnail.c under six
+ * warnings about the harness. */
+typedef struct
+{
+   gfx_thumbnail_t    thumb;
+   retro_atomic_int_t go;
+   retro_atomic_int_t stop;
+   int                torn;
+} pair_state_t;
+
+static void upload_thread(void *arg)
+{
+   pair_state_t *st = (pair_state_t*)arg;
+   int i;
+
+   for (i = 0; i < PAIR_ITERS; i++)
+   {
+      while (      !retro_atomic_load_acquire_int(&st->go)
+               && !retro_atomic_load_acquire_int(&st->stop))
+         retro_sleep(0);
+      if (retro_atomic_load_acquire_int(&st->stop))
+         return;
+
+      /* Publish, in the order the real upload callback does. */
+      st->thumb.width  = 64;
+      st->thumb.height = 64;
+      st->thumb.texture = (uintptr_t)(0x2000 + i);
+      GFX_THUMB_STATUS_STORE(&st->thumb.status,
+            GFX_THUMBNAIL_STATUS_AVAILABLE);
+
+      retro_atomic_store_release_int(&st->go, 0);
+   }
+}
+
+static void test_publish_observe(void)
+{
+   pair_state_t st;
+   sthread_t *t;
+   int i;
+
+   memset(&st, 0, sizeof(st));
+   retro_atomic_int_init(&st.go, 0);
+   retro_atomic_int_init(&st.stop, 0);
+   gfx_thumbnail_init_blank(&st.thumb);
+
+   if (!(t = sthread_create(upload_thread, &st)))
+   {
+      fprintf(stderr, "FAIL: could not start the upload thread\n");
+      failures++;
+      return;
+   }
+
+   for (i = 0; i < PAIR_ITERS; i++)
+   {
+      GFX_THUMB_STATUS_STORE(&st.thumb.status,
+            GFX_THUMBNAIL_STATUS_PENDING);
+      st.thumb.texture = 0;
+      retro_atomic_store_release_int(&st.go, 1);
+
+      while (GFX_THUMB_STATUS_LOAD(&st.thumb.status)
+            != GFX_THUMBNAIL_STATUS_AVAILABLE)
+         retro_sleep(0);
+
+      /* Everything the publisher wrote before the release store must
+       * be visible now. */
+      if (     st.thumb.width  != 64
+            || st.thumb.height != 64
+            || st.thumb.texture != (uintptr_t)(0x2000 + i))
+         st.torn++;
+   }
+
+   retro_atomic_store_release_int(&st.stop, 1);
+   retro_atomic_store_release_int(&st.go, 1);
+   sthread_join(t);
+
+   CHECK(st.torn == 0, "a published thumbnail was observed half-written");
+}
+
+int main(void)
+{
+   g_stub_quiet = 1;
+
+   if (!make_probe_file())
+   {
+      fputs("FAIL: could not create the probe file in the"
+            " working directory\n", stderr);
+      return 1;
+   }
+
+   test_lifecycle();
+   test_double_reset();
+   test_path_data_churn();
+   test_publish_observe();
+
+   remove(s_probe_path);
+
+   /* The counts are asserted, not just printed.  Zero here means the
+    * request path was never entered and everything above passed
+    * without touching the code under test. */
+   printf("texture loads=%d unloads=%d\n",
+         g_stub_texture_loads, g_stub_texture_unloads);
+
+   CHECK(g_stub_texture_loads > 0,
+         "no texture was ever loaded; the request path was not reached");
+   CHECK(g_stub_texture_loads == g_stub_texture_unloads,
+         "texture loads and unloads are unbalanced");
+
+   if (failures)
+   {
+      fprintf(stderr, "%d check(s) failed\n", failures);
+      return 1;
+   }
+   puts("ALL OK");
+   return 0;
+}

--- a/samples/gfx/gfx_thumbnail_sanitize/stubs_retroarch.c
+++ b/samples/gfx/gfx_thumbnail_sanitize/stubs_retroarch.c
@@ -1,0 +1,292 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (stubs_retroarch.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Stubs for everything gfx/gfx_thumbnail.c reaches outside itself, so
+ * it can be exercised in isolation under the sanitizers.
+ *
+ * Two of these are load-bearing rather than inert.
+ *
+ * task_push_image_load() records the request instead of queueing it,
+ * so the test can fire the callback itself, on a thread of its
+ * choosing.  That is what makes the producer/consumer pairing
+ * reachable by TSan at all.
+ *
+ * image_texture_free() really frees the pixel buffer, because that is
+ * what the real one does and it owns it.  Stubbing it as a no-op made
+ * LSan report 80 KB leaked against the harness, which would have
+ * masked a leak in the code under test.
+ *
+ * Signatures are copied from the headers rather than guessed; a stub
+ * with the wrong prototype is a different function that happens to
+ * link. */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <boolean.h>
+
+#include <queues/task_queue.h>
+#include <formats/image.h>
+
+/* --- captured image-load request --- */
+typedef struct
+{
+   retro_task_callback_t cb;
+   void                 *user_data;
+   uint32_t              type_hash;
+   char                  path[4096];
+   int                   pending;
+} stub_image_request_t;
+
+stub_image_request_t g_stub_image_req;
+int                  g_stub_texture_loads;
+int                  g_stub_texture_unloads;
+
+/* --- logging --- */
+int g_stub_quiet = 1;
+void RARCH_LOG (const char *fmt, ...) { if (!g_stub_quiet) { va_list a; va_start(a,fmt); vfprintf(stderr,fmt,a); va_end(a);} }
+void RARCH_ERR (const char *fmt, ...) { if (!g_stub_quiet) { va_list a; va_start(a,fmt); vfprintf(stderr,fmt,a); va_end(a);} }
+void RARCH_WARN(const char *fmt, ...) { if (!g_stub_quiet) { va_list a; va_start(a,fmt); vfprintf(stderr,fmt,a); va_end(a);} }
+void RARCH_DBG (const char *fmt, ...) { (void)fmt; }
+
+/* --- singletons --- */
+static char s_settings[1 << 18];
+static char s_menu_state[1 << 16];
+static char s_video_state[1 << 16];
+static char s_runloop_state[1 << 18];
+static char s_disp[1 << 16];
+
+void *config_get_ptr(void)      { return s_settings; }
+void *menu_state_get_ptr(void)  { return s_menu_state; }
+void *video_state_get_ptr(void) { return s_video_state; }
+void *runloop_state_get_ptr(void) { return s_runloop_state; }
+void *disp_get_ptr(void)        { return s_disp; }
+
+const char *msg_hash_to_str(int e) { (void)e; return "stub"; }
+
+/* --- video driver --- */
+bool video_driver_texture_load(void *data, unsigned filter, uintptr_t *id)
+{
+   (void)data; (void)filter;
+   g_stub_texture_loads++;
+   /* Non-zero, and distinct per load so a stale handle is visible. */
+   *id = (uintptr_t)(0x1000 + g_stub_texture_loads);
+   return true;
+}
+
+bool video_driver_texture_unload(uintptr_t *id)
+{
+   (void)id;
+   g_stub_texture_unloads++;
+   return true;
+}
+
+void video_driver_get_video_output_size(unsigned *w, unsigned *h,
+      char *d, size_t l)
+{
+   (void)d; (void)l;
+   if (w)
+      *w = 1920;
+   if (h)
+      *h = 1080;
+}
+
+bool video_driver_get_viewport_info(void *vp) { (void)vp; return false; }
+uint32_t video_driver_get_disp_flags(void) { return 0; }
+
+/* --- gfx --- */
+void gfx_animation_kill_by_tag(uintptr_t *tag) { (void)tag; }
+bool gfx_animation_push(void *entry) { (void)entry; return true; }
+void gfx_display_rotate_z(void *draw, void *data) { (void)draw; (void)data; }
+unsigned gfx_display_texture_filter(void) { return 0; }
+
+/* --- image loading --- */
+bool task_push_image_load(const char *fullpath, bool supports_rgba,
+      unsigned upscale_threshold, uint32_t type_hash,
+      retro_task_callback_t cb, void *user_data)
+{
+   (void)supports_rgba; (void)upscale_threshold;
+   memset(&g_stub_image_req, 0, sizeof(g_stub_image_req));
+   if (fullpath)
+      strncpy(g_stub_image_req.path, fullpath,
+            sizeof(g_stub_image_req.path) - 1);
+   g_stub_image_req.cb        = cb;
+   g_stub_image_req.user_data = user_data;
+   g_stub_image_req.type_hash = type_hash;
+   g_stub_image_req.pending   = 1;
+   return true;
+}
+
+/* Matches the real one closely enough for ownership purposes: the
+ * pixel buffer belongs to the image, and freeing it here is what makes
+ * any remaining leak attributable to gfx_thumbnail.c rather than to
+ * the harness. */
+void image_texture_free(struct texture_image *img)
+{
+   if (!img)
+      return;
+   if (img->pixels)
+      free(img->pixels);
+   img->pixels = NULL;
+}
+enum image_type_enum image_texture_get_type(const char *path)
+{ (void)path; return IMAGE_TYPE_NONE; }
+bool rpng_is_apng_ex(const char *path, void *o) { (void)path; (void)o; return false; }
+
+/* --- animated stream: never entered here, the harness feeds still
+ * images, but the symbols have to resolve.  Signatures copied from
+ * libretro-common/include/formats/image.h rather than guessed --
+ * getting them wrong is how a stub silently becomes a different
+ * function. --- */
+void *image_transfer_anim_stream_new(void *buf, size_t len,
+      enum image_type_enum type)
+{ (void)buf; (void)len; (void)type; return NULL; }
+
+void *image_transfer_anim_stream_new_avail(void *buf, size_t len,
+      size_t avail, enum image_type_enum type, int *need_more)
+{
+   (void)buf; (void)len; (void)avail; (void)type;
+   if (need_more)
+      *need_more = 0;
+   return NULL;
+}
+
+void image_transfer_anim_stream_free(void *stream,
+      enum image_type_enum type)
+{ (void)stream; (void)type; }
+
+void image_transfer_anim_stream_get_info(void *stream,
+      enum image_type_enum type, unsigned *width, unsigned *height,
+      int *num_frames, int *loop_count)
+{
+   (void)stream; (void)type;
+   if (width)
+      *width = 0;
+   if (height)
+      *height = 0;
+   if (num_frames)
+      *num_frames = 0;
+   if (loop_count)
+      *loop_count = 0;
+}
+
+const uint32_t *image_transfer_anim_stream_next(void *stream,
+      enum image_type_enum type, int *duration_ms)
+{
+   (void)stream; (void)type;
+   if (duration_ms)
+      *duration_ms = 0;
+   return NULL;
+}
+
+bool image_transfer_anim_stream_set_argb(void *stream,
+      enum image_type_enum type, int argb)
+{ (void)stream; (void)type; (void)argb; return false; }
+
+void image_transfer_anim_stream_set_avail(void *stream,
+      enum image_type_enum type, size_t avail)
+{ (void)stream; (void)type; (void)avail; }
+
+size_t image_transfer_anim_stream_media_floor(void *stream,
+      enum image_type_enum type)
+{ (void)stream; (void)type; return 0; }
+
+size_t image_transfer_anim_stream_consumed(void *stream,
+      enum image_type_enum type)
+{ (void)stream; (void)type; return 0; }
+
+void image_transfer_anim_stream_complete_scan(void *stream,
+      enum image_type_enum type, const void *buf, size_t len)
+{ (void)stream; (void)type; (void)buf; (void)len; }
+
+void image_transfer_anim_stream_rewind(void *stream,
+      enum image_type_enum type)
+{ (void)stream; (void)type; }
+
+void task_image_detach_video_stream(void *t) { (void)t; }
+
+/* --- data transfer window --- */
+void  data_transfer_complete(void *t) { (void)t; }
+void  data_transfer_failed(void *t) { (void)t; }
+void  data_transfer_free(void *t) { (void)t; }
+bool  data_transfer_iterate_while(void *t) { (void)t; return false; }
+void *data_transfer_open_window(void *t, size_t n) { (void)t; (void)n; return NULL; }
+bool  data_transfer_reserve_supported(void *t) { (void)t; return false; }
+void *data_transfer_window_base(void *t) { (void)t; return NULL; }
+bool  data_transfer_window_extend(void *t, size_t n) { (void)t; (void)n; return false; }
+void  data_transfer_window_feed(void *t, size_t n) { (void)t; (void)n; }
+bool  data_transfer_window_is_reserved(void *t) { (void)t; return false; }
+void  mem_stats_free(void *s) { (void)s; }
+
+/* --- task queue --- */
+bool task_queue_find(task_finder_data_t *find_data)
+{ (void)find_data; return false; }
+void task_set_flags(retro_task_t *t, uint8_t f, bool set)
+{ (void)t; (void)f; (void)set; }
+bool  task_push_pl_entry_thumbnail_download(const char *sys,
+      void *pl, unsigned idx, bool over, bool mute)
+{ (void)sys; (void)pl; (void)idx; (void)over; (void)mute; return false; }
+
+/* --- audio mixer --- */
+bool audio_driver_mixer_add_stream(void *p) { (void)p; return false; }
+void audio_driver_mixer_remove_stream(unsigned i) { (void)i; }
+const char *audio_driver_mixer_get_stream_name(unsigned i) { (void)i; return ""; }
+
+/* --- playlist --- */
+void *playlist_get_cached(void) { return NULL; }
+size_t playlist_get_size(void *pl) { (void)pl; return 0; }
+void playlist_get_index(void *pl, size_t i, const void **e) { (void)pl; (void)i; if (e) *e = NULL; }
+const char *playlist_get_conf_path(void *pl) { (void)pl; return ""; }
+char *playlist_get_db_name(void *pl) { (void)pl; return NULL; }
+int  playlist_get_thumbnail_mode(void *pl, unsigned id) { (void)pl; (void)id; return 0; }
+int  playlist_get_curr_thumbnail_name_flag(void *pl) { (void)pl; return 0; }
+void playlist_update_thumbnail_name_flag(void *pl, size_t i, int f) { (void)pl; (void)i; (void)f; }
+bool playlist_thumbnail_match_with_filename(void *pl) { (void)pl; return false; }
+
+/* --- misc --- */
+void runloop_path_set_redirect(void *s, const char *a, const char *b, char *c, size_t d)
+{ (void)s; (void)a; (void)b; (void)c; (void)d; }
+void dir_set(unsigned id, const char *path) { (void)id; (void)path; }
+
+/* path_is_media_type lives in file_path_special.c, which drags in the
+ * frontend; the thumbnail code only asks so it can reject non-images. */
+enum rarch_content_type { RARCH_CONTENT_NONE = 0, RARCH_CONTENT_IMAGE = 3 };
+int path_is_media_type(const char *path)
+{
+   const char *ext = strrchr(path ? path : "", '.');
+   if (ext && (!strcmp(ext, ".png") || !strcmp(ext, ".jpg")))
+      return RARCH_CONTENT_IMAGE;
+   return RARCH_CONTENT_NONE;
+}
+
+/* CDROM VFS is compiled out here. */
+void *retro_vfs_file_open_cdrom(void *p, const char *a, unsigned b, unsigned c)
+{ (void)p; (void)a; (void)b; (void)c; return NULL; }
+int   retro_vfs_file_close_cdrom(void *s) { (void)s; return -1; }
+int64_t retro_vfs_file_read_cdrom(void *s, void *b, uint64_t n)
+{ (void)s; (void)b; (void)n; return -1; }
+int64_t retro_vfs_file_seek_cdrom(void *s, int64_t o, int w)
+{ (void)s; (void)o; (void)w; return -1; }
+int64_t retro_vfs_file_tell_cdrom(void *s) { (void)s; return -1; }
+int   retro_vfs_file_error_cdrom(void *s) { (void)s; return -1; }

--- a/samples/gfx/gfx_thumbnail_status_atomic/Makefile
+++ b/samples/gfx/gfx_thumbnail_status_atomic/Makefile
@@ -29,6 +29,17 @@ ifeq ($(HAVE_THREADS),1)
    LDFLAGS += -lrt
 endif
 
+# Extra flags for the caller, e.g. the -DSTRESS_ITERS= override the
+# test documents:
+#
+#     make EXTRA_CFLAGS=-DSTRESS_ITERS=20000
+#
+# Passing those through CFLAGS= instead would clobber everything set
+# above, -DHAVE_THREADS included, and the test would quietly report
+# "[skip] HAVE_THREADS not defined; static checks only" while still
+# exiting 0 -- a pass with the whole stress section switched off.
+CFLAGS += $(EXTRA_CFLAGS)
+
 OBJS := $(SOURCES:.c=.o)
 
 ifneq ($(SANITIZER),)

--- a/samples/gfx/gfx_thumbnail_status_atomic/gfx_thumbnail_status_atomic_test.c
+++ b/samples/gfx/gfx_thumbnail_status_atomic/gfx_thumbnail_status_atomic_test.c
@@ -214,10 +214,21 @@ typedef char _gfx_thumb_status_size_check[
  * out a missing-barrier bug under TSan within a few seconds; on
  * real weak-memory hardware (qemu-aarch64) it surfaces faster.
  * Adjust upward if the bug becomes harder to reproduce.
- * Overridable (-DSTRESS_ITERS=...) for constrained environments:
- * the lock-step handshake costs scheduler timeslices per
- * iteration on a single-CPU host, and TSan's happens-before
- * detection does not depend on the count. */
+ * Overridable for constrained environments: the lock-step
+ * handshake costs scheduler timeslices per iteration on a
+ * single-CPU host, and TSan's happens-before detection does not
+ * depend on the count.  Pass it through the Makefile's
+ * EXTRA_CFLAGS, not CFLAGS:
+ *
+ *     make EXTRA_CFLAGS=-DSTRESS_ITERS=20000
+ *
+ * CFLAGS= on the command line replaces everything the Makefile
+ * sets, -DHAVE_THREADS included, and the run then reports
+ * "[skip] HAVE_THREADS not defined" and exits 0 with the whole
+ * stress section switched off.
+ *
+ * Measured on one core: 2.9 s at 20000, 14.4 s at 100000, 36 s
+ * at 250000, ~145 s at the default. */
 #ifndef STRESS_ITERS
 #define STRESS_ITERS 1000000
 #endif

--- a/samples/gfx/gfx_thumbnail_status_atomic/gfx_thumbnail_status_atomic_test.c
+++ b/samples/gfx/gfx_thumbnail_status_atomic/gfx_thumbnail_status_atomic_test.c
@@ -99,6 +99,34 @@
  * through to the static-assert checks otherwise. */
 #ifdef HAVE_THREADS
 #include <rthreads/rthreads.h>
+#include <retro_timers.h>
+
+/* Yield inside the spin waits.
+ *
+ * The three waits below are pure busy loops.  On a machine with more
+ * than one core that is exactly what is wanted -- the point is to
+ * hammer the release/acquire pair, not to test a scheduler -- but on a
+ * uniprocessor it is a livelock: the spinning thread holds the CPU for
+ * its whole quantum while the thread it is waiting on never runs, so
+ * progress happens only by preemption and a million generations takes
+ * effectively forever.  Single-core CI runners and containers are
+ * common enough to matter; this test used to hang on them.
+ *
+ * Spin a short while first and only then yield: on a multi-core host
+ * the other thread is normally already running and the wait resolves
+ * inside the spin budget, so the yield costs nothing there, while on a
+ * uniprocessor the loop still hands the CPU over instead of holding
+ * it.  retro_sleep(0) is a yield on every platform rthreads supports. */
+#define STRESS_SPIN_BUDGET 64
+
+#define STRESS_YIELD(counter) \
+   do { \
+      if (++(counter) >= STRESS_SPIN_BUDGET) \
+      { \
+         (counter) = 0; \
+         retro_sleep(0); \
+      } \
+   } while (0)
 #endif
 
 /* === Verbatim mirror of gfx_thumbnail.h's relevant pieces === */
@@ -246,7 +274,8 @@ typedef struct
 
 static void producer_thread(void *arg)
 {
-   stress_state_t *s = (stress_state_t *)arg;
+   stress_state_t *s     = (stress_state_t *)arg;
+   unsigned        spins = 0;
    int             i;
 
    for (i = 1; i <= STRESS_ITERS; i++)
@@ -258,7 +287,7 @@ static void producer_thread(void *arg)
        * previous triple. */
       while (GFX_THUMB_STATUS_LOAD(&s->thumb.status)
             != GFX_THUMBNAIL_STATUS_PENDING)
-         ; /* spin */
+         STRESS_YIELD(spins);
 
       /* Stage the generation's data (no ordering required
        * between these). */
@@ -277,13 +306,14 @@ static void producer_thread(void *arg)
     * same field. */
    while (GFX_THUMB_STATUS_LOAD(&s->thumb.status)
          != GFX_THUMBNAIL_STATUS_PENDING)
-      ; /* drain */
+      STRESS_YIELD(spins);
    GFX_THUMB_STATUS_STORE(&s->thumb.status,
          GFX_THUMBNAIL_STATUS_MISSING);
 }
 
 static void consumer_thread(void *arg)
 {
+   unsigned        spins         = 0;
    stress_state_t *s             = (stress_state_t *)arg;
    unsigned long   mismatches    = 0;
    int             expected      = 1;
@@ -300,10 +330,14 @@ static void consumer_thread(void *arg)
       unsigned                  w, h;
       enum gfx_thumbnail_status st;
 
-      do {
+      for (;;)
+      {
          st = GFX_THUMB_STATUS_LOAD(&s->thumb.status);
-      } while (st != GFX_THUMBNAIL_STATUS_AVAILABLE
-            && st != GFX_THUMBNAIL_STATUS_MISSING);
+         if (     st == GFX_THUMBNAIL_STATUS_AVAILABLE
+               || st == GFX_THUMBNAIL_STATUS_MISSING)
+            break;
+         STRESS_YIELD(spins);
+      }
 
       if (st == GFX_THUMBNAIL_STATUS_MISSING)
          break;

--- a/samples/gfx/gfx_widgets_sanitize/Makefile
+++ b/samples/gfx/gfx_widgets_sanitize/Makefile
@@ -1,0 +1,64 @@
+TARGET := gfx_widgets_sanitize_test
+
+# Path back to the repo root from this sample dir.  Links the real
+# gfx/gfx_widgets.c; the point is to put it under the sanitizers, so a
+# mirror would prove nothing.
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+# gfx_widgets.c reaches for 59 symbols outside itself.  Eight resolve
+# to real libretro-common sources and are linked; the rest are in
+# stubs_retroarch.c, including dummies for the ten gfx_widget_t
+# instances that live in gfx/widgets/.
+SOURCES := gfx_widgets_sanitize_test.c \
+           stubs_retroarch.c \
+           $(REPO_ROOT)/gfx/gfx_widgets.c \
+           $(LIBRETRO_COMM_DIR)/string/stdstring.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+           $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+           $(LIBRETRO_COMM_DIR)/queues/fifo_queue.c \
+           $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+           $(LIBRETRO_COMM_DIR)/file/file_path.c \
+           $(LIBRETRO_COMM_DIR)/lists/string_list.c \
+           $(LIBRETRO_COMM_DIR)/time/rtime.c
+
+CFLAGS  += -Wall -std=gnu99 -g -O1 \
+           -DHAVE_THREADS -DHAVE_MENU -DHAVE_GFX_WIDGETS \
+           -I$(REPO_ROOT) \
+           -I$(LIBRETRO_COMM_DIR)/include
+
+LDFLAGS += -lpthread -lm
+
+# Extra flags for the caller; CFLAGS= on the command line would replace
+# everything set above, -DHAVE_GFX_WIDGETS included.
+CFLAGS += $(EXTRA_CFLAGS)
+
+OBJS := $(SOURCES:.c=.o)
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+# ASan and TSan are mutually exclusive, hence separate passes.
+sweep:
+	$(MAKE) clean && $(MAKE) && ./$(TARGET)
+	$(MAKE) clean && $(MAKE) SANITIZER=address,undefined && \
+	   ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+	   UBSAN_OPTIONS=print_stacktrace=1 ./$(TARGET)
+	$(MAKE) clean && $(MAKE) SANITIZER=thread && \
+	   TSAN_OPTIONS=halt_on_error=0 ./$(TARGET)
+	@echo "sweep clean"
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: all sweep clean

--- a/samples/gfx/gfx_widgets_sanitize/gfx_widgets_sanitize_test.c
+++ b/samples/gfx/gfx_widgets_sanitize/gfx_widgets_sanitize_test.c
@@ -1,0 +1,261 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (gfx_widgets_sanitize_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Sanitizer sweep for gfx/gfx_widgets.c.
+ *
+ * Third of the sanitize samples, and unlike gfx_animation_sanitize
+ * this one pins no defect: gfx_widgets.c came back clean on all four
+ * sanitizers the first time it was run.  It is here as a tripwire
+ * rather than a regression test, on the same reasoning as any other
+ * clean sweep -- the value is in the next change, not this one.
+ *
+ * The focus is the message queue, because it has the same shape as
+ * the gfx_animation ticker bug that prompted this: a caller-supplied
+ * string, internal fixed buffers, and arithmetic that has to keep
+ * glyphs and bytes apart.  So it gets multi-byte text, over-long
+ * text, text with nothing to word-wrap on, an embedded newline, and
+ * empty strings, across every message/title pairing.
+ *
+ * Two details that decide whether this sweeps anything at all.
+ *
+ * The font metrics in stubs_retroarch.c return a non-zero,
+ * proportional width.  A zero-width font makes every "does this fit"
+ * test in gfx_widgets.c succeed and the layout paths are never
+ * entered -- the sweep would pass having exercised nothing.
+ *
+ * gfx_widgets_init() returns false without doing anything if
+ * gfx_display_init_first_driver() fails, and the first run of this
+ * did exactly that: pushes=0, frames=0, and every check below
+ * vacuously satisfied.  Hence the assertions on those counters at the
+ * bottom.
+ *
+ * Run it three ways:
+ *
+ *     make sweep
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../../gfx/gfx_widgets.h"
+#include "../../../gfx/gfx_display.h"
+#include "../../../gfx/gfx_animation.h"
+
+static int failures;
+static int pushes;
+static int iterations;
+
+#define CHECK(cond, msg) \
+   do { if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (msg)); failures++; } } while (0)
+
+static gfx_display_t   s_disp;
+static gfx_animation_t s_anim;
+static char            s_settings[1 << 18];
+
+static bool widgets_up(void)
+{
+   memset(&s_disp, 0, sizeof(s_disp));
+   memset(&s_anim, 0, sizeof(s_anim));
+   memset(s_settings, 0, sizeof(s_settings));
+
+   return gfx_widgets_init(&s_disp, &s_anim, s_settings,
+         (uintptr_t)&s_disp, false, 1920, 1080, false,
+         "/tmp/nonexistent-assets", NULL);
+}
+
+/* A frame's worth of work: iterate, then draw.
+ *
+ * gfx_widgets_frame() takes a video_frame_info_t and dereferences it,
+ * its ->disp_userdata and that pointer's ->dispctx without checking
+ * any of them.  The real caller in video_driver.c always supplies all
+ * three, so this mirrors that rather than treating it as a defect. */
+static void pump(int frames)
+{
+   int i;
+   for (i = 0; i < frames; i++)
+   {
+      video_frame_info_t video_info;
+
+      gfx_widgets_iterate(&s_disp, s_settings,
+            1920, 1080, false, "/tmp/nonexistent-assets", NULL, false);
+
+      memset(&video_info, 0, sizeof(video_info));
+      video_info.disp_userdata    = &s_disp;
+      video_info.widgets_userdata = dispwidget_get_ptr();
+      video_info.width            = 1920;
+      video_info.height           = 1080;
+
+      gfx_widgets_frame(&video_info);
+      iterations++;
+   }
+}
+
+static void push(const char *msg, const char *title, unsigned prio)
+{
+   char title_buf[256];
+
+   if (title)
+   {
+      strncpy(title_buf, title, sizeof(title_buf) - 1);
+      title_buf[sizeof(title_buf) - 1] = '\0';
+   }
+   else
+      title_buf[0] = '\0';
+
+   gfx_widgets_msg_queue_push(NULL, msg, msg ? strlen(msg) : 0,
+         1000, title ? title_buf : NULL,
+         MESSAGE_QUEUE_ICON_DEFAULT,
+         MESSAGE_QUEUE_CATEGORY_INFO,
+         prio, false, false);
+   pushes++;
+}
+
+/* ------------------------------------------------------------------
+ * Inputs
+ * ------------------------------------------------------------------ */
+static const char *const msgs[] =
+{
+   "",
+   "x",
+   "a short message",
+   "a message long enough to need wrapping across more than one line "
+      "of a widget that is only so wide, and then some more after that",
+   /* Multi-byte: three bytes per glyph. */
+   "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xe3\x81\xae\xe3\x83\xa1\xe3\x83"
+      "\x83\xe3\x82\xbb\xe3\x83\xbc\xe3\x82\xb8",
+   /* Multi-byte and long: the combination the ticker bug needed. */
+   "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa"
+      "\x9e\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xe6\x97\xa5\xe6\x9c\xac"
+      "\xe8\xaa\x9e\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xe6\x97\xa5\xe6"
+      "\x9c\xac\xe8\xaa\x9e\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e",
+   /* No spaces at all: nothing for the wrapper to break on. */
+   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+   /* A newline in the middle. */
+   "first line\nsecond line that is rather longer than the first one"
+};
+
+#define N_MSGS ((int)(sizeof(msgs) / sizeof(msgs[0])))
+
+static void test_push_and_expire(void)
+{
+   int i;
+
+   if (!widgets_up())
+   {
+      fputs("FAIL: gfx_widgets_init() refused\n", stderr);
+      failures++;
+      return;
+   }
+
+   for (i = 0; i < N_MSGS; i++)
+   {
+      push(msgs[i], NULL, 0);
+      pump(3);
+   }
+
+   pump(30);
+   gfx_widgets_deinit(false);
+}
+
+/* Titles go through their own composition path. */
+static void test_titles(void)
+{
+   int i, j;
+
+   if (!widgets_up())
+      return;
+
+   for (i = 0; i < N_MSGS; i++)
+      for (j = 0; j < N_MSGS; j++)
+      {
+         push(msgs[i], msgs[j], (unsigned)(i + j));
+         pump(2);
+      }
+
+   pump(20);
+   gfx_widgets_deinit(false);
+}
+
+/* Overflow the queue: more messages than it can hold, so the eviction
+ * and free paths run. */
+static void test_queue_overflow(void)
+{
+   int i;
+
+   if (!widgets_up())
+      return;
+
+   for (i = 0; i < 256; i++)
+   {
+      push(msgs[i % N_MSGS], (i & 1) ? msgs[(i + 3) % N_MSGS] : NULL,
+            (unsigned)(i % 8));
+      if ((i & 7) == 0)
+         pump(1);
+   }
+
+   pump(60);
+   gfx_widgets_deinit(false);
+}
+
+/* init/deinit repeatedly, with messages outstanding at teardown. */
+static void test_init_deinit_cycles(void)
+{
+   int c, i;
+
+   for (c = 0; c < 8; c++)
+   {
+      if (!widgets_up())
+         return;
+
+      for (i = 0; i < N_MSGS; i++)
+         push(msgs[i], msgs[N_MSGS - 1 - i], 0);
+
+      pump(2);
+      /* Deliberately does not wait for them to expire. */
+      gfx_widgets_deinit((c & 1) ? true : false);
+   }
+}
+
+int main(void)
+{
+   test_push_and_expire();
+   test_titles();
+   test_queue_overflow();
+   test_init_deinit_cycles();
+
+   printf("pushes=%d frames=%d\n", pushes, iterations);
+
+   /* Asserted, not printed: a build where init refused would otherwise
+    * sweep nothing and report success. */
+   CHECK(pushes > 0,     "no message was ever pushed");
+   CHECK(iterations > 0, "no frame was ever iterated");
+
+   if (failures)
+   {
+      fprintf(stderr, "%d check(s) failed\n", failures);
+      return 1;
+   }
+   puts("ALL OK");
+   return 0;
+}

--- a/samples/gfx/gfx_widgets_sanitize/stubs_retroarch.c
+++ b/samples/gfx/gfx_widgets_sanitize/stubs_retroarch.c
@@ -1,0 +1,209 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (stubs_retroarch.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (stubs_retroarch.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Everything gfx/gfx_widgets.c reaches for outside itself.
+ *
+ * The font metrics are the load-bearing ones.  gfx_widgets.c sizes
+ * every message box from font_driver_get_message_width(), and the
+ * width it gets back decides how many glyphs it will try to fit and
+ * therefore how much it writes.  A stub returning zero would make the
+ * layout arithmetic trivially satisfiable and hide exactly the
+ * overflows this is looking for, so these return a plausible
+ * proportional-ish width instead: it does not have to match any real
+ * font, only to grow with the string and not be zero.
+ *
+ * The ten gfx_widget_t instances are the individual widgets, defined
+ * under gfx/widgets.  Linking those would drag in the whole frontend;
+ * they are dummies here with every hook NULL, which gfx_widgets.c
+ * already handles because a build without HAVE_CHEEVOS or HAVE_NETWORKING
+ * omits several of them for real.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <boolean.h>
+
+#include "../../../gfx/gfx_widgets.h"
+#include "../../../gfx/gfx_display.h"
+#include "../../../gfx/gfx_animation.h"
+#include "../../../retroarch.h"
+#include "../../../msg_hash.h"
+
+/* --- singletons --- */
+static char s_video_state[1 << 16];
+video_driver_state_t *video_state_get_ptr(void)
+{ return (video_driver_state_t*)s_video_state; }
+
+const char *msg_hash_to_str(enum msg_hash_enums msg)
+{ (void)msg; return "stub message"; }
+
+unsigned *msg_hash_get_uint(enum msg_hash_action type)
+{ static unsigned v; (void)type; return &v; }
+
+/* --- font metrics --- */
+int font_driver_get_message_width(void *font_data, const char *msg,
+      size_t len, float scale)
+{
+   (void)font_data;
+   if (!msg)
+      return 0;
+   if (len == 0)
+      len = strlen(msg);
+   /* Deliberately non-zero and proportional: a zero here would make
+    * every "does this fit" test in gfx_widgets.c succeed and the
+    * layout paths would never be stressed. */
+   return (int)(len * 10 * (scale > 0.0f ? scale : 1.0f));
+}
+
+int font_driver_get_line_height(font_data_t *font, float scale)
+{ (void)font; return (int)(20 * (scale > 0.0f ? scale : 1.0f)); }
+int font_driver_get_line_ascender(font_data_t *font, float scale)
+{ (void)font; return (int)(15 * (scale > 0.0f ? scale : 1.0f)); }
+int font_driver_get_line_descender(font_data_t *font, float scale)
+{ (void)font; return (int)(5 * (scale > 0.0f ? scale : 1.0f)); }
+int font_driver_get_line_centre_offset(font_data_t *font, float scale)
+{ (void)font; return (int)(8 * (scale > 0.0f ? scale : 1.0f)); }
+
+void font_driver_bind_block(void *font_data, void *block)
+{ (void)font_data; (void)block; }
+void font_driver_free(font_data_t *font) { (void)font; }
+
+/* --- display: signatures copied from gfx/gfx_display.h --- */
+void gfx_display_draw_quad(gfx_display_t *p_disp, void *data,
+      unsigned video_width, unsigned video_height,
+      int x, int y, unsigned w, unsigned h,
+      unsigned width, unsigned height, float *color, uintptr_t *texture)
+{ (void)p_disp; (void)data; (void)video_width; (void)video_height;
+  (void)x; (void)y; (void)w; (void)h; (void)width; (void)height;
+  (void)color; (void)texture; }
+
+void gfx_display_draw_text(const font_data_t *font, const char *text,
+      float x, float y, int width, int height, uint32_t color,
+      enum text_alignment text_align, float scale,
+      bool shadows_enable, float shadow_offset, bool draw_outside)
+{ (void)font; (void)text; (void)x; (void)y; (void)width; (void)height;
+  (void)color; (void)text_align; (void)scale; (void)shadows_enable;
+  (void)shadow_offset; (void)draw_outside; }
+
+void gfx_display_rotate_z(gfx_display_t *p_disp, math_matrix_4x4 *matrix,
+      float cosine, float sine, void *data)
+{ (void)p_disp; (void)matrix; (void)cosine; (void)sine; (void)data; }
+
+void gfx_display_scissor_begin(gfx_display_t *p_disp, void *userdata,
+      unsigned video_width, unsigned video_height,
+      int x, int y, unsigned width, unsigned height)
+{ (void)p_disp; (void)userdata; (void)video_width; (void)video_height;
+  (void)x; (void)y; (void)width; (void)height; }
+
+enum texture_filter_type gfx_display_texture_filter(void)
+{ return TEXTURE_FILTER_LINEAR; }
+
+/* gfx_widgets_init() bails immediately on a false here, so the whole
+ * sweep would report a clean pass having initialised nothing.  The
+ * harness asserts pushes > 0 to catch that, and this returns true so
+ * it does not have to. */
+bool gfx_display_init_first_driver(gfx_display_t *p_disp,
+      bool video_is_threaded)
+{ (void)p_disp; (void)video_is_threaded; return true; }
+
+float gfx_display_get_dpi_scale(gfx_display_t *p_disp, void *settings_data,
+      unsigned width, unsigned height, bool fullscreen, bool is_widget)
+{ (void)p_disp; (void)settings_data; (void)width; (void)height;
+  (void)fullscreen; (void)is_widget; return 1.0f; }
+
+bool gfx_display_reset_textures_list_buffer(uintptr_t *item,
+      enum texture_filter_type filter_type, void *buffer,
+      unsigned buffer_len, enum image_type_enum image_type,
+      unsigned *width, unsigned *height)
+{
+   (void)item; (void)filter_type; (void)buffer; (void)buffer_len;
+   (void)image_type;
+   if (width)
+      *width = 0;
+   if (height)
+      *height = 0;
+   return false;
+}
+
+bool gfx_display_load_icon(const char *fullpath, bool supports_rgba,
+      uintptr_t *target_texture, uint64_t generation,
+      uint64_t *generation_ptr)
+{ (void)fullpath; (void)supports_rgba; (void)target_texture;
+  (void)generation; (void)generation_ptr; return false; }
+
+font_data_t *gfx_display_font_file(gfx_display_t *p_disp, char *fontpath,
+      float font_size, bool is_threaded)
+{ (void)p_disp; (void)fontpath; (void)font_size; (void)is_threaded;
+  return NULL; }
+
+/* --- animation --- */
+bool gfx_animation_push(gfx_animation_ctx_entry_t *entry)
+{ (void)entry; return true; }
+bool gfx_animation_kill_by_tag(uintptr_t *tag) { (void)tag; return true; }
+void gfx_animation_timer_start(float *timer,
+      gfx_timer_ctx_entry_t *timer_entry)
+{ (void)timer_entry; if (timer) *timer = 0.0f; }
+
+/* --- video driver --- */
+uint32_t video_driver_get_disp_flags(void) { return 0; }
+bool video_driver_get_viewport_info(struct video_viewport *vp)
+{ (void)vp; return false; }
+void video_driver_monitor_reset(void) { }
+bool video_driver_texture_unload(uintptr_t *id) { (void)id; return true; }
+void video_coord_array_free(video_coord_array_t *ca) { (void)ca; }
+
+/* --- the individual widgets --- */
+#define STUB_WIDGET(name) const gfx_widget_t name = { 0 }
+
+STUB_WIDGET(gfx_widget_screenshot);
+STUB_WIDGET(gfx_widget_volume);
+STUB_WIDGET(gfx_widget_generic_message);
+STUB_WIDGET(gfx_widget_libretro_message);
+STUB_WIDGET(gfx_widget_progress_message);
+STUB_WIDGET(gfx_widget_load_content_animation);
+STUB_WIDGET(gfx_widget_achievement_popup);
+STUB_WIDGET(gfx_widget_leaderboard_display);
+STUB_WIDGET(gfx_widget_netplay_chat);
+STUB_WIDGET(gfx_widget_netplay_ping);


### PR DESCRIPTION
Split from #19284.

- **gfx_animation**: `gfx_animation_ticker()` passed `PATH_MAX_LENGTH` (512) to `utf8cpy()` as the destination size in all five copies, regardless of the caller's buffer — and not one of the 27 call sites provides 512 bytes (mostly `NAME_MAX_LENGTH`, one 64-byte RGUI case). The guard compared glyph counts and then copied bytes; CJK/emoji glyphs are 3–4 bytes each. Reachable from content: a playlist entry with a long enough Japanese/Cyrillic/emoji title overruns an RGUI stack buffer (reproduced under ASan, 300-byte write into 256). The struct gains `s_len` in bytes, mirroring the `dst_str_len` that `ticker_smooth()` had all along; all 27 call sites set it from `sizeof()`. Negative control: reverting the one `utf8cpy()` call makes the sample fail with stack-buffer-overflow.
- **Sanitize samples** for `gfx_animation`, `gfx_thumbnail` and `gfx_widgets` under ASan/UBSan/LSan/TSan: lifecycle churn, frees mid-flight, deinit with work outstanding, and the thumbnail producer/consumer pairing across two real threads. Each sample asserts its own reach (load counters, non-zero pushes) so a run that exercises nothing fails rather than reporting a clean sweep.
- **gfx_thumbnail_status_atomic**: the SPSC stress never terminated on a uniprocessor (pure spin waits); spin-a-budget-then-yield fixes that, the documented `STRESS_ITERS` override is now actually usable via `EXTRA_CFLAGS`, and the CI step is bounded to 20000 iterations (2.4 s under TSan on one core) because the default 1000000 measures ~145 s before TSan overhead against the step's 60 s timeout.

All wired into the samples/gfx workflow. Note: this PR and the display-servers PR both append steps to `Linux-samples-gfx.yml`; whichever merges second needs a trivial append-append conflict resolution.