### PR TITLE
archive_file/file_path: cut per-member work in archive listing and extraction (listing 12.3x, path_mkdir 2.2x, extraction leak fixed)

### DIFF
--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -53,35 +53,43 @@ static int file_archive_get_file_list_cb(
 
    if (valid_exts)
    {
-      size_t _len                  = strlen(path);
-      /* Checks if this entry is a directory or a file. */
-      char last_char               = path[_len - 1];
-      struct string_list ext_list  = {0};
+      size_t _len = strlen(path);
 
-      /* Skip if directory. */
-      if (last_char == '/' || last_char == '\\' )
+      /* Reject empty names before the strlen-1 read below: a malformed
+       * central directory can carry a zero-length name, which used to
+       * index path[SIZE_MAX]. */
+      if (_len == 0)
          return 1;
 
-      string_list_initialize(&ext_list);
-      if (string_split_noalloc(&ext_list, valid_exts, "|"))
+      /* Checks if this entry is a directory or a file.
+       * Skip if directory. */
+      if (path[_len - 1] == '/' || path[_len - 1] == '\\')
+         return 1;
+
+      /* The extension list is split once per walk by the caller and
+       * carried in userdata->ext - the same field, with the same
+       * meaning, that file_archive_extract_cb already reads.  It used
+       * to be split here instead, which meant one
+       * string_list_initialize / string_split_noalloc /
+       * string_list_deinitialize cycle per archive member: a pair of
+       * heap allocations per entry, for a list that cannot change
+       * during the walk.
+       *
+       * Gate the extension test on the split list but keep the
+       * directory skip above gated on valid_exts, so that a split
+       * which failed to allocate still skips directories and still
+       * falls through to append rather than rejecting everything -
+       * exactly what the old inline code did on that path. */
+      if (userdata->ext)
       {
          const char *file_ext = path_get_extension(path);
 
          if (!file_ext)
-         {
-            string_list_deinitialize(&ext_list);
             return 1;
-         }
 
-         if (!string_list_find_elem_prefix(&ext_list, ".", file_ext))
-         {
-            /* keep iterating */
-            string_list_deinitialize(&ext_list);
-            return -1;
-         }
+         if (!string_list_find_elem_prefix(userdata->ext, ".", file_ext))
+            return -1;  /* keep iterating */
       }
-
-      string_list_deinitialize(&ext_list);
    }
 
    attr.i = RARCH_COMPRESSED_FILE_IN_ARCHIVE;
@@ -449,6 +457,7 @@ bool file_archive_get_file_list_noalloc(struct string_list *list,
       const char *valid_exts)
 {
    struct archive_extract_userdata userdata;
+   bool ret;
 
    if (!list || !string_list_initialize(list))
       return false;
@@ -457,7 +466,10 @@ bool file_archive_get_file_list_noalloc(struct string_list *list,
    userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
    userdata.extraction_directory            = NULL;
-   userdata.ext                             = NULL;
+   /* Split the extension list once for the whole walk rather than once
+    * per archive member; the listing callback reads it from here. */
+   userdata.ext                             = valid_exts
+      ? string_split(valid_exts, "|") : NULL;
    userdata.list                            = list;
    userdata.found_file                      = false;
    userdata.list_only                       = true;
@@ -465,10 +477,13 @@ bool file_archive_get_file_list_noalloc(struct string_list *list,
    userdata.transfer                        = NULL;
    userdata.dec                             = NULL;
 
-   if (!file_archive_walk(path, valid_exts,
-            file_archive_get_file_list_cb, &userdata))
-      return false;
-   return true;
+   ret = file_archive_walk(path, valid_exts,
+            file_archive_get_file_list_cb, &userdata);
+
+   if (userdata.ext)
+      string_list_free(userdata.ext);
+
+   return ret;
 }
 
 /**
@@ -486,7 +501,9 @@ struct string_list *file_archive_get_file_list(const char *path,
    userdata.current_file_path[0]            = '\0';
    userdata.first_extracted_file_path       = NULL;
    userdata.extraction_directory            = NULL;
-   userdata.ext                             = NULL;
+   /* Split once for the whole walk; see the twin above. */
+   userdata.ext                             = valid_exts
+      ? string_split(valid_exts, "|") : NULL;
    userdata.list                            = string_list_new();
    userdata.found_file                      = false;
    userdata.list_only                       = true;
@@ -495,13 +512,21 @@ struct string_list *file_archive_get_file_list(const char *path,
    userdata.dec                             = NULL;
 
    if (!userdata.list)
+   {
+      if (userdata.ext)
+         string_list_free(userdata.ext);
       return NULL;
+   }
    if (!file_archive_walk(path, valid_exts,
          file_archive_get_file_list_cb, &userdata))
    {
+      if (userdata.ext)
+         string_list_free(userdata.ext);
       string_list_free(userdata.list);
       return NULL;
    }
+   if (userdata.ext)
+      string_list_free(userdata.ext);
    return userdata.list;
 }
 

--- a/libretro-common/file/archive_file.c
+++ b/libretro-common/file/archive_file.c
@@ -439,6 +439,13 @@ bool file_archive_extract_file(
       if (    userdata.first_extracted_file_path 
           && *userdata.first_extracted_file_path)
          strlcpy(s, userdata.first_extracted_file_path, len);
+      /* The success path used to return here without freeing either
+       * the split extension list or the path strdup'd by
+       * file_archive_extract_cb, so every archive load through this
+       * function leaked both.  Only the failure path below cleaned
+       * up.  Fall through to the shared cleanup instead. */
+      free(userdata.first_extracted_file_path);
+      string_list_free(list);
       return true;
    }
 

--- a/libretro-common/file/file_path_io.c
+++ b/libretro-common/file/file_path_io.c
@@ -161,6 +161,28 @@ bool path_mkdir(const char *dir)
    if (!(dir && *dir))
       return false;
 
+   /* Nothing to do if it is already there.
+    *
+    * Without this the common case - which for archive extraction is
+    * every member after the first in a given directory - still costs
+    * a strdup, a path_parent_dir, a strcmp, a stat of the parent, a
+    * mkdir that is guaranteed to fail with EEXIST, and then a stat of
+    * the leaf to interpret that failure.  Two directory probes and a
+    * doomed syscall to answer a question one probe answers.  On Win32
+    * each of those probes is a UTF-16 conversion allocation plus both
+    * GetFileAttributesW and _wstat64, so the saving there is larger
+    * than the syscall count suggests.
+    *
+    * This is not a shortcut around the slow path's result: the slow
+    * path already returns true for an existing directory, by way of
+    * the mkdir -> -2 -> path_is_directory sequence at the bottom.  The
+    * one behavioural difference is at a filesystem root ("/", "C:\"),
+    * where path_parent_dir empties the string and the !*basedir guard
+    * below returns false today; such a directory does exist, so
+    * reporting true for it is the correction, not a regression. */
+   if (path_is_directory(dir))
+      return true;
+
    /* Use heap. Real chance of stack 
     * overflow if we recurse too hard. */
    if (!(basedir = strdup(dir)))


### PR DESCRIPTION
Three independent changes to the archive walk and to `path_mkdir`, each measured against the real code on `108cb6e` rather than against a model. No new API, no behavioural change except one documented `path_mkdir` return value.

## 1. `archive_file`: split `valid_exts` once per walk, not once per member

`file_archive_get_file_list_cb` ran `string_list_initialize`, `string_split_noalloc` and `string_list_deinitialize` on the caller's `valid_exts` string for **every entry in the archive**. The list cannot change during a walk, so that was a full re-parse of the extension string per member, paid before the entry was even tested.

Split once in the two entry points that use this callback and carry the result in `userdata->ext` — the same field, with the same meaning, that `file_archive_extract_cb` already reads. No struct change.

**40,000-entry ZIP, 57-token `valid_exts`:**

| | before | after | |
|---|---|---|---|
| wall clock | 111.7 ms | 9.1 ms | **12.3x** |
| heap operations during the walk | 2,320,000 | 58 | **40,000x** |

A 57-token extension list costs 58 allocations per split (one per token plus the array), so a 40k-entry archive did ~2.3M malloc/free pairs to answer a question whose answer never changed.

The directory skip stays gated on `valid_exts` while the extension test is gated on `userdata->ext`, so a split that failed to allocate still skips directories and still falls through to append — matching exactly what the inline code did on that path.

Also fixes a latent out-of-bounds read: a zero-length member name (which a malformed central directory can carry) made the old code index `path[SIZE_MAX]` via `strlen(path) - 1`.

## 2. `archive_file`: free the extension list and path on extract success

`file_archive_extract_file` cleaned up only on the failure path. On success it returned `true` while still holding the `string_list` from `string_split(valid_exts, "|")` and the `new_path` that `file_archive_extract_cb` strdup'd into `userdata.first_extracted_file_path`.

That means **every successful archive extraction through this function leaked both** — which covers content loading for any core with `need_fullpath` set, i.e. the ordinary path for loading a ROM out of a zip.

Found by running the extraction path under LeakSanitizer:

```
Direct leak of 24 byte(s) in 1 object(s)
  string_list_new -> string_split -> file_archive_extract_file
Direct leak of 23 byte(s) in 1 object(s)
  strdup -> file_archive_extract_cb
SUMMARY: AddressSanitizer: 819 byte(s) leaked in 4 allocation(s)
```

819 bytes in 4 allocations per call, now 0. Clean on both a single-large-member and a 4,000-member archive. Extracted output byte-identical before and after, verified on a 402,653,184-byte member compared in full.

## 3. `file_path`: return early from `path_mkdir` when the directory exists

`path_mkdir` did not check whether its argument was already a directory before starting work. The recursion short-circuits on the first existing ancestor, so for an existing tree it never nested more than one level deep — but that one level still cost a `strdup`, a `path_parent_dir`, a `strcmp`, a stat of the parent, a `mkdir` guaranteed to fail with `EEXIST`, and then a stat of the leaf to interpret that failure. **Two directory probes and a doomed syscall to answer what one probe answers.**

Instrumenting 4,000 calls over 400 distinct directories, at every depth from 1 to 8, gave a flat 8,000 stat + 4,000 mkdir + 4,000 malloc — the cost is per call, not per component. The extraction task calls this once per archive member, so a 4,000-entry archive paid it 4,000 times for 400 directories.

**Syscalls, per 4,000 calls over 400 directories:**

| | before | after |
|---|---|---|
| stat | 8,000 | 4,520 |
| mkdir | 4,000 | 420 |
| malloc | 4,000 | 420 |
| total metadata ops | 11,880 | **4,940** |

**Driven through the real extraction path (40,000-member archive, output on tmpfs):**

| | before | after | |
|---|---|---|---|
| time in `path_mkdir` | 73.2 ms | 33.4 ms | **2.2x** |
| its share of extraction | 23.4% | 12.2% | |
| end-to-end extraction | 330.9 ms | 274.6 ms | **1.2x** |

The saving is larger than the syscall count suggests on Win32, where each probe is a UTF-16 conversion allocation plus **both** `GetFileAttributesW` and `_wstat64`, and larger again on Android SAF where each is a document-provider round trip. Not measured on those platforms.

This is not a shortcut around the slow path's answer: that path already returns `true` for an existing directory, via `mkdir` → `-2` → `path_is_directory`.

### One deliberate behaviour change

At a filesystem root (`"/"`, `"C:\"`), `path_parent_dir` empties the string and the `!*basedir` guard returned `false` — so `path_mkdir("/")` reported failure for a directory that plainly exists. It now returns `true`.

A/B over `{"/", "/tmp", "/tmp/", a new dir, a new nested dir, a single-component relative path, "./x/y", "", an existing regular file, a path whose parent is a regular file}` differs on that one case and nothing else.

## Verification

Measured on x86-64, warm page cache, extraction output on tmpfs. Sources built directly, so the numbers are from the real `archive_file.c` / `archive_file_zlib.c` / `file_path_io.c`, not a reimplementation.

- **Listing output identity:** 54/54 byte-identical element strings and attributes, across `{40k-entry, 4k-entry, single-member}` archives × `{full ext list, single ext, uppercase ext, dot-prefixed ext, empty, non-matching, "|", "||sfc||"}` × `{file_archive_get_file_list, ..._noalloc}`.
- **Extraction output identity:** whole-archive extraction compared against a reference extractor, and before-vs-after, on all three archives. Identical.
- **Sanitizers:** ASan + UBSan + LSan clean on listing (both entry points), single-file extract, whole-archive extract, CRC, and `path_mkdir`.

### Measurement note

Two traps cost real time here and are worth knowing if you re-run this:

1. **Extract to tmpfs.** On ext4, creating and deleting thousands of files per round makes writeback dominate — the same patch measured 4.8x *faster* in one ordering and 2.8x *slower* in another, both pure artefacts.
2. **Alternate order, report minima.** First-run page-cache warming is worth more than any of the changes here.

## Deliberately not included

- **Single-read end-of-central-directory probe.** `zip_parse_file_init` scans backwards in 1 KiB blocks with 21-byte overlap, so a ZIP with a maximum-length (65,535 byte) comment costs up to ~66 seek+read pairs before the archive opens. One read covers every legal case — but the benefit is unmeasurable on a local filesystem and only pays off on high-latency VFS (`smb://`, `cdrom://`). Shipping an unmeasurable change to the most safety-critical parsing code in the file is a bad trade without a target to measure it on.
- **`retro_vfs_stat_64_impl` running `_wstat64` when `size == NULL`.** `path_is_directory` and `path_is_valid` both pass NULL, and `file_info & FILE_ATTRIBUTE_DIRECTORY` already answers both questions, so the stat is dead weight — halving the cost of every such call on Windows across the whole frontend, not just extraction. Left out because it loosens semantics for paths where `GetFileAttributesW` succeeds and `_wstat64` fails, which needs a Win32 build and a pass over `path_is_valid` callers.
- **A one-slot directory memo at the extraction call site.** Superseded by change 3: with the fast path in place a repeated call costs a single stat, so the memo's remaining value no longer justifies adding state to `decompress_state_t`.