### PR TITLE
(r7z_lzma) Overlap-copy chunk doubling; remove dead branchless variants

### DIFF
--- a/libretro-common/formats/7z/r7z_lzma.c
+++ b/libretro-common/formats/7z/r7z_lzma.c
@@ -723,17 +723,24 @@ int rlzma_dec_decode(rlzma_dec_t *dec,
             else
             {
                /* Overlapping copy: run-length semantics fall out of a
-                * forward copy, so memcpy is not usable. Copying in
-                * rep0-sized blocks keeps every block's source and
-                * destination disjoint, since each block reads only bytes
-                * written before it started. */
+                * forward copy, so memcpy is not usable directly. Copy
+                * from the fixed base instead, doubling the chunk each
+                * round: once done bytes are out, [copy_pos, pos + done)
+                * is one periodic run, so the next chunk may take
+                * rep0 + done bytes and still read only bytes written
+                * before it started. done stays a multiple of rep0 for
+                * every chunk but the last, which keeps the period
+                * aligned; the last chunk is a truncation and needs no
+                * alignment. Small periods are the common case here, and
+                * fixed rep0-sized chunks would mean a 2-16 byte memcpy
+                * per round for a match that can run to 273 bytes. */
                uint32_t done = 0;
                while (done < copy_len)
                {
-                  uint32_t chunk = rep0;
+                  uint32_t chunk = rep0 + done;
                   if (chunk > copy_len - done)
                      chunk = copy_len - done;
-                  memcpy(dst + pos + done, dst + copy_pos + done, chunk);
+                  memcpy(dst + pos + done, dst + copy_pos, chunk);
                   done += chunk;
                }
                pos += copy_len;

--- a/libretro-common/formats/7z/r7z_lzma.c
+++ b/libretro-common/formats/7z/r7z_lzma.c
@@ -274,41 +274,11 @@
    p2          = prob_lit + (offs + bit + symbol); \
    RC_GET_BIT_2(p2, symbol, offs ^= bit, ;)
 
-/* Branchless matched-literal step, same construction as the plain
- * literal above. The offs update (which is what makes the matched
- * literal degenerate into a normal one once the bits disagree) becomes
- * a masked xor rather than a conditional. */
-#define MATCHED_LITER_DEC_BL \
-   { \
-      uint32_t pv, bnd, m, upd; \
-      match_byte += match_byte; \
-      bit         = offs; \
-      offs       &= match_byte; \
-      p2          = prob_lit + (offs + bit + symbol); \
-      pv          = *p2; \
-      RC_NORMALIZE \
-      bnd   = (range >> NUM_MODEL_BITS) * pv; \
-      m     = (uint32_t)0 - (uint32_t)(code >= bnd); \
-      upd   = pv - (BIT_MODEL_OFFSET & ~m); \
-      *p2   = (uint16_t)(pv - (uint32_t)((int32_t)upd >> NUM_MOVE_BITS)); \
-      range = bnd + ((range - bnd - bnd) & m); \
-      code -= bnd & m; \
-      symbol = (symbol + symbol) + (m & 1); \
-      offs  ^= bit & ~m; \
-   }
-
 #undef TREE_DECODE
 #define TREE_DECODE(base, limit, dest) \
    { \
       dest = 1; \
       do { TREE_GET_BIT(base, dest) } while (dest < (limit)); \
-      dest -= (limit); \
-   }
-
-#define TREE_DECODE_BL(base, limit, dest) \
-   { \
-      dest = 1; \
-      do { TREE_GET_BIT_BL(base, dest) } while (dest < (limit)); \
       dest -= (limit); \
    }
 
@@ -754,8 +724,9 @@ int rlzma_dec_decode(rlzma_dec_t *dec,
             {
                /* Overlapping copy: run-length semantics fall out of a
                 * forward copy, so memcpy is not usable. Copying in
-                * rep0-sized blocks lets each block be non-overlapping
-                * and doubles the run each time round. */
+                * rep0-sized blocks keeps every block's source and
+                * destination disjoint, since each block reads only bytes
+                * written before it started. */
                uint32_t done = 0;
                while (done < copy_len)
                {


### PR DESCRIPTION
Two commits on the one-shot LZMA decoder, both fallout from a decode-performance comparison of r7z against LZMA SDK 24.09, liblzma 5.4.5, lzlib 1.14, and XZ Embedded (identical raw-LZMA1 input where formats allow, output memcmp'd against the original on every configuration).

## 1. Double the chunk in the overlapping match copy

The overlap path copied fixed `rep0`-sized chunks, which for the common small-period case (tile fills, silence runs, RLE-ish data at period 2–16) means a 2–16 byte `memcpy` per round for matches that can run to 273 bytes. This copies from the fixed base of the periodic run instead, growing the chunk by `rep0 + done` each round:

- every chunk still reads only bytes written before it started (`chunk ≤ rep0 + done` keeps source and destination disjoint)
- `done` stays a multiple of `rep0` for every chunk but the final truncation, which keeps the period aligned
- round count drops from `copy_len / rep0` to logarithmic

On a small-period pattern corpus (24 MiB, periods 2–16, 293× ratio):

| | whole-stream | CHD hunks (19584 B) |
|---|---|---|
| before | 1010 MB/s | 969 MB/s (20.2 µs/hunk) |
| after | **2865 MB/s** | **2455 MB/s** (8.0 µs/hunk) |
| LZMA SDK 24.09, same data | 1375 MB/s | 1150 MB/s |

Binary, text, and incompressible corpora are unchanged within noise — they rarely hit the small-period overlap case.

## 2. Remove unused branchless macro variants, fix overlap-copy comment

`MATCHED_LITER_DEC_BL` and `TREE_DECODE_BL` were defined but never used. Wiring the matched-literal variant in was measured at no gain on binary/high-entropy data and −2.5 % on text: matched literals are rare (post-match states only) and well-steered by `match_byte`, so the branchy form predicts fine there. Deleted rather than left to drift. Also makes the overlap-copy comment describe what the code does.

(For the same reason the *plain*-literal branchless kernel stays: it's why the one-shot decoder is +26–29 % over SDK 24.09 on high-entropy data, at the cost of 8–14 % on highly compressible text.)

## Verification

Both commits went through the full pre-commit sweep:

- **Functional:** outputs bit-identical across four corpora (binary / text / incompressible / small-period pattern) against liblzma, lzlib, XZ Embedded, and LZMA SDK 24.09, whole-stream and CHD-hunk shaped.
- **ASan + UBSan + LeakSan (strict):** 120k corrupted-input cases (bit flips, truncation, garbage tails, combined; exact-size heap buffers so a 1-byte overrun aborts) — zero findings. Accept/reject matches the reference decoder case-for-case; the only divergence class is truncation into the range-coder flush bytes, where r7z decodes without ever needing the missing bytes and the output verifies byte-correct.
- **TSan:** clean on an 8-thread concurrent-instances test (one-shot, streaming, and LZMA2 decoders over shared read-only input).
- **C89:** `-std=gnu89 -Wdeclaration-after-statement -Wall -Wextra` clean.

No functional change in commit 2 (differential counters bit-identical before/after); commit 1's behavior change is speed only.