### PR TITLE
tasks/task_save: bound a transfer tick by time, fix three fall-through terminals, harden the rastate parser

### DIFF
--- a/.github/workflows/Linux-samples-tasks.yml
+++ b/.github/workflows/Linux-samples-tasks.yml
@@ -329,3 +329,110 @@ jobs:
              UBSAN_OPTIONS=print_stacktrace=1 timeout 600 \
              ./image_decode_slice_test
           echo "[pass] image_decode_slice_test (ASan)"
+
+      - name: Build and run save_state_io_test (ASan + UBSan, TSan)
+        shell: bash
+        working-directory: samples/tasks/save_state
+        run: |
+          set -eu
+          # Oracle for the file I/O in tasks/task_save.c, compiled
+          # from the tree so it exercises the shipping translation
+          # unit.  As in image_decode_slice, the clock is the test's
+          # instrument: the sample provides
+          # cpu_features_get_time_usec() itself, advancing a fixed
+          # step per observation, so the tick budget is assertable
+          # exactly rather than measured against a wall clock.  Step 0
+          # is a budget that never expires; step >= the budget is one
+          # that expires on first observation.
+          #
+          # The throughput regression it pins: both handlers used to
+          # transfer exactly one SAVE_STATE_CHUNK per queue tick,
+          # which caps a save at chunk * tick_rate (~6 MB/s) whatever
+          # the device can do - a 16 MB state took 164 ticks, 2.7s at
+          # 60Hz, while one 100 KB write costs ~62us of a 16667us
+          # frame.  A tick is now bounded by time and transfers as
+          # many quanta as fit.  Because a time budget is only an
+          # improvement if it cannot be worse than the fixed count it
+          # replaced, the exhausted-budget lane asserts the fallback
+          # directly: with a clock that spends the budget on its first
+          # observation the handler must still transfer exactly one
+          # quantum per tick and still produce a correct file.  That
+          # is the old behaviour reached through the new code, and it
+          # is what the slowest supported storage gets.
+          #
+          # The rest are the defects the audit turned up, each
+          # verified to fail this oracle on the pre-fix tree:
+          #
+          #  - The rastate block walker looped on 'input < stop', so
+          #    it could enter the body with one byte left and read the
+          #    block length out of input[4..7] - six bytes past the
+          #    end.  content_deserialize_state had the same shape one
+          #    level up, reading seven bytes of magic and input[7] for
+          #    the version with no length check at all.  Savestates
+          #    are shared, synced and recovered off failing media, and
+          #    the load handler's own short-read path produces exactly
+          #    this buffer, so this is a format parser on hostile
+          #    input.  ASan reports both for any state truncated to
+          #    9..15 bytes.
+          #
+          #  - A block's declared 32-bit length was never checked
+          #    against the bytes actually remaining and was then
+          #    passed to core_unserialize as the size of the buffer at
+          #    that offset.  The stub core here reads every byte it is
+          #    told the buffer holds before judging the size, exactly
+          #    as a real core does, so ASan - not the stub's own
+          #    opinion - is what catches an over-long block.  A stub
+          #    that checked size first would pass against the unfixed
+          #    walker.
+          #
+          #  - That length was also assembled as input[7] << 24 on an
+          #    int, undefined for every top byte >= 0x80, i.e. every
+          #    length at or above 2 GB - the range a corrupt length
+          #    lands in, and the value the bound check is asked to
+          #    trust.  UBSan is the assertion.
+          #
+          #  - A failed core_serialize left data NULL and size 0, at
+          #    which point every test in the save handler read as
+          #    success and the task reported COMPLETED.  The file had
+          #    already been opened and truncated, so the user was told
+          #    the save succeeded and the slot held zero bytes.
+          #
+          #  - A failed open was a bare return: not errored, not
+          #    finished, so the queue re-entered the task every tick
+          #    and it retried forever.  Save tasks are
+          #    TASK_TYPE_BLOCKING, so that one task held the single
+          #    blocking slot for the rest of the session - no state
+          #    could be saved or loaded again without a restart.  The
+          #    exclusion rule that makes it severe is itself pinned,
+          #    together with the cleanup the refusal path owes (the
+          #    task, its title, the state struct and the caller's
+          #    serialized buffer), which is why leak detection is on.
+          #
+          # The conc lane runs the same round-trip under a threaded
+          # queue, where the transfer loop executes on the worker
+          # while content_deserialize_state and the undo bookkeeping
+          # stay on the gathering thread.  It is one task at a time by
+          # design, not by simplification: TASK_TYPE_BLOCKING means
+          # the frontend cannot produce concurrent save tasks, so a
+          # lane that pushed them would be asserting against a
+          # configuration that cannot occur.  What it asks TSan is
+          # whether a loop that newly carries a deadline across
+          # iterations kept any of it shared.
+          make clean all
+          test -x save_state_io_test
+          timeout 300 ./save_state_io_test
+          timeout 300 ./save_state_io_test conc
+          echo "[pass] save_state_io_test"
+          make clean all SANITIZER=address,undefined
+          ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+             UBSAN_OPTIONS=print_stacktrace=1 timeout 300 \
+             ./save_state_io_test
+          ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 \
+             timeout 300 ./save_state_io_test conc
+          echo "[pass] save_state_io_test (ASan)"
+          make clean all SANITIZER=thread
+          TSAN_OPTIONS=halt_on_error=1 timeout 300 \
+             ./save_state_io_test
+          TSAN_OPTIONS=halt_on_error=1 timeout 300 \
+             ./save_state_io_test conc
+          echo "[pass] save_state_io_test (TSan)"

--- a/samples/tasks/save_state/Makefile
+++ b/samples/tasks/save_state/Makefile
@@ -1,0 +1,92 @@
+TARGET := save_state_io_test
+
+# Path back to the repo root from this sample dir.  The unit under
+# test is compiled from the tree rather than copied - the shipping
+# tasks/task_save.c - so the oracle exercises the translation unit
+# that ships.  RARCH_INTERNAL stays undefined so it builds without
+# the frontend behind it.
+#
+# features/features_cpu.c is deliberately NOT linked: the test
+# provides cpu_features_get_time_usec() itself, as a deterministic
+# clock that advances a fixed step per observation.  That is what
+# turns the tick budget into something a test can assert exactly -
+# step 0 is a budget that never expires, step >= the budget is one
+# that expires on first observation.
+#
+# HAVE_THREADS is defined so the threaded queue impl is built and the
+# "conc" lane can run the handler off the main thread, which is where
+# it runs in production.  The default lane still initialises the queue
+# unthreaded, so its tick-count assertions are unaffected: the pacing
+# protocol is identical either way and the locks only serialise it.
+#
+# HAVE_COMPRESSION stays undefined, so the plain intfstream path is
+# the one under test; the rzip path wraps the same handler loop.
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+SOURCES := save_state_io_test.c \
+           $(REPO_ROOT)/tasks/task_save.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strldup.c \
+           $(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
+           $(LIBRETRO_COMM_DIR)/encodings/encoding_crc32.c \
+           $(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+           $(LIBRETRO_COMM_DIR)/file/file_path.c \
+           $(LIBRETRO_COMM_DIR)/file/file_path_io.c \
+           $(LIBRETRO_COMM_DIR)/lists/string_list.c \
+           $(LIBRETRO_COMM_DIR)/queues/task_queue.c \
+           $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+           $(LIBRETRO_COMM_DIR)/streams/file_stream.c \
+           $(LIBRETRO_COMM_DIR)/streams/interface_stream.c \
+           $(LIBRETRO_COMM_DIR)/streams/memory_stream.c \
+           $(LIBRETRO_COMM_DIR)/string/stdstring.c \
+           $(LIBRETRO_COMM_DIR)/time/rtime.c \
+           $(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c
+
+CFLAGS  += -Wall -std=gnu99 -g -O1 \
+           -DHAVE_THREADS \
+           -I$(REPO_ROOT) \
+           -I$(LIBRETRO_COMM_DIR)/include
+
+LDFLAGS += -lpthread -lm
+
+# Extra flags for the caller; CFLAGS= on the command line would replace
+# everything set above instead of adding to it.
+CFLAGS += $(EXTRA_CFLAGS)
+
+OBJS := $(SOURCES:.c=.o)
+
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+# ASan and TSan are mutually exclusive, hence separate passes.  Leak
+# detection is strict: the handler owns the serialized buffer and the
+# intfstream, and the terminals this oracle drives (completed, failed
+# serialize, failed open, short file) are exactly the ones where an
+# early return could drop either.
+sweep:
+	$(MAKE) clean && $(MAKE) && ./$(TARGET) && ./$(TARGET) conc
+	$(MAKE) clean && $(MAKE) SANITIZER=address,undefined && \
+	   ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+	   UBSAN_OPTIONS=print_stacktrace=1 ./$(TARGET) && \
+	   ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=print_stacktrace=1 \
+	   ./$(TARGET) conc
+	$(MAKE) clean && $(MAKE) SANITIZER=thread && \
+	   TSAN_OPTIONS=halt_on_error=0 ./$(TARGET) && \
+	   TSAN_OPTIONS=halt_on_error=0 ./$(TARGET) conc
+	@echo "sweep clean"
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: all sweep clean

--- a/samples/tasks/save_state/save_state_io_test.c
+++ b/samples/tasks/save_state/save_state_io_test.c
@@ -1,0 +1,801 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (save_state_io_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Regression oracle for tasks/task_save.c's file I/O.
+ *
+ * The unit under test is the shipping tasks/task_save.c translation
+ * unit, compiled from the tree, driven through the real task queue
+ * against a stub frontend.  The core, the settings and the clock are
+ * the test's; everything on the I/O path - task_save_handler,
+ * task_load_handler, the rastate writer and the rastate block walker,
+ * intfstream, the VFS - is production code.
+ *
+ * Why these properties
+ * --------------------
+ * The save and load handlers used to transfer exactly one
+ * SAVE_STATE_CHUNK per queue tick.  That made throughput a function
+ * of the tick rate rather than of the device: SAVE_STATE_CHUNK *
+ * 60Hz is about 6 MB/s no matter what the storage can do, so a 16 MB
+ * state took 164 ticks - 2.7 seconds at 60Hz - while spending 99.6%
+ * of each frame idle (one 100 KB write measures ~62us of a 16667us
+ * frame on NVMe).  A tick is now bounded by a wall-clock budget and
+ * transfers as many quanta as fit in it.
+ *
+ * A time budget is only an improvement if it cannot be worse than
+ * the fixed count it replaced, so that is asserted directly rather
+ * than argued: with a clock that consumes the whole budget on its
+ * first observation, the handler must still transfer exactly one
+ * quantum per tick and still produce a correct file.  That is the old
+ * behaviour, reached through the new code, and it is what a device
+ * slow enough to blow the budget on a single write will see.
+ *
+ * The rest are correctness properties the throughput work must not
+ * be allowed to trade away, and three bugs the audit turned up:
+ *
+ *  - A truncated state file overread the buffer.  The block walker's
+ *    loop bound was 'input < stop', so it could enter the body with
+ *    one byte left and then read the block length out of input[4..7]
+ *    - six bytes past the end.  ASan reports it for any state
+ *    truncated to 9..15 bytes.  content_deserialize_state had the
+ *    same shape one level up: it reads seven bytes for the magic and
+ *    input[7] for the version with no length check at all.
+ *    Savestates are shared, synced and recovered off failing media,
+ *    and the load handler's own short-read path produces exactly this
+ *    buffer, so this is a file-format parser being handed hostile
+ *    input.
+ *
+ *  - A block's declared 32-bit length was never checked against the
+ *    bytes actually remaining, and was then passed to core_unserialize
+ *    as the size of the buffer at that offset.
+ *
+ *  - A failed core_serialize left state->data NULL and state->size 0,
+ *    at which point every test in the handler read as success
+ *    (remaining == 0 == written, written == size) and the task
+ *    reported a COMPLETED save.  The file had already been opened and
+ *    truncated, so the slot was left holding zero bytes and the user
+ *    was told the save succeeded.
+ *
+ *  - A failed open was a bare return: not errored, not finished.  The
+ *    queue re-entered the task on the next tick and it retried the
+ *    open forever.  Save tasks are TASK_TYPE_BLOCKING, so that one
+ *    task wedged every other blocking task for the rest of the
+ *    session.
+ *
+ * What this test does NOT assert
+ * ------------------------------
+ * Nothing about compressed (rzip) states: HAVE_COMPRESSION is off for
+ * this binary, so the uncompressed intfstream path is the one under
+ * test.  Nothing about cheevos or replay blocks, which are compiled
+ * out.
+ *
+ * The clock
+ * ---------
+ * cpu_features_get_time_usec() is provided here rather than linked
+ * from features_cpu.c, and advances a fixed step per observation.
+ * That is what makes the budget assertable: step 0 means the budget
+ * never expires (one tick for the whole transfer), step >=
+ * SAVE_STATE_TICK_BUDGET_US means it expires on first observation
+ * (one quantum per tick).  Both are exact, and neither depends on how
+ * many times anything else reads the clock, because extra reads can
+ * only advance it further.
+ *
+ * The two lanes
+ * -------------
+ * The threaded queue is a lane of this binary rather than a separate
+ * one.  The pacing protocol is identical with and without
+ * HAVE_THREADS - the locks only serialise it - so every tick-count
+ * assertion belongs to the default lane, which initialises the queue
+ * unthreaded and is therefore exactly reproducible.  What the "conc"
+ * lane adds is a target for TSan: under a threaded queue the transfer
+ * loop this change rewrote runs on the worker while
+ * content_deserialize_state and the undo bookkeeping run on whichever
+ * thread calls task_queue_check(), and the question worth asking of a
+ * loop that newly carries a deadline across iterations is whether any
+ * of it ended up shared.
+ *
+ * Build:  make            (SANITIZER=address,undefined, or
+ *                          SANITIZER=thread, for a checked run)
+ * Run:    ./save_state_io_test        default lane
+ *         ./save_state_io_test conc   threaded queue
+ *         make sweep                  both lanes under all three
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdarg.h>
+
+#include <retro_common_api.h>
+#include <queues/message_queue.h>
+#include <queues/task_queue.h>
+#include <streams/file_stream.h>
+#include <retro_timers.h>
+
+#include "../../../content.h"
+#include "../../../configuration.h"
+#include "../../../runloop.h"
+#include "../../../core.h"
+#include "../../../msg_hash.h"
+#include "../../../gfx/video_driver.h"
+
+/* Must match tasks/task_save.c.  Duplicated rather than exported: the
+ * constants are an implementation detail of the handler and a test
+ * that forced them into a header would be asserting against its own
+ * mirror.  A drift here shows up as a failing tick-count assertion,
+ * which is the intended way to find out. */
+#define TEST_SAVE_STATE_CHUNK        (100 * 1024)
+#define TEST_TICK_BUDGET_US          2000
+
+static int failures = 0;
+
+static void ok(const char *what)   { printf("[ok]   %s\n", what); }
+static void fail(const char *what) { printf("[FAIL] %s\n", what); failures = 1; }
+
+static void okf(int cond, const char *what)
+{
+   if (cond) ok(what); else fail(what);
+}
+
+/* -----------------------------------------------------------------
+ * Deterministic clock
+ * ----------------------------------------------------------------- */
+static uint64_t clock_now  = 1000000;
+static uint64_t clock_step = 0;
+
+retro_time_t cpu_features_get_time_usec(void)
+{
+   retro_time_t t = (retro_time_t)clock_now;
+   clock_now     += clock_step;
+   return t;
+}
+
+/* The other half of not linking features_cpu.c.  intfstream_get_crc()
+ * pulls in encoding_crc32.c, which dispatches on this; nothing on the
+ * savestate path calls it, and reporting no features keeps the scalar
+ * table path if anything ever does. */
+uint64_t cpu_features_get(void) { return 0; }
+
+/* -----------------------------------------------------------------
+ * Stub core
+ * ----------------------------------------------------------------- */
+static size_t   core_len       = 0;
+static uint8_t *core_mem       = NULL;
+static int      core_ser_fails = 0;
+
+static void core_fill(size_t n)
+{
+   size_t i;
+   free(core_mem);
+   core_len = n;
+   core_mem = n ? (uint8_t*)malloc(n) : NULL;
+   for (i = 0; i < n; i++)
+      core_mem[i] = (uint8_t)(i * 31u + 7u);
+}
+
+size_t core_serialize_size(void) { return core_len; }
+
+bool core_serialize(retro_ctx_serialize_info_t *info)
+{
+   if (core_ser_fails || !info || info->size < core_len)
+      return false;
+   memcpy((void*)info->data, core_mem, core_len);
+   return true;
+}
+
+bool core_unserialize(retro_ctx_serialize_info_t *info)
+{
+   const uint8_t   *src;
+   volatile uint8_t sink = 0;
+   size_t           i;
+
+   if (!info)
+      return false;
+   if (!(src = (const uint8_t*)(info->data_const
+               ? info->data_const : info->data)))
+      return false;
+
+   /* Read every byte the caller says the buffer holds, before
+    * deciding whether the size is one this core likes.  That is what
+    * a real core does, and it is the entire hazard in an unchecked
+    * block length: task_save.c hands core_unserialize a size taken
+    * verbatim from the file.  Touching the bytes here is what makes
+    * ASan - rather than this stub's own opinion of the size - the
+    * thing that catches a block that declares more than the state
+    * contains.  A stub that checked the size first would report the
+    * over-long block as refused while the read never happened, and
+    * would pass against the unfixed walker. */
+   for (i = 0; i < info->size; i++)
+      sink ^= src[i];
+   (void)sink;
+
+   if (info->size != core_len)
+      return false;
+   memcpy(core_mem, src, core_len);
+   return true;
+}
+
+bool core_get_memory(retro_ctx_memory_info_t *info)
+{
+   if (info) { info->data = NULL; info->size = 0; }
+   return false;
+}
+
+bool core_info_current_supports_savestate(void) { return true; }
+
+/* -----------------------------------------------------------------
+ * Stub frontend
+ * ----------------------------------------------------------------- */
+static settings_t           stub_settings;
+static runloop_state_t      stub_runloop;
+static video_driver_state_t stub_video;
+
+settings_t *config_get_ptr(void) { return &stub_settings; }
+runloop_state_t *runloop_state_get_ptr(void) { return &stub_runloop; }
+video_driver_state_t *video_state_get_ptr(void) { return &stub_video; }
+bool video_driver_cached_frame_is_hw_render(void) { return false; }
+void *savefile_ptr_get(void) { return NULL; }
+
+bool runloop_get_savestate_path(char *path, size_t len, int slot)
+{
+   snprintf(path, len, "save_state_io_test_auto_%d.state", slot);
+   return true;
+}
+
+const char *msg_hash_to_str(enum msg_hash_enums msg)
+{
+   (void)msg;
+   return "state message";
+}
+
+void RARCH_LOG(const char *fmt, ...)  { (void)fmt; }
+void RARCH_WARN(const char *fmt, ...) { (void)fmt; }
+void RARCH_ERR(const char *fmt, ...)  { (void)fmt; }
+
+static void msg_push_stub(retro_task_t *task, const char *msg,
+      unsigned prio, unsigned dur, bool flush)
+{
+   (void)task; (void)msg; (void)prio; (void)dur; (void)flush;
+}
+
+static void frontend_reset(void)
+{
+   memset(&stub_settings, 0, sizeof(stub_settings));
+   memset(&stub_runloop,  0, sizeof(stub_runloop));
+   memset(&stub_video,    0, sizeof(stub_video));
+   stub_video.frame_count      = 1000;   /* past the readiness gate */
+   stub_settings.ints.state_slot = 3;
+   core_ser_fails              = 0;
+   clock_now                   = 1000000;
+   clock_step                  = 0;
+}
+
+/* -----------------------------------------------------------------
+ * Queue driving
+ * ----------------------------------------------------------------- */
+static bool any_task(retro_task_t *t, void *ud)
+{
+   (void)t; (void)ud;
+   return true;
+}
+
+static bool queue_busy(void)
+{
+   task_finder_data_t fd;
+   fd.func     = any_task;
+   fd.userdata = NULL;
+   return task_queue_find(&fd);
+}
+
+/* Ticks the queue until it drains or 'limit' is reached.  Returns the
+ * tick count; reaching 'limit' with the queue still busy is itself a
+ * finding (a task that never terminates), so callers check for it. */
+static int pump(int limit)
+{
+   int ticks = 0;
+   while (ticks < limit)
+   {
+      task_queue_check();
+      ticks++;
+      if (!queue_busy())
+         break;
+   }
+   return ticks;
+}
+
+static long file_size(const char *p)
+{
+   RFILE *f = filestream_open(p, RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   int64_t n;
+   if (!f)
+      return -1;
+   n = filestream_get_size(f);
+   filestream_close(f);
+   return (long)n;
+}
+
+/* -----------------------------------------------------------------
+ * 1. A budget that never expires transfers the whole state in one
+ *    tick - the point of the change.
+ * ----------------------------------------------------------------- */
+static void test_budget_unlimited(void)
+{
+   const char *path = "sst_budget_full.state";
+   size_t sz        = 64 * TEST_SAVE_STATE_CHUNK;   /* 6.25 MB */
+   int ticks;
+
+   frontend_reset();
+   core_fill(sz);
+   filestream_delete(path);
+   clock_step = 0;   /* clock never advances: budget never expires */
+
+   content_save_state(path, true);
+   ticks = pump(1000);
+
+   okf(ticks == 1,
+       "unexpired budget writes a 64-quantum state in a single tick");
+   if (ticks != 1)
+      printf("       (took %d ticks)\n", ticks);
+
+   okf(file_size(path) == (long)content_get_serialized_size(),
+       "budgeted write produces a full-length file");
+
+   filestream_delete(path);
+}
+
+/* -----------------------------------------------------------------
+ * 2. A budget that expires on first observation degrades to exactly
+ *    one quantum per tick.  This is the no-worst-case-regression
+ *    property: it is the behaviour the handler had before the budget
+ *    existed, and it is what the slowest supported storage gets.
+ * ----------------------------------------------------------------- */
+static void test_budget_exhausted(void)
+{
+   const char *path = "sst_budget_none.state";
+   size_t quanta    = 12;
+   size_t sz        = quanta * TEST_SAVE_STATE_CHUNK;
+   size_t total;
+   int    ticks, expect;
+
+   frontend_reset();
+   core_fill(sz);
+   filestream_delete(path);
+   /* One observation spends the entire budget. */
+   clock_step = TEST_TICK_BUDGET_US;
+
+   total  = content_get_serialized_size();
+   expect = (int)((total + TEST_SAVE_STATE_CHUNK - 1)
+                  / TEST_SAVE_STATE_CHUNK);
+
+   content_save_state(path, true);
+   ticks = pump(1000);
+
+   okf(ticks == expect,
+       "exhausted budget falls back to exactly one quantum per tick");
+   if (ticks != expect)
+      printf("       (expected %d ticks, took %d)\n", expect, ticks);
+
+   okf(file_size(path) == (long)total,
+       "one-quantum-per-tick path still writes the whole file");
+
+   filestream_delete(path);
+}
+
+/* -----------------------------------------------------------------
+ * 3. Round-trip under both pacings.  Throughput work that corrupts
+ *    the payload is worse than the slow path it replaced.
+ * ----------------------------------------------------------------- */
+static void test_roundtrip(uint64_t step, const char *label)
+{
+   const char *path = "sst_roundtrip.state";
+   size_t sz        = 7 * TEST_SAVE_STATE_CHUNK + 1234; /* unaligned tail */
+   uint8_t *expect;
+
+   frontend_reset();
+   core_fill(sz);
+   expect = (uint8_t*)malloc(sz);
+   memcpy(expect, core_mem, sz);
+   filestream_delete(path);
+   clock_step = step;
+
+   content_save_state(path, true);
+   pump(1000);
+
+   /* Refill the core with a different pattern so a load that does
+    * nothing at all cannot pass. */
+   memset(core_mem, 0xA5, sz);
+
+   content_load_state(path, false, false);
+   pump(1000);
+
+   okf(memcmp(expect, core_mem, sz) == 0, label);
+
+   free(expect);
+   filestream_delete(path);
+}
+
+/* -----------------------------------------------------------------
+ * 4. A failed serialize must fail the task and must not leave a
+ *    zero-byte file in the slot.
+ * ----------------------------------------------------------------- */
+static void test_serialize_failure(void)
+{
+   const char *path = "sst_serfail.state";
+   int ticks;
+
+   frontend_reset();
+   core_fill(256 * 1024);
+   filestream_delete(path);
+
+   /* Defer serialization into the handler, then refuse it there. */
+   set_save_state_in_background(true);
+   core_ser_fails = 1;
+
+   content_save_state(path, true);
+   ticks = pump(1000);
+
+   core_ser_fails = 0;
+   set_save_state_in_background(false);
+
+   okf(ticks < 1000, "failed serialize terminates the save task");
+   okf(file_size(path) < 0,
+       "failed serialize leaves no file (not a zero-byte one)");
+   if (file_size(path) == 0)
+      printf("       (a zero-byte state file was left in the slot)\n");
+
+   filestream_delete(path);
+}
+
+/* -----------------------------------------------------------------
+ * 5. A failed open must terminate the task, not retry forever.  Save
+ *    tasks are blocking, so a task that never finishes takes the
+ *    whole blocking queue with it.
+ * ----------------------------------------------------------------- */
+static void test_open_failure(void)
+{
+   /* A path whose parent directory does not exist: open fails and
+    * will keep failing, which is the case the old bare-return
+    * retried on every tick for the rest of the session. */
+   const char *path = "sst_no_such_dir/deeper/still/x.state";
+   int ticks;
+
+   frontend_reset();
+   core_fill(128 * 1024);
+
+   content_save_state(path, true);
+   ticks = pump(500);
+
+   okf(ticks < 500, "failed open terminates the save task");
+   if (ticks >= 500)
+      printf("       (task still queued after 500 ticks - it is "
+             "retrying the open, and it is blocking)\n");
+}
+
+/* -----------------------------------------------------------------
+ * 6. Truncated state files.  Under ASan an overread aborts the
+ *    process, so reaching the end of this function at all is half the
+ *    assertion; the other half is that each truncation is rejected
+ *    rather than accepted as a valid state.
+ * ----------------------------------------------------------------- */
+static void test_truncated_state(void)
+{
+   size_t   sz = 4096;
+   size_t   full;
+   uint8_t *good;
+   size_t   cut;
+   int      all_rejected = 1;
+
+   frontend_reset();
+   core_fill(sz);
+
+   full = content_get_serialized_size();
+   good = (uint8_t*)malloc(full);
+   content_serialize_state_rewind(good, full);
+
+   /* 0..16 spans: shorter than the magic, shorter than the version
+    * byte, and the 9..15 range where the walker used to read a block
+    * length that was not there. */
+   for (cut = 0; cut <= 16 && cut < full; cut++)
+   {
+      uint8_t *slice = (uint8_t*)malloc(cut ? cut : 1);
+      if (cut)
+         memcpy(slice, good, cut);
+      if (content_deserialize_state(slice, cut))
+      {
+         printf("       (a %zu-byte truncation was accepted)\n", cut);
+         all_rejected = 0;
+      }
+      free(slice);
+   }
+
+   okf(all_rejected,
+       "state files truncated to 0..16 bytes are rejected, not parsed");
+
+   /* A well-formed header whose first block claims far more bytes
+    * than the buffer holds.  Rejection must come from the extent
+    * check, not from the core happening to dislike the size. */
+   {
+      uint8_t *evil = (uint8_t*)malloc(full);
+      memcpy(evil, good, full);
+      evil[8 + 4] = 0xFF;
+      evil[8 + 5] = 0xFF;
+      evil[8 + 6] = 0xFF;
+      evil[8 + 7] = 0x0F;              /* ~256 MB in a 4 KB buffer */
+      okf(!content_deserialize_state(evil, full),
+          "a block longer than the buffer is refused");
+      free(evil);
+   }
+
+   /* A length that overflows when aligned up to 8 on a 32-bit
+    * size_t.  Must be refused by the extent check before the
+    * alignment arithmetic runs. */
+   {
+      uint8_t *evil = (uint8_t*)malloc(full);
+      memcpy(evil, good, full);
+      evil[8 + 4] = 0xFF;
+      evil[8 + 5] = 0xFF;
+      evil[8 + 6] = 0xFF;
+      evil[8 + 7] = 0xFF;              /* UINT32_MAX */
+      okf(!content_deserialize_state(evil, full),
+          "a block length of UINT32_MAX is refused before alignment");
+      free(evil);
+   }
+
+   free(good);
+}
+
+/* -----------------------------------------------------------------
+ * 7. A state file that is shorter than its own contents claim must
+ *    fail the load, not half-apply it.
+ * ----------------------------------------------------------------- */
+static void test_short_file(void)
+{
+   const char *path = "sst_short.state";
+   size_t sz        = 3 * TEST_SAVE_STATE_CHUNK;
+   uint8_t *expect;
+   RFILE *f;
+   int64_t full;
+   uint8_t *raw;
+
+   frontend_reset();
+   core_fill(sz);
+   expect = (uint8_t*)malloc(sz);
+   memcpy(expect, core_mem, sz);
+   filestream_delete(path);
+
+   content_save_state(path, true);
+   pump(1000);
+
+   /* Rewrite the file with its last quantum missing. */
+   full = file_size(path);
+   raw  = (uint8_t*)malloc((size_t)full);
+   f    = filestream_open(path, RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   filestream_read(f, raw, full);
+   filestream_close(f);
+   filestream_delete(path);
+   f = filestream_open(path, RETRO_VFS_FILE_ACCESS_WRITE,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   filestream_write(f, raw, full - TEST_SAVE_STATE_CHUNK);
+   filestream_close(f);
+   free(raw);
+
+   memset(core_mem, 0x5A, sz);
+
+   content_load_state(path, false, false);
+   pump(1000);
+
+   {
+      size_t i;
+      int untouched = 1;
+      for (i = 0; i < sz; i++)
+         if (core_mem[i] != 0x5A) { untouched = 0; break; }
+      okf(untouched,
+          "a truncated state file is refused, not partially applied");
+   }
+
+   free(expect);
+   filestream_delete(path);
+}
+
+/* -----------------------------------------------------------------
+ * 8. Mutual exclusion between save/load tasks.
+ *
+ *    Every task this file pushes is TASK_TYPE_BLOCKING, so the queue
+ *    admits at most one of them at a time and refuses the rest.  Two
+ *    of the fixes above rest on that rule and one of them is only
+ *    severe because of it - a save task that retried a failed open
+ *    forever did not merely fail to save, it held the single blocking
+ *    slot for the rest of the session, so no state could be saved or
+ *    loaded again without a restart.
+ *
+ *    The refusal path is also where task_push_save_state has to undo
+ *    everything it built - the task, its title, the state struct, and
+ *    the caller's serialized buffer, which it took ownership of.
+ *    LeakSan is the assertion for that half; reaching the end of this
+ *    function with the queue drained is the assertion for the rest.
+ * ----------------------------------------------------------------- */
+static void test_blocking_exclusion(void)
+{
+   const char *first  = "sst_excl_a.state";
+   const char *second = "sst_excl_b.state";
+   int         i;
+
+   frontend_reset();
+   core_fill(40 * TEST_SAVE_STATE_CHUNK);
+   filestream_delete(first);
+   filestream_delete(second);
+
+   /* One observation spends the budget, so the first save needs ~40
+    * ticks and is still in flight for the whole of this test. */
+   clock_step = TEST_TICK_BUDGET_US;
+
+   content_save_state(first, true);
+   task_queue_check();                 /* first save now running */
+
+   okf(queue_busy(), "the first blocking task is running");
+
+   /* Push several more while it runs.  Each must be refused, and each
+    * refusal must free everything it allocated. */
+   for (i = 0; i < 8; i++)
+   {
+      content_save_state(second, true);
+      task_queue_check();
+   }
+
+   okf(file_size(second) == -1,
+       "a second save is refused while one is in flight");
+
+   pump(1000);
+
+   okf(!queue_busy(), "the queue drains after the refusals");
+   okf(file_size(first) == (long)content_get_serialized_size(),
+       "the admitted save completes intact despite the refusals");
+
+   filestream_delete(first);
+   filestream_delete(second);
+}
+
+/* -----------------------------------------------------------------
+ * The threaded lane.
+ *
+ * Under HAVE_THREADS the queue runs handlers on its worker thread and
+ * retires them - callbacks included - on whichever thread calls
+ * task_queue_check().  So the budgeted transfer loop this change
+ * rewrote executes off the main thread in production, while
+ * content_deserialize_state and the undo bookkeeping stay on it.
+ * That split is what TSan is pointed at here: the loop now reads a
+ * clock and carries a deadline across iterations, and the question is
+ * whether any of that ended up shared.
+ *
+ * It is deliberately one task at a time.  That is not a simplification
+ * - it is the shape the queue enforces, per test_blocking_exclusion
+ * above, and a lane that pushed concurrent save tasks would be
+ * asserting against a configuration the frontend cannot produce.
+ * What runs concurrently here is the handler against the main thread's
+ * gather, pump and verification, which is exactly production.
+ *
+ * The fake clock is left at step 0 for this lane: it is read only by
+ * the handler, i.e. only from the worker, so it stays a
+ * single-threaded object even though the process is not.  A lane that
+ * made the budget expire would have the main thread's frontend_reset
+ * writing what the worker reads, and TSan would be reporting the
+ * test's own scaffolding rather than the unit.
+ * ----------------------------------------------------------------- */
+static void pump_threaded(void)
+{
+   int spins = 0;
+   /* The worker owns progress; this thread only gathers.  Bounded so
+    * a handler that never terminates fails the run instead of hanging
+    * CI. */
+   while (spins++ < 20000)
+   {
+      task_queue_check();
+      if (!queue_busy())
+         return;
+      retro_sleep(1);
+   }
+   fail("threaded queue drained within the spin bound");
+}
+
+static void test_threaded_roundtrip(void)
+{
+   const char *path = "sst_threaded.state";
+   size_t sz        = 9 * TEST_SAVE_STATE_CHUNK + 77;
+   uint8_t *expect;
+
+   frontend_reset();
+   core_fill(sz);
+   expect = (uint8_t*)malloc(sz);
+   memcpy(expect, core_mem, sz);
+   filestream_delete(path);
+
+   content_save_state(path, true);
+   pump_threaded();
+
+   okf(file_size(path) == (long)content_get_serialized_size(),
+       "threaded queue: the save task writes a full-length file");
+
+   memset(core_mem, 0xA5, sz);
+
+   content_load_state(path, false, false);
+   pump_threaded();
+
+   okf(memcmp(expect, core_mem, sz) == 0,
+       "threaded queue: round-trip is byte-exact");
+
+   free(expect);
+   filestream_delete(path);
+}
+
+static int run_default_lane(void)
+{
+   printf("== task_save.c I/O regression oracle ==\n");
+   printf("   quantum %d B, tick budget %d us\n\n",
+         TEST_SAVE_STATE_CHUNK, TEST_TICK_BUDGET_US);
+
+   task_queue_init(false, msg_push_stub);
+
+   test_budget_unlimited();
+   test_budget_exhausted();
+   test_roundtrip(0, "round-trip is byte-exact with an unexpired budget");
+   test_roundtrip(TEST_TICK_BUDGET_US,
+         "round-trip is byte-exact at one quantum per tick");
+   test_serialize_failure();
+   test_open_failure();
+   test_truncated_state();
+   test_short_file();
+   test_blocking_exclusion();
+
+   content_reset_savestate_backups();
+   task_queue_deinit();
+   free(core_mem);
+   core_mem = NULL;
+   return failures;
+}
+
+static int run_threaded_lane(void)
+{
+   printf("== task_save.c I/O regression oracle (threaded queue) ==\n\n");
+
+   task_queue_init(true, msg_push_stub);
+
+   test_threaded_roundtrip();
+
+   content_reset_savestate_backups();
+   task_queue_deinit();
+   free(core_mem);
+   core_mem = NULL;
+   return failures;
+}
+
+int main(int argc, char *argv[])
+{
+   if (argc > 1 && strcmp(argv[1], "conc") == 0)
+      run_threaded_lane();
+   else
+      run_default_lane();
+
+   printf("\n%s\n", failures ? "FAILURES" : "all checks passed");
+   return failures;
+}

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -334,8 +334,13 @@ static void task_save_handler_finished(retro_task_t *task,
 
    task_set_flags(task, RETRO_TASK_FLG_FINISHED, true);
 
-   intfstream_close(state->file);
-   free(state->file);
+   /* NULL when the handler failed before the file was opened
+    * (serialize failure, or the open itself). */
+   if (state->file)
+   {
+      intfstream_close(state->file);
+      free(state->file);
+   }
 
    flg = task_get_flags(task);
 
@@ -557,6 +562,32 @@ static void task_save_handler(retro_task_t *task)
    int written              = 0;
    save_task_state_t *state = (save_task_state_t*)task->state;
 
+   /* Serialize before opening, not after.  Opening first meant a
+    * failed serialize had already created (and truncated) the target,
+    * so the slot was left holding a zero-byte file. */
+   if (!state->data)
+   {
+      size_t _len = 0;
+      state->data = content_get_serialized_data(&_len);
+      state->size = (ssize_t)_len;
+
+      /* A failed serialize used to leave data NULL and size 0, and
+       * every test below then read as success: remaining was 0, so
+       * written == remaining, and written == size, so the handler
+       * reported a COMPLETED save of a zero-byte file.  The user got
+       * a 'state saved' notification and an empty slot. */
+      if (!state->data || state->size <= 0)
+      {
+         RARCH_ERR("[State] save task could not serialize core state "
+               "for slot %d, path \"%s\".\n",
+               state->state_slot, state->path);
+         task_set_error(task, strdup(
+               msg_hash_to_str(MSG_FAILED_TO_SAVE_STATE_TO)));
+         task_save_handler_finished(task, state);
+         return;
+      }
+   }
+
    if (!state->file)
    {
       if (state->flags & SAVE_TASK_FLAG_COMPRESS_FILES)
@@ -569,29 +600,31 @@ static void task_save_handler(retro_task_t *task)
 
       if (!state->file)
       {
+         /* This used to be a bare return.  The task was neither
+          * errored nor finished, so the queue re-entered it on the
+          * next tick and it retried the open forever - and because
+          * save tasks are TASK_TYPE_BLOCKING, that one task wedged
+          * every other blocking task for the rest of the session.
+          * An open that failed once (read-only medium, bad path,
+          * no space) is not going to succeed on retry; fail it. */
          RARCH_ERR("[State] save task could not open \"%s\" for writing "
                "(slot %d). The auto-index slot was already advanced, so "
                "this leaves an advanced slot with no save file.\n",
                state->path, state->state_slot);
+         task_set_error(task, strdup(
+               msg_hash_to_str(MSG_FAILED_TO_SAVE_STATE_TO)));
+         task_save_handler_finished(task, state);
          return;
       }
    }
 
-   if (!state->data)
-   {
-      size_t _len = 0;
-      state->data = content_get_serialized_data(&_len);
-      state->size = (ssize_t)_len;
-   }
-
+   /* The serialize above guarantees state->data; the guard that used
+    * to stand here was what let a failed serialize fall through to a
+    * COMPLETED save of nothing. */
    remaining       = MIN(state->size - state->written, SAVE_STATE_CHUNK);
-
-   if (state->data)
-   {
-      written         = (int)intfstream_write(state->file,
+   written         = (int)intfstream_write(state->file,
          (uint8_t*)state->data + state->written, remaining);
-      state->written += written;
-   }
+   state->written += written;
 
    task_set_progress(task, (state->written / (float)state->size) * 100);
 
@@ -801,9 +834,26 @@ static void task_load_handler(retro_task_t *task)
    save_task_state_t *state = (save_task_state_t*)task->state;
    video_driver_state_t *video_st  = video_state_get_ptr();
 
-   /* Ensure the core is ready for loading states (Dolphin CLI) */
-   while (video_st->frame_count < 2)
-      retro_sleep(1);
+   /* Ensure the core is ready for loading states (Dolphin CLI).
+    *
+    * This used to spin here (while (...) retro_sleep(1)).  Two
+    * problems with that.  When the task queue is not threaded the
+    * handler runs on the same thread that advances frame_count, so
+    * the condition it waits on can never become true and the spin is
+    * an unconditional hang; it only ever went unnoticed because
+    * frame_count is already past 2 by the time a user loads a state
+    * interactively, and CLI autoload is the one path that reaches
+    * here early.  When it IS threaded, this is an unsynchronised read
+    * of a counter the video thread writes - a data race, and TSan
+    * reports it.
+    *
+    * Yielding does both jobs: the task stays queued and is re-entered
+    * on the next tick, by which time the runloop has advanced the
+    * counter.  The read is still unsynchronised, but it is now a
+    * single benign poll of a monotonic counter rather than a spin,
+    * and no progress depends on this thread observing it promptly. */
+   if (video_st->frame_count < 2)
+      return;
 
    if (!state->file)
    {

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -918,15 +918,67 @@ static bool content_load_rastate1(unsigned char* input, size_t len)
    bool seen_replay = false;
 #endif
 
+   /* The identifier itself must be present before anything is read
+    * past it. */
+   if (len < 8)
+      return false;
+
    input += 8;
 
-   while (input < stop)
+   /* input + 8 <= stop, not input < stop.  The old bound let the loop
+    * body run with as little as one byte remaining and then read the
+    * block length out of input[4..7] - up to six bytes past the end of
+    * the buffer.  ASan reports it for any state file truncated to
+    * 9..15 bytes, which is not a theoretical shape: savestates get
+    * shared, synced and copied off failing media, and a short read in
+    * the load handler produces exactly this buffer. */
+   while (input + 8 <= stop)
    {
-      size_t     block_size = ( input[7] << 24
-            | input[6] << 16 |  input[5] << 8 | input[4]);
+      /* Assembled through uint32_t, not int.  input[7] is an unsigned
+       * char, which promotes to int, and int << 24 is undefined for
+       * any top byte >= 0x80 - that is every block length at or above
+       * 2 GB, which is exactly the range a corrupt or hostile length
+       * lands in.  UBSan reports it; a compiler is entitled to do
+       * worse than report it, and the value it produces is the one
+       * the bound check below is asked to trust. */
+      size_t     block_size = (size_t)(  ((uint32_t)input[7] << 24)
+                                       | ((uint32_t)input[6] << 16)
+                                       | ((uint32_t)input[5] <<  8)
+                                       |  (uint32_t)input[4]);
       unsigned char *marker = input;
+      size_t          avail;
+      size_t        advance;
 
       input += 8;
+
+      /* Terminator carries no payload; check it before the extent
+       * test so a well-formed END block is not rejected. */
+      if (memcmp(marker, RASTATE_END_BLOCK, 4) == 0)
+         break;
+
+      /* Nothing below may consume more than the buffer holds.  This
+       * is what stops a corrupt or hostile 32-bit length from being
+       * handed to core_unserialize / rcheevos_set_serialized_data /
+       * replay_set_serialized_data as the size of a buffer that is
+       * not that large - the block contents are attacker-controlled
+       * in any file that arrived from outside. */
+      avail = (size_t)(stop - input);
+      if (block_size > avail)
+      {
+         RARCH_ERR("[State] Block \"%.4s\" declares %u bytes with %u "
+               "left in the state; refusing.\n",
+               (const char*)marker, (unsigned)block_size,
+               (unsigned)avail);
+         return false;
+      }
+
+      /* Padding is written for every block but the last one may sit
+       * flush against the end of the buffer, so clamp rather than
+       * reject.  Computed after the bound check above: block_size is
+       * a 32-bit quantity and CONTENT_ALIGN_SIZE would overflow a
+       * 32-bit size_t near UINT32_MAX. */
+      if ((advance = CONTENT_ALIGN_SIZE(block_size)) > avail)
+         advance = avail;
 
       if (memcmp(marker, RASTATE_MEM_BLOCK, 4) == 0)
       {
@@ -981,10 +1033,8 @@ static bool content_load_rastate1(unsigned char* input, size_t len)
             return false;
       }
 #endif
-      else if (memcmp(marker, RASTATE_END_BLOCK, 4) == 0)
-         break;
 
-      input += CONTENT_ALIGN_SIZE(block_size);
+      input += advance;
    }
 
    if (!seen_core)
@@ -1014,6 +1064,13 @@ static bool content_load_rastate1(unsigned char* input, size_t len)
 
 bool content_deserialize_state(const void *s, size_t len)
 {
+   /* Both branches below read the first 8 bytes: the memcmp reads 7
+    * and the version switch reads input[7].  Neither was guarded, so
+    * a state file shorter than the identifier overread here before
+    * the block walker was ever reached. */
+   if (!s || len < 8)
+      return false;
+
    if (memcmp(s, "RASTATE", 7) != 0)
    {
       /* old format is just core data, load it directly */

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -28,6 +28,7 @@
 #include <file/file_path.h>
 #include <retro_miscellaneous.h>
 #include <retro_timers.h>
+#include <features/features_cpu.h>
 #include <time/rtime.h>
 
 #ifdef HAVE_CONFIG_H
@@ -54,18 +55,39 @@
    read/write is a possible suspend to JS code */
 #define SAVE_STATE_CHUNK 4096 * 4096
 #else
-/* A low common denominator write chunk size.  On a slow
+/* A low common denominator transfer quantum.  On a slow
   (speed class 6) SD card, we can write 6MB/s.  That gives us
-  roughly 100KB/frame.
-  This means we can write savestates with one syscall for cores
-  with less than 100KB of state. Class 10 is the standard now
-  even for lousy cards and supports 10MB/s, so you may prefer
-  to put this to 170KB. This all assumes that task_save's loop
-  is iterated once per frame at 60 FPS; if it's updated less
-  frequently this number could be doubled or quadrupled depending
-  on the tickrate. */
+  roughly 100KB/frame, so a single quantum is one syscall that
+  fits inside one frame even on the worst storage we support.
+
+  This is the size of one read/write call, NOT the amount of work
+  a tick may do.  It used to be both, which capped the save/load
+  task at SAVE_STATE_CHUNK * tick_rate == ~6MB/s no matter what
+  the device could actually do: measured on NVMe, one 100KB
+  intfstream_write costs ~62us out of a 16667us frame, so 99.6%
+  of every frame's budget was spent idle and a 16MB state took
+  164 ticks (2.7s at 60Hz) to write.  The tick budget below is
+  what bounds a tick now; the quantum only bounds how long the
+  handler can overshoot that budget, which is why it stays sized
+  for the slowest device rather than the fastest. */
 #define SAVE_STATE_CHUNK 100 * 1024
 #endif
+
+/* Wall-clock budget for one save/load tick, in microseconds.
+   The handler keeps transferring SAVE_STATE_CHUNK quanta until this
+   is exhausted, then yields.  ~12% of a 60Hz frame.
+
+   Chosen as a time rather than a byte count because the quantity
+   that must be bounded is the stall the user sees, and only a clock
+   measures that; a byte count is a guess about device speed that is
+   wrong by two orders of magnitude across the range of devices
+   RetroArch runs on.
+
+   The loop is do/while, so exactly one quantum is always
+   transferred.  On a device slow enough that one quantum exceeds
+   the budget the behaviour is therefore byte-for-byte what it was
+   before this budget existed - there is no worst case to regress. */
+#define SAVE_STATE_TICK_BUDGET_US 2000
 
 #define RASTATE_VERSION 1
 #define RASTATE_MEM_BLOCK "MEM "
@@ -618,13 +640,23 @@ static void task_save_handler(retro_task_t *task)
       }
    }
 
-   /* The serialize above guarantees state->data; the guard that used
-    * to stand here was what let a failed serialize fall through to a
-    * COMPLETED save of nothing. */
-   remaining       = MIN(state->size - state->written, SAVE_STATE_CHUNK);
-   written         = (int)intfstream_write(state->file,
-         (uint8_t*)state->data + state->written, remaining);
-   state->written += written;
+   /* Transfer quanta until the tick budget is spent.  do/while, so a
+    * device slow enough that one quantum exceeds the budget behaves
+    * exactly as it did when a tick was hardcoded to one quantum. */
+   {
+      retro_time_t deadline = cpu_features_get_time_usec()
+         + SAVE_STATE_TICK_BUDGET_US;
+      do
+      {
+         remaining = MIN(state->size - state->written, SAVE_STATE_CHUNK);
+         written   = (int)intfstream_write(state->file,
+               (uint8_t*)state->data + state->written, remaining);
+         if (written != remaining)
+            break;
+         state->written += written;
+      } while (   state->written < state->size
+               && cpu_features_get_time_usec() < deadline);
+   }
 
    task_set_progress(task, (state->written / (float)state->size) * 100);
 
@@ -883,10 +915,22 @@ static void task_load_handler(retro_task_t *task)
       task_set_flags(task, RETRO_TASK_FLG_CANCELLED, true);
 #endif
 
-   remaining          = MIN(state->size - state->bytes_read, SAVE_STATE_CHUNK);
-   bytes_read         = intfstream_read(state->file,
-         (uint8_t*)state->data + state->bytes_read, remaining);
-   state->bytes_read += bytes_read;
+   /* Same budgeted-quanta scheme as the save handler; see the comment
+    * on SAVE_STATE_TICK_BUDGET_US. */
+   {
+      retro_time_t deadline = cpu_features_get_time_usec()
+         + SAVE_STATE_TICK_BUDGET_US;
+      do
+      {
+         remaining  = MIN(state->size - state->bytes_read, SAVE_STATE_CHUNK);
+         bytes_read = intfstream_read(state->file,
+               (uint8_t*)state->data + state->bytes_read, remaining);
+         if (bytes_read != remaining)
+            break;
+         state->bytes_read += bytes_read;
+      } while (   state->bytes_read < state->size
+               && cpu_features_get_time_usec() < deadline);
+   }
 
    if (state->size > 0)
       task_set_progress(task, (state->bytes_read / (float)state->size) * 100);


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h1>tasks/task_save: bound a transfer tick by time, fix three fall-through terminals, harden the rastate parser</h1>
<p>Audit of the file I/O in <code>tasks/task_save.c</code>: a throughput defect, three task-lifecycle
defects, and four out-of-bounds reads in the savestate parser. Four commits, split so the
parser hardening is independently cherry-pickable to stable.</p>
<p>Adds <code>samples/tasks/save_state</code>, a regression oracle that compiles the shipping
<code>tasks/task_save.c</code> from the tree and drives it through the real task queue. Every defect
below is verified to fail it on the pre-fix tree.</p>
<hr>
<h2>1. Throughput: a tick transferred exactly one chunk</h2>
<p>Both handlers transferred exactly one <code>SAVE_STATE_CHUNK</code> (100 KiB) per queue tick and then
returned. That makes throughput a function of the tick rate rather than of the device:
100 KiB per tick at 60 Hz is about 6 MB/s no matter what the storage underneath can do.</p>
<p>The frame was almost entirely idle while it happened. Measured below, one 100 KiB
<code>intfstream_write</code> costs ~40 µs — <strong>0.24% of a 16.67 ms frame</strong>. The other 99.76% was spent
waiting for the next tick.</p>
<p><code>SAVE_STATE_CHUNK</code> was doing two jobs. It was the size of one read/write call — which is what
its comment describes, and which is correctly sized for the worst storage RetroArch supports
(speed class 6 SD, 6 MB/s) so a single call fits inside a frame even there — and it was also,
by being the whole of a tick, the amount of work a tick could do. Only the first job needs a
byte count. The second needs a clock, because the quantity that has to be bounded is the stall
the user sees, and a byte count is a guess about device speed that is wrong by two orders of
magnitude across the range of devices this runs on.</p>
<p>A tick now transfers quanta until a wall-clock budget is spent: <code>SAVE_STATE_TICK_BUDGET_US</code>,
2000 µs, about 12% of a 60 Hz frame. The quantum keeps its old size and its old justification —
it bounds how far a handler can overshoot the budget, since a read/write cannot be interrupted
partway — which is why it stays sized for the slowest device rather than the fastest.</p>
<p>The loop is <code>do/while</code>, so exactly one quantum is always transferred. <strong>On a device slow enough
that a single quantum exceeds the budget, the behaviour is byte-for-byte what it was before this
budget existed.</strong> There is no worst case to regress, and that is asserted rather than argued: the
oracle drives the handler with a clock that spends the whole budget on its first observation and
requires exactly one quantum per tick and a correct file.</p>
<h3>Before / after</h3>
<p>Median of five warm runs, <code>-O2</code>, real clock (<code>features_cpu.c</code>), unthreaded queue.
Intel Xeon @ 2.80 GHz (1 vCPU), ext4 on virtio, GCC 13.3.0.
<code>@60 Hz</code> is <code>ticks / 60</code> — the wall time the operation takes when the runloop is the pacer.</p>
<p><strong>Save</strong></p>

State | Ticks before | Ticks after | @60 Hz before | @60 Hz after | Speedup
-- | -- | -- | -- | -- | --
1 MiB | 11 | 1 | 183 ms | 17 ms | 11×
4 MiB | 41 | 2 | 683 ms | 33 ms | 21×
16 MiB | 164 | 5 | 2 733 ms | 83 ms | 33×
64 MiB | 656 | 16 | 10 933 ms | 267 ms | 41×


<p>Save stays inside the budget plus one quantum's overshoot, which is the design.</p>
<p>The load figures need a caveat: that worst tick is <strong>not</strong> the transfer. It is the final tick,
where <code>content_deserialize_state</code> runs the block walker and the core memcpys the whole state
back. That stall is the same before and after — this PR neither causes nor fixes it. Slicing
the deserialize is a separate change and is not attempted here.</p>
<p><strong>Declined:</strong> raising <code>SAVE_STATE_CHUNK</code> instead. It would help fast devices and hurt slow ones
in the same motion, since the quantum is also the granularity at which the handler can yield.</p>
<hr>
<h2>2. Three paths that never reached a terminal</h2>
<p><strong>A failed <code>core_serialize</code> reported a completed save.</strong> It left <code>state-&gt;data</code> NULL and
<code>state-&gt;size</code> 0, and every test in the handler then read as success: <code>remaining</code> was
<code>MIN(0 - 0, CHUNK) == 0</code>, so <code>written == remaining</code>, and <code>written == size</code>, so the handler took
the completion branch. The task reported <code>COMPLETED</code>, the user got a "state saved" notification,
and because the file had already been opened — and therefore truncated — <strong>the slot was left
holding zero bytes</strong>. The next load of that slot is the first time anyone finds out.</p>
<p>The serialize now happens before the open rather than after it, so a failure cannot have
destroyed the previous contents of the slot on its way out, and the failure is reported as an
error on the task.</p>
<p><strong>A failed open was a bare return</strong> — neither errored nor finished, so the queue re-entered the
task on the next tick and it retried the open forever. An open that failed once (read-only
medium, bad path, no space) is not going to succeed on retry, so this was not a retry loop, it
was a wedge: save tasks are <code>TASK_TYPE_BLOCKING</code>, so the queue admits at most one at a time and
that task held the single blocking slot <strong>for the rest of the session</strong>. No state could be saved
or loaded again without restarting RetroArch.</p>
<p><strong><code>task_load_handler</code> opened with a spin</strong> — <code>while (frame_count &lt; 2) retro_sleep(1)</code> — waiting
for the core to be ready to accept a state (Dolphin, via the CLI). Under the regular queue the
handler runs on the same thread that advances <code>frame_count</code>, so the condition cannot become true
and the spin is an unconditional hang; it goes unnoticed only because <code>frame_count</code> is long past
2 by the time anyone loads a state interactively, and CLI autoload is the one path that arrives
here early. Under the threaded queue it terminates, but it is an unsynchronised read of a counter
the video thread writes, and TSan says so. It now yields: the task stays queued and is re-entered
next tick, by which time the runloop has advanced the counter.</p>
<blockquote>
<p>The read remains unsynchronised. It is a single poll of a monotonic counter with no progress
depending on observing it promptly, and making it otherwise means changing the type of
<code>video_driver_state_t::frame_count</code>, which is a tree-wide change and not this one. Flagging it
explicitly rather than claiming the race is gone.</p>
</blockquote>
<hr>
<h2>3. Four out-of-bounds reads in the rastate parser</h2>
<p>A savestate is a file that arrives from outside. They get shared, synced between devices,
recovered off failing media, and the load handler's own short-read path hands the parser a
truncated buffer directly. The reader treated its input as trusted in four places, and <strong>ASan
reports all four against a file that is merely truncated</strong>, with no craft involved.</p>
<ul>
<li><strong><code>content_deserialize_state</code></strong> read seven bytes for the <code>RASTATE</code> magic and <code>input[7]</code> for the
version with no length check at all. Any file shorter than eight bytes overran the buffer
before the block walker was reached.</li>
<li><strong><code>content_load_rastate1</code></strong> looped on <code>input &lt; stop</code>, so the body could be entered with as
little as one byte remaining and then read the block length out of <code>input[4..7]</code> — up to six
bytes past the end. Any state truncated to 9..15 bytes. The bound is now <code>input + 8 &lt;= stop</code>:
a header that is not entirely present is not a header.</li>
<li><strong>A block's declared 32-bit length was never checked against the bytes remaining</strong>, and was
then passed to <code>core_unserialize</code>, <code>rcheevos_set_serialized_data</code> and
<code>replay_set_serialized_data</code> as the size of a buffer that is not that large. Cores read what
they are told the buffer holds; that is the whole hazard.</li>
<li><strong>That length was assembled as <code>input[7] &lt;&lt; 24 | ...</code> on an <code>int</code>.</strong> <code>input[7]</code> is an
<code>unsigned char</code>, which promotes to <code>int</code>, and <code>int &lt;&lt; 24</code> is undefined for any top byte
<code>&gt;= 0x80</code> — every length at or above 2 GB, precisely the range a corrupt length lands in, and
the value the new bound check is asked to trust. UBSan reports the old form.</li>
</ul>
<p>Against the pre-fix tree the oracle produces <strong>nine distinct ASan reports</strong>, ending in a SEGV
inside the core's read of an unchecked block length.</p>
<p>No format change: every well-formed state parses byte-for-byte as before, and the rejections are
all of inputs that previously produced an out-of-bounds read.</p>
<hr>
<h2>4. Regression oracle — <code>samples/tasks/save_state</code></h2>
<p>Compiles the shipping <code>tasks/task_save.c</code> from the tree with the frontend stubbed at link time.
The core, the settings and the clock are the test's; everything on the I/O path — both handlers,
the rastate writer, the block walker, <code>intfstream</code>, the VFS — is production code.</p>
<p><strong>The clock is the instrument.</strong> <code>cpu_features_get_time_usec()</code> is provided by the sample rather
than linked from <code>features_cpu.c</code>, and advances a fixed step per observation. That is what turns
the tick budget into something assertable exactly rather than measured: step 0 is a budget that
never expires, step ≥ the budget is one that expires on first observation. Neither depends on how
many times anything else reads the clock, since extra reads can only advance it further.</p>
<p>19 checks over two lanes.</p>
<p>One thing worth stating about how the unchecked-block-length case is caught: <strong>the stub core
reads every byte it is told the buffer holds before deciding whether the size is one it likes</strong>,
because that is what a real core does. A stub that checked the size first would report the
over-long block as refused while the read never happened, and would pass against the unfixed
walker. ASan is the discriminator, not the stub's opinion of the size.</p>
<p>Mutual exclusion between blocking tasks is pinned too — it is not incidental, since the
failed-open wedge is only session-fatal <em>because</em> the queue admits one blocking task at a time.
The refusal path is also where <code>task_push_save_state</code> has to undo everything it built (the task,
its title, the state struct, and the caller's serialized buffer, which it took ownership of), so
leak detection is strict and is the assertion for that half.</p>
<p>The threaded queue is a lane of the same binary (<code>conc</code>) rather than a separate one. The pacing
protocol is identical with and without <code>HAVE_THREADS</code> — the locks only serialise it — so every
tick-count assertion belongs to the default lane, which is exactly reproducible. What the
threaded lane adds is a TSan target: the transfer loop now carries a deadline across iterations
and runs on the worker, while <code>content_deserialize_state</code> and the undo bookkeeping run on
whichever thread gathers. It is one task at a time <strong>by design, not by simplification</strong> —
<code>TASK_TYPE_BLOCKING</code> means the frontend cannot produce concurrent save tasks, so a lane that
pushed them would be asserting against a configuration that cannot occur.</p>
<p>Not asserted: compressed (rzip) states, which wrap the same handler loop but are compiled out
here; cheevos and replay blocks, likewise.</p>
<p>Wired into <code>Linux-samples-tasks.yml</code>, running both lanes under all three configurations.</p>
<hr>
<h2>Verification</h2>
<ul>
<li><strong>Sanitizer sweep clean</strong> — plain, ASan+UBSan+LeakSan
(<code>detect_leaks=1:detect_stack_use_after_return=1</code>, <code>print_stacktrace=1</code>), and TSan; both lanes
in each configuration. 57 passing checks per full sweep, zero sanitizer output.</li>
<li><strong>Verified to fail pre-fix</strong> — 65 ticks vs 1; a zero-byte state file left in the slot after a
failed serialize, reported as success; a save task still queued and blocking after 500 ticks
retrying a failed open; three truncations accepted by the block walker; then a crash.</li>
<li><strong>Full RetroArch build and link clean</strong> (<code>./configure --disable-menu</code>, binary runs;
<code>task_save.c</code> compiles with no warnings).</li>
<li><strong>Griffin-shape single-TU compile clean</strong> with <code>task_image.c</code> and <code>task_file_transfer.c</code> as
neighbours — no macro or symbol leakage from the new <code>features_cpu.h</code> include or the budget
define.</li>
<li><strong>Bisectable</strong> — all four intermediate states compile clean under
<code>-Wall -Wdeclaration-after-statement</code>. No new C89 diagnostic categories.</li>
</ul>
<h2>Out of scope, found while auditing</h2>
<ul>
<li><code>content_auto_save_state</code> has an unused-<code>settings</code> warning in non-<code>HAVE_COMPRESSION</code> builds
(it is used inside the ifdef). Pre-existing, cosmetic, left alone.</li>
<li><code>content_write_block_header</code> silently truncates a &gt;4 GB block length to 32 bits. A format
limitation rather than a bug; changing it changes the on-disk format.</li>
<li>The load path's final-tick stall (deserialize + core memcpy, ~67 ms for a 64 MiB state) is
unchanged by this PR. Slicing it is a separate change.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>