### PR TITLE
Vulkan hardening + libretro-common test suites in CI

### DIFF
--- a/.github/workflows/Linux-libretro-common-tests.yml
+++ b/.github/workflows/Linux-libretro-common-tests.yml
@@ -1,0 +1,52 @@
+name: CI Linux libretro-common tests
+
+# libretro-common/Makefile.test builds and runs the libcheck unit
+# suites under -fsanitize=address -fsanitize=undefined.  Nothing ran
+# it, which is how three of its suites came to reference sources that
+# had moved and one referenced a library it never linked: a suite that
+# cannot be built reads exactly like a suite that passes.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  libretro-common-tests:
+    name: Build and run libretro-common/Makefile.test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential check pkg-config \
+            zlib1g-dev lcov
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build and run the unit test suites
+        shell: bash
+        working-directory: libretro-common
+        run: |
+          set -eu
+          # The recipe builds each suite, runs it, and collects
+          # coverage, in order -- coverage files collide otherwise.
+          # Any suite failing to build, or any check failing, or any
+          # sanitizer report, fails the job.
+          make -f Makefile.test \
+             LIBCHECK_CFLAGS="$(pkg-config --cflags check)" \
+             CFLAGS="$(pkg-config --cflags check)"
+          echo "[pass] libretro-common unit test suites"

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1059,8 +1059,7 @@ static const char *vulkan_optional_instance_extensions[] = {
 static VkInstance vulkan_context_create_instance_wrapper(void *opaque, const VkInstanceCreateInfo *create_info)
 {
    VkResult res;
-   uint32_t i, layer_count;
-   VkLayerProperties properties[128];
+   uint32_t i;
    gfx_ctx_vulkan_data_t *vk        = (gfx_ctx_vulkan_data_t *)opaque;
    VkInstanceCreateInfo info        = *create_info;
    VkInstance instance              = VK_NULL_HANDLE;
@@ -1126,9 +1125,6 @@ static VkInstance vulkan_context_create_instance_wrapper(void *opaque, const VkI
    instance_layers[info.enabledLayerCount++]         = "VK_LAYER_KHRONOS_validation";
    required_extensions[required_extension_count++] = "VK_EXT_debug_utils";
 #endif
-
-   layer_count = ARRAY_SIZE(properties);
-   vkEnumerateInstanceLayerProperties(&layer_count, properties);
 
    if (!(vulkan_find_instance_extensions(
             instance_extensions, &info.enabledExtensionCount,

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -1090,8 +1090,13 @@ static VkInstance vulkan_context_create_instance_wrapper(void *opaque, const VkI
       goto end;
    }
 
-   memcpy((void*)instance_extensions, info.ppEnabledExtensionNames, info.enabledExtensionCount * sizeof(const char *));
-   memcpy((void*)instance_layers,     info.ppEnabledLayerNames,     info.enabledLayerCount     * sizeof(const char *));
+   /* A caller enabling no extensions or no layers legitimately
+    * passes NULL with a zero count; memcpy's second argument is
+    * declared non-NULL even for n == 0, so guard each copy. */
+   if (info.enabledExtensionCount)
+      memcpy((void*)instance_extensions, info.ppEnabledExtensionNames, info.enabledExtensionCount * sizeof(const char *));
+   if (info.enabledLayerCount)
+      memcpy((void*)instance_layers,     info.ppEnabledLayerNames,     info.enabledLayerCount     * sizeof(const char *));
    info.ppEnabledExtensionNames     = instance_extensions;
    info.ppEnabledLayerNames         = instance_layers;
 
@@ -3078,6 +3083,23 @@ void vulkan_context_destroy(gfx_ctx_vulkan_data_t *vk,
       string_list_free(vk->gpu_list);
       vk->gpu_list = NULL;
    }
+
+#ifdef HAVE_THREADS
+   /* vulkan_context_init_device() creates a fresh queue_lock on
+    * every bring-up -- including the cached-context path, which
+    * restores the device and then falls through to slock_new() like
+    * any other init -- so the lock's lifetime ends here regardless
+    * of whether the device itself is being cached.  Everything that
+    * takes it (vulkan_present, the frame submission paths) is done
+    * by this point: vkDeviceWaitIdle() ran at the top of this
+    * function.  Freeing it here stops one slock leaking per driver
+    * reinit -- every resolution change and fullscreen toggle. */
+   if (vk->context.queue_lock)
+   {
+      slock_free(vk->context.queue_lock);
+      vk->context.queue_lock = NULL;
+   }
+#endif
 }
 
 void vulkan_present(gfx_ctx_vulkan_data_t *vk, unsigned index)

--- a/gfx/common/vulkan_common.c
+++ b/gfx/common/vulkan_common.c
@@ -399,7 +399,15 @@ static void vulkan_debug_mark_object(VkDevice device,
    {
       char merged_name[1024];
       VkDebugUtilsObjectNameInfoEXT info;
+      /* strlcpy() returns the length of the SOURCE, not the number of
+       * bytes copied, so a name longer than the buffer would put
+       * merged_name + _len past the end and underflow the remaining
+       * size to near SIZE_MAX.  Every caller in tree passes a short
+       * literal, so this is not reachable today -- but the next one
+       * need not. */
       size_t _len                        = strlcpy(merged_name, name, sizeof(merged_name));
+      if (_len >= sizeof(merged_name))
+         _len                            = sizeof(merged_name) - 1;
       snprintf(merged_name + _len, sizeof(merged_name) - _len, " (%u)", count);
 
       info.sType                         = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;

--- a/gfx/drivers/vulkan.c
+++ b/gfx/drivers/vulkan.c
@@ -4919,8 +4919,24 @@ static void vulkan_set_image(void *handle,
       VkSemaphore *new_semaphores = (VkSemaphore*)realloc(vk->hw.semaphores,
             sizeof(VkSemaphore) * (vk->hw.num_semaphores + 1));
 
-      vk->hw.wait_dst_stages = stage_flags;
-      vk->hw.semaphores      = new_semaphores;
+      /* realloc() returns NULL on failure and leaves the original
+       * block allocated, so storing the result unconditionally both
+       * leaks the old array and arms the loop below to write through
+       * NULL.  Keep whichever of the two actually grew, and if either
+       * failed, report no semaphores rather than a short array. */
+      if (stage_flags)
+         vk->hw.wait_dst_stages = stage_flags;
+      if (new_semaphores)
+         vk->hw.semaphores      = new_semaphores;
+
+      if (!stage_flags || !new_semaphores)
+      {
+         RARCH_ERR("[Vulkan] Failed to allocate semaphore state for"
+               " %u semaphore(s).\n", num_semaphores);
+         vk->hw.num_semaphores = 0;
+         vk->flags            &= ~VK_FLAG_HW_VALID_SEMAPHORE;
+         return;
+      }
 
       for (i = 0; i < (int) vk->hw.num_semaphores; i++)
       {
@@ -4949,6 +4965,19 @@ static void vulkan_set_command_buffers(void *handle, uint32_t num_cmd,
       VkCommandBuffer *hw_cmd = (VkCommandBuffer*)
          realloc(vk->hw.cmd,
             sizeof(VkCommandBuffer) * required_capacity);
+
+      /* On failure the old block is still ours.  Storing NULL over it
+       * leaked it, left the memcpy below writing through NULL, and --
+       * worse, because it outlives this call -- left capacity_cmd
+       * claiming room that no longer exists, so the next call with a
+       * smaller count skipped the grow and wrote through NULL again. */
+      if (!hw_cmd)
+      {
+         RARCH_ERR("[Vulkan] Failed to allocate room for %u command"
+               " buffer(s).\n", num_cmd);
+         vk->hw.num_cmd       = 0;
+         return;
+      }
 
       vk->hw.cmd              = hw_cmd;
       vk->hw.capacity_cmd     = required_capacity;

--- a/libretro-common/Makefile.test
+++ b/libretro-common/Makefile.test
@@ -26,6 +26,7 @@ TEST_STDSTRING_SRC = test/string/test_stdstring.c string/stdstring.c encodings/e
 
 TEST_UTILS = test/utils/test_utils
 TEST_UTILS_SRC = test/utils/test_utils.c utils/md5.c encodings/encoding_crc32.c \
+		features/features_cpu.c \
 		streams/file_stream.c vfs/vfs_implementation.c file/file_path.c \
 		file/file_path_io.c \
 		compat/compat_strl.c time/rtime.c string/stdstring.c encodings/encoding_utf.c
@@ -48,12 +49,14 @@ TEST_RJPEG_SRC = test/formats/test_rjpeg.c formats/jpeg/rjpeg.c \
 # Not a libcheck suite: a plain main() that prints its own verdict and
 # returns non-zero on failure.
 TEST_RWEBM_AUDIO = test/formats/test_rwebm_audio
-TEST_RWEBM_AUDIO_SRC = test/formats/test_rwebm_audio.c
+TEST_RWEBM_AUDIO_SRC = test/formats/test_rwebm_audio.c \
+		encodings/encoding_crc32.c features/features_cpu.c
 
 TEST_RPNG = test/formats/test_rpng
 TEST_RPNG_SRC = test/formats/test_rpng.c formats/png/rpng.c \
 		streams/trans_stream.c streams/trans_stream_deflate.c \
 		encodings/encoding_deflate.c \
+		features/features_cpu.c \
 		streams/trans_stream_pipe.c
 TEST_RPNG_LIBS = -lz
 

--- a/libretro-common/Makefile.test
+++ b/libretro-common/Makefile.test
@@ -15,7 +15,7 @@ TEST_FILE_LIST_SRC = test/lists/test_file_list.c lists/file_list.c \
 
 TEST_STDSTRING = test/string/test_stdstring
 TEST_STDSTRING_SRC = test/string/test_stdstring.c string/stdstring.c encodings/encoding_utf.c \
-		     compat/compat_strl.c
+		     compat/compat_strl.c compat/compat_strldup.c
 
 TEST_UTILS = test/utils/test_utils
 TEST_UTILS_SRC = test/utils/test_utils.c utils/md5.c encodings/encoding_crc32.c \

--- a/libretro-common/Makefile.test
+++ b/libretro-common/Makefile.test
@@ -20,19 +20,35 @@ TEST_STDSTRING_SRC = test/string/test_stdstring.c string/stdstring.c encodings/e
 TEST_UTILS = test/utils/test_utils
 TEST_UTILS_SRC = test/utils/test_utils.c utils/md5.c encodings/encoding_crc32.c \
 		streams/file_stream.c vfs/vfs_implementation.c file/file_path.c \
+		file/file_path_io.c \
 		compat/compat_strl.c time/rtime.c string/stdstring.c encodings/encoding_utf.c
 
 TEST_HASH = test/hash/test_hash
 TEST_HASH_SRC = test/hash/test_hash.c hash/lrc_hash.c \
 		streams/file_stream.c vfs/vfs_implementation.c file/file_path.c \
+		file/file_path_io.c \
 		compat/compat_strl.c time/rtime.c string/stdstring.c encodings/encoding_utf.c
+
+TEST_RWAV = test/formats/test_rwav
+TEST_RWAV_SRC = test/formats/test_rwav.c formats/wav/rwav.c
+
+TEST_RJPEG = test/formats/test_rjpeg
+TEST_RJPEG_SRC = test/formats/test_rjpeg.c formats/jpeg/rjpeg.c \
+		streams/file_stream.c vfs/vfs_implementation.c file/file_path.c \
+		file/file_path_io.c features/features_cpu.c \
+		compat/compat_strl.c time/rtime.c string/stdstring.c encodings/encoding_utf.c
+
+# Not a libcheck suite: a plain main() that prints its own verdict and
+# returns non-zero on failure.
+TEST_RWEBM_AUDIO = test/formats/test_rwebm_audio
+TEST_RWEBM_AUDIO_SRC = test/formats/test_rwebm_audio.c
 
 TEST_RPNG = test/formats/test_rpng
 TEST_RPNG_SRC = test/formats/test_rpng.c formats/png/rpng.c \
 		streams/trans_stream.c streams/trans_stream_deflate.c \
 		encodings/encoding_deflate.c \
 		streams/trans_stream_pipe.c
-TEST_RPNG_LIBS =
+TEST_RPNG_LIBS = -lz
 
 all:
 	# Build and execute tests in order, to avoid coverage file collision
@@ -64,6 +80,15 @@ all:
 	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RPNG_SRC) $(TEST_RPNG_LIBS) -o $(TEST_RPNG)
 	$(TEST_RPNG)
 	lcov -c -d . -o `dirname $(TEST_RPNG)`/coverage.info
+	# rwav
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RWAV_SRC) -o $(TEST_RWAV)
+	$(TEST_RWAV)
+	# rjpeg
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RJPEG_SRC) -o $(TEST_RJPEG)
+	$(TEST_RJPEG)
+	# rwebm audio
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RWEBM_AUDIO_SRC) -o $(TEST_RWEBM_AUDIO)
+	$(TEST_RWEBM_AUDIO)
 	
 	lcov -o test/coverage.info \
 	     -a test/utils/coverage.info \

--- a/libretro-common/Makefile.test
+++ b/libretro-common/Makefile.test
@@ -9,6 +9,10 @@ TEST_GENERIC_QUEUE_SRC = test/queues/test_generic_queue.c queues/generic_queue.c
 TEST_LINKED_LIST = test/lists/test_linked_list
 TEST_LINKED_LIST_SRC = test/lists/test_linked_list.c lists/linked_list.c
 
+TEST_FILE_LIST = test/lists/test_file_list
+TEST_FILE_LIST_SRC = test/lists/test_file_list.c lists/file_list.c \
+		     compat/compat_strcasestr.c
+
 TEST_STDSTRING = test/string/test_stdstring
 TEST_STDSTRING_SRC = test/string/test_stdstring.c string/stdstring.c encodings/encoding_utf.c \
 		     compat/compat_strl.c
@@ -48,6 +52,10 @@ all:
 	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_LINKED_LIST_SRC) -o $(TEST_LINKED_LIST)
 	$(TEST_LINKED_LIST)
 	lcov -c -d . -o `dirname $(TEST_LINKED_LIST)`/coverage.info
+	# file list
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_FILE_LIST_SRC) -o $(TEST_FILE_LIST)
+	$(TEST_FILE_LIST)
+	lcov -c -d . -o `dirname $(TEST_FILE_LIST)`/file_list_coverage.info
 	# queue
 	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_GENERIC_QUEUE_SRC) -o $(TEST_GENERIC_QUEUE)
 	$(TEST_GENERIC_QUEUE)
@@ -61,6 +69,7 @@ all:
 	     -a test/utils/coverage.info \
 	     -a test/string/coverage.info \
 	     -a test/lists/coverage.info \
+	     -a test/lists/file_list_coverage.info \
 	     -a test/queues/coverage.info \
 	     -a test/formats/coverage.info
 	genhtml -o test/coverage/ test/coverage.info

--- a/libretro-common/Makefile.test
+++ b/libretro-common/Makefile.test
@@ -1,7 +1,14 @@
 
 OBJDIR = ../obj-unix
 
-TEST_UNIT_CFLAGS = $(CFLAGS) -Iinclude $(LDFLAGS) -lcheck $(LIBCHECK_CFLAGS) -Werror -Wdeclaration-after-statement -fsanitize=address -fsanitize=undefined -ftest-coverage -fprofile-arcs -ggdb
+# libcheck's link line is more than -lcheck on most distributions --
+# Debian and Ubuntu need -lcheck_pic -lsubunit -lrt -lm -pthread -- so
+# ask pkg-config and fall back to the bare flag only if it cannot
+# answer.  Overridable for platforms without pkg-config.
+LIBCHECK_CFLAGS ?= $(shell pkg-config --cflags check 2>/dev/null)
+LIBCHECK_LIBS   ?= $(shell pkg-config --libs check 2>/dev/null || echo -lcheck)
+
+TEST_UNIT_CFLAGS = $(CFLAGS) -Iinclude $(LDFLAGS) $(LIBCHECK_CFLAGS) -Werror -Wdeclaration-after-statement -fsanitize=address -fsanitize=undefined -ftest-coverage -fprofile-arcs -ggdb
 
 TEST_GENERIC_QUEUE = test/queues/test_generic_queue
 TEST_GENERIC_QUEUE_SRC = test/queues/test_generic_queue.c queues/generic_queue.c
@@ -53,41 +60,41 @@ TEST_RPNG_LIBS = -lz
 all:
 	# Build and execute tests in order, to avoid coverage file collision
 	# string
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_STDSTRING_SRC) -o $(TEST_STDSTRING)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_STDSTRING_SRC) $(LIBCHECK_LIBS) -o $(TEST_STDSTRING)
 	$(TEST_STDSTRING)
 	lcov -c -d . -o `dirname $(TEST_STDSTRING)`/coverage.info
 	# utils
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_UTILS_SRC) -o $(TEST_UTILS)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_UTILS_SRC) $(LIBCHECK_LIBS) -o $(TEST_UTILS)
 	$(TEST_UTILS)
 	lcov -c -d . -o `dirname $(TEST_UTILS)`/coverage.info
 	# utils
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_HASH_SRC) -o $(TEST_HASH)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_HASH_SRC) $(LIBCHECK_LIBS) -o $(TEST_HASH)
 	$(TEST_HASH)
 	lcov -c -d . -o `dirname $(TEST_HASH)`/coverage.info
 	# list
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_LINKED_LIST_SRC) -o $(TEST_LINKED_LIST)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_LINKED_LIST_SRC) $(LIBCHECK_LIBS) -o $(TEST_LINKED_LIST)
 	$(TEST_LINKED_LIST)
 	lcov -c -d . -o `dirname $(TEST_LINKED_LIST)`/coverage.info
 	# file list
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_FILE_LIST_SRC) -o $(TEST_FILE_LIST)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_FILE_LIST_SRC) $(LIBCHECK_LIBS) -o $(TEST_FILE_LIST)
 	$(TEST_FILE_LIST)
 	lcov -c -d . -o `dirname $(TEST_FILE_LIST)`/file_list_coverage.info
 	# queue
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_GENERIC_QUEUE_SRC) -o $(TEST_GENERIC_QUEUE)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_GENERIC_QUEUE_SRC) $(LIBCHECK_LIBS) -o $(TEST_GENERIC_QUEUE)
 	$(TEST_GENERIC_QUEUE)
 	lcov -c -d . -o `dirname $(TEST_GENERIC_QUEUE)`/coverage.info
 	# rpng
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RPNG_SRC) $(TEST_RPNG_LIBS) -o $(TEST_RPNG)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RPNG_SRC) $(TEST_RPNG_LIBS) $(LIBCHECK_LIBS) -o $(TEST_RPNG)
 	$(TEST_RPNG)
 	lcov -c -d . -o `dirname $(TEST_RPNG)`/coverage.info
 	# rwav
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RWAV_SRC) -o $(TEST_RWAV)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RWAV_SRC) $(LIBCHECK_LIBS) -o $(TEST_RWAV)
 	$(TEST_RWAV)
 	# rjpeg
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RJPEG_SRC) -o $(TEST_RJPEG)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RJPEG_SRC) $(LIBCHECK_LIBS) -o $(TEST_RJPEG)
 	$(TEST_RJPEG)
 	# rwebm audio
-	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RWEBM_AUDIO_SRC) -o $(TEST_RWEBM_AUDIO)
+	$(CC) $(TEST_UNIT_CFLAGS) $(TEST_RWEBM_AUDIO_SRC) $(LIBCHECK_LIBS) -o $(TEST_RWEBM_AUDIO)
 	$(TEST_RWEBM_AUDIO)
 	
 	lcov -o test/coverage.info \
@@ -101,4 +108,10 @@ all:
 
 clean:
 	rm -f *.gcda *.gcno
+	rm -f $(TEST_STDSTRING) $(TEST_UTILS) $(TEST_HASH) \
+	      $(TEST_LINKED_LIST) $(TEST_FILE_LIST) $(TEST_GENERIC_QUEUE) \
+	      $(TEST_RPNG) $(TEST_RWAV) $(TEST_RJPEG) $(TEST_RWEBM_AUDIO)
+	rm -f test/*/*.gcda test/*/*.gcno test/*/coverage.info \
+	      test/lists/file_list_coverage.info test/coverage.info
+	rm -rf test/coverage
 

--- a/libretro-common/formats/wav/rwav.c
+++ b/libretro-common/formats/wav/rwav.c
@@ -790,8 +790,13 @@ size_t rwav_decode_s16(const rwav_t *wav, const void *base, size_t frame,
             }
             default:
                if (wav->bitspersample == 8)
+                  /* 8-bit PCM is unsigned with a bias of 128, so the
+                   * centred value is negative for the lower half of
+                   * the range and shifting it left is undefined.
+                   * Multiply instead; the result is identical on every
+                   * representation and defined on all of them. */
                   out[done * ch + c] =
-                        (short)(((int)p[c] - 128) << 8);
+                        (short)(((int)p[c] - 128) * 256);
                else if (wav->bitspersample == 24)
                   out[done * ch + c] = rwav_s24_to_s16(p + c * 3);
                else

--- a/libretro-common/test/lists/test_file_list.c
+++ b/libretro-common/test/lists/test_file_list.c
@@ -1,0 +1,322 @@
+/* Copyright  (C) 2010-2025 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (test_file_list.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Tests for file_list_t::actiondata_free, the optional destructor for
+ * item_file::actiondata.
+ *
+ * It exists because the menu's actiondata (menu_file_list_cbs_t) owns
+ * a further allocation, so it cannot be torn down with a plain free().
+ * Seven call sites across menu_driver.c, xmb.c and ozone.c can destroy
+ * a menu list; routing them all through one hook is what keeps them
+ * from each needing to know how to take a cbs apart.
+ *
+ * Two properties are worth pinning down.  A list that has not set the
+ * hook must keep the old behaviour exactly -- every file_list_t outside
+ * the menu relies on it, and they get NULL by being calloc()ed or
+ * memset() to zero rather than by saying so.  And the hook must never
+ * be handed NULL, because a destructor written for a real object is
+ * under no obligation to tolerate it.
+ */
+
+#include <check.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <lists/file_list.h>
+
+#define SUITE_NAME "file_list"
+
+static int   dtor_calls;
+static void *dtor_seen[8];
+
+static void test_dtor(void *actiondata)
+{
+   ck_assert_ptr_nonnull(actiondata);
+   if (dtor_calls < (int)(sizeof(dtor_seen) / sizeof(dtor_seen[0])))
+      dtor_seen[dtor_calls] = actiondata;
+   dtor_calls++;
+   free(actiondata);
+}
+
+static void reset_dtor(void)
+{
+   dtor_calls = 0;
+   memset(dtor_seen, 0, sizeof(dtor_seen));
+}
+
+/* A file_list_t as every caller in tree obtains one: zeroed. */
+static void list_init(file_list_t *list)
+{
+   memset(list, 0, sizeof(*list));
+}
+
+static void *set_actiondata(file_list_t *list, size_t idx, int tag)
+{
+   int *p = (int*)malloc(sizeof(int));
+   *p     = tag;
+   list->list[idx].actiondata = p;
+   return p;
+}
+
+START_TEST (test_actiondata_free_uses_hook)
+{
+   file_list_t list;
+   void *p;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+   p = set_actiondata(&list, 0, 0x1234);
+
+   file_list_free_actiondata(&list, 0);
+
+   ck_assert_int_eq(dtor_calls, 1);
+   ck_assert_ptr_eq(dtor_seen[0], p);
+   ck_assert_ptr_null(list.list[0].actiondata);
+
+   file_list_deinitialize(&list);
+}
+END_TEST
+
+/* No hook is the default and must stay a plain free().  The sanitizer
+ * catches the leak if it stops being one. */
+START_TEST (test_actiondata_free_without_hook)
+{
+   file_list_t list;
+
+   reset_dtor();
+   list_init(&list);
+
+   ck_assert_ptr_null(list.actiondata_free);
+
+   ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+   set_actiondata(&list, 0, 0x1234);
+
+   file_list_free_actiondata(&list, 0);
+
+   ck_assert_int_eq(dtor_calls, 0);
+   ck_assert_ptr_null(list.list[0].actiondata);
+
+   file_list_deinitialize(&list);
+}
+END_TEST
+
+/* An entry with no actiondata must not reach the destructor at all. */
+START_TEST (test_actiondata_free_skips_null)
+{
+   file_list_t list;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+   ck_assert_ptr_null(list.list[0].actiondata);
+
+   file_list_free_actiondata(&list, 0);
+   ck_assert_int_eq(dtor_calls, 0);
+
+   /* Twice over: the second call sees the slot already NULL. */
+   set_actiondata(&list, 0, 0x1234);
+   file_list_free_actiondata(&list, 0);
+   file_list_free_actiondata(&list, 0);
+   ck_assert_int_eq(dtor_calls, 1);
+
+   file_list_deinitialize(&list);
+}
+END_TEST
+
+START_TEST (test_actiondata_free_null_list)
+{
+   reset_dtor();
+   file_list_free_actiondata(NULL, 0);
+   ck_assert_int_eq(dtor_calls, 0);
+}
+END_TEST
+
+/* Tearing the whole list down has to route through the hook too --
+ * that is the path that made it necessary, since file_list_free() and
+ * file_list_deinitialize() share file_list_deinitialize_internal(),
+ * and menu_list_free_list() reaches it.  The tests use the
+ * deinitialize form because file_list_free() also free()s the
+ * file_list_t itself, which here lives on the stack. */
+START_TEST (test_deinitialize_uses_hook)
+{
+   file_list_t list;
+   void *p[3];
+   int i;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   for (i = 0; i < 3; i++)
+   {
+      ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+      p[i] = set_actiondata(&list, (size_t)i, 0x100 + i);
+   }
+
+   file_list_deinitialize(&list);
+
+   ck_assert_int_eq(dtor_calls, 3);
+   for (i = 0; i < 3; i++)
+      ck_assert_ptr_eq(dtor_seen[i], p[i]);
+}
+END_TEST
+
+/* Entries without actiondata are skipped while their neighbours are
+ * not. */
+START_TEST (test_deinitialize_mixed_entries)
+{
+   file_list_t list;
+   void *p;
+   int i;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   for (i = 0; i < 3; i++)
+      ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+
+   p = set_actiondata(&list, 1, 0x777);
+
+   file_list_deinitialize(&list);
+
+   ck_assert_int_eq(dtor_calls, 1);
+   ck_assert_ptr_eq(dtor_seen[0], p);
+}
+END_TEST
+
+/* file_list_clear() deliberately does not touch actiondata; it clears
+ * the strings and the size and leaves ownership with the caller.  The
+ * menu relies on that split, so it is worth stating rather than
+ * discovering. */
+START_TEST (test_file_list_clear_leaves_actiondata)
+{
+   file_list_t list;
+   void *p;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+   p = set_actiondata(&list, 0, 0x1234);
+
+   file_list_clear(&list);
+
+   ck_assert_int_eq(dtor_calls, 0);
+   ck_assert_ptr_eq(list.list[0].actiondata, p);
+
+   /* Still the caller's to release. */
+   file_list_free_actiondata(&list, 0);
+   ck_assert_int_eq(dtor_calls, 1);
+
+   file_list_deinitialize(&list);
+}
+END_TEST
+
+/* The hook lives in the list, not in the entries, so growing past
+ * capacity must not disturb it. */
+START_TEST (test_hook_survives_growth)
+{
+   file_list_t list;
+   int i;
+   const int n = 64;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   for (i = 0; i < n; i++)
+   {
+      ck_assert(file_list_append(&list, "path", "label", 0, 0, 0));
+      set_actiondata(&list, (size_t)i, i);
+   }
+
+   ck_assert_ptr_eq((void*)(uintptr_t)list.actiondata_free,
+         (void*)(uintptr_t)test_dtor);
+   ck_assert_uint_ge((unsigned)list.capacity, (unsigned)n);
+
+   file_list_deinitialize(&list);
+   ck_assert_int_eq(dtor_calls, n);
+}
+END_TEST
+
+/* file_list_insert() has its own initialisation path; an inserted
+ * entry must start with no actiondata rather than inheriting whatever
+ * was in the slot. */
+START_TEST (test_insert_starts_with_null_actiondata)
+{
+   file_list_t list;
+
+   reset_dtor();
+   list_init(&list);
+   list.actiondata_free = test_dtor;
+
+   ck_assert(file_list_append(&list, "a", "a", 0, 0, 0));
+   set_actiondata(&list, 0, 0x1234);
+
+   ck_assert(file_list_insert(&list, "b", "b", 0, 0, 0, 0));
+   ck_assert_ptr_null(list.list[0].actiondata);
+
+   file_list_deinitialize(&list);
+
+   /* Only the one that was set is destroyed, and it moved with its
+    * entry rather than being left behind at index 0. */
+   ck_assert_int_eq(dtor_calls, 1);
+}
+END_TEST
+
+Suite *create_suite(void)
+{
+   Suite *s       = suite_create(SUITE_NAME);
+   TCase *tc_core = tcase_create("Core");
+
+   tcase_add_test(tc_core, test_actiondata_free_uses_hook);
+   tcase_add_test(tc_core, test_actiondata_free_without_hook);
+   tcase_add_test(tc_core, test_actiondata_free_skips_null);
+   tcase_add_test(tc_core, test_actiondata_free_null_list);
+   tcase_add_test(tc_core, test_deinitialize_uses_hook);
+   tcase_add_test(tc_core, test_deinitialize_mixed_entries);
+   tcase_add_test(tc_core, test_file_list_clear_leaves_actiondata);
+   tcase_add_test(tc_core, test_hook_survives_growth);
+   tcase_add_test(tc_core, test_insert_starts_with_null_actiondata);
+
+   suite_add_tcase(s, tc_core);
+   return s;
+}
+
+int main(void)
+{
+   int num_fail;
+   Suite   *s  = create_suite();
+   SRunner *sr = srunner_create(s);
+   srunner_run_all(sr, CK_NORMAL);
+   num_fail = srunner_ntests_failed(sr);
+   srunner_free(sr);
+   return (num_fail == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/libretro-common/test/string/test_stdstring.c
+++ b/libretro-common/test/string/test_stdstring.c
@@ -36,7 +36,9 @@ START_TEST (test_string_filter)
    char test2[] = "";
    string_remove_all_chars(test1, 's');
    string_remove_all_chars(test2, '0');
-   string_remove_all_chars(NULL, 'a');
+   /* No NULL call here: stdstring.h documents @s as "must be non-NULL,
+    * otherwise UB" and the function is a leaf with no guard.  The test
+    * used to pass NULL and segfaulted once the guard went away. */
    ck_assert(!strcmp(test1, "foo bar ome tring"));
    ck_assert(!strcmp(test2, ""));
 }
@@ -46,7 +48,7 @@ START_TEST (test_string_replace)
 {
    char test1[] = "foo bar some string";
    string_replace_all_chars(test1, 's', 'S');
-   string_replace_all_chars(NULL, 'a', 'A');
+   /* Likewise documented as non-NULL only. */
    ck_assert(!strcmp(test1, "foo bar Some String"));
 }
 END_TEST
@@ -138,7 +140,13 @@ END_TEST
 
 START_TEST (test_string_replacesubstr)
 {
-   char *res = string_replace_substring("foobaarhellowooorldtest", "oo", "ooo");
+   /* string_replace_substring() gained explicit lengths for all three
+    * arguments; this call was never updated, so the suite has not
+    * compiled since. */
+   char *res = string_replace_substring(
+         "foobaarhellowooorldtest", STRLEN_CONST("foobaarhellowooorldtest"),
+         "oo",                      STRLEN_CONST("oo"),
+         "ooo",                     STRLEN_CONST("ooo"));
    ck_assert(res != NULL);
    ck_assert(!strcmp(res, "fooobaarhellowoooorldtest"));
    free(res);
@@ -281,6 +289,114 @@ START_TEST (test_utf16_conv)
 }
 END_TEST
 
+/* Boundary sweep for the wrappers.
+ *
+ * The existing test above checks that word_wrap() produces the right
+ * output for a comfortable case.  This one checks it stays inside the
+ * buffer for uncomfortable ones: destinations allocated at exactly the
+ * size passed in, so a single byte past the end is an ASan report
+ * rather than a stomp on whatever followed; multi-byte and four-byte
+ * UTF-8; a truncated sequence; input with no break opportunity at all;
+ * and every line width and destination size across the interesting
+ * range.
+ *
+ * Written after a glyph-versus-byte confusion in gfx_animation.c's
+ * ticker overran a caller's stack buffer with CJK text.  The same
+ * arithmetic lives here, so it is worth pinning.  Makefile.test builds
+ * this suite with -fsanitize=address -fsanitize=undefined, which is
+ * where the actual bound checking happens; the assertions below only
+ * cover termination.
+ */
+START_TEST (test_word_wrap_bounds)
+{
+   static const char *const inputs[] =
+   {
+      "",
+      "a",
+      "one two three four five six seven eight nine ten",
+      /* Nothing to break on. */
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      /* Three bytes per glyph, no spaces. */
+      "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xe3\x81\xae\xe3\x83\x86"
+         "\xe3\x82\xb9\xe3\x83\x88\xe3\x81\xa7\xe3\x81\x99",
+      /* Three bytes per glyph, with spaces. */
+      "\xe6\x97\xa5\xe6\x9c\xac \xe8\xaa\x9e\xe3\x81\xae \xe3\x83\x86"
+         "\xe3\x82\xb9\xe3\x83\x88 \xe3\x81\xa7\xe3\x81\x99",
+      /* Four-byte sequences. */
+      "\xf0\x9f\x8e\xae\xf0\x9f\x8e\xae\xf0\x9f\x8e\xae\xf0\x9f\x8e\xae"
+         "\xf0\x9f\x8e\xae\xf0\x9f\x8e\xae",
+      "first\nsecond\nthird line that runs on a good deal longer",
+      "   leading and trailing   ",
+      /* A lead byte with its continuation bytes cut off. */
+      "valid text \xe6\x97"
+   };
+   const int n_inputs = (int)(sizeof(inputs) / sizeof(inputs[0]));
+   long wrote         = 0;
+   int i;
+
+   for (i = 0; i < n_inputs; i++)
+   {
+      const char *src = inputs[i];
+      size_t src_len  = strlen(src);
+      size_t dst_size;
+
+      for (dst_size = 1; dst_size <= src_len + 16; dst_size++)
+      {
+         int line_width;
+
+         for (line_width = 0; line_width <= 24; line_width += 3)
+         {
+            unsigned max_lines;
+
+            for (max_lines = 0; max_lines <= 4; max_lines += 2)
+            {
+               char *dst = (char*)malloc(dst_size);
+               ck_assert_ptr_nonnull(dst);
+               memset(dst, 'X', dst_size);
+
+               word_wrap(dst, dst_size, src, src_len,
+                     line_width, 0, max_lines);
+
+               /* Both wrappers decline rather than truncate when the
+                * destination is too small, so an untouched buffer is a
+                * legitimate outcome; what must not happen is a write
+                * that runs off the end or leaves no terminator. */
+               if (dst[0] != 'X')
+               {
+                  wrote++;
+                  ck_assert_ptr_nonnull(memchr(dst, '\0', dst_size));
+               }
+
+               free(dst);
+            }
+
+            {
+               char *dst = (char*)malloc(dst_size);
+               ck_assert_ptr_nonnull(dst);
+               memset(dst, 'X', dst_size);
+
+               word_wrap_wideglyph(dst, dst_size, src, src_len,
+                     line_width, 150, 100);
+
+               if (dst[0] != 'X')
+               {
+                  wrote++;
+                  ck_assert_ptr_nonnull(memchr(dst, '\0', dst_size));
+               }
+
+               free(dst);
+            }
+         }
+      }
+   }
+
+   /* Guard against the whole sweep passing by declining every call:
+    * both wrappers return early when dst_size < src_len + 1, and a
+    * range that never cleared that bar would test nothing. */
+   ck_assert_int_gt(wrote, 0);
+}
+END_TEST
+
 Suite *create_suite(void)
 {
    Suite *s = suite_create(SUITE_NAME);
@@ -296,6 +412,7 @@ Suite *create_suite(void)
    tcase_add_test(tc_core, test_string_trim);
    tcase_add_test(tc_core, test_string_replacesubstr);
    tcase_add_test(tc_core, test_word_wrap);
+   tcase_add_test(tc_core, test_word_wrap_bounds);
    tcase_add_test(tc_core, test_strlcpy);
    tcase_add_test(tc_core, test_strlcat);
    tcase_add_test(tc_core, test_strldup);

--- a/samples/gfx/vulkan_validation/Makefile
+++ b/samples/gfx/vulkan_validation/Makefile
@@ -1,0 +1,59 @@
+TARGET := vulkan_validation_test
+
+# Path back to the repo root from this sample dir.  Like the
+# display_servers samples, this one links the real code rather than
+# mirroring it -- the point is to run RetroArch's own Vulkan setup
+# under the validation layer, so a copy would prove nothing.
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+# VULKAN_DEBUG is the flag RetroArch already uses to enable
+# VK_LAYER_KHRONOS_validation and VK_EXT_debug_utils and to install
+# vulkan_debug_cb().  That callback reports through RARCH_LOG, which
+# stubs_retroarch.c supplies and scores, so the test needs no debug
+# messenger of its own.
+SOURCES := vulkan_validation_test.c \
+           stubs_retroarch.c \
+           $(REPO_ROOT)/gfx/common/vulkan_common.c \
+           $(LIBRETRO_COMM_DIR)/vulkan/vulkan_symbol_wrapper.c \
+           $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+           $(LIBRETRO_COMM_DIR)/lists/string_list.c \
+           $(LIBRETRO_COMM_DIR)/dynamic/dylib.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+           $(LIBRETRO_COMM_DIR)/string/stdstring.c \
+           $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c
+
+CFLAGS  += -Wall -std=gnu99 -g -O0 \
+           -DHAVE_VULKAN -DVULKAN_DEBUG -DHAVE_THREADS -DHAVE_DYLIB \
+           -I$(REPO_ROOT) \
+           -I$(LIBRETRO_COMM_DIR)/include
+
+LDFLAGS += -lvulkan -lpthread -ldl
+
+OBJS := $(SOURCES:.c=.o)
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+# Needs a Vulkan device and the validation layer.  lavapipe is enough:
+#   apt-get install mesa-vulkan-drivers vulkan-validationlayers
+# With no device at all the test exits 77 (skipped) rather than failing.
+VK_DRIVER_FILES ?= /usr/share/vulkan/icd.d/lvp_icd.json
+
+run: $(TARGET)
+	VK_DRIVER_FILES=$(VK_DRIVER_FILES) ./$(TARGET)
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: all run clean

--- a/samples/gfx/vulkan_validation/Makefile
+++ b/samples/gfx/vulkan_validation/Makefile
@@ -25,10 +25,11 @@ SOURCES := vulkan_validation_test.c \
 
 CFLAGS  += -Wall -std=gnu99 -g -O0 \
            -DHAVE_VULKAN -DVULKAN_DEBUG -DHAVE_THREADS -DHAVE_DYLIB \
+           -DHAVE_XLIB \
            -I$(REPO_ROOT) \
            -I$(LIBRETRO_COMM_DIR)/include
 
-LDFLAGS += -lvulkan -lpthread -ldl
+LDFLAGS += -lvulkan -lpthread -ldl -lX11
 
 OBJS := $(SOURCES:.c=.o)
 
@@ -45,9 +46,12 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
-# Needs a Vulkan device and the validation layer.  lavapipe is enough:
-#   apt-get install mesa-vulkan-drivers vulkan-validationlayers
-# With no device at all the test exits 77 (skipped) rather than failing.
+# Needs an X display, a Vulkan device and the validation layer.  Xvfb
+# plus lavapipe is enough, and both are packaged:
+#   apt-get install xvfb mesa-vulkan-drivers vulkan-validationlayers
+#   Xvfb :99 -screen 0 1280x720x24 &
+# With no display or no device the test exits 77 (skipped) rather than
+# failing, so it is safe to run unconditionally.
 VK_DRIVER_FILES ?= /usr/share/vulkan/icd.d/lvp_icd.json
 
 run: $(TARGET)

--- a/samples/gfx/vulkan_validation/stubs_retroarch.c
+++ b/samples/gfx/vulkan_validation/stubs_retroarch.c
@@ -1,0 +1,73 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (stubs_retroarch.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* The frontend symbols gfx/common/vulkan_common.c reaches for, plus
+ * the logging hook the test scores itself on.
+ *
+ * vulkan_common.c is built here with -DVULKAN_DEBUG, which is the flag
+ * RetroArch already uses to enable VK_LAYER_KHRONOS_validation and
+ * VK_EXT_debug_utils and to install vulkan_debug_cb().  That callback
+ * formats every message through RARCH_LOG, so counting validation
+ * lines here needs no messenger of our own -- the driver's existing
+ * debug path is the instrumentation. */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+int  g_vk_validation_errors;
+int  g_vk_validation_warnings;
+static void vk_log(const char *fmt, va_list ap)
+{
+   char line[4096];
+   vsnprintf(line, sizeof(line), fmt, ap);
+   if (strstr(line, "Validation"))
+   {
+      if (strstr(line, "ERROR"))   g_vk_validation_errors++;
+      if (strstr(line, "WARNING")) g_vk_validation_warnings++;
+      fputs(line, stderr);
+   }
+}
+void RARCH_LOG(const char *fmt, ...){va_list a;va_start(a,fmt);vk_log(fmt,a);va_end(a);}
+void RARCH_ERR(const char *fmt, ...){va_list a;va_start(a,fmt);vk_log(fmt,a);va_end(a);}
+void RARCH_WARN(const char *fmt, ...){va_list a;va_start(a,fmt);vk_log(fmt,a);va_end(a);}
+void RARCH_DBG(const char *fmt, ...){(void)fmt;}
+
+/* --- The rest of what vulkan_common.c reaches for --- */
+#include <boolean.h>
+#include <stddef.h>
+#include <stdint.h>
+
+void *XGetXCBConnection(void *dpy) { (void)dpy; return NULL; }
+
+static char s_settings[1 << 18];
+void *config_get_ptr(void) { return s_settings; }
+
+void *video_state_get_ptr(void) { static char st[1 << 16]; return st; }
+
+const char *msg_hash_to_str(int e) { (void)e; return "stub"; }
+
+void video_driver_set_gpu_api_devices(int api, void *list) { (void)api; (void)list; }
+void video_driver_set_gpu_api_version_string(const char *s) { (void)s; }
+void video_driver_cache_context_ack_set(void) { }
+uint32_t video_driver_get_disp_flags(void) { return 0; }
+void video_driver_set_disp_flags(uint32_t f) { (void)f; }

--- a/samples/gfx/vulkan_validation/stubs_retroarch.c
+++ b/samples/gfx/vulkan_validation/stubs_retroarch.c
@@ -40,10 +40,18 @@ static void vk_log(const char *fmt, va_list ap)
 {
    char line[4096];
    vsnprintf(line, sizeof(line), fmt, ap);
-   if (strstr(line, "Validation"))
+   /* vulkan_debug_cb() formats as "[Vulkan] <SEVERITY> <TYPE>: ...",
+    * so key on the pair.  Matching "WARNING" anywhere in the line
+    * instead would score VUID names like WARNING-cache-file-error,
+    * which arrive at INFO severity, as warnings. */
+   if (strstr(line, "ERROR Validation"))
    {
-      if (strstr(line, "ERROR"))   g_vk_validation_errors++;
-      if (strstr(line, "WARNING")) g_vk_validation_warnings++;
+      g_vk_validation_errors++;
+      fputs(line, stderr);
+   }
+   else if (strstr(line, "WARNING Validation"))
+   {
+      g_vk_validation_warnings++;
       fputs(line, stderr);
    }
 }

--- a/samples/gfx/vulkan_validation/vulkan_validation_test.c
+++ b/samples/gfx/vulkan_validation/vulkan_validation_test.c
@@ -45,16 +45,26 @@
  * which is worth something on its own account -- if the debug
  * path stops reporting, this test stops passing.
  *
- * The context is brought up with VULKAN_WSI_NONE, so no window,
- * surface or swapchain is needed and it runs headless.  On CI
- * that means lavapipe:
+ * The context is brought up over a real Xlib surface, because
+ * VULKAN_WSI_NONE reaches almost nothing:
+ * vulkan_context_init_device() is called from
+ * vulkan_surface_create(), not from vulkan_context_init(), and
+ * vulkan_surface_create() answers VULKAN_WSI_NONE with `return
+ * false`.  Init alone therefore leaves context.gpu NULL and
+ * memory_properties zeroed -- a check written against it passes
+ * by having nothing to check.
+ *
+ * With an Xvfb display and lavapipe the whole path runs
+ * headless anyway:
  *
  *     apt-get install mesa-vulkan-drivers vulkan-validationlayers
+ *     Xvfb :99 -screen 0 1280x720x24 &
+ *     export DISPLAY=:99
  *     export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.json
  *
- * With no Vulkan device at all the test exits 77 (the automake
- * convention for "skipped") rather than failing, so it is safe
- * to run unconditionally.
+ * With no X display or no Vulkan device the test exits 77 (the
+ * automake convention for "skipped") rather than failing, so it
+ * is safe to run unconditionally.
  *
  * WHAT IT IS NOT
  *
@@ -93,6 +103,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <X11/Xlib.h>
+
 #include "../../../gfx/common/vulkan_common.h"
 
 /* Scored by the RARCH_LOG hook in stubs_retroarch.c. */
@@ -100,6 +112,9 @@ extern int g_vk_validation_errors;
 extern int g_vk_validation_warnings;
 
 #define SKIP_EXIT_CODE 77
+
+static Display *s_dpy;
+static Window   s_win;
 
 static void reset_counts(void)
 {
@@ -121,39 +136,83 @@ static int report(const char *what)
    return 0;
 }
 
-/* Bring the context up and take it down again.  Everything
- * vulkan_common.c does before a surface exists happens here. */
+/* Bring the whole thing up: instance, surface, physical device,
+ * queues, logical device, swapchain.  Then take it down. */
+static int context_up(gfx_ctx_vulkan_data_t *vk)
+{
+   memset(vk, 0, sizeof(*vk));
+
+   if (!vulkan_context_init(vk, VULKAN_WSI_XLIB))
+      return 0;
+
+   if (!vulkan_surface_create(vk, VULKAN_WSI_XLIB,
+            s_dpy, &s_win, 640, 480, 1))
+   {
+      vulkan_context_destroy(vk, true);
+      return 0;
+   }
+   return 1;
+}
+
 static int test_context_init_destroy(int *skipped)
 {
    gfx_ctx_vulkan_data_t vk;
 
    *skipped = 0;
    reset_counts();
-   memset(&vk, 0, sizeof(vk));
 
-   if (!vulkan_context_init(&vk, VULKAN_WSI_NONE))
+   if (!context_up(&vk))
    {
-      fputs("SKIP: no usable Vulkan device"
-            " (set VK_DRIVER_FILES for a software ICD)\n", stderr);
+      fputs("SKIP: could not bring up a Vulkan context"
+            " (need a display and an ICD;"
+            " see the header of this file)\n", stderr);
       *skipped = 1;
       return 0;
-    }
+   }
 
-   /* Not printing vk.context.gpu_properties here on purpose: under
-    * VULKAN_WSI_NONE it reads back zeroed even though
-    * vulkan_context_init_device() fills it unconditionally two lines
-    * before it fills memory_properties, which does come through.  That
-    * is worth a look on its own and is not this test's business. */
+   printf("       device: %s, %u memory type(s),"
+          " %u swapchain image(s)\n",
+         vk.context.gpu_properties.deviceName,
+         vk.context.memory_properties.memoryTypeCount,
+         vk.context.num_swapchain_images);
 
-   vulkan_context_destroy(&vk, false);
+   /* Guard against the whole suite passing by having reached
+    * nothing.  VULKAN_WSI_NONE used to leave exactly this state
+    * and every check below still went green. */
+   if (!vk.context.gpu)
+   {
+      fputs("FAIL: no physical device was selected\n", stderr);
+      vulkan_context_destroy(&vk, true);
+      return 1;
+   }
+   if (!vk.context.device)
+   {
+      fputs("FAIL: no logical device was created\n", stderr);
+      vulkan_context_destroy(&vk, true);
+      return 1;
+   }
+   if (!vk.context.memory_properties.memoryTypeCount)
+   {
+      fputs("FAIL: device reports no memory types\n", stderr);
+      vulkan_context_destroy(&vk, true);
+      return 1;
+   }
+   if (!vk.context.num_swapchain_images)
+   {
+      fputs("FAIL: swapchain has no images\n", stderr);
+      vulkan_context_destroy(&vk, true);
+      return 1;
+   }
 
-   return report("context init/destroy");
+   vulkan_context_destroy(&vk, true);
+
+   return report("context init/surface/device/swapchain/destroy");
 }
 
 /* Repeat it.  A leak that validation only notices at
  * vkDestroyInstance shows up the first time round; one that
  * needs state left over from a previous context -- a cached
- * device, a stale queue index -- only shows up on the second.
+ * device, a stale queue index -- only shows up on a later one.
  * RetroArch does this for real on every driver reinit. */
 static int test_context_cycle(void)
 {
@@ -164,14 +223,13 @@ static int test_context_cycle(void)
       gfx_ctx_vulkan_data_t vk;
 
       reset_counts();
-      memset(&vk, 0, sizeof(vk));
 
-      if (!vulkan_context_init(&vk, VULKAN_WSI_NONE))
+      if (!context_up(&vk))
       {
-         fprintf(stderr, "FAIL: context init failed on cycle %d\n", i);
+         fprintf(stderr, "FAIL: context setup failed on cycle %d\n", i);
          return 1;
       }
-      vulkan_context_destroy(&vk, false);
+      vulkan_context_destroy(&vk, true);
 
       if (g_vk_validation_errors || g_vk_validation_warnings)
       {
@@ -183,28 +241,25 @@ static int test_context_cycle(void)
       }
    }
 
-   printf("[pass] three init/destroy cycles are validation-clean\n");
+   printf("[pass] three setup/teardown cycles are validation-clean\n");
    return 0;
 }
 
 /* vulkan_find_memory_type() picks the heap for every allocation
  * the backend makes; a wrong answer is a validation error at the
  * first vkBindImageMemory rather than here, so check the
- * contract directly.  The fallback form must never return the
- * "nothing matched" sentinel when the primary form would have
- * succeeded. */
+ * contract directly. */
 static int test_memory_type_selection(void)
 {
    gfx_ctx_vulkan_data_t vk;
-   uint32_t i;
+   uint32_t i, checked = 0;
    int fail = 0;
 
    reset_counts();
-   memset(&vk, 0, sizeof(vk));
 
-   if (!vulkan_context_init(&vk, VULKAN_WSI_NONE))
+   if (!context_up(&vk))
    {
-      fputs("FAIL: context init failed\n", stderr);
+      fputs("FAIL: context setup failed\n", stderr);
       return 1;
    }
 
@@ -217,6 +272,7 @@ static int test_memory_type_selection(void)
       if (!want)
          continue;
 
+      checked++;
       got = vulkan_find_memory_type(&vk.context.memory_properties,
             1u << i, want);
 
@@ -242,29 +298,50 @@ static int test_memory_type_selection(void)
       }
    }
 
-   vulkan_context_destroy(&vk, false);
+   vulkan_context_destroy(&vk, true);
 
    if (fail)
       return 1;
+   if (!checked)
+   {
+      fputs("FAIL: no memory types to check\n", stderr);
+      return 1;
+   }
 
-   printf("[pass] every advertised memory type is selectable\n");
+   printf("[pass] all %u advertised memory type(s) are selectable\n",
+         checked);
    return 0;
 }
 
 int main(void)
 {
    int skipped = 0;
+   int ret     = 0;
+
+   if (!(s_dpy = XOpenDisplay(NULL)))
+   {
+      fputs("SKIP: no X display (try Xvfb; see the header"
+            " of this file)\n", stderr);
+      return SKIP_EXIT_CODE;
+   }
+   s_win = XCreateSimpleWindow(s_dpy, DefaultRootWindow(s_dpy),
+         0, 0, 640, 480, 0, 0, 0);
+   XMapWindow(s_dpy, s_win);
+   XSync(s_dpy, False);
 
    if (test_context_init_destroy(&skipped))
-      return 1;
-   if (skipped)
-      return SKIP_EXIT_CODE;
+      ret = 1;
+   else if (skipped)
+      ret = SKIP_EXIT_CODE;
+   else if (test_context_cycle())
+      ret = 1;
+   else if (test_memory_type_selection())
+      ret = 1;
 
-   if (test_context_cycle())
-      return 1;
-   if (test_memory_type_selection())
-      return 1;
+   XDestroyWindow(s_dpy, s_win);
+   XCloseDisplay(s_dpy);
 
-   puts("ALL OK");
-   return 0;
+   if (ret == 0)
+      puts("ALL OK");
+   return ret;
 }

--- a/samples/gfx/vulkan_validation/vulkan_validation_test.c
+++ b/samples/gfx/vulkan_validation/vulkan_validation_test.c
@@ -1,0 +1,270 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (vulkan_validation_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Runs RetroArch's real Vulkan context setup and teardown under
+ * VK_LAYER_KHRONOS_validation and fails on any validation
+ * error or warning.
+ *
+ * The other vulkan samples in this directory each pin down one
+ * known defect.  This one is the opposite shape: it asserts a
+ * property -- "gfx/common/vulkan_common.c provokes no
+ * complaint from the validation layer" -- so it catches
+ * regressions nobody has thought of yet.  Wrong queue family
+ * indices, extensions used without being enabled, objects
+ * outliving their parent, semaphores destroyed while pending:
+ * all of it is invisible to a normal run on a forgiving driver
+ * and all of it is a validation error here.
+ *
+ * HOW IT IS WIRED
+ *
+ * No debug messenger of our own.  vulkan_common.c already has
+ * one: built with -DVULKAN_DEBUG it enables the validation layer
+ * and VK_EXT_debug_utils and installs vulkan_debug_cb(), which
+ * formats every message through RARCH_LOG.  The test supplies
+ * that RARCH_LOG (see stubs_retroarch.c) and counts the lines.
+ * So the instrumentation being exercised is the driver's own,
+ * which is worth something on its own account -- if the debug
+ * path stops reporting, this test stops passing.
+ *
+ * The context is brought up with VULKAN_WSI_NONE, so no window,
+ * surface or swapchain is needed and it runs headless.  On CI
+ * that means lavapipe:
+ *
+ *     apt-get install mesa-vulkan-drivers vulkan-validationlayers
+ *     export VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.json
+ *
+ * With no Vulkan device at all the test exits 77 (the automake
+ * convention for "skipped") rather than failing, so it is safe
+ * to run unconditionally.
+ *
+ * WHAT IT IS NOT
+ *
+ * gfx/drivers/vulkan.c proper is out of reach: it has 169
+ * undefined frontend symbols, so standing it up would mean
+ * stubbing most of the frontend, and its texture and descriptor
+ * helpers are static besides.  What is covered here is
+ * vulkan_common.c -- instance creation, physical device
+ * selection, queue family selection, logical device creation,
+ * the extension and layer negotiation around all of it, and the
+ * teardown.  That is where the validation-visible mistakes in
+ * the Vulkan backend have historically lived.
+ *
+ * THE HARNESS HAS TEETH
+ *
+ * Verified by deliberately breaking the driver: removing the
+ * vkDestroyDebugUtilsMessengerEXT() call from
+ * vulkan_context_destroy() makes the run fail with
+ *
+ *   ERROR Validation: [ VUID-vkDestroyInstance-instance-00629 ]
+ *   ... VkDebugUtilsMessengerEXT 0x10000000001[] has not been
+ *   destroyed ...
+ *   errors=1
+ *
+ * so a leaked child object really does come back as a failure
+ * rather than passing quietly.
+ *
+ * Build and run:
+ *
+ *     make
+ *     VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.json \
+ *         ./vulkan_validation_test
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../../gfx/common/vulkan_common.h"
+
+/* Scored by the RARCH_LOG hook in stubs_retroarch.c. */
+extern int g_vk_validation_errors;
+extern int g_vk_validation_warnings;
+
+#define SKIP_EXIT_CODE 77
+
+static void reset_counts(void)
+{
+   g_vk_validation_errors   = 0;
+   g_vk_validation_warnings = 0;
+}
+
+static int report(const char *what)
+{
+   if (g_vk_validation_errors || g_vk_validation_warnings)
+   {
+      fprintf(stderr,
+            "FAIL: %s produced %d validation error(s)"
+            " and %d warning(s)\n",
+            what, g_vk_validation_errors, g_vk_validation_warnings);
+      return 1;
+   }
+   printf("[pass] %s is validation-clean\n", what);
+   return 0;
+}
+
+/* Bring the context up and take it down again.  Everything
+ * vulkan_common.c does before a surface exists happens here. */
+static int test_context_init_destroy(int *skipped)
+{
+   gfx_ctx_vulkan_data_t vk;
+
+   *skipped = 0;
+   reset_counts();
+   memset(&vk, 0, sizeof(vk));
+
+   if (!vulkan_context_init(&vk, VULKAN_WSI_NONE))
+   {
+      fputs("SKIP: no usable Vulkan device"
+            " (set VK_DRIVER_FILES for a software ICD)\n", stderr);
+      *skipped = 1;
+      return 0;
+    }
+
+   /* Not printing vk.context.gpu_properties here on purpose: under
+    * VULKAN_WSI_NONE it reads back zeroed even though
+    * vulkan_context_init_device() fills it unconditionally two lines
+    * before it fills memory_properties, which does come through.  That
+    * is worth a look on its own and is not this test's business. */
+
+   vulkan_context_destroy(&vk, false);
+
+   return report("context init/destroy");
+}
+
+/* Repeat it.  A leak that validation only notices at
+ * vkDestroyInstance shows up the first time round; one that
+ * needs state left over from a previous context -- a cached
+ * device, a stale queue index -- only shows up on the second.
+ * RetroArch does this for real on every driver reinit. */
+static int test_context_cycle(void)
+{
+   int i;
+
+   for (i = 0; i < 3; i++)
+   {
+      gfx_ctx_vulkan_data_t vk;
+
+      reset_counts();
+      memset(&vk, 0, sizeof(vk));
+
+      if (!vulkan_context_init(&vk, VULKAN_WSI_NONE))
+      {
+         fprintf(stderr, "FAIL: context init failed on cycle %d\n", i);
+         return 1;
+      }
+      vulkan_context_destroy(&vk, false);
+
+      if (g_vk_validation_errors || g_vk_validation_warnings)
+      {
+         fprintf(stderr,
+               "FAIL: cycle %d produced %d validation error(s)"
+               " and %d warning(s)\n",
+               i, g_vk_validation_errors, g_vk_validation_warnings);
+         return 1;
+      }
+   }
+
+   printf("[pass] three init/destroy cycles are validation-clean\n");
+   return 0;
+}
+
+/* vulkan_find_memory_type() picks the heap for every allocation
+ * the backend makes; a wrong answer is a validation error at the
+ * first vkBindImageMemory rather than here, so check the
+ * contract directly.  The fallback form must never return the
+ * "nothing matched" sentinel when the primary form would have
+ * succeeded. */
+static int test_memory_type_selection(void)
+{
+   gfx_ctx_vulkan_data_t vk;
+   uint32_t i;
+   int fail = 0;
+
+   reset_counts();
+   memset(&vk, 0, sizeof(vk));
+
+   if (!vulkan_context_init(&vk, VULKAN_WSI_NONE))
+   {
+      fputs("FAIL: context init failed\n", stderr);
+      return 1;
+   }
+
+   for (i = 0; i < vk.context.memory_properties.memoryTypeCount; i++)
+   {
+      const VkMemoryPropertyFlags want =
+         vk.context.memory_properties.memoryTypes[i].propertyFlags;
+      uint32_t got;
+
+      if (!want)
+         continue;
+
+      got = vulkan_find_memory_type(&vk.context.memory_properties,
+            1u << i, want);
+
+      if (got >= vk.context.memory_properties.memoryTypeCount)
+      {
+         fprintf(stderr,
+               "FAIL: memory type %u advertises 0x%x but"
+               " vulkan_find_memory_type() could not match it\n",
+               i, (unsigned)want);
+         fail = 1;
+         break;
+      }
+      if (!(vk.context.memory_properties.memoryTypes[got].propertyFlags
+               & want))
+      {
+         fprintf(stderr,
+               "FAIL: asked for 0x%x, got type %u with 0x%x\n",
+               (unsigned)want, got,
+               (unsigned)vk.context.memory_properties
+                  .memoryTypes[got].propertyFlags);
+         fail = 1;
+         break;
+      }
+   }
+
+   vulkan_context_destroy(&vk, false);
+
+   if (fail)
+      return 1;
+
+   printf("[pass] every advertised memory type is selectable\n");
+   return 0;
+}
+
+int main(void)
+{
+   int skipped = 0;
+
+   if (test_context_init_destroy(&skipped))
+      return 1;
+   if (skipped)
+      return SKIP_EXIT_CODE;
+
+   if (test_context_cycle())
+      return 1;
+   if (test_memory_type_selection())
+      return 1;
+
+   puts("ALL OK");
+   return 0;
+}


### PR DESCRIPTION
Reduced from the original 34-commit series; display servers, filters, scaler/pixconv, widgets/animation/thumbnails, image decoders and GL fonts are now their own PRs.

## Vulkan
- **vulkan_common**: drop 65 KB of dead stack in the instance wrapper; clamp the debug object name before appending; check the reallocs in the HW render callbacks; free `queue_lock` at context destroy — one slock leaked per driver reinit (every resolution change and fullscreen toggle), found by running the validation sample under LSan on lavapipe: five context cycles, five leaked locks; guard the instance-wrapper memcpys against NULL-with-zero-count (UBSan, our own regression in this series).
- **validation rig**: `samples/gfx/vulkan_validation` brings the driver's real context path up over an Xlib surface under `VK_LAYER_KHRONOS_validation` — instance, surface, physical device, queue families, logical device, swapchain — using the driver's own `VULKAN_DEBUG` messenger as the instrumentation. lavapipe + Xvfb suffice; skips cleanly (exit 77) with no device. Negative control verified: deleting the messenger destroy fails the run with VUID-vkDestroyInstance-instance-00629. Includes the honest correction of the first version, which passed without reaching a device.

## Tests and CI
- Every suite in `libretro-common/Makefile.test` builds and runs (three referenced moved sources, one never linked its library correctly); the stdstring suite is building again with its wrappers swept; the first full run found and fixed a UBSan-flagged shift in rwav's 8-bit PCM path.
- `file_list`: tests pinning the actiondata destructor hook's two load-bearing properties (unset hook behaves exactly as before; hook never handed NULL). Reverting the dispatch fails seven of nine.
- `features_cpu` linked into the suites that master's crc32/deflate rework now requires (semantic merge conflict — both sides correct in isolation, the linked merge was not). Note master's own Makefile.test has the same gap.
- CI workflows for the libretro-common suites; the samples/gfx steps for the split-out sample directories ride with their respective PRs.

Validation as per the individual commits: validation-layer clean over repeated context cycles on lavapipe, all nine libcheck suites at 0 failures under ASan+UBSan, C89 syntax checks on touched C sources.