### PR TITLE
android: fix input on google tv

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1571,7 +1571,8 @@ static void handle_hotplug(android_input_t *android,
    /* If device is keyboard only and didn't match any of the devices above
     * then assume it is a keyboard, register the id, and return unless the
     * maximum number of keyboards are already registered. */
-   else if (source == AINPUT_SOURCE_KEYBOARD && kbd_num < MAX_NUM_KEYBOARDS)
+   else if (((source & AINPUT_SOURCE_KEYBOARD) == AINPUT_SOURCE_KEYBOARD)
+      && kbd_num < MAX_NUM_KEYBOARDS)
    {
       kbd_id[kbd_num] = id;
       kbd_num++;
@@ -1585,9 +1586,9 @@ static void handle_hotplug(android_input_t *android,
    else if ((source & AINPUT_SOURCE_KEYBOARD) && kbd_num < MAX_NUM_KEYBOARDS &&
             is_configured_as_physical_keyboard(vendorId, productId, device_name))
    {
-       kbd_id[kbd_num] = id;
-       kbd_num++;
-       return;
+      kbd_id[kbd_num] = id;
+      kbd_num++;
+      return;
    }
 
    /* if device was not keyboard only, yet did not match any of the devices
@@ -1604,6 +1605,9 @@ static void handle_hotplug(android_input_t *android,
 
    if (*port < 0)
       *port = android->pads_connected;
+
+   if (!*name_buf)
+      strlcpy(name_buf, device_name, sizeof(name_buf));
 
    input_autoconfigure_connect(
          name_buf,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Input on google TV is completely broken.

The original checks for exact equality, while the new one checks that the keyboard bit is present (which is keyboard + d-pad)

The last else if is probably dead code now: 

```
else if ((source & AINPUT_SOURCE_KEYBOARD) && kbd_num < MAX_NUM_KEYBOARDS &&
            is_configured_as_physical_keyboard(vendorId, productId, device_name))
   {
      kbd_id[kbd_num] = id;
      kbd_num++;
      return;
   }
```

## Related Issues


## Related Pull Requests


## Reviewers
