### PR TITLE
sdl2: restore original intent for non-webos for mouse x/y

### DIFF
--- a/input/drivers/sdl_input.c
+++ b/input/drivers/sdl_input.c
@@ -310,12 +310,6 @@ static int16_t sdl_input_state(
                       return 1;
                   }
                   break;
-#else
-               case RETRO_DEVICE_ID_MOUSE_WHEELUP:
-                  return sdl->mouse_wu;
-               case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
-                  return sdl->mouse_wd;
-#endif
                case RETRO_DEVICE_ID_MOUSE_X:
                   /* MOUSE_SCREEN must be absolute (menu/OSK hit-test);
                    * RETRO_DEVICE_MOUSE stays relative for cores. */
@@ -324,6 +318,16 @@ static int16_t sdl_input_state(
                case RETRO_DEVICE_ID_MOUSE_Y:
                   return (device == RARCH_DEVICE_MOUSE_SCREEN)
                         ? sdl->mouse_abs_y : sdl->mouse_y;
+#else
+               case RETRO_DEVICE_ID_MOUSE_WHEELUP:
+                  return sdl->mouse_wu;
+               case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
+                  return sdl->mouse_wd;
+               case RETRO_DEVICE_ID_MOUSE_X:
+                  return sdl->mouse_x;
+               case RETRO_DEVICE_ID_MOUSE_Y:
+                  return sdl->mouse_y;
+#endif
                case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                   return sdl->mouse_m;
                case RETRO_DEVICE_ID_MOUSE_BUTTON_4:


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Fixes original intent that this PR altered: https://github.com/libretro/RetroArch/pull/19277

## Related Issues

## Related Pull Requests


## Reviewers
