### PR TITLE
android: for play plus version increase min SDK for 100 feature modules

### DIFF
--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -107,7 +107,7 @@ android {
       }
     }
     playStorePlus {
-      minSdkVersion 21
+      minSdkVersion 26
       targetSdkVersion 36
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Need to increase min SDK to 26 for 100 modules as per: https://support.google.com/googleplay/android-developer/answer/9859372?hl=en-GB for Play Plus version only.

Other versions not affected.

This is the current setup now:

RA: sideload -> Android 5+
RA: play -> Android 6+
RA: play plus -> Android 8+

## Related Issues

## Related Pull Requests

## Reviewers

