### PR TITLE
rh264: decoder performance series (~1.2x, -18.7% instructions)

### DIFF
--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -2639,6 +2639,200 @@ static void rh264_filter_chroma_edge_n(uint8_t *e, int s, int ls, int n,
       rh264_filter_chroma_edge(e + k * ls, s, bS, a, be, tc0v);
 }
 
+/* Per-segment chroma edge filter: the whole chroma edge of a macroblock
+ * in one pass, lanes carrying each 4-sample luma segment's own strength
+ * class and tc0 (bS[4]/tc[4], lane k of n belongs to segment k*4/n).
+ * The P/B derivation gives every segment its own strength, which the
+ * scalar per-sample walk this replaces paid for one pixel at a time;
+ * here both filter branches are computed vector-wide and blended per
+ * lane, inactive lanes keeping their samples. */
+#ifdef RH264_SSE2
+static void rh264_sse2_chroma_kernel_seg(__m128i v[4], __m128i vt,
+      __m128i vnorm, __m128i vstrong, int a, int be)
+{
+   __m128i p1 = v[0], p0 = v[1], q0 = v[2], q1 = v[3];
+   __m128i va  = _mm_set1_epi16((short)a);
+   __m128i vbe = _mm_set1_epi16((short)be);
+   __m128i filt = _mm_and_si128(
+         _mm_cmplt_epi16(RH264_SSE2_ABS16(_mm_sub_epi16(p0, q0)), va),
+         _mm_and_si128(
+         _mm_cmplt_epi16(RH264_SSE2_ABS16(_mm_sub_epi16(p1, p0)), vbe),
+         _mm_cmplt_epi16(RH264_SSE2_ABS16(_mm_sub_epi16(q1, q0)), vbe)));
+   __m128i mn = _mm_and_si128(filt, vnorm);
+   __m128i ms = _mm_and_si128(filt, vstrong);
+   {
+      __m128i tc = _mm_add_epi16(vt, _mm_set1_epi16(1));
+      __m128i d = _mm_srai_epi16(_mm_add_epi16(_mm_add_epi16(
+            _mm_slli_epi16(_mm_sub_epi16(q0, p0), 2),
+            _mm_sub_epi16(p1, q1)), _mm_set1_epi16(4)), 3);
+      __m128i np, nq;
+      d = _mm_max_epi16(_mm_min_epi16(d, tc),
+            _mm_sub_epi16(_mm_setzero_si128(), tc));
+      np = _mm_max_epi16(_mm_min_epi16(_mm_add_epi16(p0, d),
+            _mm_set1_epi16(255)), _mm_setzero_si128());
+      nq = _mm_max_epi16(_mm_min_epi16(_mm_sub_epi16(q0, d),
+            _mm_set1_epi16(255)), _mm_setzero_si128());
+      v[1] = RH264_SSE2_SEL(mn, np, p0);
+      v[2] = RH264_SSE2_SEL(mn, nq, q0);
+   }
+   {
+      __m128i two = _mm_set1_epi16(2);
+      __m128i np = _mm_srai_epi16(_mm_add_epi16(_mm_add_epi16(
+            _mm_slli_epi16(p1, 1), _mm_add_epi16(p0, q1)), two), 2);
+      __m128i nq = _mm_srai_epi16(_mm_add_epi16(_mm_add_epi16(
+            _mm_slli_epi16(q1, 1), _mm_add_epi16(q0, p1)), two), 2);
+      v[1] = RH264_SSE2_SEL(ms, np, v[1]);
+      v[2] = RH264_SSE2_SEL(ms, nq, v[2]);
+   }
+}
+#elif defined(RH264_NEON)
+static void rh264_neon_chroma_kernel_seg(int16x8_t v[4], int16x8_t vt,
+      uint16x8_t vnorm, uint16x8_t vstrong, int a, int be)
+{
+   int16x8_t p1 = v[0], p0 = v[1], q0 = v[2], q1 = v[3];
+   int16x8_t va  = vdupq_n_s16((int16_t)a);
+   int16x8_t vbe = vdupq_n_s16((int16_t)be);
+   uint16x8_t filt = vandq_u16(
+         vcltq_s16(vabsq_s16(vsubq_s16(p0, q0)), va), vandq_u16(
+         vcltq_s16(vabsq_s16(vsubq_s16(p1, p0)), vbe),
+         vcltq_s16(vabsq_s16(vsubq_s16(q1, q0)), vbe)));
+   uint16x8_t mn = vandq_u16(filt, vnorm);
+   uint16x8_t ms = vandq_u16(filt, vstrong);
+   {
+      int16x8_t tc = vaddq_s16(vt, vdupq_n_s16(1));
+      int16x8_t d = vshrq_n_s16(vaddq_s16(vaddq_s16(
+            vshlq_n_s16(vsubq_s16(q0, p0), 2),
+            vsubq_s16(p1, q1)), vdupq_n_s16(4)), 3);
+      int16x8_t np, nq;
+      d = vmaxq_s16(vminq_s16(d, tc), vnegq_s16(tc));
+      np = vmaxq_s16(vminq_s16(vaddq_s16(p0, d), vdupq_n_s16(255)),
+            vdupq_n_s16(0));
+      nq = vmaxq_s16(vminq_s16(vsubq_s16(q0, d), vdupq_n_s16(255)),
+            vdupq_n_s16(0));
+      v[1] = RH264_NEON_SEL(mn, np, p0);
+      v[2] = RH264_NEON_SEL(mn, nq, q0);
+   }
+   {
+      int16x8_t two = vdupq_n_s16(2);
+      int16x8_t np = vshrq_n_s16(vaddq_s16(vaddq_s16(
+            vshlq_n_s16(p1, 1), vaddq_s16(p0, q1)), two), 2);
+      int16x8_t nq = vshrq_n_s16(vaddq_s16(vaddq_s16(
+            vshlq_n_s16(q1, 1), vaddq_s16(q0, p1)), two), 2);
+      v[1] = RH264_NEON_SEL(ms, np, v[1]);
+      v[2] = RH264_NEON_SEL(ms, nq, v[2]);
+   }
+}
+#endif
+
+static void rh264_filter_chroma_edge_seg(uint8_t *e, int s, int ls, int n,
+      const int *bS, const int *tc, int a, int be)
+{
+   int k = 0;
+#if defined(RH264_SSE2) || defined(RH264_NEON)
+   short lt[16], lnm[16], lst[16];
+   {
+      int i;
+      for (i = 0; i < n; i++)
+      {
+         int sg = (i * 4) / n;
+         lt[i]  = (short)tc[sg];
+         lnm[i] = (short)((bS[sg] && bS[sg] < 4) ? -1 : 0);
+         lst[i] = (short)((bS[sg] == 4) ? -1 : 0);
+      }
+   }
+#endif
+#ifdef RH264_SSE2
+   if (ls == 1)
+   {
+      const __m128i vz = _mm_setzero_si128();
+      for (; k + 8 <= n; k += 8)
+      {
+         __m128i v[4];
+         int i;
+         for (i = 0; i < 4; i++)
+            v[i] = _mm_unpacklo_epi8(_mm_loadl_epi64(
+                  (const __m128i*)(e + k + (i - 2) * s)), vz);
+         rh264_sse2_chroma_kernel_seg(v,
+               _mm_loadu_si128((const __m128i*)(lt + k)),
+               _mm_loadu_si128((const __m128i*)(lnm + k)),
+               _mm_loadu_si128((const __m128i*)(lst + k)), a, be);
+         _mm_storel_epi64((__m128i*)(e + k - s), _mm_packus_epi16(v[1], v[1]));
+         _mm_storel_epi64((__m128i*)(e + k),     _mm_packus_epi16(v[2], v[2]));
+      }
+   }
+   else if (s == 1)
+   {
+      const __m128i vz = _mm_setzero_si128();
+      for (; k + 8 <= n; k += 8)
+      {
+         __m128i r[8], c[8], v[4];
+         int i;
+         for (i = 0; i < 8; i++)
+            r[i] = rh264_sse2_load4(e + (k + i) * ls - 2);
+         rh264_sse2_tr8x8(r, c);
+         for (i = 0; i < 4; i++)
+            v[i] = _mm_unpacklo_epi8(c[i], vz);
+         rh264_sse2_chroma_kernel_seg(v,
+               _mm_loadu_si128((const __m128i*)(lt + k)),
+               _mm_loadu_si128((const __m128i*)(lnm + k)),
+               _mm_loadu_si128((const __m128i*)(lst + k)), a, be);
+         for (i = 0; i < 4; i++)
+            c[i] = _mm_packus_epi16(v[i], v[i]);
+         for (; i < 8; i++) c[i] = vz;
+         rh264_sse2_tr8x8(c, r);
+         for (i = 0; i < 8; i++)
+            rh264_sse2_store4(e + (k + i) * ls - 2, r[i]);
+      }
+   }
+#elif defined(RH264_NEON)
+   if (ls == 1)
+   {
+      for (; k + 8 <= n; k += 8)
+      {
+         int16x8_t v[4];
+         int i;
+         for (i = 0; i < 4; i++)
+            v[i] = vreinterpretq_s16_u16(vmovl_u8(
+                  vld1_u8(e + k + (i - 2) * s)));
+         rh264_neon_chroma_kernel_seg(v, vld1q_s16(lt + k),
+               vreinterpretq_u16_s16(vld1q_s16(lnm + k)),
+               vreinterpretq_u16_s16(vld1q_s16(lst + k)), a, be);
+         vst1_u8(e + k - s, vqmovun_s16(v[1]));
+         vst1_u8(e + k,     vqmovun_s16(v[2]));
+      }
+   }
+   else if (s == 1)
+   {
+      for (; k + 8 <= n; k += 8)
+      {
+         uint8x8_t r[8], c[8];
+         int16x8_t v[4];
+         int i;
+         for (i = 0; i < 8; i++)
+            r[i] = rh264_neon_load4(e + (k + i) * ls - 2);
+         rh264_neon_tr8x8(r, c);
+         for (i = 0; i < 4; i++)
+            v[i] = vreinterpretq_s16_u16(vmovl_u8(c[i]));
+         rh264_neon_chroma_kernel_seg(v, vld1q_s16(lt + k),
+               vreinterpretq_u16_s16(vld1q_s16(lnm + k)),
+               vreinterpretq_u16_s16(vld1q_s16(lst + k)), a, be);
+         for (i = 0; i < 4; i++)
+            c[i] = vqmovun_s16(v[i]);
+         for (; i < 8; i++) c[i] = vdup_n_u8(0);
+         rh264_neon_tr8x8(c, r);
+         for (i = 0; i < 8; i++)
+            rh264_neon_store4(e + (k + i) * ls - 2, r[i]);
+      }
+   }
+#endif
+   for (; k < n; k++)
+   {
+      int sg = (k * 4) / n;
+      if (bS[sg])
+         rh264_filter_chroma_edge(e + k * ls, s, bS[sg], a, be, tc[sg]);
+   }
+}
+
 /* In-loop deblocking (8.7) for an all-intra frame. */
 /* Deblock an all-intra picture. Parameters come per macroblock from the
  * slice that macroblock belongs to (idc/oA/oB indexed by f->mbslice, 8.7):
@@ -5516,35 +5710,33 @@ static void rh264_deblock_pslice(rh264_frame *f, const signed char *sidc,
                seg++;
             }
          }
-         if ((edge&1)==0)
-         for (seg = 0; seg < 4; seg++)
+         /* chroma on even luma edges: the whole chroma edge in one
+          * pass, lanes carrying each luma segment's strength and tc
+          * (4:2:2 keeps the luma height, so a segment covers twice as
+          * many chroma rows) */
+         if ((edge&1)==0 && (vbS[0]|vbS[1]|vbS[2]|vbS[3]))
          {
-            int bS = vbS[seg];
-            if (bS == 0) continue;
-            /* chroma on even luma edges; two chroma rows per luma segment */
-            if ((edge&1)==0)
+            int cx = mbx*8 + (edge>>1)*4, cc;
+            for (cc = 0; cc < 2; cc++)
             {
-               int cx = mbx*8 + (edge>>1)*4, cc;
-               for (cc = 0; cc < 2; cc++)
-               {
-                  int coff = cc?f->chroma_qp_offset2:f->chroma_qp_offset;
-                  int qc = rh264_chroma_qp(qp, coff);
-                  int cqpavg = mbedge ?
-                     ((qc + rh264_chroma_qp(qpp,coff) + 1)>>1) : qc;
-                  int cA=cqpavg+oA, cB=cqpavg+oB, ca, cbe, ct, ci;
-                  uint8_t *pl = cc?f->V:f->U;
-                  if(cA<0)cA=0; else if(cA>51)cA=51;
-                  if(cB<0)cB=0; else if(cB>51)cB=51;
-                  ca=rh264_alpha[cA]; cbe=rh264_beta[cB];
-                  ct=rh264_tc0[bS==4?2:bS-1][cA];
-                  /* 4:2:2 keeps the luma height, so each luma segment
-                   * covers twice as many chroma rows */
-                  for (ci = 0; ci < f->cmbh/4; ci++)
-                  { int cy = mby*f->cmbh + seg*(f->cmbh/4) + ci;
-                    rh264_filter_chroma_edge(pl+cy*f->cstride+cx,1,bS,ca,cbe,ct); }
-               }
-               (void)cgw;
+               int coff = cc?f->chroma_qp_offset2:f->chroma_qp_offset;
+               int qc = rh264_chroma_qp(qp, coff);
+               int cqpavg = mbedge ?
+                  ((qc + rh264_chroma_qp(qpp,coff) + 1)>>1) : qc;
+               int cA=cqpavg+oA, cB=cqpavg+oB, ca, cbe, si;
+               int ctv[4];
+               uint8_t *pl = cc?f->V:f->U;
+               if(cA<0)cA=0; else if(cA>51)cA=51;
+               if(cB<0)cB=0; else if(cB>51)cB=51;
+               ca=rh264_alpha[cA]; cbe=rh264_beta[cB];
+               for (si = 0; si < 4; si++)
+                  ctv[si] = vbS[si]
+                        ? rh264_tc0[vbS[si]==4?2:vbS[si]-1][cA] : 0;
+               rh264_filter_chroma_edge_seg(
+                     pl + (size_t)(mby*f->cmbh)*f->cstride + cx,
+                     1, f->cstride, f->cmbh, vbS, ctv, ca, cbe);
             }
+            (void)cgw;
          }
       }
 
@@ -5606,31 +5798,31 @@ static void rh264_deblock_pslice(rh264_frame *f, const signed char *sidc,
                seg++;
             }
          }
-         if ((edge&1)==0 || f->cmbh==16)
-         for (seg = 0; seg < 4; seg++)
+         /* chroma edge in one pass, lanes along x carrying each luma
+          * segment's strength and tc */
+         if (((edge&1)==0 || f->cmbh==16)
+               && (hbS[0]|hbS[1]|hbS[2]|hbS[3]))
          {
-            int bS = hbS[seg];
-            if (bS == 0) continue;
-            if ((edge&1)==0 || f->cmbh==16)
+            int cy = mby*f->cmbh
+                   + ((f->cmbh==16) ? edge*4 : (edge>>1)*4), cc;
+            for (cc = 0; cc < 2; cc++)
             {
-               int cy = mby*f->cmbh
-                      + ((f->cmbh==16) ? edge*4 : (edge>>1)*4), cc;
-               for (cc = 0; cc < 2; cc++)
-               {
-                  int coff = cc?f->chroma_qp_offset2:f->chroma_qp_offset;
-                  int qc = rh264_chroma_qp(qp, coff);
-                  int cqpavg = mbedge ?
-                     ((qc + rh264_chroma_qp(qpp,coff) + 1)>>1) : qc;
-                  int cA=cqpavg+oA, cB=cqpavg+oB, ca, cbe, ct, ci;
-                  uint8_t *pl = cc?f->V:f->U;
-                  if(cA<0)cA=0; else if(cA>51)cA=51;
-                  if(cB<0)cB=0; else if(cB>51)cB=51;
-                  ca=rh264_alpha[cA]; cbe=rh264_beta[cB];
-                  ct=rh264_tc0[bS==4?2:bS-1][cA];
-                  for (ci = 0; ci < 2; ci++)
-                  { int cx = mbx*8 + seg*2 + ci;
-                    rh264_filter_chroma_edge(pl+cy*f->cstride+cx,f->cstride,bS,ca,cbe,ct); }
-               }
+               int coff = cc?f->chroma_qp_offset2:f->chroma_qp_offset;
+               int qc = rh264_chroma_qp(qp, coff);
+               int cqpavg = mbedge ?
+                  ((qc + rh264_chroma_qp(qpp,coff) + 1)>>1) : qc;
+               int cA=cqpavg+oA, cB=cqpavg+oB, ca, cbe, si;
+               int ctv[4];
+               uint8_t *pl = cc?f->V:f->U;
+               if(cA<0)cA=0; else if(cA>51)cA=51;
+               if(cB<0)cB=0; else if(cB>51)cB=51;
+               ca=rh264_alpha[cA]; cbe=rh264_beta[cB];
+               for (si = 0; si < 4; si++)
+                  ctv[si] = hbS[si]
+                        ? rh264_tc0[hbS[si]==4?2:hbS[si]-1][cA] : 0;
+               rh264_filter_chroma_edge_seg(
+                     pl + (size_t)cy*f->cstride + mbx*8,
+                     f->cstride, 1, 8, hbS, ctv, ca, cbe);
             }
          }
       }

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -1394,6 +1394,10 @@ levels:
 /* rh264 -- intra prediction (H.264 clause 8.3), baseline modes. */
 #define RH264_CLIP(v) ((v)<0?0:((v)>255?255:(v)))
 
+/* residual add-and-clip; defined with the SIMD helpers it uses, below */
+static void rh264_add_residual(uint8_t *dst,int stride,
+      const int32_t *r,int n);
+
 static void rh264_intra16x16(uint8_t *dst,int stride,int mode,int have_up,int have_left){
    int x,y; const uint8_t *up=dst-stride;
    /* Vertical(0)/Horizontal(1)/Plane(3) require the corresponding neighbours;
@@ -1879,10 +1883,7 @@ static int rh264_cavlc_luma8x8(rh264_bits *b, rh264_frame *f,
      for (k = 0; k < 64; k++) coef[sc[k]] = scan[k]; }
    rh264_dequant8x8(coef, f->qp, f->w8[intra ? 0 : 1]);
    rh264_itransform8x8(coef, r);
-   { int yy, xx, v;
-     for (yy = 0; yy < 8; yy++) for (xx = 0; xx < 8; xx++)
-     { v = d[yy*f->ystride+xx] + ((r[yy*8+xx] + 32) >> 6);
-       d[yy*f->ystride+xx] = (uint8_t)RH264_CLIP(v); } }
+   rh264_add_residual(d, f->ystride, r, 8);
    return 0;
 }
 
@@ -2026,10 +2027,8 @@ static int rh264_decode_chroma_residual(rh264_bits *b, rh264_frame *f,
                f->w4[(inter?4:1)+comp]);
          rh264_itransform4x4(ac,r);
          {
-            uint8_t *d=p+by*4*f->cstride+bx*4; int xx,yy,val;
-            for (yy=0;yy<4;yy++) for(xx=0;xx<4;xx++)
-            { val=d[yy*f->cstride+xx]+((r[yy*4+xx]+32)>>6);
-              d[yy*f->cstride+xx]=(uint8_t)RH264_CLIP(val); }
+            uint8_t *d=p+by*4*f->cstride+bx*4;
+            rh264_add_residual(d, f->cstride, r, 4);
          }
       }
    }
@@ -2124,6 +2123,72 @@ static RH264_INLINE uint8x8_t rh264_neon_load4(const uint8_t *s)
    return vreinterpret_u8_u32(vdup_n_u32(t));
 }
 #endif
+/* Add a dequantised, inverse-transformed residual block to the
+ * prediction already in the plane and clip (8.5.13.3): r is rounded by
+ * (r + 32) >> 6, n is 4 or 8, and stride is the plane's.  Every
+ * residual path in the decoder ends here, so it runs a row at a time
+ * rather than a sample at a time: unpack the predicted bytes into
+ * 16-bit lanes, add, and pack back with unsigned saturation, which
+ * performs the clip to [0,255] for free. */
+static void rh264_add_residual(uint8_t *dst,int stride,const int32_t *r,int n)
+{
+   int y;
+#ifdef RH264_SSE2
+   const __m128i vz=_mm_setzero_si128();
+   const __m128i v32=_mm_set1_epi32(32);
+   /* The sum is formed in 32-bit lanes and narrowed with saturation at
+    * each step (32->16 signed, 16->8 unsigned).  Adding in 16-bit lanes
+    * instead would be shorter but wraps on the out-of-range residuals a
+    * corrupt stream can produce, which would make this path disagree
+    * with the scalar one below. */
+   for(y=0;y<n;y++){
+      const int32_t *rr=r+y*n;
+      __m128i p8=(n==8) ? _mm_loadl_epi64((const __m128i*)(dst+y*stride))
+                        : rh264_sse2_load4(dst+y*stride);
+      __m128i p16=_mm_unpacklo_epi8(p8,vz);
+      __m128i s0=_mm_add_epi32(_mm_unpacklo_epi16(p16,vz),
+            _mm_srai_epi32(_mm_add_epi32(
+                  _mm_loadu_si128((const __m128i*)rr),v32),6));
+      if(n==8){
+         __m128i s1=_mm_add_epi32(_mm_unpackhi_epi16(p16,vz),
+               _mm_srai_epi32(_mm_add_epi32(
+                     _mm_loadu_si128((const __m128i*)(rr+4)),v32),6));
+         _mm_storel_epi64((__m128i*)(dst+y*stride),
+               _mm_packus_epi16(_mm_packs_epi32(s0,s1),vz));
+      }else{
+         uint32_t w=(uint32_t)_mm_cvtsi128_si32(
+               _mm_packus_epi16(_mm_packs_epi32(s0,vz),vz));
+         memcpy(dst+y*stride,&w,4);
+      }
+   }
+#elif defined(RH264_NEON)
+   /* as above: sum in 32-bit lanes, saturate on the way down */
+   for(y=0;y<n;y++){
+      const int32_t *rr=r+y*n;
+      uint16x8_t p16=vmovl_u8((n==8) ? vld1_u8(dst+y*stride)
+                                     : rh264_neon_load4(dst+y*stride));
+      int32x4_t s0=vaddq_s32(
+            vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(p16))),
+            vshrq_n_s32(vaddq_s32(vld1q_s32(rr),vdupq_n_s32(32)),6));
+      if(n==8){
+         int32x4_t s1=vaddq_s32(
+               vreinterpretq_s32_u32(vmovl_u16(vget_high_u16(p16))),
+               vshrq_n_s32(vaddq_s32(vld1q_s32(rr+4),vdupq_n_s32(32)),6));
+         vst1_u8(dst+y*stride,vqmovun_s16(
+               vcombine_s16(vqmovn_s32(s0),vqmovn_s32(s1))));
+      }else{
+         rh264_neon_store4(dst+y*stride,vqmovun_s16(
+               vcombine_s16(vqmovn_s32(s0),vdup_n_s16(0))));
+      }
+   }
+#else
+   { int x;
+     for(y=0;y<n;y++) for(x=0;x<n;x++){
+        int v=dst[y*stride+x]+((r[y*n+x]+32)>>6);
+        dst[y*stride+x]=(uint8_t)RH264_CLIP(v); } }
+#endif
+}
+
 
 #ifdef RH264_SSE2
 #define RH264_SSE2_ABS16(x) _mm_max_epi16((x), _mm_sub_epi16(_mm_setzero_si128(), (x)))
@@ -3231,9 +3296,7 @@ static int rh264_decode_intra_mb_cavlc(rh264_bits *b, rh264_frame *f,
                     for(k=0;k<16;k++)coef[sc[k]]=scan[k]; }
                   rh264_dequant4x4(coef,f->qp,0,f->w4[0]);
                   rh264_itransform4x4(coef,r);
-                  {int xx,yy,val;for(yy=0;yy<4;yy++)for(xx=0;xx<4;xx++){
-                     val=d[yy*f->ystride+xx]+((r[yy*4+xx]+32)>>6);
-                     d[yy*f->ystride+xx]=(uint8_t)RH264_CLIP(val);}}
+                  rh264_add_residual(d, f->ystride, r, 4);
                }
                f->nzL[gy*gw+gx]=(uint8_t)nzc;
             }
@@ -3292,10 +3355,8 @@ static int rh264_decode_intra_mb_cavlc(rh264_bits *b, rh264_frame *f,
             ac[0]=dc[(byy*4+bxx)]; /* raster DC index within 4x4 grid */
             rh264_dequant4x4(ac,f->qp,1,f->w4[0]);
             rh264_itransform4x4(ac,r);
-            { uint8_t *bd=y+byy*4*f->ystride+bxx*4; int xx,yy,val;
-              for(yy=0;yy<4;yy++)for(xx=0;xx<4;xx++){
-                 val=bd[yy*f->ystride+xx]+((r[yy*4+xx]+32)>>6);
-                 bd[yy*f->ystride+xx]=(uint8_t)RH264_CLIP(val);} }
+            { uint8_t *bd=y+byy*4*f->ystride+bxx*4;
+              rh264_add_residual(bd, f->ystride, r, 4); }
             f->nzL[gy*gw+gx]=(uint8_t)nzc;
             f->i4mode[gy*gw+gx]=2;  /* I_16x16 -> DC for neighbour MPM (8.3.1.1) */
          }
@@ -4309,12 +4370,7 @@ static int rh264_inter_luma_residual(rh264_bits *b, rh264_frame *f,
          rh264_dequant4x4(coef, f->qp, 0, f->w4[3]);
          rh264_itransform4x4(coef, r);
          {
-            int xx, yy, val;
-            for (yy = 0; yy < 4; yy++) for (xx = 0; xx < 4; xx++)
-            {
-               val = d[yy * f->ystride + xx] + ((r[yy * 4 + xx] + 32) >> 6);
-               d[yy * f->ystride + xx] = (uint8_t)RH264_CLIP(val);
-            }
+            rh264_add_residual(d, f->ystride, r, 4);
          }
       }
       f->nzL[gy * gw + gx] = (uint8_t)nzc;
@@ -7190,9 +7246,7 @@ static int rh264_cabac_decode_mb_ctx(rh264_cabac *cb, const rh264_sps *sps,
          { int32_t q[16]; for(k=0;k<16;k++)q[k]=ac[k];
            rh264_dequant4x4(q,f->qp,1,f->w4[0]); q[0]=ac[0];
            rh264_itransform4x4(q,r); }
-         { int yy,xx; for(yy=0;yy<4;yy++)for(xx=0;xx<4;xx++){
-            int val=d[yy*f->ystride+xx]+((r[yy*4+xx]+32)>>6);
-            d[yy*f->ystride+xx]=(uint8_t)RH264_CLIP(val);} }
+         rh264_add_residual(d, f->ystride, r, 4);
          f->nzL[(gy0+by)*gw+(gx0+bx)] = cur->luma[raster];
          }
       } }
@@ -7234,10 +7288,7 @@ static int rh264_cabac_decode_mb_ctx(rh264_cabac *cb, const rh264_sps *sps,
      for (k = 0; k < 64; k++) coef[sc[k]] = scan[k]; }
             rh264_dequant8x8(coef, f->qp, f->w8[0]);
             rh264_itransform8x8(coef, r);
-            { int yy, xx, val;
-              for (yy = 0; yy < 8; yy++) for (xx = 0; xx < 8; xx++)
-              { val = d[yy*f->ystride+xx] + ((r[yy*8+xx] + 32) >> 6);
-                d[yy*f->ystride+xx] = (uint8_t)RH264_CLIP(val); } }
+            rh264_add_residual(d, f->ystride, r, 8);
          }
          /* the four covered 4x4s inherit the 8x8's coded state (both for
           * neighbouring coded_block_flag contexts and for deblocking) */
@@ -7306,9 +7357,7 @@ static int rh264_cabac_decode_mb_ctx(rh264_cabac *cb, const rh264_sps *sps,
             cur->luma[raster]=nz?1:0;
             rh264_dequant4x4(coef,f->qp,0,f->w4[0]);
             rh264_itransform4x4(coef,r);
-            { int yy,xx; for(yy=0;yy<4;yy++)for(xx=0;xx<4;xx++){
-               int val=d[yy*f->ystride+xx]+((r[yy*4+xx]+32)>>6);
-               d[yy*f->ystride+xx]=(uint8_t)RH264_CLIP(val);} }
+            rh264_add_residual(d, f->ystride, r, 4);
          }
          f->nzL[(gy0+by)*gw+(gx0+bx)]=cur->luma[raster];
       }
@@ -7383,9 +7432,7 @@ static int rh264_cabac_decode_mb_ctx(rh264_cabac *cb, const rh264_sps *sps,
            rh264_dequant4x4(q,qpcc[comp],1,f->w4[1+comp]);
            q[0]=cdc[comp][blk];
            rh264_itransform4x4(q,r);
-           { int yy,xx; for(yy=0;yy<4;yy++)for(xx=0;xx<4;xx++){
-              int val=d[yy*f->cstride+xx]+((r[yy*4+xx]+32)>>6);
-              d[yy*f->cstride+xx]=(uint8_t)RH264_CLIP(val);} }
+           rh264_add_residual(d, f->cstride, r, 4);
            f->nzC[comp][(mby*(f->cmbh/4)+by)*cgw+(mbx*2+bx)]=cur->cAC[comp][blk];
         }
      }
@@ -7693,15 +7740,11 @@ static void rh264_cabac_p_residual(rh264_cabac *cb, rh264_frame *f,
             int32_t scan[64], coef[64], r[64];
             uint8_t *d = Y + (by8*8)*f->ystride + bx8*8;
             rh264_cabac_residual(cb, 5, 0, 64, scan);
-            for (k = 0; k < 64; k++) coef[k] = 0;
             { const uint8_t *sc = RH264_SCAN8(f);
      for (k = 0; k < 64; k++) coef[sc[k]] = scan[k]; }
             rh264_dequant8x8(coef, f->qp, f->w8[1]);
             rh264_itransform8x8(coef, r);
-            { int yy, xx, v;
-              for (yy = 0; yy < 8; yy++) for (xx = 0; xx < 8; xx++)
-              { v = d[yy*f->ystride+xx] + ((r[yy*8+xx] + 32) >> 6);
-                d[yy*f->ystride+xx] = (uint8_t)RH264_CLIP(v); } }
+            rh264_add_residual(d, f->ystride, r, 8);
          }
          for (cy2 = 0; cy2 < 2; cy2++) for (cx2 = 0; cx2 < 2; cx2++)
          {
@@ -7716,7 +7759,9 @@ static void rh264_cabac_p_residual(rh264_cabac *cb, rh264_frame *f,
       int bx = rh264_blk_x[bi], by = rh264_blk_y[bi], raster = by*4 + bx;
       int32_t coef[16], r[16];
       int nz = 0;
-      for (k = 0; k < 16; k++) coef[k] = 0;
+      /* coef needs no clearing: it is only read under nz, and the scan
+       * scatter below writes all sixteen entries from an array
+       * rh264_cabac_residual has already zero-filled. */
       if (cbp_luma & (1 << (bi >> 2)))
       {
          int32_t scan[16];
@@ -7729,10 +7774,8 @@ static void rh264_cabac_p_residual(rh264_cabac *cb, rh264_frame *f,
            for (k = 0; k < 16; k++) coef[sc[k]] = scan[k]; }
             rh264_dequant4x4(coef, f->qp, 0, f->w4[3]);
             rh264_itransform4x4(coef, r);
-            { uint8_t *d = Y + (by*4)*f->ystride + bx*4; int xx, yy, v;
-              for (yy = 0; yy < 4; yy++) for (xx = 0; xx < 4; xx++)
-              { v = d[yy*f->ystride+xx] + ((r[yy*4+xx] + 32) >> 6);
-                d[yy*f->ystride+xx] = (uint8_t)RH264_CLIP(v); } }
+            rh264_add_residual(Y + (by*4)*f->ystride + bx*4,
+                  f->ystride, r, 4);
          }
       }
       cur->luma[raster] = nz ? 1 : 0;
@@ -7797,10 +7840,8 @@ static void rh264_cabac_p_residual(rh264_cabac *cb, rh264_frame *f,
                comp?f->chroma_qp_offset2:f->chroma_qp_offset), 1,
                f->w4[4+comp]);
          rh264_itransform4x4(ac, r);
-         { uint8_t *d = p + by*4*f->cstride + bx*4; int xx, yy, v;
-           for (yy = 0; yy < 4; yy++) for (xx = 0; xx < 4; xx++)
-           { v = d[yy*f->cstride+xx] + ((r[yy*4+xx] + 32) >> 6);
-             d[yy*f->cstride+xx] = (uint8_t)RH264_CLIP(v); } }
+         rh264_add_residual(p + by*4*f->cstride + bx*4,
+               f->cstride, r, 4);
       }
    }
 }

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -2776,12 +2776,17 @@ static void rh264_filter_chroma_edge_seg(uint8_t *e, int s, int ls, int n,
                _mm_loadu_si128((const __m128i*)(lt + k)),
                _mm_loadu_si128((const __m128i*)(lnm + k)),
                _mm_loadu_si128((const __m128i*)(lst + k)), a, be);
-         for (i = 0; i < 4; i++)
-            c[i] = _mm_packus_epi16(v[i], v[i]);
-         for (; i < 8; i++) c[i] = vz;
-         rh264_sse2_tr8x8(c, r);
-         for (i = 0; i < 8; i++)
-            rh264_sse2_store4(e + (k + i) * ls - 2, r[i]);
+         /* only p0/q0 change: interleave the two filtered columns into
+          * per-row byte pairs and store two bytes a row, instead of
+          * transposing all four columns back */
+         {
+            uint8_t pr[16];
+            _mm_storeu_si128((__m128i*)pr, _mm_unpacklo_epi8(
+                  _mm_packus_epi16(v[1], v[1]),
+                  _mm_packus_epi16(v[2], v[2])));
+            for (i = 0; i < 8; i++)
+               memcpy(e + (k + i) * ls - 1, pr + 2 * i, 2);
+         }
       }
    }
 #elif defined(RH264_NEON)
@@ -2816,12 +2821,17 @@ static void rh264_filter_chroma_edge_seg(uint8_t *e, int s, int ls, int n,
          rh264_neon_chroma_kernel_seg(v, vld1q_s16(lt + k),
                vreinterpretq_u16_s16(vld1q_s16(lnm + k)),
                vreinterpretq_u16_s16(vld1q_s16(lst + k)), a, be);
-         for (i = 0; i < 4; i++)
-            c[i] = vqmovun_s16(v[i]);
-         for (; i < 8; i++) c[i] = vdup_n_u8(0);
-         rh264_neon_tr8x8(c, r);
-         for (i = 0; i < 8; i++)
-            rh264_neon_store4(e + (k + i) * ls - 2, r[i]);
+         /* only p0/q0 change: store the two filtered columns as
+          * per-row byte pairs instead of transposing back */
+         {
+            uint8_t pr[16];
+            uint8x8x2_t z;
+            z.val[0] = vqmovun_s16(v[1]);
+            z.val[1] = vqmovun_s16(v[2]);
+            vst2_u8(pr, z);
+            for (i = 0; i < 8; i++)
+               memcpy(e + (k + i) * ls - 1, pr + 2 * i, 2);
+         }
       }
    }
 #endif

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -3375,7 +3375,7 @@ static void rh264_mc_luma(uint8_t *dst, int dstride,
     * dense patch instead of re-clamping per tap. */
    uint8_t pat[21 * 21];
    int pw = bw + 5, ph = bh + 5, r, c;
-   const uint8_t *pc = pat + 2 * pw + 2;    /* patch centre (block origin) */
+   const uint8_t *pc;
 
    if (fx == 0 && fy == 0)
    {
@@ -3393,17 +3393,25 @@ static void rh264_mc_luma(uint8_t *dst, int dstride,
       return;
    }
 
-   if (ix >= 2 && iy >= 2 && ix + bw + 3 <= rw && iy + bh + 3 <= rh)
+   /* When the margined window lies inside the picture the filters can
+    * run straight off the reference plane - the patch only exists to
+    * bake the edge clamp in, so it is gathered solely at the borders. */
+   if (ix >= 2 && iy >= 2 && ix + bw + 3 <= rw && iy + bh + 3 < rh)
    {
-      const uint8_t *s = ref + (iy - 2) * rstride + (ix - 2);
-      for (r = 0; r < ph; r++)
-         memcpy(pat + r * pw, s + r * rstride, (size_t)pw);
+      /* strictly above the last row: the vector tails read a few bytes
+       * past the 6-tap margin, and the spare row keeps them inside the
+       * plane */
+      pw = rstride;
+      pc = ref + iy * rstride + ix;
    }
    else
+   {
       for (r = 0; r < ph; r++)
          for (c = 0; c < pw; c++)
             pat[r * pw + c] = (uint8_t)
                rh264_ref_luma(ref, rstride, rw, rh, ix - 2 + c, iy - 2 + r);
+      pc = pat + 2 * pw + 2;                /* patch centre (block origin) */
+   }
 
 #define PP(dx,dy) ((int)pc[(y + (dy)) * pw + x + (dx)])
 #define HTAP(px,py) rh264_tap6((int)pc[(py)*pw+(px)-2],(int)pc[(py)*pw+(px)-1],\
@@ -3545,14 +3553,14 @@ static void rh264_mc_luma(uint8_t *dst, int dstride,
 #ifdef RH264_SSE2
          for (; c + 8 <= bw; c += 8)
          {
-            const uint8_t *rp = pat + r * pw + c;
+            const uint8_t *rp = pc - 2 * pw - 2 + r * pw + c;
             _mm_storeu_si128((__m128i*)(hb + r * bw + c),
                   rh264_sse2_tap6_u8(rp, rp + 1, rp + 2, rp + 3, rp + 4,
                         rp + 5));
          }
          if (c + 4 <= bw)
          {
-            const uint8_t *rp = pat + r * pw + c;
+            const uint8_t *rp = pc - 2 * pw - 2 + r * pw + c;
             _mm_storel_epi64((__m128i*)(hb + r * bw + c),
                   rh264_sse2_tap6_u8(rp, rp + 1, rp + 2, rp + 3, rp + 4,
                         rp + 5));
@@ -3561,14 +3569,14 @@ static void rh264_mc_luma(uint8_t *dst, int dstride,
 #elif defined(RH264_NEON)
          for (; c + 8 <= bw; c += 8)
          {
-            const uint8_t *rp = pat + r * pw + c;
+            const uint8_t *rp = pc - 2 * pw - 2 + r * pw + c;
             vst1q_s16(hb + r * bw + c,
                   rh264_neon_tap6_u8(rp, rp + 1, rp + 2, rp + 3, rp + 4,
                         rp + 5));
          }
          if (c + 4 <= bw)
          {
-            const uint8_t *rp = pat + r * pw + c;
+            const uint8_t *rp = pc - 2 * pw - 2 + r * pw + c;
             vst1_s16(hb + r * bw + c,
                   vget_low_s16(rh264_neon_tap6_u8(rp, rp + 1, rp + 2,
                         rp + 3, rp + 4, rp + 5)));
@@ -3576,9 +3584,12 @@ static void rh264_mc_luma(uint8_t *dst, int dstride,
          }
 #endif
          for (; c < bw; c++)
+         {
+            const uint8_t *rp = pc - 2 * pw - 2 + r * pw + c;
             hb[r * bw + c] = (int16_t)rh264_tap6(
-                  (int)pat[r*pw+c],   (int)pat[r*pw+c+1], (int)pat[r*pw+c+2],
-                  (int)pat[r*pw+c+3], (int)pat[r*pw+c+4], (int)pat[r*pw+c+5]);
+                  (int)rp[0], (int)rp[1], (int)rp[2],
+                  (int)rp[3], (int)rp[4], (int)rp[5]);
+         }
       }
       for (y = 0; y < bh; y++)
       {
@@ -3765,12 +3776,16 @@ static void rh264_mc_chroma(uint8_t *dst, int dstride,
    /* bilinear window: 4:2:0 chroma blocks are at most 8x8, 4:2:2 ones
     * at most 8x16, and the window is one sample wider and taller */
    uint8_t pat[9 * 17];
+   const uint8_t *pc = pat;
    int pw = bw + 1;
-   if (ix >= 0 && iy >= 0 && ix + bw + 1 <= rw && iy + bh + 1 <= rh)
+   /* run off the reference plane when the window is in-bounds; the
+    * patch is gathered only at the picture borders */
+   if (ix >= 0 && iy >= 0 && ix + bw + 1 <= rw && iy + bh + 1 < rh)
    {
-      const uint8_t *s = ref + iy * rstride + ix;
-      for (r = 0; r < bh + 1; r++)
-         memcpy(pat + r * pw, s + r * rstride, (size_t)pw);
+      /* strictly above the last row so vector tails past the bilinear
+       * window stay inside the plane */
+      pw = rstride;
+      pc = ref + iy * rstride + ix;
    }
    else
       for (r = 0; r < bh + 1; r++)
@@ -3781,7 +3796,7 @@ static void rh264_mc_chroma(uint8_t *dst, int dstride,
    if (fx == 0 && fy == 0)
    {
       for (y = 0; y < bh; y++)
-         memcpy(dst + y * dstride, pat + y * pw, (size_t)bw);
+         memcpy(dst + y * dstride, pc + y * pw, (size_t)bw);
       return;
    }
 #ifdef RH264_SSE2
@@ -3794,7 +3809,7 @@ static void rh264_mc_chroma(uint8_t *dst, int dstride,
       const __m128i rnd = _mm_set1_epi16(32);
       for (y = 0; y < bh; y++)
       {
-         const uint8_t *r0 = pat + y * pw, *r1 = r0 + pw;
+         const uint8_t *r0 = pc + y * pw, *r1 = r0 + pw;
          for (x = 0; x + 8 <= bw; x += 8)
          {
             __m128i a = _mm_unpacklo_epi8(_mm_loadl_epi64((const __m128i*)(r0 + x)), vz);
@@ -3839,7 +3854,7 @@ static void rh264_mc_chroma(uint8_t *dst, int dstride,
       int w01 = (8 - fx) * fy,       w11 = fx * fy;
       for (y = 0; y < bh; y++)
       {
-         const uint8_t *r0 = pat + y * pw, *r1 = r0 + pw;
+         const uint8_t *r0 = pc + y * pw, *r1 = r0 + pw;
          for (x = 0; x + 8 <= bw; x += 8)
          {
             uint16x8_t s = vmull_u8(vld1_u8(r0 + x), vdup_n_u8((uint8_t)w00));
@@ -3870,8 +3885,8 @@ static void rh264_mc_chroma(uint8_t *dst, int dstride,
    for (y = 0; y < bh; y++)
       for (x = 0; x < bw; x++)
       {
-         int a = pat[y * pw + x],       b = pat[y * pw + x + 1];
-         int c2 = pat[(y+1) * pw + x],  d = pat[(y+1) * pw + x + 1];
+         int a = pc[y * pw + x],        b = pc[y * pw + x + 1];
+         int c2 = pc[(y+1) * pw + x],   d = pc[(y+1) * pw + x + 1];
          dst[y * dstride + x] = (uint8_t)(((8 - fx) * (8 - fy) * a
                + fx * (8 - fy) * b + (8 - fx) * fy * c2
                + fx * fy * d + 32) >> 6);

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -4444,78 +4444,109 @@ static void rh264_wp_row(uint8_t *d, int n, int w, int rnd, int sh, int o)
  * bi-prediction combine (explicit or implicit, 8.4.2.3.2). Products can
  * exceed int16 (implicit weights reach -64..128), so the accumulation is
  * 32-bit. */
-static void rh264_bi_row(uint8_t *d, const uint8_t *s0, const uint8_t *s1,
-      int n, int w0, int w1, int bias, int sh, int o)
+
+/* Weighted bi-prediction (8.4.2.3) over a whole block.  This was a
+ * per-row helper that rebuilt its weight, bias, shift and offset
+ * vectors on entry, so a 16-row block paid sixteen identical setups;
+ * the weights are constant across a block, so the rows are driven from
+ * inside one setup instead. */
+static void rh264_bi_block(uint8_t *d, int dstride,
+      const uint8_t *s0, int s0stride, const uint8_t *s1, int s1stride,
+      int w, int h, int w0, int w1, int bias, int sh, int o)
 {
-   int x = 0;
+   int y;
 #ifdef RH264_SSE2
+   const __m128i vz = _mm_setzero_si128();
+   const __m128i vk = _mm_set1_epi32(
+         (int32_t)(((uint32_t)(uint16_t)(int16_t)w1 << 16)
+                 |  (uint32_t)(uint16_t)(int16_t)w0));
+   const __m128i vb = _mm_set1_epi32(bias);
+   const __m128i vo = _mm_set1_epi32(o);
+   const __m128i sc = _mm_cvtsi32_si128(sh);
+   for (y = 0; y < h; y++)
    {
-      const __m128i vz = _mm_setzero_si128();
-      const __m128i vk = _mm_set1_epi32(
-            (int32_t)(((uint32_t)(uint16_t)(int16_t)w1 << 16)
-                    |  (uint32_t)(uint16_t)(int16_t)w0));
-      const __m128i vb = _mm_set1_epi32(bias);
-      const __m128i vo = _mm_set1_epi32(o);
-      const __m128i sc = _mm_cvtsi32_si128(sh);
-      for (; x + 8 <= n; x += 8)
+      uint8_t *dr = d + y * dstride;
+      const uint8_t *a0 = s0 + y * s0stride, *a1 = s1 + y * s1stride;
+      int x = 0;
+      for (; x + 8 <= w; x += 8)
       {
-         __m128i a = _mm_unpacklo_epi8(_mm_loadl_epi64((const __m128i*)(s0 + x)), vz);
-         __m128i b = _mm_unpacklo_epi8(_mm_loadl_epi64((const __m128i*)(s1 + x)), vz);
+         __m128i a = _mm_unpacklo_epi8(
+               _mm_loadl_epi64((const __m128i*)(a0 + x)), vz);
+         __m128i b = _mm_unpacklo_epi8(
+               _mm_loadl_epi64((const __m128i*)(a1 + x)), vz);
          __m128i lo = _mm_add_epi32(_mm_sra_epi32(_mm_add_epi32(
                _mm_madd_epi16(_mm_unpacklo_epi16(a, b), vk), vb), sc), vo);
          __m128i hi = _mm_add_epi32(_mm_sra_epi32(_mm_add_epi32(
                _mm_madd_epi16(_mm_unpackhi_epi16(a, b), vk), vb), sc), vo);
-         __m128i w = _mm_packs_epi32(lo, hi);
-         _mm_storel_epi64((__m128i*)(d + x), _mm_packus_epi16(w, w));
+         __m128i pw = _mm_packs_epi32(lo, hi);
+         _mm_storel_epi64((__m128i*)(dr + x), _mm_packus_epi16(pw, pw));
       }
-      if (x + 4 <= n)
+      if (x + 4 <= w)
       {
-         __m128i a = _mm_unpacklo_epi8(rh264_sse2_load4(s0 + x), vz);
-         __m128i b = _mm_unpacklo_epi8(rh264_sse2_load4(s1 + x), vz);
+         __m128i a = _mm_unpacklo_epi8(rh264_sse2_load4(a0 + x), vz);
+         __m128i b = _mm_unpacklo_epi8(rh264_sse2_load4(a1 + x), vz);
          __m128i lo = _mm_add_epi32(_mm_sra_epi32(_mm_add_epi32(
                _mm_madd_epi16(_mm_unpacklo_epi16(a, b), vk), vb), sc), vo);
-         __m128i w = _mm_packs_epi32(lo, lo);
-         rh264_sse2_store4(d + x, _mm_packus_epi16(w, w));
+         __m128i pw = _mm_packs_epi32(lo, lo);
+         rh264_sse2_store4(dr + x, _mm_packus_epi16(pw, pw));
          x += 4;
+      }
+      for (; x < w; x++)
+      {
+         int v = ((a0[x] * w0 + a1[x] * w1 + bias) >> sh) + o;
+         dr[x] = (uint8_t)RH264_CLIP(v);
       }
    }
 #elif defined(RH264_NEON)
+   const int32x4_t vb = vdupq_n_s32(bias);
+   const int32x4_t vo = vdupq_n_s32(o);
+   const int32x4_t vs = vdupq_n_s32(-sh);
+   for (y = 0; y < h; y++)
    {
-      const int32x4_t vb = vdupq_n_s32(bias);
-      const int32x4_t vo = vdupq_n_s32(o);
-      const int32x4_t vs = vdupq_n_s32(-sh);
-      for (; x + 8 <= n; x += 8)
+      uint8_t *dr = d + y * dstride;
+      const uint8_t *a0 = s0 + y * s0stride, *a1 = s1 + y * s1stride;
+      int x = 0;
+      for (; x + 8 <= w; x += 8)
       {
-         int16x8_t a = vreinterpretq_s16_u16(vmovl_u8(vld1_u8(s0 + x)));
-         int16x8_t b = vreinterpretq_s16_u16(vmovl_u8(vld1_u8(s1 + x)));
+         int16x8_t a = vreinterpretq_s16_u16(vmovl_u8(vld1_u8(a0 + x)));
+         int16x8_t b = vreinterpretq_s16_u16(vmovl_u8(vld1_u8(a1 + x)));
          int32x4_t lo = vmlal_n_s16(vmull_n_s16(vget_low_s16(a),
                (int16_t)w0), vget_low_s16(b), (int16_t)w1);
          int32x4_t hi = vmlal_n_s16(vmull_n_s16(vget_high_s16(a),
                (int16_t)w0), vget_high_s16(b), (int16_t)w1);
          lo = vaddq_s32(vshlq_s32(vaddq_s32(lo, vb), vs), vo);
          hi = vaddq_s32(vshlq_s32(vaddq_s32(hi, vb), vs), vo);
-         vst1_u8(d + x, vqmovun_s16(vcombine_s16(vqmovn_s32(lo),
+         vst1_u8(dr + x, vqmovun_s16(vcombine_s16(vqmovn_s32(lo),
                vqmovn_s32(hi))));
       }
-      if (x + 4 <= n)
+      if (x + 4 <= w)
       {
-         int16x8_t a = vreinterpretq_s16_u16(vmovl_u8(rh264_neon_load4(s0 + x)));
-         int16x8_t b = vreinterpretq_s16_u16(vmovl_u8(rh264_neon_load4(s1 + x)));
+         int16x8_t a = vreinterpretq_s16_u16(vmovl_u8(rh264_neon_load4(a0 + x)));
+         int16x8_t b = vreinterpretq_s16_u16(vmovl_u8(rh264_neon_load4(a1 + x)));
          int32x4_t lo = vmlal_n_s16(vmull_n_s16(vget_low_s16(a),
                (int16_t)w0), vget_low_s16(b), (int16_t)w1);
-         int16x4_t w;
+         int16x4_t pw;
          lo = vaddq_s32(vshlq_s32(vaddq_s32(lo, vb), vs), vo);
-         w = vqmovn_s32(lo);
-         rh264_neon_store4(d + x, vqmovun_s16(vcombine_s16(w, w)));
+         pw = vqmovn_s32(lo);
+         rh264_neon_store4(dr + x, vqmovun_s16(vcombine_s16(pw, pw)));
          x += 4;
       }
+      for (; x < w; x++)
+      {
+         int v = ((a0[x] * w0 + a1[x] * w1 + bias) >> sh) + o;
+         dr[x] = (uint8_t)RH264_CLIP(v);
+      }
    }
+#else
+   { int x;
+     for (y = 0; y < h; y++)
+        for (x = 0; x < w; x++)
+        {
+           int v = ((s0[y*s0stride+x] * w0 + s1[y*s1stride+x] * w1
+                 + bias) >> sh) + o;
+           d[y*dstride+x] = (uint8_t)RH264_CLIP(v);
+        } }
 #endif
-   for (; x < n; x++)
-   {
-      int v = ((s0[x] * w0 + s1[x] * w1 + bias) >> sh) + o;
-      d[x] = (uint8_t)RH264_CLIP(v);
-   }
 }
 
 static void rh264_weight_pred(rh264_frame *f, const rh264_slice_hdr *sh,
@@ -4998,9 +5029,8 @@ static void rh264_b_pred_block(rh264_frame *f, const rh264_bctx *bc,
          int w0 = sh->wp_lw[r0 > 31 ? 31 : r0], w1 = sh->wp1_lw[r1 > 31 ? 31 : r1];
          int o  = (sh->wp_lo[r0 > 31 ? 31 : r0]
                  + sh->wp1_lo[r1 > 31 ? 31 : r1] + 1) >> 1;
-         for (y = 0; y < bh; y++)
-            rh264_bi_row(f->Y + (oy+y)*f->ystride + ox,
-                  t0y + y*16, t1y + y*16, bw, w0, w1, 1 << ld, ld + 1, o);
+         rh264_bi_block(f->Y + oy*f->ystride + ox, f->ystride,
+               t0y, 16, t1y, 16, bw, bh, w0, w1, 1 << ld, ld + 1, o);
          for (c = 0; c < 2; c++)
          {
             const uint8_t *s0 = c ? t0v : t0u, *s1 = c ? t1v : t1u;
@@ -5009,25 +5039,22 @@ static void rh264_b_pred_block(rh264_frame *f, const rh264_bctx *bc,
             int cw1 = sh->wp1_cw[r1 > 31 ? 31 : r1][c];
             int co  = (sh->wp_co[r0 > 31 ? 31 : r0][c]
                      + sh->wp1_co[r1 > 31 ? 31 : r1][c] + 1) >> 1;
-            for (y = 0; y < cbh; y++)
-               rh264_bi_row(pl + (coy+y)*f->cstride + cox,
-                     s0 + y*8, s1 + y*8, cbw, cw0, cw1, 1 << cd, cd + 1, co);
+            rh264_bi_block(pl + coy*f->cstride + cox, f->cstride,
+                  s0, 8, s1, 8, cbw, cbh, cw0, cw1, 1 << cd, cd + 1, co);
          }
       }
       else if (bc->wbidc == 2)
       {
          int w1 = bc->w1imp[r0 > 31 ? 31 : r0][r1 > 31 ? 31 : r1];
          int w0 = 64 - w1;
-         for (y = 0; y < bh; y++)
-            rh264_bi_row(f->Y + (oy+y)*f->ystride + ox,
-                  t0y + y*16, t1y + y*16, bw, w0, w1, 32, 6, 0);
+         rh264_bi_block(f->Y + oy*f->ystride + ox, f->ystride,
+               t0y, 16, t1y, 16, bw, bh, w0, w1, 32, 6, 0);
          for (c = 0; c < 2; c++)
          {
             const uint8_t *s0 = c ? t0v : t0u, *s1 = c ? t1v : t1u;
             uint8_t *pl = c ? f->V : f->U;
-            for (y = 0; y < cbh; y++)
-               rh264_bi_row(pl + (coy+y)*f->cstride + cox,
-                     s0 + y*8, s1 + y*8, cbw, w0, w1, 32, 6, 0);
+            rh264_bi_block(pl + coy*f->cstride + cox, f->cstride,
+                  s0, 8, s1, 8, cbw, cbh, w0, w1, 32, 6, 0);
          }
       }
       else

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -6877,6 +6877,18 @@ static const uint8_t rh264_sig8map[64]={
 static const uint8_t rh264_last8map[64]={
    0,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 2,2,2,2,2,2,2,2, 2,2,2,2,2,2,2,2,
    3,3,3,3,3,3,3,3, 4,4,4,4,4,4,4,4, 5,5,5,5,6,6,6,6, 7,7,7,7,8,8,8,8};
+/* ctxIdxInc maps for the 4x4/chroma-DC significance and last flags, so
+ * the per-coefficient derivation is a table load rather than a chain of
+ * tests on values fixed for the whole block: identity for the 4x4
+ * categories, and min(i,2) / min(i>>1,2) for chroma DC in 4:2:0 and
+ * 4:2:2 respectively (9.3.3.1.3). */
+static const uint8_t rh264_sig_ident[64]={
+ 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,
+ 16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+ 32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,
+ 48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63};
+static const uint8_t rh264_sig_cdc420[8]={0,1,2,2,2,2,2,2};
+static const uint8_t rh264_sig_cdc422[8]={0,0,1,1,2,2,2,2};
 
 /* significant_coeff_flag ctxIdxInc = scan position (0..14) for 4x4 blocks.
   * last_significant likewise. abs_level uses its own numDecodAbsLevel logic. */
@@ -6896,30 +6908,39 @@ static int rh264_cabac_residual(rh264_cabac *c, int cat, int cbf_ctxinc,
       coded = rh264_cabac_decode(c,
             CTX_CBF + rh264_cbf_catoff[cat] + cbf_ctxinc);
    if (!coded) return 0;
-   /* significance map (forward scan) */
-   for (i = 0; i < maxNumCoeff - 1; i++)
+   /* significance map (forward scan).  The context bases and the
+    * ctxIdxInc maps depend only on the category and the field/4:2:2
+    * flags, all fixed for the block, so they are settled once here
+    * instead of per coefficient. */
    {
-      int sinc = (cat==5) ? (c->field ? rh264_sig8map_fld[i]
-                                      : rh264_sig8map[i])
-                          : (cat==3)
-                            ? (c->c422 ? ((i>>1)>2?2:(i>>1)) : (i>2?2:i))
-                            : i;
-      int sctx = (cat==5) ? (c->field ? RH264_CTX_SIG8_F : RH264_CTX_SIG8) + sinc
-                          : (c->field ? RH264_CTX_SIG_F : CTX_SIG)
-                            + rh264_sig_catoff[cat] + sinc;
-      if (rh264_cabac_decode(c, sctx))
+      const uint8_t *sm, *lm;
+      int sbase, lbase;
+      if (cat == 5)
       {
-         int linc = (cat==5) ? rh264_last8map[i]
-                  : (cat==3)
-                    ? (c->c422 ? ((i>>1)>2?2:(i>>1)) : (i>2?2:i))
-                    : i;
-         int lctx = (cat==5) ? (c->field ? RH264_CTX_LAST8_F
-                                         : RH264_CTX_LAST8) + linc
-                             : (c->field ? RH264_CTX_LAST_F : CTX_LAST)
-                               + rh264_last_catoff[cat] + linc;
-         sig[nsig++] = i;
-         if (rh264_cabac_decode(c, lctx))
-            break;
+         sm    = c->field ? rh264_sig8map_fld : rh264_sig8map;
+         lm    = rh264_last8map;
+         sbase = c->field ? RH264_CTX_SIG8_F  : RH264_CTX_SIG8;
+         lbase = c->field ? RH264_CTX_LAST8_F : RH264_CTX_LAST8;
+      }
+      else
+      {
+         if (cat == 3)
+            sm = lm = c->c422 ? rh264_sig_cdc422 : rh264_sig_cdc420;
+         else
+            sm = lm = rh264_sig_ident;
+         sbase = (c->field ? RH264_CTX_SIG_F  : CTX_SIG)
+               + rh264_sig_catoff[cat];
+         lbase = (c->field ? RH264_CTX_LAST_F : CTX_LAST)
+               + rh264_last_catoff[cat];
+      }
+      for (i = 0; i < maxNumCoeff - 1; i++)
+      {
+         if (rh264_cabac_decode(c, sbase + sm[i]))
+         {
+            sig[nsig++] = i;
+            if (rh264_cabac_decode(c, lbase + lm[i]))
+               break;
+         }
       }
    }
    if (i == maxNumCoeff - 1) sig[nsig++] = maxNumCoeff - 1;

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -6297,8 +6297,11 @@ typedef struct {
    uint32_t offset;     /* codIOffset */
    uint32_t bitbuf;
    int      bitcnt;
-   uint8_t  state[1024];
-   uint8_t  mps[1024];
+   uint8_t  state[1024];   /* pStateIdx * 2 | valMPS, fused */
+   /* fused state transitions, built from rh264_transIdxMPS/LPS at init:
+    * next[0] follows an MPS, next[1] an LPS (including the valMPS flip
+    * at pStateIdx 0, 9.3.3.2.1.1) */
+   uint8_t  next[2][128];
    /* field-coded picture: the significance maps use their own context
     * offsets and, for 8x8 blocks, their own position-to-context map
     * (Tables 9-11 and 9-43) */
@@ -6308,32 +6311,27 @@ typedef struct {
    int      c422;
 } rh264_cabac;
 
-static int rh264_cb_bit(rh264_cabac *c)
-{
-   int b;
-   if (c->bitcnt == 0)
-   {
-      c->bitbuf = (uint32_t)((c->buf < c->end) ? *c->buf++ : 0);
-      c->bitcnt = 8;
-   }
-   c->bitcnt--;
-   b = (int)((c->bitbuf >> c->bitcnt) & 1);
-   return b;
-}
-
-/* Pull n (1..7) bits at once for renormalisation: at most one byte of
- * refill is ever needed since bitcnt < 8 going in.  Bytes past the end
- * read as zero, matching rh264_cb_bit. */
+/* Pull n (1..7) bits for renormalisation.  When the buffer runs low it
+ * is topped up past 16 bits so consecutive renormalisations share one
+ * refill; bytes past the end read as zero (end-of-data semantics). */
 static RH264_INLINE uint32_t rh264_cb_bits(rh264_cabac *c, int n)
 {
    if (c->bitcnt < n)
    {
-      c->bitbuf = (c->bitbuf << 8)
-            | (uint32_t)((c->buf < c->end) ? *c->buf++ : 0);
-      c->bitcnt += 8;
+      do
+      {
+         c->bitbuf = (c->bitbuf << 8)
+               | (uint32_t)((c->buf < c->end) ? *c->buf++ : 0);
+         c->bitcnt += 8;
+      } while (c->bitcnt <= 16);
    }
    c->bitcnt -= n;
    return (c->bitbuf >> c->bitcnt) & ((1u << n) - 1u);
+}
+
+static RH264_INLINE int rh264_cb_bit(rh264_cabac *c)
+{
+   return (int)rh264_cb_bits(c, 1);
 }
 
 static const int8_t rh264_cabac_init_PB[3][460][2]={
@@ -6544,35 +6542,37 @@ static void rh264_cabac_init_contexts(rh264_cabac *c, int sliceQP, int init_idc)
                              : rh264_cabac_init_PB[init_idc][i][1];
       int pre = ((m * sliceQP) >> 4) + n;
       if (pre < 1) pre = 1; else if (pre > 126) pre = 126;
-      if (pre <= 63) { c->state[i] = (uint8_t)(63 - pre); c->mps[i] = 0; }
-      else           { c->state[i] = (uint8_t)(pre - 64); c->mps[i] = 1; }
+      if (pre <= 63) c->state[i] = (uint8_t)((63 - pre) * 2);
+      else           c->state[i] = (uint8_t)((pre - 64) * 2 + 1);
    }
    /* contexts above the extracted range default to a neutral state; they are
     * only used by High-profile 8x8 residual, which this decoder rejects. */
-   for (; i < 1024; i++) { c->state[i] = 0; c->mps[i] = 0; }
+   for (; i < 1024; i++) c->state[i] = 0;
+   for (i = 0; i < 128; i++)
+   {
+      int st = i >> 1, mp = i & 1;
+      c->next[0][i] = (uint8_t)(rh264_transIdxMPS[st] * 2 + mp);
+      c->next[1][i] = (st == 0)
+            ? (uint8_t)(rh264_transIdxLPS[0] * 2 + (1 - mp))
+            : (uint8_t)(rh264_transIdxLPS[st] * 2 + mp);
+   }
 }
 
 static int rh264_cabac_decode(rh264_cabac *c, int ctxIdx)
 {
-   int pState = c->state[ctxIdx];
-   int valMPS = c->mps[ctxIdx];
-   uint32_t qIdx = (c->range >> 6) & 3;
-   uint32_t rLPS = rh264_rangeTabLPS[pState][qIdx];
+   uint32_t s    = c->state[ctxIdx];
+   uint32_t rLPS = rh264_rangeTabLPS[s >> 1][(c->range >> 6) & 3];
+   uint32_t m;
    int bin;
    c->range -= rLPS;
-   if (c->offset >= c->range)
-   {
-      bin = 1 - valMPS;
-      c->offset -= c->range;
-      c->range   = rLPS;
-      if (pState == 0) c->mps[ctxIdx] = (uint8_t)(1 - valMPS);
-      c->state[ctxIdx] = rh264_transIdxLPS[pState];
-   }
-   else
-   {
-      bin = valMPS;
-      c->state[ctxIdx] = rh264_transIdxMPS[pState];
-   }
+   /* the LPS/MPS decision is the decoded bin itself, so as a branch it
+    * mispredicts at exactly the bin entropy; taken as an all-ones mask
+    * instead, both outcomes cost the same straight-line code */
+   m   = (uint32_t)0 - (uint32_t)(c->offset >= c->range);
+   bin = (int)((s ^ m) & 1u);
+   c->offset -= c->range & m;
+   c->range  ^= (c->range ^ rLPS) & m;
+   c->state[ctxIdx] = c->next[m & 1u][s];
    if (c->range < 256)
    {
       /* range is 2..255 here, so 1..7 doublings restore it; take them
@@ -6586,9 +6586,13 @@ static int rh264_cabac_decode(rh264_cabac *c, int ctxIdx)
 
 static int rh264_cabac_bypass(rh264_cabac *c)
 {
+   uint32_t m;
    c->offset = (c->offset << 1) | (uint32_t)rh264_cb_bit(c);
-   if (c->offset >= c->range) { c->offset -= c->range; return 1; }
-   return 0;
+   /* bypass bins (signs, suffix bits) are near-uniform - the worst
+    * case for a branch, the indifferent case for a mask */
+   m = (uint32_t)0 - (uint32_t)(c->offset >= c->range);
+   c->offset -= c->range & m;
+   return (int)(m & 1u);
 }
 
 static int rh264_cabac_terminate(rh264_cabac *c)

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -672,22 +672,142 @@ static int rh264_parse_slice_header_adv(rh264_bits *b,int nal_unit_type,int nal_
 
 
 /* ==================== rh264_xform.h ==================== */
+#ifdef RH264_SSE2
+/* 32x32->32 low multiply; _mm_mullo_epi32 is SSE4.1, so combine the two
+ * odd/even 32x32->64 products SSE2 does have. */
+static __inline __m128i rh264_sse2_mullo32(__m128i a,__m128i b){
+   /* even lanes (0,2) from the direct product, odd lanes (1,3) from the
+    * shifted one; each 64-bit result keeps its low half, and the two
+    * are interleaved so lane order is preserved */
+   __m128i e=_mm_mul_epu32(a,b);
+   __m128i o=_mm_mul_epu32(_mm_srli_si128(a,4),_mm_srli_si128(b,4));
+   return _mm_unpacklo_epi32(
+         _mm_shuffle_epi32(e,_MM_SHUFFLE(0,0,2,0)),
+         _mm_shuffle_epi32(o,_MM_SHUFFLE(0,0,2,0)));
+}
+#define RH264_SSE2_TR4_32(a,b,c,d) do { \
+   __m128i t0=_mm_unpacklo_epi32((a),(b)), t1=_mm_unpackhi_epi32((a),(b)); \
+   __m128i t2=_mm_unpacklo_epi32((c),(d)), t3=_mm_unpackhi_epi32((c),(d)); \
+   (a)=_mm_unpacklo_epi64(t0,t2); (b)=_mm_unpackhi_epi64(t0,t2); \
+   (c)=_mm_unpacklo_epi64(t1,t3); (d)=_mm_unpackhi_epi64(t1,t3); \
+} while (0)
+#elif defined(RH264_NEON)
+#define RH264_NEON_TR4_32(a,b,c,d) do { \
+   int32x4x2_t p0=vtrnq_s32((a),(b)), p1=vtrnq_s32((c),(d)); \
+   (a)=vcombine_s32(vget_low_s32(p0.val[0]),vget_low_s32(p1.val[0])); \
+   (b)=vcombine_s32(vget_low_s32(p0.val[1]),vget_low_s32(p1.val[1])); \
+   (c)=vcombine_s32(vget_high_s32(p0.val[0]),vget_high_s32(p1.val[0])); \
+   (d)=vcombine_s32(vget_high_s32(p0.val[1]),vget_high_s32(p1.val[1])); \
+} while (0)
+#endif
 static const int rh264_dequant4_v[6][3]={{10,16,13},{11,18,14},{13,20,16},{14,23,18},{16,25,20},{18,29,23}};
 static const uint8_t rh264_dequant4_idx[16]={0,2,0,2,2,1,2,1,0,2,0,2,2,1,2,1};
+/* The per-coefficient scale w[i] * LevelScale(qP%6, i) depends only on
+ * the weight matrix and qP, both fixed for a whole block, so the two
+ * table lookups and the multiply that built it per coefficient are
+ * hoisted into one 16-entry vector.  The per/shift decision is likewise
+ * invariant across the block: taking it once turns the body into a
+ * straight multiply-and-shift over sixteen lanes.  has_dc_sep leaves
+ * blk[0] untouched (the DC arrives already scaled from the Hadamard
+ * path); it is restored after the vector pass rather than tested per
+ * lane. */
 static void rh264_dequant4x4(int32_t *blk,int qP,int has_dc_sep,
       const uint8_t *w){
    int i,per=qP/6,rem=qP%6;
-   for(i=0;i<16;i++){ int sc=w[i]*rh264_dequant4_v[rem][rh264_dequant4_idx[i]];
-      if(has_dc_sep&&i==0) continue;
-      if(per>=4) blk[i]=(int32_t)((uint32_t)(blk[i]*sc)<<(per-4)); else blk[i]=(blk[i]*sc+(1<<(3-per)))>>(4-per); }
+   int32_t sc[16];
+   int32_t dc = blk[0];
+   for(i=0;i<16;i++)
+      sc[i]=(int32_t)w[i]*rh264_dequant4_v[rem][rh264_dequant4_idx[i]];
+   if(per>=4){
+      int sh=per-4;
+#ifdef RH264_SSE2
+      for(i=0;i<16;i+=4){
+         __m128i b=_mm_loadu_si128((const __m128i*)(blk+i));
+         __m128i m=_mm_loadu_si128((const __m128i*)(sc+i));
+         _mm_storeu_si128((__m128i*)(blk+i),
+               _mm_sll_epi32(rh264_sse2_mullo32(b,m),_mm_cvtsi32_si128(sh)));
+      }
+#elif defined(RH264_NEON)
+      for(i=0;i<16;i+=4)
+         vst1q_s32(blk+i,vshlq_s32(vmulq_s32(vld1q_s32(blk+i),
+               vld1q_s32(sc+i)),vdupq_n_s32(sh)));
+#else
+      for(i=0;i<16;i++)
+         blk[i]=(int32_t)((uint32_t)(blk[i]*sc[i])<<sh);
+#endif
+   }else{
+      int sh=4-per;
+      int32_t rnd=1<<(3-per);
+#ifdef RH264_SSE2
+      __m128i vr=_mm_set1_epi32(rnd),vs=_mm_cvtsi32_si128(sh);
+      for(i=0;i<16;i+=4){
+         __m128i b=_mm_loadu_si128((const __m128i*)(blk+i));
+         __m128i m=_mm_loadu_si128((const __m128i*)(sc+i));
+         _mm_storeu_si128((__m128i*)(blk+i),
+               _mm_sra_epi32(_mm_add_epi32(rh264_sse2_mullo32(b,m),vr),vs));
+      }
+#elif defined(RH264_NEON)
+      for(i=0;i<16;i+=4)
+         vst1q_s32(blk+i,vshlq_s32(vaddq_s32(vmulq_s32(vld1q_s32(blk+i),
+               vld1q_s32(sc+i)),vdupq_n_s32(rnd)),vdupq_n_s32(-sh)));
+#else
+      for(i=0;i<16;i++)
+         blk[i]=(blk[i]*sc[i]+rnd)>>sh;
+#endif
+   }
+   if(has_dc_sep) blk[0]=dc;
 }
+/* 8.5.12.2 residual inverse transform.  The row pass runs four rows in
+ * parallel over transposed data, then one transpose feeds the identical
+ * column pass, so the same butterfly serves both directions. */
 static void rh264_itransform4x4(const int32_t *d,int32_t *r){
+#ifdef RH264_SSE2
+   __m128i s0=_mm_loadu_si128((const __m128i*)(d+0));
+   __m128i s1=_mm_loadu_si128((const __m128i*)(d+4));
+   __m128i s2=_mm_loadu_si128((const __m128i*)(d+8));
+   __m128i s3=_mm_loadu_si128((const __m128i*)(d+12));
+   int pass;
+   for(pass=0;pass<2;pass++){
+      /* transpose first so the butterfly runs down lanes: pass 0 then
+       * transforms the rows, pass 1 the columns of the result, and the
+       * vectors are left holding rows ready to store */
+      __m128i z0,z1,z2,z3;
+      RH264_SSE2_TR4_32(s0,s1,s2,s3);
+      z0=_mm_add_epi32(s0,s2);
+      z1=_mm_sub_epi32(s0,s2);
+      z2=_mm_sub_epi32(_mm_srai_epi32(s1,1),s3);
+      z3=_mm_add_epi32(s1,_mm_srai_epi32(s3,1));
+      s0=_mm_add_epi32(z0,z3); s1=_mm_add_epi32(z1,z2);
+      s2=_mm_sub_epi32(z1,z2); s3=_mm_sub_epi32(z0,z3);
+   }
+   _mm_storeu_si128((__m128i*)(r+0),s0);
+   _mm_storeu_si128((__m128i*)(r+4),s1);
+   _mm_storeu_si128((__m128i*)(r+8),s2);
+   _mm_storeu_si128((__m128i*)(r+12),s3);
+#elif defined(RH264_NEON)
+   int32x4_t s0=vld1q_s32(d+0),s1=vld1q_s32(d+4);
+   int32x4_t s2=vld1q_s32(d+8),s3=vld1q_s32(d+12);
+   int pass;
+   for(pass=0;pass<2;pass++){
+      int32x4_t z0,z1,z2,z3;
+      RH264_NEON_TR4_32(s0,s1,s2,s3);
+      z0=vaddq_s32(s0,s2);
+      z1=vsubq_s32(s0,s2);
+      z2=vsubq_s32(vshrq_n_s32(s1,1),s3);
+      z3=vaddq_s32(s1,vshrq_n_s32(s3,1));
+      s0=vaddq_s32(z0,z3); s1=vaddq_s32(z1,z2);
+      s2=vsubq_s32(z1,z2); s3=vsubq_s32(z0,z3);
+   }
+   vst1q_s32(r+0,s0); vst1q_s32(r+4,s1);
+   vst1q_s32(r+8,s2); vst1q_s32(r+12,s3);
+#else
    int32_t e[16]; int i;
    for(i=0;i<4;i++){ const int32_t*s=d+i*4;
       int32_t z0=s[0]+s[2],z1=s[0]-s[2],z2=(s[1]>>1)-s[3],z3=s[1]+(s[3]>>1);
       e[i*4+0]=z0+z3;e[i*4+1]=z1+z2;e[i*4+2]=z1-z2;e[i*4+3]=z0-z3; }
    for(i=0;i<4;i++){ int32_t z0=e[0*4+i]+e[2*4+i],z1=e[0*4+i]-e[2*4+i],z2=(e[1*4+i]>>1)-e[3*4+i],z3=e[1*4+i]+(e[3*4+i]>>1);
       r[0*4+i]=z0+z3;r[1*4+i]=z1+z2;r[2*4+i]=z1-z2;r[3*4+i]=z0-z3; }
+#endif
 }
 static void rh264_ihadamard4x4(const int32_t *in,int32_t *out){
    int32_t e[16]; int i;

--- a/libretro-common/formats/h264/rh264.c
+++ b/libretro-common/formats/h264/rh264.c
@@ -8853,7 +8853,30 @@ static int rh264_out_push(rh264_video *v, int poc, int is_idr)
    if (slot < 0) return -1;            /* cannot happen: delay < slot count */
    if (!v->out[slot].Yb)
       if (rh264_frame_alloc(&v->out[slot], &v->sps) != 0) return -1;
-   rh264_frame_copy_planes(&v->out[slot], &v->f);
+   if (!v->cur_field)
+   {
+      /* Frame pictures swap their planes into the output slot instead
+       * of copying them: the reference copy (when the picture is one)
+       * already sits in the DPB, every macroblock of the next picture
+       * rewrites the working planes, and the slot was allocated from
+       * the same SPS so the geometry is identical.  Field pairs keep
+       * the copy - their two pictures fill the working planes
+       * incrementally, which a swapped-in stale buffer would break. */
+      uint8_t *ty = v->out[slot].Yb, *tu = v->out[slot].Ub,
+              *tv = v->out[slot].Vb;
+      v->out[slot].Yb = v->f.Yb; v->out[slot].Ub = v->f.Ub;
+      v->out[slot].Vb = v->f.Vb;
+      v->f.Yb = ty; v->f.Ub = tu; v->f.Vb = tv;
+      v->f.Y = v->f.Yb; v->f.U = v->f.Ub; v->f.V = v->f.Vb;
+      v->out[slot].Y = v->out[slot].Yb;
+      v->out[slot].U = v->out[slot].Ub;
+      v->out[slot].V = v->out[slot].Vb;
+      v->out[slot].qp = v->f.qp;
+      v->out[slot].chroma_qp_offset  = v->f.chroma_qp_offset;
+      v->out[slot].chroma_qp_offset2 = v->f.chroma_qp_offset2;
+   }
+   else
+      rh264_frame_copy_planes(&v->out[slot], &v->f);
    v->out[slot].w = v->f.w; v->out[slot].h = v->f.h;
    v->out_poc[slot] = poc; v->out_gen[slot] = v->idr_gen;
    v->out_used[slot] = 1;  v->out_len++;


### PR DESCRIPTION
## Description

Nine commits continuing the rh264 audit, all performance work — no behaviour change. Every commit is bit-exact against reference decoders and passed a full sanitizer sweep before landing; the per-commit messages carry the detailed rationale and measurements.

### Measured effect of the whole series

End-to-end A/B of the branch base against its tip, same binary flags, same machine, same session, best of five runs. 300-frame x264-encoded streams, single thread, x86_64, `-O2 -march=native`:

| Stream | Before | After | |
|---|---|---|---|
| CAVLC I/P 480p | 265 fps | 321 fps | **1.21×** |
| CABAC I/P 480p | 199 fps | 237 fps | **1.19×** |
| CABAC+B main 480p | 201 fps | 243 fps | **1.21×** |
| High profile 480p | 197 fps | 236 fps | **1.20×** |
| CABAC+B main 720p | 111 fps | 131 fps | **1.18×** |
| CRF 8, coefficient-dense | 176 fps | 195 fps | 1.11× |

Instruction count (callgrind, deterministic, 60-frame CABAC+B stream, `-O2`): **−18.7%**.

Two commits are wall-clock-neutral on this desktop and were landed for their instruction and memory-traffic reductions, which should matter more on the narrow in-order cores and bandwidth-limited handhelds RetroArch also ships to. Those commits say so explicitly rather than claiming a speedup.

### What the commits do

**Entropy decoding**
* `38fdb3f` — branchless CABAC engine. The LPS/MPS decision *is* the decoded bin, so as a branch it mispredicts at the bin entropy; it becomes an all-ones mask selecting range, offset, bin and state. `pStateIdx`/`valMPS` fuse into one byte with a per-instance 2×128 transition table built from the spec tables.
* `af96580` — significance/last context derivation settled once per block instead of a four-deep test chain per coefficient. Honest result: −0.6%, wall clock in the noise; the compiler was already hoisting most of it.

**Prediction**
* `111af54` — motion compensation runs directly off the reference plane when the interpolation window is in-bounds, instead of gathering a `(bw+5)×(bh+5)` patch per call whose only purpose is baking in the edge clamp. Border blocks still take the patch.
* `d8d66e3` — weighted bi-prediction sets up its weight/bias/shift vectors once per block rather than once per row.

**Reconstruction**
* `22d5887` — 4×4 dequantisation and the inverse transform vectorised (SSE2/NEON). SSE2 lacks a 32-bit low multiply before SSE4.1, so the even/odd 32×32→64 products are combined.
* `53afaff` — twelve separate per-sample add-and-clip loops (intra/inter, luma/chroma, CAVLC/CABAC, 4×4/8×8) collapse into one row-at-a-time kernel where saturating narrowing performs the clip for free. Largest single win in the series at −6.0% instructions.

**Deblocking and output**
* `88607af` — P/B chroma deblocking vectorised across the whole edge, with per-lane strength and `tc0` vectors so the four differing 4-sample segments are handled in one pass.
* `f4bb40f` — chroma vertical edges skip the store-side transpose, since only `p0`/`q0` are written.
* `961ecb7` — frame pictures swap plane buffers into the output slot instead of copying a full frame per displayed picture. Field pairs keep the copy.

### Validation

Every commit was verified **bit-exact against libavcodec** on six streams (CAVLC I/P, CABAC I/P, CABAC+B main, high profile, 720p B-frame, CRF 8) and **against openh264** on left/top/bottom-cropped vectors, in both the SIMD build and a forced-scalar build so the fallback paths are covered too.

Per commit: ASan + UBSan across all streams plus 350–700 mutated/truncated/spliced inputs, LeakSanitizer in strict mode including the decode-error paths, and TSan with four concurrent decoder instances on both entropy modes. C89 verified with `C89_BUILD=1`.

New SIMD kernels were additionally differential-tested against their scalar references in isolation before integration — 200k random multiplies, 500k random transform blocks, 400k random residual blocks. That caught three lane-ordering and saturation faults that every conformance stream would have passed, including one where adding in 16-bit lanes wrapped on out-of-range residuals from corrupt input and would have made the SIMD and scalar builds disagree.

### Notes for review

The riskiest commit is `111af54`: aliasing onto the reference plane means the SIMD tails read a few bytes past the filter margin, so the direct path requires the window to sit strictly above the last row and bottom-edge blocks fall back to the gathered patch. Worth a close look, and it is the commit the corrupt-vector fuzz corpus was aimed at.

`961ecb7` changes buffer ownership rather than arithmetic — the working planes and the output slot exchange buffers. The argument for safety is that the DPB already holds the reference copy, every macroblock of the next picture rewrites the working planes, and the displayed slot is excluded from selection while borrowed.

## Related Issues

None filed; these are follow-ups from the decoder audit rather than reported bugs.

## Related Pull Requests

Continues #19304 (correctness and first-round performance work) on the same branch. Self-contained in `libretro-common/formats/h264/rh264.c`.