### PR TITLE
menu_cbs_ok: Restore dedicated core backup list actions

### DIFF
--- a/menu/cbs/menu_cbs_ok.c
+++ b/menu/cbs/menu_cbs_ok.c
@@ -1968,8 +1968,6 @@ static const ok_dl_map_t ok_dl_map[] = {
    { MENU_ENUM_LABEL_AUDIO_OUTPUT_SETTINGS, ACTION_OK_DL_AUDIO_OUTPUT_SETTINGS_LIST },
    { MENU_ENUM_LABEL_LATENCY_SETTINGS, ACTION_OK_DL_LATENCY_SETTINGS_LIST },
    { MENU_ENUM_LABEL_CORE_SETTINGS, ACTION_OK_DL_CORE_SETTINGS_LIST },
-   { MENU_ENUM_LABEL_CORE_RESTORE_BACKUP_LIST, ACTION_OK_DL_CORE_RESTORE_BACKUP_LIST },
-   { MENU_ENUM_LABEL_CORE_DELETE_BACKUP_LIST, ACTION_OK_DL_CORE_DELETE_BACKUP_LIST },
    { MENU_ENUM_LABEL_CONFIGURATION_SETTINGS, ACTION_OK_DL_CONFIGURATION_SETTINGS_LIST },
    { MENU_ENUM_LABEL_PLAYLIST_SETTINGS, ACTION_OK_DL_PLAYLIST_SETTINGS_LIST },
    { MENU_ENUM_LABEL_PLAYLIST_MANAGER_LIST, ACTION_OK_DL_PLAYLIST_MANAGER_LIST },
@@ -6830,6 +6828,8 @@ static int action_ok_delete_entry(const char *path,
 }
 
 STATIC_DEFAULT_ACTION_OK_FUNC(action_ok_cdrom_info_list, ACTION_OK_DL_CDROM_INFO_DETAIL_LIST)
+STATIC_DEFAULT_ACTION_OK_FUNC(action_ok_push_core_restore_backup_list, ACTION_OK_DL_CORE_RESTORE_BACKUP_LIST)
+STATIC_DEFAULT_ACTION_OK_FUNC(action_ok_push_core_delete_backup_list, ACTION_OK_DL_CORE_DELETE_BACKUP_LIST)
 #if defined(HAVE_CG) || defined(HAVE_GLSL) || defined(HAVE_SLANG) || defined(HAVE_HLSL)
 STATIC_DEFAULT_ACTION_OK_FUNC(action_ok_shader_preset_manager, ACTION_OK_DL_SHADER_PRESET_MANAGER_LIST)
 STATIC_DEFAULT_ACTION_OK_FUNC(action_ok_shader_parameters, ACTION_OK_DL_SHADER_PARAMETERS)
@@ -9534,6 +9534,8 @@ static int menu_cbs_init_bind_ok_compare_label(menu_file_list_cbs_t *cbs,
 #ifdef HAVE_MIST
          {MENU_ENUM_LABEL_CORE_MANAGER_STEAM_ENTRY,            action_ok_push_core_information_steam_list},
 #endif
+         {MENU_ENUM_LABEL_CORE_RESTORE_BACKUP_LIST,            action_ok_push_core_restore_backup_list},
+         {MENU_ENUM_LABEL_CORE_DELETE_BACKUP_LIST,             action_ok_push_core_delete_backup_list},
          {MENU_ENUM_LABEL_PLAYLIST_MANAGER_SETTINGS,           action_ok_push_playlist_manager_settings},
          {MENU_ENUM_LABEL_PLAYLIST_MANAGER_RESET_CORES,        action_ok_playlist_reset_cores},
          {MENU_ENUM_LABEL_PLAYLIST_MANAGER_CLEAN_PLAYLIST,     action_ok_playlist_clean},


### PR DESCRIPTION
## Description

The conversion of display-list actions to ok_dl_map caused Restore Core Backup and Delete Core Backup to open the generic file browser instead of displaying the available backup list.

The shared action_ok_dl_from_map() handler dispatches an action by comparing its callback label with the canonical label stored in the map. These two actions also require that callback label as the display-list path: generic_action_ok_displaylist_push() assigns it to info_path when processing ACTION_OK_DL_CORE_RESTORE_BACKUP_LIST and ACTION_OK_DL_CORE_DELETE_BACKUP_LIST.

Because the label cannot reliably serve both purposes for these entries, the shared lookup can miss and fall through to ACTION_OK_DL_OPEN_ARCHIVE.

Remove these two exceptional entries from ok_dl_map and restore their dedicated callbacks. This supplies the correct display-list ID directly while preserving the callback label as the backup-list path. Other data-driven display-list actions remain unchanged.

Reproduction:

1. Install a core.
2. Back up the installed core.
3. Select Restore Core Backup or Delete Core Backup.
4. Without this change, RetroArch opens the file browser instead of listing the available backups.

Tested on Android against current upstream master. Both Restore Core Backup and Delete Core Backup correctly display the backup list after this change.

## Related Issues

Fixes #19251.