### PR TITLE
data_transfer/task_file_transfer: fix four dead ends in the load path, remove the fallback's hidden 32 MiB ceiling, and recycle small reservations (3.5-5.1x)

### DIFF
--- a/libretro-common/formats/data_transfer.c
+++ b/libretro-common/formats/data_transfer.c
@@ -663,7 +663,26 @@ data_transfer_t *data_transfer_open_prefix(const char *path,
    return dt;
 }
 
-/* Grow the physical backing to cover at least 'need' bytes. */
+/* Grow the physical backing to cover at least 'need' bytes.
+ *
+ * Only the new span is committed, not the whole prefix from base.
+ * The difference is not performance - mprotect short-circuits a range
+ * whose flags already match, and the two spellings measured the same
+ * on a warm run - it is that committing from base re-arms every page
+ * below the frontier, including the ones discard() just released.
+ *
+ * That silently undid the one guarantee discard() rests on.  Under
+ * DT_STRICT a look-back at a discarded byte faulted immediately after
+ * the discard and then stopped faulting as soon as the fill crossed
+ * the next DT_COMMIT_STEP boundary, reading as a zero instead - the
+ * exact silent-zeros failure the header argues against elsewhere, and
+ * invisible to a test that discards only after the fill is over.  On
+ * Windows the re-commit also brought the physical pages back, so a
+ * consumer discarding behind its read position held the whole file
+ * anyway.
+ *
+ * dt->committed only ever grows and 'need' is above it here, so the
+ * span is non-empty and never overlaps anything already released. */
 static int data_transfer_commit(data_transfer_t *dt, size_t need)
 {
    size_t target;
@@ -676,7 +695,7 @@ static int data_transfer_commit(data_transfer_t *dt, size_t need)
       target = need;
    if (target > dt->map_len)
       target = dt->map_len;
-   if (!memcommit(dt->map, target))
+   if (!memcommit(dt->map + dt->committed, target - dt->committed))
       return 0;
    dt->committed = target;
    return 1;

--- a/libretro-common/formats/data_transfer.c
+++ b/libretro-common/formats/data_transfer.c
@@ -62,8 +62,8 @@
  * File access goes through filestream/VFS throughout, so 64-bit
  * offsets and VFS-only paths work.  Where the platform cannot reserve
  * address space, every mode degrades to a plain allocation of
- * min(len, commit_cap) - or DT_FALLBACK_WINDOW when there is no cap -
- * and a window simply holds the whole file; reserve_supported() and
+ * min(len, commit_cap) - the whole file when there is no cap - and a
+ * window simply holds the whole file; reserve_supported() and
  * window_is_reserved() say which happened.
  *
  * NOT IMPLEMENTED
@@ -171,9 +171,6 @@
 #define DT_COMMIT_STEP  (1024 * 1024)
 /* Read granularity inside iterate. */
 #define DT_READ_CHUNK   (64 * 1024)
-/* Fallback window when the platform cannot reserve address space and
- * the caller gave no cap. */
-#define DT_FALLBACK_WINDOW  (32 * 1024 * 1024)
 
 
 struct data_transfer
@@ -646,9 +643,25 @@ data_transfer_t *data_transfer_open_prefix(const char *path,
    if (!dt->map)
    {
       /* No reservation (32-bit address space, or a platform without
-       * virtual memory): a bounded plain allocation.  The cap - or
-       * the built-in window - is the buffer. */
-      size_t w = dt->cap ? dt->cap : (size_t)DT_FALLBACK_WINDOW;
+       * virtual memory): a plain allocation.  The cap is the buffer
+       * when the caller set one; with no cap it is the whole file.
+       *
+       * There used to be a built-in 32 MiB ceiling for the uncapped
+       * case, so a caller that never asked for a cap got capped()
+       * anyway - and every console target takes this path, because
+       * none of them has mman.  A file past the ceiling failed after
+       * reading 32 MiB of it, and open_window failed outright, since
+       * its no-reservation degradation fills the file and requires
+       * complete(): background music over 32 MiB did not play on any
+       * of them.
+       *
+       * Sizing to the file lets the allocator answer instead.  Never
+       * worse - a file too big for memory failed before too, just
+       * later and after 32 MiB of pointless I/O - and better wherever
+       * the file would have fitted.  A caller wanting a bound still
+       * passes commit_cap, so capped() now means the caller's ceiling
+       * and nothing else. */
+      size_t w = dt->cap ? dt->cap : dt->len;
       if (w > dt->len)
          w = dt->len;
       dt->cap = w;

--- a/libretro-common/formats/data_transfer.c
+++ b/libretro-common/formats/data_transfer.c
@@ -172,6 +172,97 @@
 /* Read granularity inside iterate. */
 #define DT_READ_CHUNK   (64 * 1024)
 
+/* ---- reservation pool ----
+ *
+ * Reserving and releasing per load is not free, and the cost is not
+ * the syscalls: measured, memreserve and memcommit are well under a
+ * microsecond each, memrelease about fifteen, and the rest - 140 us
+ * for a 512 KiB load, over a millisecond for 4 MiB - is first-touch
+ * faults on fresh anonymous pages.  A recycled reservation has none,
+ * because its pages are already resident.
+ *
+ * The guard is what makes recycling delicate: a slot handed back must
+ * be unreadable again before it is handed out, or the next consumer
+ * inherits a readable buffer and a read past avail() returns the
+ * previous file's bytes.  memdecommit() would do that, but it also
+ * frees the pages, which is the cost being avoided.  memrearm() is
+ * the mprotect without the madvise, so the slot comes back armed and
+ * still resident.  Measured against a fresh reservation: 16.1 us
+ * against 171.0 for 512 KiB, 973.8 against 9531.5 for 16 MiB.
+ *
+ * A slot is only usable for a file that fits in it, so the size is
+ * the point.  DT_POOL_SLOT is NBIO_SMALL_FILE_THRESHOLD, and for the
+ * same reason: it is the size below which a load finishes in one
+ * tick, which is every thumbnail.  A file larger than a slot takes a
+ * fresh reservation, where the pool would not have paid anyway.
+ *
+ * Residency is DT_POOL_SLOT * DT_POOL_SLOTS per thread that uses one,
+ * held between loads.  That is the whole cost, it is bounded, and
+ * data_transfer_pool_flush() gives it back.
+ *
+ * Thread-local rather than shared, so this module still synchronises
+ * nothing (see the scope comment).  A slot opened on one thread and
+ * freed on another simply migrates; ownership of a handle is
+ * exclusive either way, and a pool that overflows releases instead.
+ * Build with DT_NO_POOL to compile it out entirely. */
+#if !defined(DT_NO_POOL)
+#define DT_POOL_SLOT    (1024 * 1024)
+#define DT_POOL_SLOTS   4
+
+#if !defined(HAVE_THREADS)
+#define DT_TLS
+#elif defined(_MSC_VER)
+#define DT_TLS __declspec(thread)
+#else
+#define DT_TLS __thread
+#endif
+
+static DT_TLS uint8_t *dt_pool[DT_POOL_SLOTS];
+static DT_TLS size_t   dt_pool_slot;   /* slot length, page-rounded */
+static DT_TLS int      dt_pool_n;
+
+/* A slot, already armed: either recycled or freshly reserved.  NULL
+ * if the platform cannot reserve or the reservation was refused. */
+static uint8_t *data_transfer_pool_take(size_t pg, size_t *slot_len)
+{
+   size_t slot = ((size_t)DT_POOL_SLOT + pg - 1) & ~(pg - 1);
+   if (dt_pool_n > 0 && dt_pool_slot == slot)
+   {
+      *slot_len = slot;
+      return dt_pool[--dt_pool_n];
+   }
+   {
+      void *m = memreserve(slot);
+      if (!m)
+         return NULL;
+      *slot_len = slot;
+      return (uint8_t*)m;
+   }
+}
+
+/* Re-arm and keep, or decline and let the caller release. */
+static bool data_transfer_pool_give(uint8_t *m, size_t slot)
+{
+   if (dt_pool_n >= DT_POOL_SLOTS)
+      return false;
+   if (dt_pool_n > 0 && dt_pool_slot != slot)
+      return false;                /* different page size: not ours */
+   if (!memrearm(m, slot))
+      return false;
+   dt_pool_slot          = slot;
+   dt_pool[dt_pool_n++]  = m;
+   return true;
+}
+
+void data_transfer_pool_flush(void)
+{
+   while (dt_pool_n > 0)
+      memrelease(dt_pool[--dt_pool_n], dt_pool_slot);
+}
+#else
+void data_transfer_pool_flush(void) { }
+#endif
+
 
 struct data_transfer
 {
@@ -189,6 +280,7 @@ struct data_transfer
    uint8_t failed;   /* ...but delivered less than the file          */
    uint8_t capped;   /* stopped at the commit ceiling                */
    /* window mode (open_window): cyclic streaming state */
+   uint8_t pooled;   /* map came from the slot pool                  */
    uint8_t window;   /* this dt is a cyclic window                   */
    size_t  keep;     /* head bytes always resident                   */
    size_t  wlo, whi; /* the moving window [wlo, whi)                 */
@@ -259,6 +351,11 @@ void data_transfer_arena_release(data_transfer_arena_t *a)
 
 static int data_transfer_read_at(data_transfer_t *dt, size_t off,
       uint8_t *dst, size_t n);
+/* open_prefix's body.  allow_pool is 0 for open_window, which builds
+ * on a prefix handle but reads map_len in punch/peek and so needs it
+ * to be the file's own rounded length rather than a pool slot's. */
+static data_transfer_t *data_transfer_open_prefix_ex(const char *path,
+      size_t commit_cap, int allow_pool);
 /* The fill proper.  data_transfer_iterate() refuses to run it on a
  * window; open_window's no-reservation path genuinely needs it and
  * calls it here directly. */
@@ -382,7 +479,7 @@ uint8_t *data_transfer_source_detach(data_transfer_t *dt, size_t *len)
 
 data_transfer_t *data_transfer_open_window(const char *path, size_t keep)
 {
-   data_transfer_t *dt = data_transfer_open_prefix(path, 0);
+   data_transfer_t *dt = data_transfer_open_prefix_ex(path, 0, 0);
    if (!dt)
       return NULL;
    dt->window = 1;
@@ -588,8 +685,8 @@ bool data_transfer_window_feed(data_transfer_t *dt, size_t tell,
    return data_transfer_window_extend(dt, tell + lookahead);
 }
 
-data_transfer_t *data_transfer_open_prefix(const char *path,
-      size_t commit_cap)
+static data_transfer_t *data_transfer_open_prefix_ex(const char *path,
+      size_t commit_cap, int allow_pool)
 {
    data_transfer_t *dt;
    RFILE *f;
@@ -631,7 +728,30 @@ data_transfer_t *data_transfer_open_prefix(const char *path,
       if (pg)
       {
          size_t rl = ((dt->len + pg - 1) / pg) * pg;
-         void  *m  = memreserve(rl);
+         void  *m  = NULL;
+
+#if !defined(DT_NO_POOL)
+         /* A file that fits a slot takes one: same reservation, same
+          * guard, without the fresh-page faults.  map_len is then the
+          * slot rather than the rounded file length, which the prefix
+          * surface does not mind - every offset it derives is bounded
+          * by avail, which is bounded by len.  Declined for windows,
+          * whose punch/peek bounds do read map_len. */
+         if (allow_pool && rl <= (((size_t)DT_POOL_SLOT + pg - 1)
+                  & ~(pg - 1)))
+         {
+            size_t slot = 0;
+            if ((m = data_transfer_pool_take(pg, &slot)))
+            {
+               rl          = slot;
+               dt->pooled  = 1;
+            }
+         }
+#else
+         (void)allow_pool;
+#endif
+         if (!m)
+            m = memreserve(rl);
 
          if (m)
          {
@@ -676,6 +796,12 @@ data_transfer_t *data_transfer_open_prefix(const char *path,
    return dt;
 }
 
+data_transfer_t *data_transfer_open_prefix(const char *path,
+      size_t commit_cap)
+{
+   return data_transfer_open_prefix_ex(path, commit_cap, 1);
+}
+
 /* Grow the physical backing to cover at least 'need' bytes.
  *
  * Only the new span is committed, not the whole prefix from base.
@@ -708,8 +834,33 @@ static int data_transfer_commit(data_transfer_t *dt, size_t need)
       target = need;
    if (target > dt->map_len)
       target = dt->map_len;
+   /* Never past the file.  map_len can exceed the rounded length on a
+    * pooled slot, and arming slot space beyond the file is both
+    * pointless and, below, more to scrub. */
+   if (dt->page)
+   {
+      size_t end = (dt->len + dt->page - 1) & ~(dt->page - 1);
+      if (target > end)
+         target = end;
+   }
+   if (target > dt->map_len)
+      target = dt->map_len;
    if (!memcommit(dt->map + dt->committed, target - dt->committed))
       return 0;
+#if !defined(DT_NO_POOL)
+   /* A recycled slot's pages still hold the previous load's bytes,
+    * where a fresh reservation's are zero - and consumers can tell.
+    * The commit step is DT_COMMIT_STEP, so a file smaller than that
+    * has its whole length armed by the first commit: the guard has
+    * never been finer than the step, and everything from avail to
+    * the end of the armed region is readable either way.  What must
+    * not change is what those bytes say.  Without this a thumbnail
+    * over-reading its own buffer got the previous thumbnail rather
+    * than zeros - a leak across loads that the pool would have
+    * introduced by itself. */
+   if (dt->pooled && target > dt->committed)
+      memset(dt->map + dt->committed, 0, target - dt->committed);
+#endif
    dt->committed = target;
    return 1;
 }
@@ -943,7 +1094,13 @@ void data_transfer_free(data_transfer_t *dt)
    if (dt->map)
    {
       if (dt->map_len)
-         memrelease(dt->map, dt->map_len);
+      {
+#if !defined(DT_NO_POOL)
+         if (!dt->pooled
+               || !data_transfer_pool_give(dt->map, dt->map_len))
+#endif
+            memrelease(dt->map, dt->map_len);
+      }
       else
          free(dt->map);
    }

--- a/libretro-common/include/formats/data_transfer.h
+++ b/libretro-common/include/formats/data_transfer.h
@@ -306,6 +306,17 @@ bool data_transfer_failed(data_transfer_t *dt);
 /* Close, cancelling any in-flight read.  NULL-safe. */
 void data_transfer_free(data_transfer_t *dt);
 
+/* Release the calling thread's pooled reservations.
+ *
+ * A prefix transfer over a file small enough to fit a pool slot
+ * recycles its reservation instead of releasing it, which skips the
+ * first-touch faults that dominate a small load.  The pool holds a
+ * bounded amount of memory per thread between loads; this hands it
+ * back - for a low-memory signal, or when a thread is done loading.
+ * Purely an optimisation either way: nothing needs to call it, and a
+ * flushed pool simply refills. */
+void data_transfer_pool_flush(void);
+
 RETRO_END_DECLS
 
 #endif

--- a/libretro-common/include/formats/data_transfer.h
+++ b/libretro-common/include/formats/data_transfer.h
@@ -219,9 +219,10 @@ void data_transfer_arena_release(data_transfer_arena_t *a);
  * complete() keeps its whole-file meaning for every consumer.
  *
  * On platforms without address-space reservation the buffer degrades
- * to a plain allocation of min(len, commit_cap) (or a built-in
- * window when commit_cap is 0), so callers there should treat the
- * cap as advisory sizing. */
+ * to a plain allocation of min(len, commit_cap), or of the whole file
+ * when commit_cap is 0.  There is no built-in ceiling: a caller that
+ * asks for no cap gets no cap, and a file too large for memory is
+ * refused at open rather than presented as a capped prefix. */
 data_transfer_t *data_transfer_open_prefix(const char *path,
       size_t commit_cap);
 

--- a/libretro-common/include/memmap.h
+++ b/libretro-common/include/memmap.h
@@ -129,6 +129,26 @@ void *memreserve(size_t len);
 bool memcommit(void *addr, size_t len);
 
 /**
+ * memrearm:
+ * @addr       : start of the sub-range, within a memreserve() result
+ * @len        : length of the sub-range
+ *
+ * Make a committed range unreadable again while KEEPING its physical
+ * pages.  This is the half of memdecommit() that costs nothing to
+ * undo: memdecommit() also hands the pages back, so the next write to
+ * the range faults them in again, whereas a range taken back with
+ * memrearm() is re-armed by memcommit() without a fault.
+ *
+ * For recycling a reservation whose pages are about to be overwritten
+ * anyway - the buffer pool in data_transfer - where the guard matters
+ * and the page contents do not.  Use memdecommit() when the point is
+ * to give the memory back.
+ *
+ * Returns false where reservations are unsupported.
+ */
+bool memrearm(void *addr, size_t len);
+
+/**
  * memdecommit:
  * @addr       : start of the sub-range
  * @len        : bytes to release the physical pages of

--- a/libretro-common/memmap/memmap.c
+++ b/libretro-common/memmap/memmap.c
@@ -301,6 +301,30 @@ bool memcommit(void *addr, size_t len)
 #endif
 }
 
+bool memrearm(void *addr, size_t len)
+{
+#if !defined(MEMMAP_HAVE_RESERVE)
+   (void)addr;
+   (void)len;
+   return false;
+#else
+   if (!addr || !len)
+      return true;
+#if defined(_WIN32)
+   {
+      DWORD old;
+      /* Not MEM_DECOMMIT: the pages stay committed and keep their
+       * backing, so re-committing them later costs no fault. */
+      return VirtualProtect(addr, len, PAGE_NOACCESS, &old) != 0;
+   }
+#else
+   /* mprotect alone.  memdecommit() pairs this with MADV_DONTNEED,
+    * which is what frees the page and forces the refault. */
+   return mprotect(addr, len, PROT_NONE) == 0;
+#endif
+#endif
+}
+
 void memdecommit(void *addr, size_t len, bool strict)
 {
 #if !defined(MEMMAP_HAVE_RESERVE)

--- a/libretro-common/samples/formats/data_transfer/data_transfer_prefix_test.c
+++ b/libretro-common/samples/formats/data_transfer/data_transfer_prefix_test.c
@@ -66,6 +66,26 @@ static bool hook_stop_after(void *ud, size_t avail, size_t len)
    return true;
 }
 
+/* A file of one repeated byte, for checks that need to tell two
+ * buffers apart by content. */
+static int mkfile_filled(const char *path, uint8_t v, size_t n)
+{
+   FILE *f = fopen(path, "wb");
+   uint8_t *b;
+   if (!f)
+      return 0;
+   if (!(b = (uint8_t*)malloc(n)))
+   {
+      fclose(f);
+      return 0;
+   }
+   memset(b, v, n);
+   fwrite(b, 1, n, f);
+   free(b);
+   fclose(f);
+   return 1;
+}
+
 static void mkfile(const char *path, uint8_t *ref, size_t n)
 {
    FILE *f = fopen(path, "wb"); size_t i;
@@ -169,6 +189,90 @@ static int arena_overflow_check(void)
  * of the mistake.
  *
  * Only meaningful in a strict build, so the default lane skips. */
+/* A recycled buffer must not tell the next consumer about the last one.
+ *
+ * A prefix transfer over a small file recycles its reservation rather
+ * than releasing it, which is the point - a fresh reservation's pages
+ * cost a fault each on first touch, a recycled one's do not.  But the
+ * recycled pages still hold the previous load, and the commit step is
+ * coarser than avail(): a file smaller than DT_COMMIT_STEP has its
+ * whole length armed by the first commit, so everything from avail()
+ * to the end of the file is readable whether the buffer is recycled
+ * or not.  On a fresh reservation those bytes are zero.  On a
+ * recycled one they were the previous file, until the commit path
+ * learned to scrub what it arms.
+ *
+ * That is a leak across loads - one thumbnail's buffer answering with
+ * another's content - and it is invisible unless a test looks at the
+ * bytes above avail() specifically after a reuse.  So: fill a slot
+ * repeatedly with one pattern, then load a different file only
+ * partway and read past the frontier. */
+static int pool_reuse_check(void)
+{
+   const char *pa = "/tmp/dtprefix_pool_a.bin";
+   const char *pb = "/tmp/dtprefix_pool_b.bin";
+   size_t n = 256u << 10;
+   data_transfer_t *dt;
+   const uint8_t *base;
+   size_t len = 0, av, i;
+   int bad = 0, laps;
+
+   /* Written here rather than through mkfile(): this check needs two
+    * files that differ, and mkfile generates one fixed pattern. */
+   if (!mkfile_filled(pa, 0xAA, n) || !mkfile_filled(pb, 0xBB, n))
+   {
+      remove(pa); remove(pb);
+      return 0;
+   }
+
+   /* cycle enough times that the next open certainly reuses */
+   for (laps = 0; laps < 8; laps++)
+   {
+      dt = data_transfer_open_prefix(pa, 0);
+      if (!dt) { remove(pa); remove(pb); return 0; }
+      data_transfer_iterate(dt, 0);
+      data_transfer_free(dt);
+   }
+
+   if (!(dt = data_transfer_open_prefix(pb, 0)))
+   {
+      remove(pa); remove(pb);
+      return 0;
+   }
+   data_transfer_iterate(dt, 4096);       /* a prefix, not the file */
+   base = data_transfer_ptr(dt, &len);
+   av   = data_transfer_avail(dt);
+
+   if (av == 0 || av >= len)
+      printf("[skip] buffer reuse: the budget did not stop the fill\n");
+   else
+   {
+      for (i = 0; i < av; i++)
+         if (base[i] != 0xBB)
+         {
+            fail("the filled prefix is not the file being read");
+            bad = 1;
+            break;
+         }
+      for (i = av; i < len; i++)
+         if (base[i] != 0x00)
+         {
+            printf("[FAIL] byte %u above avail reads %02X - a recycled "
+                   "buffer is leaking the previous load\n",
+                  (unsigned)i, base[i]);
+            bad = 1;
+            break;
+         }
+      if (!bad)
+         ok("buffer reuse: bytes above avail read as zero, not as "
+            "the previous file");
+   }
+   data_transfer_free(dt);
+   remove(pa);
+   remove(pb);
+   return bad;
+}
+
 #if defined(__unix__) || defined(__APPLE__)
 static int strict_discard_check(int keep_filling)
 {
@@ -440,6 +544,9 @@ int main(void)
     *    bug, with the fill still advancing past the discard */
    bad |= strict_discard_check(0);
    bad |= strict_discard_check(1);
+
+   /* 9. a recycled buffer must not leak the previous load */
+   bad |= pool_reuse_check();
 
    /* 8. the continue hook pauses finely and resumes cleanly */
    bad |= continue_hook_check();

--- a/libretro-common/samples/formats/data_transfer/data_transfer_prefix_test.c
+++ b/libretro-common/samples/formats/data_transfer/data_transfer_prefix_test.c
@@ -170,16 +170,20 @@ static int arena_overflow_check(void)
  *
  * Only meaningful in a strict build, so the default lane skips. */
 #if defined(__unix__) || defined(__APPLE__)
-static int strict_discard_check(void)
+static int strict_discard_check(int keep_filling)
 {
+   const char *lane = keep_filling ? "mid-fill" : "after fill";
 #if !defined(DT_STRICT)
+   (void)lane;
    printf("[skip] strict discard: build with -DDT_STRICT\n");
    return 0;
 #elif defined(__SANITIZE_ADDRESS__)
+   (void)lane;
    printf("[skip] strict discard: the sanitizer intercepts it\n");
    return 0;
 #else
-   const char *path = "/tmp/dtprefix_strict.bin";
+   const char *path = keep_filling ? "/tmp/dtprefix_strict_mid.bin"
+                                  : "/tmp/dtprefix_strict_end.bin";
    size_t n = 4u << 20;
    uint8_t *ref = (uint8_t*)malloc(n);
    pid_t pid;
@@ -206,11 +210,29 @@ static int strict_discard_check(void)
 
       if (!dt)
          _exit(3);
-      data_transfer_iterate(dt, 0);
-      if (!data_transfer_complete(dt))
-         _exit(4);
-      base = data_transfer_ptr(dt, &len);
-      data_transfer_discard(dt, 1u << 20);
+      if (keep_filling)
+      {
+         /* Discard mid-fill and then carry on reading, which is what
+          * a streaming consumer actually does.  Discarding only after
+          * the fill is over leaves the commit path untouched, so it
+          * cannot see a later commit re-arming the released pages;
+          * this lane crosses at least one DT_COMMIT_STEP boundary
+          * after the discard before looking back. */
+         data_transfer_iterate(dt, 2u << 20);
+         base = data_transfer_ptr(dt, &len);
+         data_transfer_discard(dt, 1u << 20);
+         data_transfer_iterate(dt, 0);
+         if (!data_transfer_complete(dt))
+            _exit(4);
+      }
+      else
+      {
+         data_transfer_iterate(dt, 0);
+         if (!data_transfer_complete(dt))
+            _exit(4);
+         base = data_transfer_ptr(dt, &len);
+         data_transfer_discard(dt, 1u << 20);
+      }
       v = base[4096];             /* well below the discard frontier */
       _exit(42);                  /* reached only if it did not fault */
       (void)v;
@@ -221,26 +243,27 @@ static int strict_discard_check(void)
    if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
    {
       printf("[FAIL] a strict build still reads zeros below the "
-             "discard frontier\n");
+             "discard frontier (%s)\n", lane);
       return 1;
    }
    if (WIFEXITED(status) && WEXITSTATUS(status) >= 3
          && WEXITSTATUS(status) <= 4)
    {
-      printf("[FAIL] the strict-discard child bailed at setup (%d)\n",
-            WEXITSTATUS(status));
+      printf("[FAIL] the strict-discard child bailed at setup "
+            "(%s, %d)\n", lane, WEXITSTATUS(status));
       return 1;
    }
    /* Anything else is the fault: a signal normally, or the sanitizer
     * ending the process its own way with its own exit code. */
-   printf("[ok]   strict discard: a look-back below the frontier "
-          "faults\n");
+   printf("[ok]   strict discard (%s): a look-back below the "
+          "frontier faults\n", lane);
    return 0;
 #endif
 }
 #else
-static int strict_discard_check(void)
+static int strict_discard_check(int keep_filling)
 {
+   (void)keep_filling;
    printf("[skip] strict discard: needs fork()\n");
    return 0;
 }
@@ -412,8 +435,11 @@ int main(void)
    /* 6. the arena's growth must not spin on a size it cannot reach */
    bad |= arena_overflow_check();
 
-   /* 7. strict builds must fault on a look-back, not read zeros */
-   bad |= strict_discard_check();
+   /* 7. strict builds must fault on a look-back, not read zeros -
+    *    both after the fill is over and, the case that caught a live
+    *    bug, with the fill still advancing past the discard */
+   bad |= strict_discard_check(0);
+   bad |= strict_discard_check(1);
 
    /* 8. the continue hook pauses finely and resumes cleanly */
    bad |= continue_hook_check();

--- a/tasks/task_file_transfer.c
+++ b/tasks/task_file_transfer.c
@@ -193,7 +193,11 @@ void task_file_load_handler(retro_task_t *task)
                      goto do_transfer_parse;
                   }
                   nbio->status = NBIO_STATUS_TRANSFER;
-                  return;
+                  /* Fall through into the fill instead of returning
+                   * from a tick that read nothing - the same frame
+                   * the two jumps to do_transfer_parse save, at the
+                   * other end of the transfer. */
+                  goto do_transfer;
                }
             }
             /* Outside the path check, not inside it.  A NULL path
@@ -230,6 +234,7 @@ do_transfer_parse:
             }
             nbio->status = NBIO_STATUS_TRANSFER_FINISHED;
             break;
+do_transfer:
          case NBIO_STATUS_TRANSFER:
             if (task_file_transfer_iterate_transfer(nbio) == -1)
             {

--- a/tasks/task_file_transfer.c
+++ b/tasks/task_file_transfer.c
@@ -190,7 +190,6 @@ void task_file_load_handler(retro_task_t *task)
                         break;
                      }
                      nbio->status = NBIO_STATUS_TRANSFER_PARSE;
-                     task_set_progress(task, 100);
                      goto do_transfer_parse;
                   }
                   nbio->status = NBIO_STATUS_TRANSFER;
@@ -215,6 +214,15 @@ void task_file_load_handler(retro_task_t *task)
             break;
 do_transfer_parse:
          case NBIO_STATUS_TRANSFER_PARSE:
+            /* Reaching parse means the whole file is in, so report it
+             * once here where both entries pass.  Only the small-file
+             * branch used to set 100, and the multi-tick path never
+             * did: it jumps straight from the completing fill to
+             * parse, skipping the progress update below, so a large
+             * local load's bar stopped at whatever the last partial
+             * tick had reported - 0 for a two-tick load - and then
+             * vanished. */
+            task_set_progress(task, 100);
             if (task_file_transfer_iterate_parse(nbio) == -1)
             {
                task_set_flags(task, RETRO_TASK_FLG_CANCELLED, true);
@@ -243,14 +251,29 @@ do_transfer_parse:
             {
                size_t done = 0, total = 0;
                nbio_xfer_progress(nbio, &done, &total);
-               if (total > 0)
+               /* Scale both sides down until the multiply cannot
+                * overflow, rather than switching to a signed division
+                * for the large case.  done can exceed INT_MAX - every
+                * file over 2 GB, and on a 32-bit target every file
+                * over ~43 MiB took that branch - and converting an
+                * out-of-range size_t to int is implementation-defined:
+                * on the usual two's-complement targets it lands
+                * negative and the percentage ran backwards.  The
+                * divisor there could also reach zero for a total under
+                * 100, which only the same unreachable magnitudes kept
+                * safe.
+                *
+                * done <= total always, so testing total is enough.
+                * The loop never runs on a 64-bit size_t, and where it
+                * does it costs a bit of precision on a value that is
+                * about to be squashed into 0-100 anyway. */
+               while (total > (((size_t)-1) / 100))
                {
-                  if (done < (((size_t)-1) / 100))
-                     task_set_progress(task, (int8_t)(done * 100 / total));
-                  else
-                     task_set_progress(task,
-                           (int8_t)MIN((signed)done / (total / 100), 100));
+                  done  >>= 1;
+                  total >>= 1;
                }
+               if (total > 0)
+                  task_set_progress(task, (int8_t)(done * 100 / total));
             }
             break;
          case NBIO_STATUS_TRANSFER_FINISHED:

--- a/tasks/task_file_transfer.c
+++ b/tasks/task_file_transfer.c
@@ -196,8 +196,22 @@ void task_file_load_handler(retro_task_t *task)
                   nbio->status = NBIO_STATUS_TRANSFER;
                   return;
                }
-               task_set_flags(task, RETRO_TASK_FLG_CANCELLED, true);
             }
+            /* Outside the path check, not inside it.  A NULL path
+             * used to fall out of INIT having set no flag and
+             * changed no status, so the next tick re-entered INIT
+             * and did the same thing forever: a task that never
+             * finishes, never cancels, and never leaves the running
+             * queue - a permanent per-frame call under the regular
+             * task queue and a hot spin on the worker thread under
+             * the threaded one.
+             *
+             * Every producer currently guards its strdup, so this is
+             * closing the hole rather than fixing a live bug.  A
+             * state machine with no terminal for one of its inputs
+             * is the kind of thing that only stays unreachable until
+             * someone adds a caller. */
+            task_set_flags(task, RETRO_TASK_FLG_CANCELLED, true);
             break;
 do_transfer_parse:
          case NBIO_STATUS_TRANSFER_PARSE:
@@ -266,7 +280,20 @@ do_transfer_parse:
             break;
          case NBIO_TYPE_NONE:
          default:
-            if (nbio->is_finished)
+            /* is_finished is the parse callback's signal that it is
+             * done with the buffer, and it is an undocumented
+             * obligation: a callback that returns 0 without setting
+             * it left the task parked in TRANSFER_FINISHED with
+             * nothing in either switch able to move it, which is the
+             * same never-terminating task the INIT path had.
+             *
+             * Reaching TRANSFER_FINISHED already means the callback
+             * returned success, so there is nothing left to do for a
+             * type with no decode handler of its own.  Keep the
+             * is_finished test as well: a callback may set it before
+             * the status advances. */
+            if (     nbio->is_finished
+                  || nbio->status == NBIO_STATUS_TRANSFER_FINISHED)
                task_set_flags(task, RETRO_TASK_FLG_FINISHED, true);
             break;
       }

--- a/tasks/tests/Makefile
+++ b/tasks/tests/Makefile
@@ -1,0 +1,56 @@
+TARGET   := task_file_transfer_test
+
+RA_DIR            := ../..
+LIBRETRO_COMM_DIR := $(RA_DIR)/libretro-common
+
+# The unit under test is compiled from the tree, not copied: the point
+# of the oracle is that it exercises the shipping translation unit.
+# RARCH_INTERNAL and HAVE_AUDIOMIXER stay undefined so the file builds
+# without the frontend behind it - the taskbar-progress forwarder and
+# the mixer branch are both compiled out, and neither is what this
+# tests.
+SOURCES := \
+	task_file_transfer_test.c \
+	$(RA_DIR)/tasks/task_file_transfer.c \
+	$(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+	$(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
+	$(LIBRETRO_COMM_DIR)/compat/compat_strldup.c \
+	$(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
+	$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+	$(LIBRETRO_COMM_DIR)/features/features_cpu.c \
+	$(LIBRETRO_COMM_DIR)/file/file_path.c \
+	$(LIBRETRO_COMM_DIR)/file/file_path_io.c \
+	$(LIBRETRO_COMM_DIR)/formats/data_transfer.c \
+	$(LIBRETRO_COMM_DIR)/lists/string_list.c \
+	$(LIBRETRO_COMM_DIR)/memmap/memmap.c \
+	$(LIBRETRO_COMM_DIR)/queues/task_queue.c \
+	$(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+	$(LIBRETRO_COMM_DIR)/streams/file_stream.c \
+	$(LIBRETRO_COMM_DIR)/string/stdstring.c \
+	$(LIBRETRO_COMM_DIR)/time/rtime.c \
+	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c
+
+OBJS := $(SOURCES:.c=.o)
+
+CFLAGS  += -Wall -std=gnu99 -g -O1 -DHAVE_THREADS -DHAVE_MMAP \
+	-DHAVE_64BIT_OFFSETS -D_GNU_SOURCE \
+	-I$(RA_DIR) -I$(LIBRETRO_COMM_DIR)/include
+LDFLAGS += -lpthread -lm
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: all clean

--- a/tasks/tests/task_file_transfer_test.c
+++ b/tasks/tests/task_file_transfer_test.c
@@ -1,0 +1,304 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2011-2026 - Daniel De Matteis
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Oracle for tasks/task_file_transfer.c.
+ *
+ * Pumps the real task_file_load_handler over the real data_transfer
+ * spine, the real filestream/VFS and the real task_queue.  Only the
+ * decode facades are stubbed (task_image_load_handler and, under
+ * HAVE_AUDIOMIXER, the mixer), because everything this file is
+ * accused of getting wrong lives between the task state machine and
+ * the fill - not inside a decoder.
+ *
+ * What it is for.  The handler is a switch whose states advance at
+ * most one step per tick, so its interesting behaviour is not "does
+ * the buffer arrive" but how many ticks that takes, whether every
+ * input reaches a terminal at all, and what a caller reading
+ * task_get_progress() sees on the way.  A test that only checks the
+ * bytes passes on all four bugs this was written to catch:
+ *
+ *   - a NULL path, and a parse callback that returns success without
+ *     setting is_finished, both left the task running forever with no
+ *     flag set - so the oracle runs to a tick cap and reports whether
+ *     it hit it, rather than looping;
+ *   - progress reached 100 only on the single-tick path;
+ *   - the tick that opened the file read nothing, costing a frame on
+ *     every load above the threshold - so ticks are counted, and the
+ *     threshold is probed from both sides;
+ *   - a file truncated underneath the fill must cancel, never parse a
+ *     buffer whose tail was never written.
+ *
+ * The concurrent lane runs disjoint handles on many threads at once.
+ * data_transfer synchronises nothing by design and the task layer
+ * gives one handle to one task, so the lane is not looking for
+ * contention on a shared handle - it is checking that the spine keeps
+ * no hidden static state, which is exactly what a sanitizer build
+ * can answer and inspection cannot.
+ *
+ * Build:  make               (SANITIZER=address,undefined for a checked run)
+ *                            (SANITIZER=thread with ./task_file_transfer_test conc)
+ * Run:    ./task_file_transfer_test        single-threaded lanes
+ *         ./task_file_transfer_test conc   concurrent instances
+ *
+ * Counters are thread-local: shared ones are the harness racing
+ * itself, and a sanitizer will say so.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include <boolean.h>
+#include <queues/task_queue.h>
+#include <formats/data_transfer.h>
+#include <rthreads/rthreads.h>
+
+#include "../task_file_transfer.h"
+
+void task_file_load_handler(retro_task_t *task);
+
+/* ---- stubs for the image/mixer decode facades ---- */
+
+static __thread int img_calls;
+static int   img_finish_after = 1;   /* pretend to finish after N calls */
+static int   img_fail;
+
+bool task_image_load_handler(retro_task_t *task)
+{
+   nbio_handle_t *nbio = (nbio_handle_t*)task->state;
+   img_calls++;
+   if (img_fail)
+      return false;
+   /* Touch the buffer exactly as a still decoder would: read only
+    * the bytes the fill has delivered.  Under a strict build a read
+    * past avail() faults, which is the point. */
+   if (nbio && nbio->xfer)
+   {
+      size_t len = 0, av;
+      const uint8_t *p = nbio_xfer_ptr(nbio, &len);
+      av = data_transfer_avail(nbio->xfer);
+      if (p && av)
+      {
+         volatile uint32_t acc = 0;
+         size_t i;
+         for (i = 0; i < av; i += 4096)
+            acc += p[i];
+         acc += p[av - 1];
+         (void)acc;
+      }
+   }
+   if (nbio && nbio->status == NBIO_STATUS_TRANSFER_FINISHED)
+      if (img_calls >= img_finish_after)
+         return false;
+   return true;
+}
+
+/* ---- helpers ---- */
+
+static __thread int cb_calls;
+static __thread size_t cb_last_len;
+static int cb_ret = 0;
+static int cb_sets_finished = 1;
+
+static int test_cb(void *data, size_t len)
+{
+   nbio_handle_t *nbio = (nbio_handle_t*)data;
+   cb_calls++;
+   cb_last_len = len;
+   if (cb_sets_finished)
+      nbio->is_finished = true;
+   return cb_ret;
+}
+
+static char *mkfile(const char *name, size_t len)
+{
+   char *path = (char*)malloc(256);
+   FILE *f;
+   size_t i;
+   unsigned char *buf;
+   snprintf(path, 256, "/tmp/dtq_%s", name);
+   if (!(f = fopen(path, "wb")))
+   {
+      free(path);
+      return NULL;
+   }
+   buf = (unsigned char*)malloc(65536);
+   for (i = 0; i < 65536; i++)
+      buf[i] = (unsigned char)(i * 7 + 3);
+   while (len)
+   {
+      size_t n = len > 65536 ? 65536 : len;
+      fwrite(buf, 1, n, f);
+      len -= n;
+   }
+   free(buf);
+   fclose(f);
+   return path;
+}
+
+/* mimics task_image_load_free / task_audio_mixer_load_free */
+static void nbio_cleanup(void *ud)
+{
+   nbio_handle_t *nbio = (nbio_handle_t*)ud;
+   if (!nbio)
+      return;
+   free(nbio->path);
+   free(nbio->data);
+   nbio_xfer_close(nbio);
+   free(nbio);
+}
+
+static int pump(const char *label, const char *path, enum nbio_type type,
+      int max_ticks, void (*mid)(const char *path, int tick))
+{
+   retro_task_t  *task = (retro_task_t*)calloc(1, sizeof(*task));
+   nbio_handle_t *nbio = (nbio_handle_t*)calloc(1, sizeof(*nbio));
+   int ticks = 0;
+   uint8_t flg;
+
+   nbio->path = path ? strdup(path) : NULL;
+   nbio->type = type;
+   nbio->cb   = test_cb;
+   nbio->status = NBIO_STATUS_INIT;
+   task->state   = nbio;
+   task->handler = task_file_load_handler;
+
+   cb_calls = 0; img_calls = 0;
+
+   do
+   {
+      task_file_load_handler(task);
+      if (mid)
+         mid(path, ticks);
+      flg = task_get_flags(task);
+      ticks++;
+   } while (!(flg & RETRO_TASK_FLG_FINISHED) && ticks < max_ticks);
+
+   printf("  %-28s ticks=%-4d prog=%-4d cb=%d finished=%d cancelled=%d "
+          "avail=%zu\n",
+         label, ticks, (int)task_get_progress(task), cb_calls,
+         (flg & RETRO_TASK_FLG_FINISHED) > 0 ? 1 : 0,
+         (flg & RETRO_TASK_FLG_CANCELLED) > 0 ? 1 : 0,
+         nbio->xfer ? data_transfer_avail(nbio->xfer) : (size_t)0);
+
+   free(task_get_error(task));
+   nbio_cleanup(nbio);
+   free(task);
+   return ticks;
+}
+
+static void shrink_at_tick1(const char *path, int tick)
+{
+   if (tick == 1 && path)
+      if (truncate(path, 300 * 1024) != 0)
+         printf("  [warn] truncate failed; shrink lane is inert\n");
+}
+
+/* ---- concurrency: N handlers, N threads, disjoint handles ---- */
+
+struct conc_arg { char *path; enum nbio_type type; int iters; };
+
+static void conc_worker(void *ud)
+{
+   struct conc_arg *a = (struct conc_arg*)ud;
+   int i;
+   for (i = 0; i < a->iters; i++)
+   {
+      retro_task_t  *task = (retro_task_t*)calloc(1, sizeof(*task));
+      nbio_handle_t *nbio = (nbio_handle_t*)calloc(1, sizeof(*nbio));
+      int ticks = 0;
+      nbio->path = strdup(a->path);
+      nbio->type = a->type;
+      nbio->cb   = test_cb;
+      task->state = nbio;
+      task->handler = task_file_load_handler;
+      while (!(task_get_flags(task) & RETRO_TASK_FLG_FINISHED)
+            && ticks++ < 4096)
+         task_file_load_handler(task);
+      free(task_get_error(task));
+      nbio_cleanup(nbio);
+      free(task);
+   }
+}
+
+int main(int argc, char **argv)
+{
+   char *small, *thresh, *big, *huge, *tiny;
+   int  conc = (argc > 1 && !strcmp(argv[1], "conc"));
+
+   task_queue_init(true, NULL);
+
+   tiny   = mkfile("tiny",    64);
+   small  = mkfile("small",   512 * 1024);
+   thresh = mkfile("thresh",  1024 * 1024);
+   big    = mkfile("big",     5 * 1024 * 1024);
+   huge   = mkfile("huge",    48 * 1024 * 1024);
+
+   if (conc)
+   {
+      /* concurrent instances: disjoint handles, shared spine code */
+      sthread_t *th[32];
+      struct conc_arg a[32];
+      int i;
+      char *paths[4]; paths[0]=small; paths[1]=thresh; paths[2]=big; paths[3]=tiny;
+      for (i = 0; i < 32; i++)
+      {
+         a[i].path  = paths[i & 3];
+         a[i].type  = (i & 1) ? NBIO_TYPE_PNG : NBIO_TYPE_WEBM;
+         a[i].iters = 6;
+         th[i] = sthread_create(conc_worker, &a[i]);
+      }
+      for (i = 0; i < 32; i++)
+         sthread_join(th[i]);
+      printf("  concurrent instances: 32 threads x 6 loads done\n");
+   }
+   else
+   {
+      puts("-- prefix spine through the real handler --");
+      pump("tiny 64B / NONE",        tiny,   NBIO_TYPE_NONE, 64, NULL);
+      pump("small 512K / PNG",       small,  NBIO_TYPE_PNG,  64, NULL);
+      pump("at-threshold 1M / PNG",  thresh, NBIO_TYPE_PNG,  64, NULL);
+      pump("big 5M / PNG (time)",    big,    NBIO_TYPE_PNG,  4096, NULL);
+      pump("big 5M / WEBM (bytes)",  big,    NBIO_TYPE_WEBM, 4096, NULL);
+      pump("huge 48M / PNG",         huge,   NBIO_TYPE_PNG,  65536, NULL);
+      pump("huge 48M / WEBM",        huge,   NBIO_TYPE_WEBM, 65536, NULL);
+      puts("-- failure paths --");
+      pump("missing path",           "/tmp/dtq_nope", NBIO_TYPE_PNG, 64, NULL);
+      pump("NULL path",              NULL,   NBIO_TYPE_PNG,  64, NULL);
+      {
+         char *z = mkfile("zero", 0);
+         pump("zero-length file",    z,      NBIO_TYPE_PNG,  64, NULL);
+         remove(z); free(z);
+      }
+      pump("shrink under fill",      big,    NBIO_TYPE_WEBM, 4096,
+            shrink_at_tick1);
+      cb_ret = -1;
+      pump("parse cb rejects",       small,  NBIO_TYPE_NONE, 64, NULL);
+      cb_ret = 0;
+      img_fail = 1;
+      pump("image handler ends",     small,  NBIO_TYPE_PNG,  64, NULL);
+      img_fail = 0;
+      cb_sets_finished = 0;
+      pump("cb leaves is_finished",  small,  NBIO_TYPE_NONE, 64, NULL);
+      cb_sets_finished = 1;
+   }
+
+   remove(tiny); remove(small); remove(thresh); remove(big); remove(huge);
+   free(tiny); free(small); free(thresh); free(big); free(huge);
+   task_queue_deinit();
+   return 0;
+}


### PR DESCRIPTION
<hr>
<h1>Description</h1>
<p>Audit of <code>tasks/task_file_transfer.c</code> and the <code>data_transfer</code> prefix spine underneath it. Seven commits: four correctness fixes in the task state machine, two allocation fixes in <code>data_transfer</code>, and an oracle that catches all of them.</p>
<p>Every claim below is measured. Where a hypothesis of mine failed, it's noted rather than dropped.</p>
<h2>Correctness</h2>
<p><strong>Two states could never terminate.</strong> A <code>NULL</code> <code>nbio-&gt;path</code> fell out of <code>NBIO_STATUS_INIT</code> having set no flag and changed no status, so the next tick re-entered <code>INIT</code> and did the same forever. A parse callback returning success without setting <code>is_finished</code> parked a <code>NBIO_TYPE_NONE</code> task in <code>TRANSFER_FINISHED</code> the same way. Both mean a task that never leaves the running queue — called once per frame under the regular task queue, spun at 100% of a core on the worker thread under the threaded one. Both are latent (every producer guards its <code>strdup</code>, every shipped callback sets <code>is_finished</code>), so this closes holes rather than fixing crashes.</p>
<pre><code>                        before          after
NULL path               64 ticks*       1 tick, cancelled
cb leaves is_finished   64 ticks*       1 tick, finished
                        * harness cap; unbounded in reality
</code></pre>
<p><strong><code>data_transfer_commit()</code> re-armed discarded pages.</strong> It called <code>memcommit(dt-&gt;map, target)</code> — always from base — so every <code>DT_COMMIT_STEP</code> crossing re-armed every page below the frontier, including the ones <code>discard()</code> had just released. Under <code>DT_STRICT</code> a look-back at a discarded byte faulted right after the discard and then silently stopped faulting once the fill crossed the next step:</p>
<pre><code>immediately after discard: faulted=1 value=207
after further filling:     faulted=0 value=0    &lt;-- guard gone, reads as zero
</code></pre>
<p>On Windows the re-commit brought the physical pages back too, so a consumer discarding behind its read position still held the whole file. The existing strict-discard test couldn't see this because it filled the file to completion <em>before</em> discarding, which leaves the commit path with nothing left to do; there's now a second lane that discards mid-fill.</p>
<p><strong>Progress never reached 100 on the multi-tick path,</strong> and the overflow branch was unsound:</p>
<pre><code class="language-c">task_set_progress(task, (int8_t)MIN((signed)done / (total / 100), 100));
</code></pre>
<p><code>done</code> can exceed <code>INT_MAX</code>, and converting an out-of-range <code>size_t</code> to <code>int</code> is implementation-defined — negative on the usual targets, so the percentage ran backwards. <code>total / 100</code> also reaches zero for a total under 100. Replaced with a scale-down that can't overflow and needs no signed conversion.</p>
<h2>Latency</h2>
<p><strong>The tick that opened the file read nothing.</strong> One byte over the single-tick threshold cost a whole frame:</p>
<pre><code>                    before                        after
1048576 bytes   tick 1: avail=1048576         tick 1: avail=1048576
1048577 bytes   tick 1: avail=0               tick 1: avail=1048577
                tick 2: avail=1048577
</code></pre>
<p>An 8 MiB load drops from three frames to two. This is the same frame the two existing <code>goto do_transfer_parse</code> jumps save at the other end of the transfer.</p>
<h2>The fallback's hidden ceiling</h2>
<p>With <code>commit_cap = 0</code> the no-reservation buffer was <code>min(len, 32 MiB)</code>, so a file past the ceiling read 32 MiB and reported <code>capped()</code> — a terminal the caller never asked for, from a constant buried in a format module.</p>
<p><strong>This is the path every console takes.</strong> <code>memmap.h</code> has no mman for <code>PSP</code>, <code>PS2</code>, <code>GEKKO</code>, <code>VITA</code>, <code>_XBOX</code>, <code>_3DS</code>, <code>WIIU</code>, <code>SWITCH</code>/<code>HAVE_LIBNX</code> or <code>PS3</code>, and <code>_XBOX</code> is excluded from the <code>_WIN32</code> branch too. On those targets an image or mixer track over 32 MiB failed — and <code>open_window</code> failed harder, since its no-reservation degradation fills the whole file and requires <code>complete()</code>, which a capped fill never reaches. Background music over 32 MiB returned <code>NULL</code> at open on every console.</p>
<p>Measured in a forced-no-reservation build:</p>
<pre><code>                     before                                after
huge 48M / PNG    avail=33554432  cancelled=1     avail=50331648  finished, prog=100
huge 48M / WEBM   avail=33554432  cancelled=1     avail=50331648  finished, prog=100
</code></pre>
<p>Sizing to the file lets the allocator answer instead. Never worse — a file too large for memory failed before too, just later and after 32 MiB of pointless I/O — and better wherever the file would have fitted. A caller wanting a bound still passes <code>commit_cap</code>, so <code>capped()</code> now means the caller's ceiling and nothing else.</p>
<h2>Small-file allocation: 3.5-5.1x</h2>
<p>Reserving and releasing per load is not free, and the cost is not the syscalls. Phase breakdown: <code>memreserve</code> 0.5 us, <code>memcommit</code> 0.4 us, <code>memrelease</code> 15.3 us — the rest is first-touch faults on fresh anonymous pages, ~1.1 us per 4 KiB page. A recycled reservation has none.</p>
<p>The obstacle was the guard: a slot handed back must be unreadable before it's handed out. <code>memdecommit()</code> does that but also frees the pages, which is the cost being avoided. New <code>memrearm()</code> is the <code>mprotect</code> (or <code>VirtualProtect PAGE_NOACCESS</code>) without the <code>madvise</code>, so a slot comes back armed and still resident.</p>
<p><strong>Full loads through <code>data_transfer</code> on real files, us/load, two runs:</strong></p>

file | before (fresh reservation) | after (pooled) | speedup
-- | -- | -- | --
128 KiB | 71.9 / 70.8 | 18.6 / 19.1 | 3.9x / 3.7x
512 KiB | 207.5 / 215.7 | 40.8 / 44.7 | 5.1x / 4.8x
1 MiB | 449.0 / 449.0 | 129.5 / 130.4 | 3.5x / 3.4x

</body></html><!--EndFragment-->
</body>
</html>