### PR TITLE
Migrate remaining single-word mutex/intrinsic sites to retro_atomic; fix two data races in task_cloudsync

### DIFF
--- a/audio/drivers/opensl.c
+++ b/audio/drivers/opensl.c
@@ -19,6 +19,7 @@
 #include <SLES/OpenSLES_Android.h>
 #endif
 
+#include <retro_atomic.h>
 #include <rthreads/rthreads.h>
 
 #include "../audio_driver.h"
@@ -60,7 +61,12 @@ typedef struct sl
    unsigned buf_count;
    unsigned buffer_index;
    unsigned buffer_ptr;
-   volatile unsigned buffered_blocks;
+   /* Blocks currently enqueued on the device.  Decremented by
+    * opensl_callback on the OpenSL engine thread, incremented and
+    * read by the writer thread.  Android is always weakly-ordered
+    * ARM/AArch64, so the reads need acquire semantics to pair with
+    * the acq_rel RMWs - the previous plain volatile reads had none. */
+   retro_atomic_int_t buffered_blocks;
    bool nonblock;
    bool is_paused;
 } sl_t;
@@ -68,7 +74,7 @@ typedef struct sl
 static void opensl_callback(SLAndroidSimpleBufferQueueItf bq, void *ctx)
 {
    sl_t *sl = (sl_t*)ctx;
-   __sync_fetch_and_sub(&sl->buffered_blocks, 1);
+   retro_atomic_fetch_sub_int(&sl->buffered_blocks, 1);
    scond_signal(sl->cond);
 }
 
@@ -123,6 +129,10 @@ static void *sl_init(const char *device, unsigned rate, unsigned latency,
    (void)device;
    if (!sl)
       goto error;
+
+   /* calloc zero-fill is not a portable initializer for an atomic -
+    * initialize it explicitly before anything can touch it. */
+   retro_atomic_int_init(&sl->buffered_blocks, 0);
 
    RARCH_LOG("[OpenSL] Requested audio latency: %u ms.\n", latency);
 
@@ -191,7 +201,8 @@ static void *sl_init(const char *device, unsigned rate, unsigned latency,
    (*sl->buffer_queue)->RegisterCallback(sl->buffer_queue, opensl_callback, sl);
 
    /* Enqueue a bit to get stuff rolling. */
-   sl->buffered_blocks    = sl->buf_count;
+   retro_atomic_store_release_int(&sl->buffered_blocks,
+         (int)sl->buf_count);
    sl->buffer_index       = 0;
 
    for (i = 0; i < sl->buf_count; i++)
@@ -252,7 +263,8 @@ static ssize_t sl_write(void *data, const void *s, size_t len)
 
       if (sl->nonblock)
       {
-         if (sl->buffered_blocks == sl->buf_count)
+         if (retro_atomic_load_acquire_int(&sl->buffered_blocks)
+               == (int)sl->buf_count)
             break;
       }
       else
@@ -262,7 +274,7 @@ static ssize_t sl_write(void *data, const void *s, size_t len)
          /* Bounded.  opensl_callback is the only thing in this file
           * that ever signals sl->cond, and it does not hold sl->lock
           * while doing so - the predicate is buffered_blocks, updated
-          * with __sync_fetch_and_sub - so a signal raised between the
+          * with an atomic fetch_sub - so a signal raised between the
           * test above and this wait reaches no waiter.  While the
           * device keeps consuming blocks the next callback covers
           * that.  If it has stopped consuming - device loss, a player
@@ -271,7 +283,8 @@ static ssize_t sl_write(void *data, const void *s, size_t len)
           * below sits past the wait where a blocked thread can never
           * reach it.  An untimed wait here parked the thread the core
           * runs on for good. */
-         while (sl->buffered_blocks == sl->buf_count)
+         while (retro_atomic_load_acquire_int(&sl->buffered_blocks)
+               == (int)sl->buf_count)
          {
             if (!(signalled = scond_wait_timeout(sl->cond, sl->lock,
                         OPENSL_STALL_TIMEOUT_US)))
@@ -301,7 +314,7 @@ static ssize_t sl_write(void *data, const void *s, size_t len)
       {
          SLresult res     = (*sl->buffer_queue)->Enqueue(sl->buffer_queue, sl->buffer[sl->buffer_index], sl->buf_size);
          sl->buffer_index = (sl->buffer_index + 1) % sl->buf_count;
-         __sync_fetch_and_add(&sl->buffered_blocks, 1);
+         retro_atomic_fetch_add_int(&sl->buffered_blocks, 1);
          sl->buffer_ptr   = 0;
 
          if (res != SL_RESULT_SUCCESS)
@@ -317,8 +330,9 @@ static ssize_t sl_write(void *data, const void *s, size_t len)
 
 static size_t sl_write_avail(void *data)
 {
-   sl_t *sl = (sl_t*)data;
-   return ((sl->buf_count - (int)sl->buffered_blocks - 1) * sl->buf_size + (sl->buf_size - (int)sl->buffer_ptr));
+   sl_t *sl     = (sl_t*)data;
+   int buffered = retro_atomic_load_acquire_int(&sl->buffered_blocks);
+   return ((sl->buf_count - buffered - 1) * sl->buf_size + (sl->buf_size - (int)sl->buffer_ptr));
 }
 
 static size_t sl_buffer_size(void *data)

--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -40,11 +40,12 @@
 #endif
 #endif
 
+#include <retro_atomic.h>
+
 #ifdef HAVE_MMDEVICE
 #include "../common/mmdevice_common.h"
 #include "../common/mmdevice_common_inline.h"
 #ifdef HAVE_THREADS
-#include <retro_atomic.h>
 #include <rthreads/rthreads.h>
 #endif
 #endif

--- a/audio/drivers/xaudio.c
+++ b/audio/drivers/xaudio.c
@@ -44,6 +44,7 @@
 #include "../common/mmdevice_common.h"
 #include "../common/mmdevice_common_inline.h"
 #ifdef HAVE_THREADS
+#include <retro_atomic.h>
 #include <rthreads/rthreads.h>
 #endif
 #endif
@@ -68,11 +69,11 @@ typedef struct xaudio2 xaudio2_t;
  * the nonblocking clamp.  At a full queue this reports 0 rather than
  * underflowing size_t on the bufptr subtraction; the staging remainder
  * it forgoes there cannot be flushed without blocking anyway. */
-#define XAUDIO2_WRITE_AVAILABLE(handle) \
-   (((handle)->buffers < MAX_BUFFERS - 1) \
-    ? ((handle)->bufsize * (MAX_BUFFERS - (handle)->buffers - 1) \
-       - (handle)->bufptr) \
-    : 0)
+/* Bytes-writable computation lives in xaudio2_write_available()
+ * below the struct definition: it reads the cross-thread `buffers`
+ * counter exactly once, with acquire semantics.  The macro it
+ * replaces read the field twice, so the occupancy report could mix
+ * two different counter values. */
 #define XAUDIO_TIMEOUT   256
 
 enum xa_flags
@@ -152,7 +153,7 @@ struct xaudio2
    STDMETHOD_(void, OnBufferStart) (void *) {}
    STDMETHOD_(void, OnBufferEnd) (void *)
    {
-      InterlockedDecrement((LONG volatile*)&buffers);
+      retro_atomic_fetch_sub_int(&buffers, 1);
       SetEvent(hEvent);
    }
    STDMETHOD_(void, OnLoopEnd) (void *) {}
@@ -182,19 +183,33 @@ struct xaudio2
    char _pad0[XA_CACHE_LINE];
 
    /* Touched by the XAudio2 engine thread: OnBufferEnd decrements
-    * `buffers` and signals `hEvent`.  The producer reads both. */
+    * `buffers` and signals `hEvent`.  The producer reads both.
+    * retro_atomic rather than raw Interlocked + volatile: the
+    * Interlocked RMWs were full barriers, but the producer-side
+    * plain volatile reads carried no acquire ordering, which is
+    * real on Windows-on-ARM (MSVC defaults to /volatile:iso on
+    * ARM64, unlike /volatile:ms on x86/x64). */
    HANDLE hEvent;
-   unsigned long volatile buffers;
+   retro_atomic_int_t buffers;
 
    char _pad1[XA_CACHE_LINE];
 };
+
+static INLINE size_t xaudio2_write_available(xaudio2_t *handle)
+{
+   int buffers = retro_atomic_load_acquire_int(&handle->buffers);
+   if (buffers < MAX_BUFFERS - 1)
+      return handle->bufsize * (size_t)(MAX_BUFFERS - buffers - 1)
+            - handle->bufptr;
+   return 0;
+}
 
 #if !defined(__cplusplus) || defined(CINTERFACE)
 static void WINAPI xa_voice_on_buffer_end(IXAudio2VoiceCallback *handle_, void *data)
 {
    xaudio2_t *handle = (xaudio2_t*)handle_;
    (void)data;
-   InterlockedDecrement((LONG volatile*)&handle->buffers);
+   retro_atomic_fetch_sub_int(&handle->buffers, 1);
    SetEvent(handle->hEvent);
 }
 
@@ -370,6 +385,11 @@ static xaudio2_t *xaudio2_new(unsigned *rate, unsigned channels,
    handle = new xaudio2;
 #else
    handle = (xaudio2_t*)calloc(1, sizeof(*handle));
+   /* calloc zero-fill is not a portable initializer for an atomic -
+    * initialize it explicitly.  (The C++ path handles this in the
+    * constructor's mem-initializer list.) */
+   if (handle)
+      retro_atomic_int_init(&handle->buffers, 0);
 #endif
 
    if (!handle)
@@ -550,7 +570,7 @@ static ssize_t xa_write(void *data, const void *s, size_t len)
 
    if (xa->flags & XA2_FLAG_NONBLOCK)
    {
-      size_t avail = XAUDIO2_WRITE_AVAILABLE(xa->xa);
+      size_t avail = xaudio2_write_available(xa->xa);
 
       if (avail == 0)
          return 0;
@@ -577,7 +597,8 @@ static ssize_t xa_write(void *data, const void *s, size_t len)
       {
          XAUDIO2_BUFFER xa2buffer;
 
-         while (handle->buffers == MAX_BUFFERS - 1)
+         while (retro_atomic_load_acquire_int(&handle->buffers)
+               == MAX_BUFFERS - 1)
             if (!(WaitForSingleObject(handle->hEvent, XAUDIO_TIMEOUT) == WAIT_OBJECT_0))
                return -1;
 
@@ -599,7 +620,7 @@ static ssize_t xa_write(void *data, const void *s, size_t len)
             return 0;
          }
 
-         InterlockedIncrement((LONG volatile*)&handle->buffers);
+         retro_atomic_fetch_add_int(&handle->buffers, 1);
          handle->bufptr       = 0;
          handle->write_buffer = (handle->write_buffer + 1) & MAX_BUFFERS_MASK;
       }
@@ -670,7 +691,7 @@ static void xa_free(void *data)
 static size_t xa_write_avail(void *data)
 {
    xa_t *xa = (xa_t*)data;
-   return XAUDIO2_WRITE_AVAILABLE(xa->xa);
+   return xaudio2_write_available(xa->xa);
 }
 
 static size_t xa_buffer_size(void *data)

--- a/play_feature_delivery/play_feature_delivery.c
+++ b/play_feature_delivery/play_feature_delivery.c
@@ -18,6 +18,8 @@
 
 #include "com_retroarch_browser_retroactivity_RetroActivityCommon.h"
 
+#include <retro_atomic.h>
+
 #ifdef HAVE_THREADS
 #include <rthreads/rthreads.h>
 #include <stdlib.h>
@@ -43,28 +45,30 @@
 typedef struct
 {
 #ifdef HAVE_THREADS
-   slock_t *enabled_lock;
    slock_t *status_lock;
 #endif
+   /* Cached result of play_feature_delivery_enabled_internal():
+    * -1 = not yet queried, 0 = disabled, 1 = enabled.  Queried
+    * frequently, often in loops, so the fast path is a single
+    * acquire load with no lock.  A cold race can at worst issue
+    * the (idempotent) Java query twice; both stores write the
+    * same value. */
+   retro_atomic_int_t enabled_cached;
    unsigned download_progress;
    enum play_feature_delivery_install_status last_status;
    char last_core_name[256];
-   bool enabled;
-   bool enabled_set;
    bool active;
 } play_feature_delivery_state_t;
 
 static play_feature_delivery_state_t play_feature_delivery_state = {
 
 #ifdef HAVE_THREADS
-   NULL,                       /* enabled_lock */
    NULL,                       /* status_lock */
 #endif
+   RETRO_ATOMIC_INT_INITIALIZER(-1), /* enabled_cached */
    0,                          /* download_progress */
    PLAY_FEATURE_DELIVERY_IDLE, /* last_status */
    {'\0'},                     /* last_core_name */
-   false,                      /* enabled */
-   false,                      /* enabled_set */
    false,                      /* active */
 };
 
@@ -204,8 +208,6 @@ void play_feature_delivery_init(void)
    play_feature_delivery_deinit();
 
 #ifdef HAVE_THREADS
-   if (!state->enabled_lock)
-      state->enabled_lock = slock_new();
    if (!state->status_lock)
       state->status_lock  = slock_new();
 #endif
@@ -222,12 +224,6 @@ void play_feature_delivery_deinit(void)
    play_feature_delivery_state_t* state = play_feature_delivery_get_state();
 
 #ifdef HAVE_THREADS
-   if (state->enabled_lock)
-   {
-      slock_free(state->enabled_lock);
-      state->enabled_lock = NULL;
-   }
-
    if (state->status_lock)
    {
       slock_free(state->status_lock);
@@ -292,32 +288,21 @@ static bool play_feature_delivery_enabled_internal(void)
 bool play_feature_delivery_enabled(void)
 {
    play_feature_delivery_state_t* state = play_feature_delivery_get_state();
-   bool enabled;
-
-   /* Lock mutex */
-#ifdef HAVE_THREADS
-   slock_lock(state->enabled_lock);
-#endif
 
    /* Calling Java functions is slow. We need to
     * check Play Store build status frequently,
     * often in loops, so rely on a cached global
     * status flag instead dealing with Java
     * interfaces */
-   if (!state->enabled_set)
+   int cached = retro_atomic_load_acquire_int(&state->enabled_cached);
+
+   if (cached < 0)
    {
-      state->enabled     = play_feature_delivery_enabled_internal();
-      state->enabled_set = true;
+      cached = play_feature_delivery_enabled_internal() ? 1 : 0;
+      retro_atomic_store_release_int(&state->enabled_cached, cached);
    }
 
-   enabled = state->enabled;
-
-   /* Unlock mutex */
-#ifdef HAVE_THREADS
-   slock_unlock(state->enabled_lock);
-#endif
-
-   return enabled;
+   return (cached == 1);
 }
 
 /* Returns a list of cores currently available

--- a/tasks/task_cloudsync.c
+++ b/tasks/task_cloudsync.c
@@ -24,6 +24,7 @@
 #include <streams/file_stream.h>
 #include <string/stdstring.h>
 #include <time/rtime.h>
+#include <retro_atomic.h>
 #include <retro_inline.h>
 
 #include "../configuration.h"
@@ -54,8 +55,20 @@ enum task_cloud_sync_phase
 
 typedef struct
 {
-   enum task_cloud_sync_phase phase;
-   uint32_t waiting;
+   /* Current phase.  Written by the task thread during dispatch AND
+    * by driver completion callbacks (other threads) on phase
+    * transitions; read by the task thread's poll while transfers are
+    * still in flight.  The pre-atomic code wrote it unlocked in the
+    * callbacks while the poll read it under the old lock, which was
+    * a data race (the lock never covered the write side).  Atomic
+    * with release stores / acquire loads via the accessors below. */
+   retro_atomic_int_t phase;
+   /* In-flight async transfer count.  Written by the task thread when
+    * dispatching cloud_sync_* operations and by driver completion
+    * callbacks, which a driver is free to invoke from another thread.
+    * All accesses go through the task_cloud_sync_waiting_* helpers
+    * below; see the comment there for the ordering contract. */
+   retro_atomic_int_t waiting;
    /* Manifest present on the server (may be modified by other clients)*/
    file_list_t *server_manifest;
    size_t server_idx;
@@ -77,9 +90,66 @@ typedef struct
    retro_time_t start_time;
 } task_cloud_sync_state_t;
 
+/* Serialises appends to updated_server_manifest /
+ * updated_local_manifest: fetch/upload/delete completion callbacks
+ * can append concurrently with each other and with the task thread's
+ * dispatch-failure paths.  The lists are only *read* once `waiting`
+ * has drained to zero, so the lock is not needed on the read side.
+ *
+ * This lock used to guard `waiting` as well, but only on the
+ * callback (decrement) side - every increment and dispatch-side
+ * store ran unlocked, which was a data race whenever a driver
+ * invoked its completion callback from another thread.  `waiting`
+ * is now a retro_atomic counter instead; see below. */
 #ifdef HAVE_THREADS
-static slock_t *tcs_running_lock = NULL;
+static slock_t *tcs_manifest_lock = NULL;
 #endif
+
+/* Ordering contract for `waiting`: a completion callback publishes
+ * its side effects (phase, failures, need_manifest_uploaded, list
+ * appends) *before* dropping the counter with a release/acq_rel
+ * operation; the task handler's poll reads the counter with an
+ * acquire load, so once it observes the drained count all of those
+ * writes are visible to it.  This reproduces the release/acquire
+ * chain the old lock provided on the decrement side while also
+ * covering the increments that previously raced. */
+static INLINE void task_cloud_sync_waiting_set(
+      task_cloud_sync_state_t *sync_state, int v)
+{
+   retro_atomic_store_release_int(&sync_state->waiting, v);
+}
+
+static INLINE void task_cloud_sync_waiting_inc(
+      task_cloud_sync_state_t *sync_state)
+{
+   retro_atomic_fetch_add_int(&sync_state->waiting, 1);
+}
+
+static INLINE void task_cloud_sync_waiting_dec(
+      task_cloud_sync_state_t *sync_state)
+{
+   retro_atomic_fetch_sub_int(&sync_state->waiting, 1);
+}
+
+static INLINE int task_cloud_sync_waiting_get(
+      task_cloud_sync_state_t *sync_state)
+{
+   return retro_atomic_load_acquire_int(&sync_state->waiting);
+}
+
+static INLINE void task_cloud_sync_phase_set(
+      task_cloud_sync_state_t *sync_state,
+      enum task_cloud_sync_phase phase)
+{
+   retro_atomic_store_release_int(&sync_state->phase, (int)phase);
+}
+
+static INLINE enum task_cloud_sync_phase task_cloud_sync_phase_get(
+      task_cloud_sync_state_t *sync_state)
+{
+   return (enum task_cloud_sync_phase)
+         retro_atomic_load_acquire_int(&sync_state->phase);
+}
 
 /* Forward declarations for conflict resolution */
 static void task_cloud_sync_upload_current_file(task_cloud_sync_state_t *sync_state);
@@ -99,7 +169,7 @@ static void task_cloud_sync_begin_handler(void *user_data, const char *path, boo
    if (success)
    {
       RARCH_LOG(CSPFX "Begin succeeded.\n");
-      sync_state->phase = CLOUD_SYNC_PHASE_FETCH_SERVER_MANIFEST;
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_FETCH_SERVER_MANIFEST);
    }
    else
    {
@@ -108,13 +178,7 @@ static void task_cloud_sync_begin_handler(void *user_data, const char *path, boo
       task_set_title(task, strdup("Cloud Sync failed"));
       task_set_flags(task, RETRO_TASK_FLG_FINISHED, true);
    }
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-   sync_state->waiting = 0;
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
+   task_cloud_sync_waiting_set(sync_state, 0);
 }
 
 static bool tcs_object_member_handler(void *ctx, const char *s, size_t len)
@@ -212,14 +276,8 @@ static void task_cloud_sync_manifest_handler(void *user_data, const char *path,
    {
       RARCH_WARN(CSPFX "Server manifest fetch failed.\n");
       sync_state->failures = true;
-      sync_state->phase    = CLOUD_SYNC_PHASE_END;
-#ifdef HAVE_THREADS
-      slock_lock(tcs_running_lock);
-#endif
-      sync_state->waiting = 0;
-#ifdef HAVE_THREADS
-      slock_unlock(tcs_running_lock);
-#endif
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
+      task_cloud_sync_waiting_set(sync_state, 0);
       return;
    }
 
@@ -230,14 +288,8 @@ static void task_cloud_sync_manifest_handler(void *user_data, const char *path,
       sync_state->server_manifest = task_cloud_sync_create_manifest(file);
       filestream_close(file);
    }
-   sync_state->phase = CLOUD_SYNC_PHASE_READ_LOCAL_MANIFEST;
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-   sync_state->waiting = 0;
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
+   task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_READ_LOCAL_MANIFEST);
+   task_cloud_sync_waiting_set(sync_state, 0);
 }
 
 static void task_cloud_sync_fetch_server_manifest(task_cloud_sync_state_t *sync_state)
@@ -246,12 +298,12 @@ static void task_cloud_sync_fetch_server_manifest(task_cloud_sync_state_t *sync_
 
    task_cloud_sync_manifest_filename(manifest_path, sizeof(manifest_path), true);
 
-   sync_state->waiting = 1;
+   task_cloud_sync_waiting_set(sync_state, 1);
    if (!cloud_sync_read(MANIFEST_FILENAME_SERVER, manifest_path, task_cloud_sync_manifest_handler, sync_state))
    {
       RARCH_WARN(CSPFX "Could not read server manifest.\n");
-      sync_state->waiting = 0;
-      sync_state->phase = CLOUD_SYNC_PHASE_END;
+      task_cloud_sync_waiting_set(sync_state, 0);
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
    }
 }
 
@@ -274,7 +326,7 @@ static void task_cloud_sync_read_local_manifest(task_cloud_sync_state_t *sync_st
       }
    }
 
-   sync_state->phase = CLOUD_SYNC_PHASE_BUILD_CURRENT_MANIFEST;
+   task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_BUILD_CURRENT_MANIFEST);
 }
 
 /* takes the filename in manifest format, e.g. "config/retroarch.cfg" */
@@ -420,19 +472,19 @@ static void task_cloud_sync_build_current_manifest(task_cloud_sync_state_t *sync
 
    if (!(sync_state->current_manifest = (file_list_t *)calloc(1, sizeof(file_list_t))))
    {
-      sync_state->phase = CLOUD_SYNC_PHASE_END;
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
       return;
    }
 
    if (!(sync_state->updated_server_manifest = (file_list_t *)calloc(1, sizeof(file_list_t))))
    {
-      sync_state->phase = CLOUD_SYNC_PHASE_END;
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
       return;
    }
 
    if (!(sync_state->updated_local_manifest = (file_list_t *)calloc(1, sizeof(file_list_t))))
    {
-      sync_state->phase = CLOUD_SYNC_PHASE_END;
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
       return;
    }
 
@@ -443,7 +495,7 @@ static void task_cloud_sync_build_current_manifest(task_cloud_sync_state_t *sync
             (const char*)dirlist->elems[i].userdata, dirlist->elems[i].data);
 
    file_list_sort_on_alt(sync_state->current_manifest);
-   sync_state->phase = CLOUD_SYNC_PHASE_DIFF;
+   task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_DIFF);
    RARCH_LOG(CSPFX "Created in-memory manifest of current disk state with %d files.\n", sync_state->current_manifest->size);
 }
 
@@ -487,7 +539,7 @@ static void task_cloud_sync_add_to_updated_manifest(task_cloud_sync_state_t *syn
    file_list_t *list;
    size_t       idx;
 #ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
+   slock_lock(tcs_manifest_lock);
 #endif
    list = server ? sync_state->updated_server_manifest : sync_state->updated_local_manifest;
    idx = list->size;
@@ -495,7 +547,7 @@ static void task_cloud_sync_add_to_updated_manifest(task_cloud_sync_state_t *syn
    file_list_set_alt_at_offset(list, idx, key);
    list->list[idx].userdata = hash;
 #ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
+   slock_unlock(tcs_manifest_lock);
 #endif
 }
 
@@ -629,13 +681,7 @@ static void task_cloud_sync_fetch_cb(void *user_data, const char *path, bool suc
       sync_state->failures = true;
    }
 
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-   sync_state->waiting--;
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
+   task_cloud_sync_waiting_dec(sync_state);
 
    free(fetch_state);
 }
@@ -710,7 +756,7 @@ static void task_cloud_sync_fetch_server_file(task_cloud_sync_state_t *sync_stat
    fetch_state->sync_state  = sync_state;
    fetch_state->server_file = server_file;
    if (cloud_sync_read(key, filename, task_cloud_sync_fetch_cb, fetch_state))
-      sync_state->waiting++;
+      task_cloud_sync_waiting_inc(sync_state);
    else
    {
       RARCH_WARN(CSPFX "Wanted to fetch %s but failed.\n", key);
@@ -782,13 +828,7 @@ static void task_cloud_sync_upload_cb(void *user_data, const char *path, bool su
       sync_state->failures = true;
    }
 
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-   sync_state->waiting--;
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
+   task_cloud_sync_waiting_dec(sync_state);
 }
 
 /**
@@ -823,7 +863,7 @@ static void task_cloud_sync_upload_current_file(task_cloud_sync_state_t *sync_st
    item->userdata = task_cloud_sync_md5_rfile(file);
 
    filestream_seek(file, 0, SEEK_SET);
-   sync_state->waiting++;
+   task_cloud_sync_waiting_inc(sync_state);
    if (!cloud_sync_update(path, file, task_cloud_sync_upload_cb, sync_state))
    {
       /* if the upload fails, try to resurrect the hash from the last sync */
@@ -834,7 +874,7 @@ static void task_cloud_sync_upload_current_file(task_cloud_sync_state_t *sync_st
          task_cloud_sync_add_to_updated_manifest(sync_state, path, CS_FILE_HASH(local_file), false);
       }
       filestream_close(file);
-      sync_state->waiting--;
+      task_cloud_sync_waiting_dec(sync_state);
       sync_state->failures = true;
       RARCH_WARN(CSPFX "Uploading \"%s\" failed.\n", path);
    }
@@ -925,13 +965,7 @@ static void task_cloud_sync_delete_cb(void *user_data, const char *path, bool su
       }
       RARCH_WARN(CSPFX "Deleting \"%s\" failed.\n", path);
       sync_state->failures = true;
-#ifdef HAVE_THREADS
-      slock_lock(tcs_running_lock);
-#endif
-      sync_state->waiting--;
-#ifdef HAVE_THREADS
-      slock_unlock(tcs_running_lock);
-#endif
+      task_cloud_sync_waiting_dec(sync_state);
       return;
    }
 
@@ -942,13 +976,7 @@ static void task_cloud_sync_delete_cb(void *user_data, const char *path, bool su
    task_cloud_sync_add_to_updated_manifest(sync_state, path, NULL, true);
    task_cloud_sync_add_to_updated_manifest(sync_state, path, NULL, false);
    sync_state->need_manifest_uploaded = true;
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-   sync_state->waiting--;
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
+   task_cloud_sync_waiting_dec(sync_state);
 }
 
 static void task_cloud_sync_delete_server_file(task_cloud_sync_state_t *sync_state)
@@ -964,7 +992,7 @@ static void task_cloud_sync_delete_server_file(task_cloud_sync_state_t *sync_sta
 
    RARCH_LOG(CSPFX "Deleting \"%s\".\n", key);
 
-   sync_state->waiting++;
+   task_cloud_sync_waiting_inc(sync_state);
    if (!cloud_sync_free(key, task_cloud_sync_delete_cb, sync_state))
    {
       /* if the delete fails, resurrect the hash from the last sync */
@@ -976,7 +1004,7 @@ static void task_cloud_sync_delete_server_file(task_cloud_sync_state_t *sync_sta
       }
       task_cloud_sync_add_to_updated_manifest(sync_state, key, CS_FILE_HASH(server_file), true);
       /* we don't mark need_manifest_uploaded here, nothing has changed */
-      sync_state->waiting--;
+      task_cloud_sync_waiting_dec(sync_state);
    }
 }
 
@@ -1051,7 +1079,7 @@ static void task_cloud_sync_diff_next(task_cloud_sync_state_t *sync_state)
    if (!server_file && !local_file && !current_file)
    {
       RARCH_LOG(CSPFX "Finished processing manifests.\n");
-      sync_state->phase = CLOUD_SYNC_PHASE_UPDATE_MANIFESTS;
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_UPDATE_MANIFESTS);
       return;
    }
 
@@ -1173,14 +1201,8 @@ static void task_cloud_sync_update_manifest_cb(void *user_data, const char *path
       return;
 
    RARCH_LOG(CSPFX "Uploading updated manifest succeeded.\n");
-   sync_state->phase = CLOUD_SYNC_PHASE_END;
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-   sync_state->waiting = 0;
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
+   task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
+   task_cloud_sync_waiting_set(sync_state, 0);
 }
 
 static RFILE *task_cloud_sync_write_updated_manifest(file_list_t *manifest, char *path)
@@ -1274,23 +1296,23 @@ static void task_cloud_sync_update_manifests(task_cloud_sync_state_t *sync_state
          RARCH_ERR(CSPFX "Failed to write updated manifest to \"%s\".\n",
                manifest_path);
          sync_state->failures = true;
-         sync_state->phase    = CLOUD_SYNC_PHASE_END;
+         task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
          return;
       }
       filestream_seek(file, 0, SEEK_SET);
-      sync_state->waiting = 1;
+      task_cloud_sync_waiting_set(sync_state, 1);
       if (!cloud_sync_update(MANIFEST_FILENAME_SERVER, file, task_cloud_sync_update_manifest_cb, sync_state))
       {
          RARCH_ERR(CSPFX "Uploading updated manifest failed.\n");
          filestream_close(file);
-         sync_state->waiting = 0;
+         task_cloud_sync_waiting_set(sync_state, 0);
          sync_state->failures = true;
-         sync_state->phase = CLOUD_SYNC_PHASE_END;
+         task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
       }
       return;
    }
    else
-      sync_state->phase = CLOUD_SYNC_PHASE_END;
+      task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_END);
 }
 
 static void task_cloud_sync_end_handler(void *user_data, const char *path, bool success, RFILE *file)
@@ -1337,31 +1359,24 @@ static void task_cloud_sync_task_handler(retro_task_t *task)
    if (!(sync_state = (task_cloud_sync_state_t *)task->state))
       goto task_finished;
 
-#ifdef HAVE_THREADS
-   slock_lock(tcs_running_lock);
-#endif
-
-   /* We can transfer more than one file at a time */
-   if (sync_state->waiting > ((sync_state->phase == CLOUD_SYNC_PHASE_DIFF) 
-       ? 4U : 0U))
+   /* We can transfer more than one file at a time.  Both loads are
+    * acquire: completion callbacks may transition `phase` and drop
+    * `waiting` concurrently with this poll, and everything they
+    * published beforehand is visible once the loads observe it. */
+   if (task_cloud_sync_waiting_get(sync_state) >
+         ((task_cloud_sync_phase_get(sync_state) == CLOUD_SYNC_PHASE_DIFF) ? 4 : 0))
    {
       task->when = cpu_features_get_time_usec() + 17 * 1000; /* 17ms */
-#ifdef HAVE_THREADS
-      slock_unlock(tcs_running_lock);
-#endif
       return;
    }
-#ifdef HAVE_THREADS
-   slock_unlock(tcs_running_lock);
-#endif
 
    if (task->flags & RETRO_TASK_FLG_FINISHED)
        goto task_finished;
 
-   switch (sync_state->phase)
+   switch (task_cloud_sync_phase_get(sync_state))
    {
       case CLOUD_SYNC_PHASE_BEGIN:
-         sync_state->waiting = 1;
+         task_cloud_sync_waiting_set(sync_state, 1);
          if (!cloud_sync_begin(task_cloud_sync_begin_handler, task))
          {
             RARCH_WARN(CSPFX "Could not begin.\n");
@@ -1387,7 +1402,7 @@ static void task_cloud_sync_task_handler(retro_task_t *task)
          task_cloud_sync_update_manifests(sync_state);
          break;
       case CLOUD_SYNC_PHASE_END:
-         sync_state->waiting = 1;
+         task_cloud_sync_waiting_set(sync_state, 1);
          if (!cloud_sync_end(task_cloud_sync_end_handler, task))
          {
             RARCH_WARN(CSPFX "Could not end?!\n");
@@ -1446,8 +1461,8 @@ static void task_push_cloud_sync_with_mode(int conflict_resolution)
       return;
 
 #ifdef HAVE_THREADS
-   if (!tcs_running_lock)
-      tcs_running_lock = slock_new();
+   if (!tcs_manifest_lock)
+      tcs_manifest_lock = slock_new();
 #endif
 
    find_data.func = task_cloud_sync_task_finder;
@@ -1467,7 +1482,13 @@ static void task_push_cloud_sync_with_mode(int conflict_resolution)
       return;
    }
 
-   sync_state->phase               = CLOUD_SYNC_PHASE_BEGIN;
+   /* calloc zero-fill is not a portable initializer for an atomic
+    * (illegal formally under C11 stdatomic, and a class type on the
+    * C++11 backend) - initialize it explicitly. */
+   retro_atomic_int_init(&sync_state->waiting, 0);
+   retro_atomic_int_init(&sync_state->phase, (int)CLOUD_SYNC_PHASE_BEGIN);
+
+   task_cloud_sync_phase_set(sync_state, CLOUD_SYNC_PHASE_BEGIN);
    sync_state->start_time          = cpu_features_get_time_usec();
    sync_state->conflict_resolution = conflict_resolution;
 


### PR DESCRIPTION
## Summary

Audit of every `slock_t` / `std::mutex` / raw-intrinsic site outside `deps/` for candidates where a mutex or ad-hoc atomic should be `retro_atomic`. Most locks in the tree are correct and stay (scond coupling, multi-field invariants, operation serialization); this PR migrates the four sites that shouldn't be locks or raw intrinsics, and in doing so fixes two real data races in cloud sync.

Four commits, independent, ordered by severity:

## 1. `task_cloudsync`: fix data races on the phase and in-flight counters

Two cross-thread races around the async transfer bookkeeping:

- **`waiting` counter** — every decrement in a `cloud_sync_*` completion callback took `tcs_running_lock`, but all three increments, the dispatch-side `= 0` / `= 1` stores, and the dispatch-failure rollbacks ran with **no lock at all**. A driver may invoke its completion callback from another thread, at which point an unlocked `++` racing a locked `--` is a data race on a plain `uint32_t`.
- **`phase`** — written by completion callbacks with no lock while the task handler's poll read it under the lock. A lock only orders accesses that both take it, so the write side raced the poll regardless. This one predates the counter problem and **reproduces on the unpatched file**: driving the pristine TU with a completion-on-another-thread driver, TSan flags `begin_handler`'s phase store against the poll's read immediately.

Both fields become `retro_atomic_int_t` behind small accessors: release stores / acq_rel RMWs on the writer side, acquire loads in the poll and dispatch switch. The release/acquire pairing reproduces the ordering the old lock provided on the one path it actually covered, and closes the paths it didn't. The mutex is **not** removed — it still serializes concurrent appends to `updated_*_manifest` from callbacks, renamed `tcs_manifest_lock` to say so. `waiting` also changes `uint32_t` → `int`: an underflow bug now reads negative (observable) instead of wrapping to ~4 billion and wedging the sync forever.

## 2. `opensl`: real acquire/release semantics for `buffered_blocks`

`buffered_blocks` was `volatile unsigned` mutated with raw `__sync_fetch_and_sub/add` but **read** with plain volatile loads: the nonblock full-queue check, the cond-wait predicate, and `sl_write_avail` all lacked acquire semantics; the initial store was plain. This driver only runs on Android — always weakly-ordered ARM/AArch64, where a volatile load orders nothing. Migrated to `retro_atomic_int_t` (acq_rel RMWs, acquire loads, release init store, explicit `retro_atomic_int_init` after calloc). Also removes the last raw `__sync_*` intrinsics in the audio drivers, matching the consolidation `retro_atomic.h`'s header comment already claims for this file. `sl->lock` / `sl->cond` and the wait-predicate bounding logic are untouched.

## 3. `play_feature_delivery`: lock-free Play-Store-build query

`play_feature_delivery_enabled()` is called frequently, often in loops (its own comment says so), yet every call took `enabled_lock` just to read two bools implementing a lazy-init cache. Collapsed `enabled`/`enabled_set` into one `retro_atomic_int_t` (−1 unknown / 0 / 1, statically initialized to −1). Hot path is a single acquire load, no lock. A cold race can at worst issue the idempotent JNI query twice with both threads storing the same value. `status_lock` is untouched (multi-field struct + string). Net −15 lines.

## 4. `xaudio`: migrate the `buffers` counter to retro_atomic

`InterlockedIncrement/Decrement` on the RMW side but plain volatile loads on every read: the full-queue spin in `xa_write` and both `XAUDIO2_WRITE_AVAILABLE` call sites. MSVC volatile carries acquire/release only under `/volatile:ms` (x86/x64 default); ARM64 defaults to `/volatile:iso`, so on Windows-on-ARM the producer's reads ordered nothing against the engine thread's `OnBufferEnd`. Migrated to `retro_atomic_int_t` in both callback paths (C++ member and C vtable). The `XAUDIO2_WRITE_AVAILABLE` macro also read the counter **twice** per evaluation, so the occupancy report could mix two different counter values; replaced by `xaudio2_write_available()`, which reads once with acquire and keeps the bufptr-aware arithmetic.

## Not migrated (deliberately)

Everything else was audited and stays mutexed, for one of two reasons: scond coupling (all remaining audio drivers, thread wrappers, video_filter, save autosave, rzip parallel, task_queue, record/ffmpeg cores, dispmanx/drm/sunxi/vc_egl vsync waits, vulkan mailbox, thumbnail worker, cocoa cond pump) or multi-word invariants / operation serialization (net_http pools, audio_mixer voices, core_info lifecycle, cheevos badge-queue iterator, widget queues, mmdevice ID strings, coremidi queues, video_driver display/context/cached_frame locks, rtime, libusb transfer serialization, vulkan `queue_lock`, glslang). `winraw_input`'s `InterlockedExchange` needs a swap op `retro_atomic` deliberately doesn't offer; left as-is. COM refcount `Interlocked*` in mmdevice is AddRef/Release convention; left as-is.

## Verification

**Compile:**
- cloudsync: full TU via make (gcc 13) + `-std=c89 -pedantic` pass
- opensl: aarch64 cross-compile against AOSP OpenSL ES headers, warning profile identical to baseline
- play_feature: aarch64 against NDK headers, baseline parity
- xaudio: mingw-w64 C mode clean (baseline also clean); C++ mode fails with the same 8 pre-existing harness errors as baseline (mingw's `xaudio2.h` lacks the C-macro shims), none from the patch

**Sanitizers — real-TU sweeps** (actual patched objects linked against real libretro-common, only the platform boundary faked):
- **cloudsync**: fake cloud driver completing on its own threads; 20 iterations × 24-file sync, full phase walk, >4 concurrent-upload DIFF gate exercised. Clean under ASan+UBSan+LSan and TSan (3 runs). *Baseline control: the unpatched TU under the same harness trips TSan on the phase race — the harness demonstrably detects what it's meant to.*
- **opensl**: fake SLES engine firing completion callbacks from a real second thread; 8.4 MB of byte-sequence-validated payload through blocking + nonblock paths + stop/start. Clean under ASan+UBSan+LSan and TSan (3 runs).
- **play_feature**: fake JNI env with a widened cold-init window; 60 independent TSan process runs × 16 threads hammering the unresolved cache, plus init/deinit lifecycle churn. Zero races, LSan clean.
- **xaudio**: cannot be executed under sanitizers off-Windows (no COM/Win32 runtime, no libtsan for mingw targets). Covered by a pattern harness (real `retro_atomic` + rthreads replicating the exact buffers-ring and read-once write_avail pattern) clean under both configs, with a working negative control: degrading the acquire load back to a plain volatile read makes TSan fire immediately.