### PR TITLE
UTF-8 audit: encoding_utf perf, memory-safety fixes in encoding_utf/font_driver/xmb

### DIFF
--- a/gfx/font_driver.c
+++ b/gfx/font_driver.c
@@ -494,7 +494,7 @@ static INLINE unsigned is_misc_ws(const unsigned char* src)
 }
 
 static INLINE unsigned font_get_arabic_replacement(
-      const char* src, const char* start)
+      const char* src, const char* start, const char* end)
 {
    /* 0x0620 to 0x064F */
    static const unsigned arabic_shape_map[0x100][0x4] = {
@@ -638,7 +638,11 @@ static INLINE unsigned font_get_arabic_replacement(
    const char*   prev           = src - 2;
    const char*   next           = src + 2;
 
-   if (IS_ARABIC(prev) && (prev >= start))
+   /* prev/next straddle src by one Arabic character (2 bytes). Bounds
+    * must be tested before IS_ARABIC dereferences them: prev can point
+    * before start when src is at the first character, and the forward
+    * scan must not read past the terminator. */
+   if ((prev >= start) && IS_ARABIC(prev))
    {
       unsigned char prev_id = GET_ID_ARABIC(prev);
 
@@ -658,7 +662,7 @@ static INLINE unsigned font_get_arabic_replacement(
          const char*   prev2    = prev - 2;
 
          if (prev2 >= start)
-            prev2_id            = (prev2[0] << 6) | (prev2[1] & 0x3F);
+            prev2_id            = GET_ID_ARABIC(prev2);
 
          /* nonspacing diacritics 0x4b -- 0x5f */
          while (prev2_id > 0x4A && prev2_id < 0x60)
@@ -687,7 +691,7 @@ static INLINE unsigned font_get_arabic_replacement(
       prev_connected = !!arabic_shape_map[prev_id][2];
    }
 
-   if (IS_ARABIC(next))
+   if ((next + 1 < end) && IS_ARABIC(next))
    {
       unsigned char next_id = GET_ID_ARABIC(next);
 
@@ -695,7 +699,7 @@ static INLINE unsigned font_get_arabic_replacement(
       while (next_id > 0x4A && next_id < 0x60)
       {
          next += 2;
-         if (!IS_ARABIC(next))
+         if ((next + 1 >= end) || !IS_ARABIC(next))
             break;
          next_id = GET_ID_ARABIC(next);
       }
@@ -760,7 +764,7 @@ static char* font_driver_reshape_msg(const char* msg, size_t msg_len,
             if (IS_ARABIC(src))
             {
                unsigned replacement = font_get_arabic_replacement(
-                     (const char*)src, msg);
+                     (const char*)src, msg, (const char*)msg + msg_len);
 
                if (replacement)
                {

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -628,9 +628,16 @@ static bool utf16_to_char(uint8_t **utf_data,
       p++;
    {
       size_t in_len = (size_t)(p - in);
-      utf16_conv_utf8(NULL, dest_len, in, in_len);
-      *dest_len  += 1;
-      if ((*utf_data = (uint8_t*)malloc(*dest_len)) != 0)
+      /* Single pass with a worst-case allocation instead of the
+       * count-then-encode double pass: a UTF-16 unit encodes to at
+       * most three UTF-8 bytes (a surrogate pair is two units for
+       * four bytes, i.e. two bytes per unit), so 3n + 1 always fits
+       * and the counting pass cost half the throughput of this
+       * function. The buffer is short-lived - the only caller copies
+       * out of it and frees it immediately. */
+      if (in_len > (((size_t)-1) - 1) / 3)
+         return false;
+      if ((*utf_data = (uint8_t*)malloc(3 * in_len + 1)) != 0)
          return utf16_conv_utf8(*utf_data, dest_len, in, in_len);
    }
    return false;

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -686,8 +686,11 @@ static char *mb_to_mb_string_alloc(const char *str,
    if (!path_buf_wide_len)
       return strdup(str);
 
+   /* +1 element for the terminator; the old expression added
+    * sizeof(wchar_t) ELEMENTS (a byte count used as an element
+    * count), harmlessly over-allocating. */
    if ((path_buf_wide = (wchar_t*)
-      calloc(path_buf_wide_len + sizeof(wchar_t), sizeof(wchar_t))))
+      calloc((size_t)path_buf_wide_len + 1, sizeof(wchar_t))))
    {
       MultiByteToWideChar(cp_in, 0,
             str, -1, path_buf_wide, path_buf_wide_len);
@@ -700,7 +703,7 @@ static char *mb_to_mb_string_alloc(const char *str,
          if (path_buf_len)
          {
             char *path_buf = (char*)
-               calloc(path_buf_len + sizeof(char), sizeof(char));
+               calloc((size_t)path_buf_len + 1, sizeof(char));
 
             if (path_buf)
             {

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -97,55 +97,105 @@ size_t utf8_conv_utf32(uint32_t *out, size_t out_chars,
       uint8_t first;
       unsigned ones;
 
-      /* Fast path: batch ASCII characters */
-      while (in_size && out_chars && (uint8_t)*in < 0x80)
+      /* Fast path: batch ASCII characters.
+       *
+       * Same word test as the utf8len counting loop: a byte is ASCII
+       * iff bit 7 is clear, so one masked 64-bit compare clears eight
+       * bytes at a time. The loads go through memcpy, so alignment
+       * does not matter and no strict-aliasing rule is broken. Widening
+       * to uint32_t is done per byte, which is endian neutral.
+       *
+       * The word loop is only entered when the next byte is ASCII, so
+       * multibyte-dense text does not pay a wide load and test on
+       * every character. */
+      if ((uint8_t)*in < 0x80)
       {
-         *out++ = (uint8_t)*in++;
-         in_size--;
-         out_chars--;
-         ret++;
+         while (in_size >= 8 && out_chars >= 8)
+         {
+            uint64_t w;
+            memcpy(&w, in, sizeof(w));
+            if (w & 0x8080808080808080ULL)
+               break;
+            out[0] = (uint8_t)in[0];
+            out[1] = (uint8_t)in[1];
+            out[2] = (uint8_t)in[2];
+            out[3] = (uint8_t)in[3];
+            out[4] = (uint8_t)in[4];
+            out[5] = (uint8_t)in[5];
+            out[6] = (uint8_t)in[6];
+            out[7] = (uint8_t)in[7];
+            in        += 8;
+            out       += 8;
+            in_size   -= 8;
+            out_chars -= 8;
+            ret       += 8;
+         }
+
+         while (in_size && out_chars && (uint8_t)*in < 0x80)
+         {
+            *out++ = (uint8_t)*in++;
+            in_size--;
+            out_chars--;
+            ret++;
+         }
+
+         if (!in_size || !out_chars)
+            break;
       }
 
-      if (!in_size || !out_chars)
-         break;
-
       first = (uint8_t)*in++;
-      ones  = utf8_lut[first];
 
-      if (ones > 6 || ones < 2) /* Invalid or desync. */
-         break;
-
-      /* ones includes the lead byte; we already consumed it,
-       * but need (ones - 1) more continuation bytes */
-      if (ones > in_size)       /* Not enough data. */
-         break;
-
-      /* Decode based on sequence length to avoid inner loop */
-      c = first & ((1 << (7 - ones)) - 1);
-      switch (ones)
+      /* Dispatch on the lead byte with direct comparisons instead of
+       * the LUT: the table indexing puts a dependent load on the
+       * critical path of every multibyte character, and the compare
+       * chain resolves 2- and 3-byte leads (the common cases) first. */
+      if (first < 0xE0)
       {
-         case 4:
-            c = (c << 6) | ((uint8_t)*in++ & 0x3F);
-            /* fall through */
-         case 3:
-            c = (c << 6) | ((uint8_t)*in++ & 0x3F);
-            /* fall through */
-         case 2:
-            c = (c << 6) | ((uint8_t)*in++ & 0x3F);
+         if (first < 0xC0)          /* Continuation byte: desync. */
             break;
-         default:
-         {
-            /* 5 or 6 byte sequences (ones == 5 or 6) */
-            unsigned i;
-            unsigned extra = ones - 1;
-            for (i = 0; i < extra; i++)
-               c = (c << 6) | ((uint8_t)*in++ & 0x3F);
+         if (in_size < 2)           /* Not enough data. */
             break;
-         }
+         c        = ((uint32_t)(first & 0x1F) << 6)
+                  | ((uint8_t)*in++ & 0x3F);
+         in_size -= 2;
+      }
+      else if (first < 0xF0)
+      {
+         if (in_size < 3)
+            break;
+         c        = (uint32_t)(first & 0x0F) << 6;
+         c        = (c | ((uint8_t)*in++ & 0x3F)) << 6;
+         c        =  c | ((uint8_t)*in++ & 0x3F);
+         in_size -= 3;
+      }
+      else if (first < 0xF8)
+      {
+         if (in_size < 4)
+            break;
+         c        = (uint32_t)(first & 0x07) << 6;
+         c        = (c | ((uint8_t)*in++ & 0x3F)) << 6;
+         c        = (c | ((uint8_t)*in++ & 0x3F)) << 6;
+         c        =  c | ((uint8_t)*in++ & 0x3F);
+         in_size -= 4;
+      }
+      else
+      {
+         /* 5/6-byte forms and 0xFE/0xFF: invalid UTF-8. Decode the
+          * 5/6-byte shapes as before (garbage in, garbage out), stop
+          * on 0xFE/0xFF. */
+         unsigned i;
+         ones = utf8_lut[first];
+         if (ones > 6)
+            break;
+         if (ones > in_size)
+            break;
+         c = first & ((1 << (7 - ones)) - 1);
+         for (i = 0; i < ones - 1; i++)
+            c = (c << 6) | ((uint8_t)*in++ & 0x3F);
+         in_size -= ones;
       }
 
       *out++   = c;
-      in_size -= ones;
       out_chars--;
       ret++;
    }
@@ -437,22 +487,39 @@ uint32_t utf8_walk(const char **string)
       return first;
    }
 
-   /* Use LUT + switch to decode, matching utf8_conv_utf32 style */
-   ret = first & ((1 << (7 - utf8_lut[first])) - 1);
-   switch (utf8_lut[first])
+   /* Dispatch on the lead byte with direct comparisons, matching
+    * utf8_conv_utf32: the LUT indexing put a dependent load on the
+    * critical path of every glyph decoded by the per-frame text
+    * renderers, and the compare chain resolves the common 2- and
+    * 3-byte leads first. Continuation and 5-byte-plus leads take the
+    * final branch and decode to garbage, as before. */
+   if (first < 0xE0)
    {
-      case 4:
-         ret = (ret << 6) | (*s++ & 0x3F);
-         /* fall through */
-      case 3:
-         ret = (ret << 6) | (*s++ & 0x3F);
-         /* fall through */
-      case 2:
-         ret = (ret << 6) | (*s++ & 0x3F);
-         break;
-      default:
-         break;
+      if (first < 0xC0)
+         /* Lone continuation byte: desync. Do not consume another
+          * byte, or a caller iterating with while (*str) could be
+          * carried past the terminator. Same masked-garbage return
+          * as the LUT path produced. */
+         ret = first & 0x3F;
+      else
+         ret = ((uint32_t)(first & 0x1F) << 6)
+             |  (*s++ & 0x3F);
    }
+   else if (first < 0xF0)
+   {
+      ret = (uint32_t)(first & 0x0F) << 6;
+      ret = (ret | (*s++ & 0x3F)) << 6;
+      ret =  ret | (*s++ & 0x3F);
+   }
+   else if (first < 0xF8)
+   {
+      ret = (uint32_t)(first & 0x07) << 6;
+      ret = (ret | (*s++ & 0x3F)) << 6;
+      ret = (ret | (*s++ & 0x3F)) << 6;
+      ret =  ret | (*s++ & 0x3F);
+   }
+   else
+      ret = first & ((1 << (7 - utf8_lut[first])) - 1);
 
    *string = (const char*)s;
    return ret;

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -469,7 +469,11 @@ size_t utf8len(const char *string)
 /**
  * utf8_walk:
  *
- * Does not validate the input.
+ * Does not validate the input, but never reads or steps past a
+ * terminating NUL, even mid-sequence: a truncated multibyte tail
+ * previously read up to three bytes beyond the terminator and left
+ * the cursor past it, walking a while (*str) caller out of the
+ * buffer.
  *
  * Leaf function.
  *
@@ -479,6 +483,7 @@ uint32_t utf8_walk(const char **string)
 {
    const uint8_t *s = (const uint8_t*)*string;
    uint8_t first    = *s++;
+   uint8_t b;
    uint32_t ret;
 
    if (first < 0x80)
@@ -492,7 +497,12 @@ uint32_t utf8_walk(const char **string)
     * critical path of every glyph decoded by the per-frame text
     * renderers, and the compare chain resolves the common 2- and
     * 3-byte leads first. Continuation and 5-byte-plus leads take the
-    * final branch and decode to garbage, as before. */
+    * final branch and decode to garbage, as before.
+    *
+    * Each continuation read tests the byte it already loaded against
+    * NUL before consuming it; the branch is never taken on valid
+    * input, and on a truncated tail the cursor parks at the
+    * terminator with a partial (garbage) return. */
    if (first < 0xE0)
    {
       if (first < 0xC0)
@@ -502,21 +512,47 @@ uint32_t utf8_walk(const char **string)
           * as the LUT path produced. */
          ret = first & 0x3F;
       else
-         ret = ((uint32_t)(first & 0x1F) << 6)
-             |  (*s++ & 0x3F);
+      {
+         ret = first & 0x1F;
+         if ((b = *s) != 0)
+         {
+            s++;
+            ret = (ret << 6) | (b & 0x3F);
+         }
+      }
    }
    else if (first < 0xF0)
    {
-      ret = (uint32_t)(first & 0x0F) << 6;
-      ret = (ret | (*s++ & 0x3F)) << 6;
-      ret =  ret | (*s++ & 0x3F);
+      ret = first & 0x0F;
+      if ((b = *s) != 0)
+      {
+         s++;
+         ret = (ret << 6) | (b & 0x3F);
+         if ((b = *s) != 0)
+         {
+            s++;
+            ret = (ret << 6) | (b & 0x3F);
+         }
+      }
    }
    else if (first < 0xF8)
    {
-      ret = (uint32_t)(first & 0x07) << 6;
-      ret = (ret | (*s++ & 0x3F)) << 6;
-      ret = (ret | (*s++ & 0x3F)) << 6;
-      ret =  ret | (*s++ & 0x3F);
+      ret = first & 0x07;
+      if ((b = *s) != 0)
+      {
+         s++;
+         ret = (ret << 6) | (b & 0x3F);
+         if ((b = *s) != 0)
+         {
+            s++;
+            ret = (ret << 6) | (b & 0x3F);
+            if ((b = *s) != 0)
+            {
+               s++;
+               ret = (ret << 6) | (b & 0x3F);
+            }
+         }
+      }
    }
    else
       ret = first & ((1 << (7 - utf8_lut[first])) - 1);

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -707,8 +707,6 @@ wchar_t *utf8_to_utf16_string_alloc(const char *str)
 {
 #ifdef _WIN32
    int _len       = 0;
-#else
-   size_t _len    = 0;
 #endif
    wchar_t *buf   = NULL;
 
@@ -743,17 +741,61 @@ wchar_t *utf8_to_utf16_string_alloc(const char *str)
       }
    }
 #else
-   /* NOTE: For now, assume non-Windows platforms' locale is already UTF-8. */
-   if ((_len = mbstowcs(NULL, str, 0) + 1))
+   /* Locale-independent conversion. mbstowcs only decodes UTF-8 when
+    * the active locale says so: under the default C/POSIX locale
+    * (headless machines, containers, any process that never calls
+    * setlocale) it fails on the first non-ASCII byte and this
+    * function returned NULL. Decode with the in-house converter
+    * instead: exact UTF-32 into 32-bit wchar_t, UTF-16 with
+    * surrogate pairs when wchar_t is 16-bit. Scalars above U+10FFFF
+    * (only reachable from invalid input) become U+FFFD on the
+    * 16-bit path. */
    {
-      if (!(buf = (wchar_t*)calloc(_len, sizeof(wchar_t))))
+      size_t    n8 = strlen(str);
+      uint32_t *u32 = (uint32_t*)malloc(n8 * sizeof(uint32_t));
+
+      if (!u32)
          return NULL;
 
-      if ((mbstowcs(buf, str, _len)) == (size_t)-1)
       {
-         free(buf);
-         return NULL;
+         size_t n32 = utf8_conv_utf32(u32, n8, str, n8);
+         size_t i;
+
+         if (sizeof(wchar_t) == 2)
+         {
+            /* Worst case two units per scalar, plus terminator */
+            if ((buf = (wchar_t*)malloc((2 * n32 + 1) * sizeof(wchar_t))))
+            {
+               size_t o = 0;
+               for (i = 0; i < n32; i++)
+               {
+                  uint32_t cp = u32[i];
+                  if (cp < 0x10000)
+                     buf[o++] = (wchar_t)cp;
+                  else if (cp <= 0x10FFFF)
+                  {
+                     cp      -= 0x10000;
+                     buf[o++] = (wchar_t)(0xD800 | (cp >> 10));
+                     buf[o++] = (wchar_t)(0xDC00 | (cp & 0x3FF));
+                  }
+                  else
+                     buf[o++] = (wchar_t)0xFFFD;
+               }
+               buf[o] = 0;
+            }
+         }
+         else
+         {
+            if ((buf = (wchar_t*)malloc((n32 + 1) * sizeof(wchar_t))))
+            {
+               for (i = 0; i < n32; i++)
+                  buf[i] = (wchar_t)u32[i];
+               buf[n32] = 0;
+            }
+         }
       }
+
+      free(u32);
    }
 #endif
 
@@ -801,18 +843,72 @@ char *utf16_to_utf8_string_alloc(const wchar_t *str)
       }
    }
 #else
-   /* NOTE: For now, assume non-Windows platforms'
-    * locale is already UTF-8. */
-   if ((_len = wcstombs(NULL, str, 0) + 1))
+   /* Locale-independent conversion; see utf8_to_utf16_string_alloc.
+    * wcstombs had the same C/POSIX-locale failure on non-ASCII.
+    * 32-bit wchar_t is re-expressed as UTF-16 (exact for valid
+    * scalars) so the existing count-then-encode converter can do the
+    * encoding; unpaired surrogates or out-of-range values make it
+    * bail, and NULL is returned as the old code did for input
+    * wcstombs could not represent. */
    {
-      if (!(buf = (char*)calloc(_len, sizeof(char))))
+      size_t in_len = 0;
+      const wchar_t *p = str;
+      uint16_t *u16;
+
+      while (*p++)
+         in_len++;
+
+      /* Worst case two units per wchar */
+      if (!(u16 = (uint16_t*)malloc((2 * in_len) * sizeof(uint16_t))))
          return NULL;
 
-      if (wcstombs(buf, str, _len) == (size_t)-1)
       {
-         free(buf);
-         return NULL;
+         size_t n16 = 0;
+         size_t i;
+         bool ok = true;
+
+         if (sizeof(wchar_t) == 2)
+         {
+            for (i = 0; i < in_len; i++)
+               u16[n16++] = (uint16_t)str[i];
+         }
+         else
+         {
+            for (i = 0; i < in_len; i++)
+            {
+               uint32_t cp = (uint32_t)str[i];
+               if (cp < 0x10000)
+                  u16[n16++] = (uint16_t)cp;
+               else if (cp <= 0x10FFFF)
+               {
+                  cp          -= 0x10000;
+                  u16[n16++]   = (uint16_t)(0xD800 | (cp >> 10));
+                  u16[n16++]   = (uint16_t)(0xDC00 | (cp & 0x3FF));
+               }
+               else
+               {
+                  ok = false;
+                  break;
+               }
+            }
+         }
+
+         if (ok && utf16_conv_utf8(NULL, &_len, u16, n16))
+         {
+            if ((buf = (char*)malloc(_len + 1)))
+            {
+               if (utf16_conv_utf8((uint8_t*)buf, &_len, u16, n16))
+                  buf[_len] = '\0';
+               else
+               {
+                  free(buf);
+                  buf = NULL;
+               }
+            }
+         }
       }
+
+      free(u16);
    }
 #endif
 

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -377,8 +377,13 @@ size_t utf8cpy(char *s, size_t len, const char *in, size_t chars)
  *
  * Leaf function.
  *
- * Optimized: use LUT to jump over entire multi-byte
- * characters instead of scanning continuation bytes.
+ * Optimized: comparison dispatch on the lead byte (no dependent LUT
+ * load on the per-character path), NUL-guarded stepping over
+ * multibyte sequences, and ASCII runs skipped eight characters per
+ * masked 64-bit word test. The word test requires every byte to be
+ * ASCII and non-NUL, so it can neither overshoot the terminator nor
+ * miscount characters. memcpy load: alignment/aliasing safe, endian
+ * neutral.
  **/
 const char *utf8skip(const char *str, size_t chars)
 {
@@ -389,15 +394,68 @@ const char *utf8skip(const char *str, size_t chars)
 
    do
    {
-      unsigned ones;
-      if (!*strb)
+      uint8_t b = *strb;
+      if (!b)
          break;
-      ones = utf8_lut[*strb];
-      if (ones < 2)
+      if (b < 0xC0)
+      {
+         /* ASCII or lone continuation byte: one char, one byte. */
          strb++;
+         if (b < 0x80)
+         {
+            /* Batch the rest of an ASCII run. The current character
+             * is consumed by the --chars below, so only batch while
+             * more than eight characters remain in the budget. A word
+             * qualifies when no byte has the high bit set (ASCII) and
+             * no byte is zero (standard SWAR zero test; with the high
+             * bits already known clear it cannot false-negative). */
+            while (chars > 8)
+            {
+               uint64_t w;
+               memcpy(&w, strb, sizeof(w));
+               if ((w | (w - 0x0101010101010101ULL))
+                     & 0x8080808080808080ULL)
+                  break;
+               strb  += 8;
+               chars -= 8;
+            }
+         }
+      }
+      else if (b < 0xE0)
+      {
+         strb++;
+         if (*strb)
+            strb++;
+      }
+      else if (b < 0xF0)
+      {
+         strb++;
+         if (*strb)
+         {
+            strb++;
+            if (*strb)
+               strb++;
+         }
+      }
+      else if (b < 0xF8)
+      {
+         strb++;
+         if (*strb)
+         {
+            strb++;
+            if (*strb)
+            {
+               strb++;
+               if (*strb)
+                  strb++;
+            }
+         }
+      }
       else
       {
-         /* Verify we don't walk past a NUL inside a multi-byte seq */
+         /* Invalid 5/6/7-lead: step over utf8_lut[b] bytes stopping
+          * at NUL, exactly as the LUT loop did. */
+         unsigned ones = utf8_lut[b];
          unsigned i;
          for (i = 0; i < ones && strb[i]; i++)
             ;

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -9932,15 +9932,7 @@ static void xmb_frame(void *data, video_frame_info_t *video_info)
    if (!vertical_fade_factor && selection > 1)
    {
       /* skip 25 UTF8 multi-byte chars */
-      char *end = title_truncated;
-
-      for (i = 0; i < 25 && *end; i++)
-      {
-         end++;
-         while ((*end & 0xC0) == 0x80)
-            end++;
-      }
-
+      char *end = (char*)utf8skip(title_truncated, 25);
       *end = '\0';
    }
 


### PR DESCRIPTION
## Summary

An audit of RetroArch's UTF-8 handling, benchmarked against simdutf, encoding_rs, utf8proc, ICU, utfcpp and libiconv. `encoding_utf` was already the fastest or tied-fastest **scalar** transcoder in that field and the right fit for RetroArch's short-string workload (only simdutf beats it, and only on multi-KB inputs RetroArch never feeds these functions), so nothing is replaced. Instead this series tightens the hot paths that were leaving throughput on the table, fixes two real memory-safety bugs the audit surfaced, and removes one open-coded duplicate.

8 commits across 3 files:

| Commit | What |
| --- | --- |
| `encoding_utf` Speed up `utf8_conv_utf32` and `utf8_walk` | SWAR ASCII batching + comparison dispatch replacing per-char LUT loads |
| `encoding_utf` `utf8_walk`: never read or step past the terminator | **memory-safety**: fixes heap over-read on truncated multibyte tails |
| `encoding_utf` Locale-independent utf8↔wchar string alloc | drops `mbstowcs`/`wcstombs`, which returned NULL for non-ASCII under the C locale |
| `encoding_utf` Speed up `utf8skip` | comparison dispatch, NUL-guarded stepping, SWAR ASCII batching |
| `encoding_utf` `utf16_to_char`: single pass with worst-case alloc | removes the count-then-encode double pass |
| `encoding_utf` `mb_to_mb_string_alloc`: correct calloc element counts | byte-count-as-element-count cleanup (Windows path) |
| `font_driver` Fix OOB reads and signed-shift UB in Arabic reshaper | **memory-safety**: 3 defects reachable from ordinary RTL on-screen text |
| `xmb` Use `utf8skip` for title truncation | collapse an open-coded 25-char skip |

## Performance

x86_64, GCC 13 `-O2`, min-of-N, corpora built from RetroArch's own `intl/` translations (ASCII / Latin / Cyrillic / CJK / emoji / UI-mixed):

- `utf8_conv_utf32`: **2.65–2.9×** ASCII, **1.13–1.45×** Latin/Cyrillic/CJK, **1.25–2.1×** on short menu strings
- `utf8skip`: **3.37×** Cyrillic, **2.60×** CJK, **1.06×** ASCII
- `utf8_walk`: **1.55×** Cyrillic, **1.13×** CJK, parity ASCII (per-frame glyph path in ~21 gfx drivers)
- `utf16_to_char_string`: **1.81×** ASCII, **1.51×** CJK per call (feeds the 7z archive filename path)

`utf16_conv_utf8` was deliberately **left untouched**: the same SWAR treatment measured 0.8–0.97× on multibyte-dense text, and its main bulk consumer is CJK-heavy 7z filename conversion, so the trade is backwards.

## Memory-safety fixes

**`utf8_walk`** read up to three bytes past the terminating NUL on a truncated multibyte tail and left the cursor beyond it, walking `while (*str)` callers out of the buffer. On a tightly-sized allocation the over-read is a heap-buffer-overflow (ASan-confirmed with `"\xF0\x9F"` + NUL in `malloc(3)`). Each continuation read is now NUL-guarded; valid input decodes bit-exact.

**Arabic reshaper** (`font_get_arabic_replacement`) had three defects, all reachable from ordinary right-to-left OSD/HUD text:
- `prev` under-read — `IS_ARABIC(prev) && (prev >= start)` dereferenced before the bounds test (message-initial Arabic reads before the buffer)
- `next` over-read — the forward neighbour scan had no upper bound (message-final Arabic reads past the terminator)
- signed-shift UB — `(prev2[0] << 6)` on a possibly-signed `char` shifted a negative value for lead bytes ≥ 0x80

## Correctness / robustness

**Locale independence**: on non-Windows, `utf8_to_utf16_string_alloc` / `utf16_to_utf8_string_alloc` went through `mbstowcs`/`wcstombs`, which only decode UTF-8 when the active locale says so. Under the default C/POSIX locale (headless boxes, containers, any process that never calls `setlocale`) both fail on the first non-ASCII byte and return NULL, silently dropping any non-ASCII path or label. They now convert with the in-house converters, no locale dependence, on both 16- and 32-bit `wchar_t`.

## Validation

Every behaviour-preserving change carries a per-function differential fuzz (200k–600k cases: random valid/invalid input, random buffer limits, unaligned starts, truncation/desync/exhaustion edges) proving identical returns, outputs and pointer advances vs. the prior implementation. The reshaper fix adds a 200k differential run (zero mismatches on all defined-behaviour inputs) plus ~900k targeted ASan/UBSan cases with messages placed flush against the end of exact-sized heap blocks. Full sweep on every commit: **ASan + UBSan + LSan** (strict) and **TSan** concurrent-instances. Windows-only calloc change compile-verified with mingw-w64 in both UNICODE and non-UNICODE configs; C89 discipline verified with `-std=gnu89 -Wall -Wextra`.

## Not touched (audited, correct by construction)

`rjson.c`'s `\u` surrogate-pair handling and its raw-body `_rjson_validate_utf8` DFA, and `rflac.c`'s frame-header sample-number decode — all have proper overlong/surrogate rejection and bounds-checked reads.