### PR TITLE
android: partial revert, make it only keyboard + d-pad

### DIFF
--- a/.github/workflows/webOS.yml
+++ b/.github/workflows/webOS.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: "webosbrew/dev-toolbox-cli"
           latest: true
-          fileName: "webosbrew-toolbox-gen-manifest_*.deb"
+          fileName: "webosbrew-toolbox-gen-manifest_*_amd64.deb"
           out-file-path: "temp"
 
       - name: Update packages

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1571,7 +1571,8 @@ static void handle_hotplug(android_input_t *android,
    /* If device is keyboard only and didn't match any of the devices above
     * then assume it is a keyboard, register the id, and return unless the
     * maximum number of keyboards are already registered. */
-   else if (((source & AINPUT_SOURCE_KEYBOARD) == AINPUT_SOURCE_KEYBOARD)
+   else if ((source == AINPUT_SOURCE_KEYBOARD ||
+      source == (AINPUT_SOURCE_KEYBOARD | AINPUT_SOURCE_DPAD))
       && kbd_num < MAX_NUM_KEYBOARDS)
    {
       kbd_id[kbd_num] = id;
@@ -1605,9 +1606,6 @@ static void handle_hotplug(android_input_t *android,
 
    if (*port < 0)
       *port = android->pads_connected;
-
-   if (!*name_buf)
-      strlcpy(name_buf, device_name, sizeof(name_buf));
 
    input_autoconfigure_connect(
          name_buf,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Good job I tested on stock android, it was too loose so it now skipped gamepads.. now fixed.

Now it particular does keyboard + d-pad (301) which is what the simulator requires, but still keeps original logic intact.

Also fix updated gen manifest package breaking webOS github CI.

## Related Issues

## Related Pull Requests

## Reviewers

