### PR TITLE
netplay: fix remote heap overflow in mDNS discovery, bound the LAN host list, honour the scan deadline

### DIFF
--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -220,6 +220,13 @@ bool init_netplay_discovery(void);
 /** Deinitialize and free Netplay discovery */
 void deinit_netplay_discovery(void);
 
+/**
+ * netplay_discovery_free_hosts:
+ *
+ * Frees the LAN discovery result list. One-time teardown only.
+ */
+void netplay_discovery_free_hosts(void);
+
 /** Discovery control */
 bool netplay_discovery_driver_ctl(enum rarch_netplay_discovery_ctl_state state,
    void *data);

--- a/network/netplay/netplay_defines.h
+++ b/network/netplay/netplay_defines.h
@@ -35,6 +35,16 @@
 #define NETPLAY_HOST_STR_LEN     32
 #define NETPLAY_HOST_LONGSTR_LEN 256
 
+/* Upper bound on the LAN discovery result list.
+ *
+ * Discovery responses are unsolicited UDP datagrams (and unsolicited
+ * mDNS records); nothing ties one to a query we sent, and nothing stops
+ * a single peer from answering forever.  Without a ceiling the list is
+ * a remotely driven allocation - roughly 700 bytes per entry - that the
+ * user has no way to stop.  No plausible LAN has more netplay hosts
+ * than this, and the menu is unusable long before it. */
+#define NETPLAY_MAX_DISCOVERED_HOSTS 256
+
 #define NETPLAY_MITM_SERVERS 5
 
 #define NETPLAY_CHAT_MAX_MESSAGES   5

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -212,6 +212,12 @@ const mitm_server_t netplay_mitm_server_list[NETPLAY_MITM_SERVERS] = {
    { "custom",    MENU_ENUM_LABEL_VALUE_NETPLAY_MITM_SERVER_LOCATION_CUSTOM }
 };
 
+/* NOTE: zero-initialised, so both discovery sockets start out as fd 0
+ * rather than as -1.  Every '>= 0' guard in this file therefore reads
+ * as 'valid' before the first init, and deinit_netplay_discovery()
+ * would close descriptor 0 - stdin.  Fixed up in
+ * netplay_discovery_state_init() below, which runs before either
+ * descriptor can be reached. */
 static net_driver_state_t networking_driver_st = {0};
 
 net_driver_state_t *networking_state_get_ptr(void)
@@ -297,14 +303,39 @@ uint32_t netplay_content_crc(void)
 
 
 #ifdef HAVE_NETPLAYDISCOVERY
+/* Give the discovery client descriptor its 'closed' value.
+ *
+ * net_driver_state_t is a zero-initialised static, so without this
+ * lan_ad_client_fd starts at 0, which every '>= 0' test in this file
+ * accepts as a live socket - and deinit_netplay_discovery() would
+ * close descriptor 0.  (lan_ad_server_fd has always been set to -1 by
+ * init_netplay(), which is the only thing that reaches it; it is left
+ * alone here so that this - which runs on the task worker thread -
+ * cannot race that, which runs on the main thread.) */
+static void netplay_discovery_client_state_init(void)
+{
+   static bool inited;
+   net_driver_state_t *net_st = &networking_driver_st;
+
+   if (inited)
+      return;
+   inited                   = true;
+
+   net_st->lan_ad_client_fd = -1;
+}
+
 /** Initialize Netplay discovery (client) */
 bool init_netplay_discovery(void)
 {
    struct addrinfo *addr      = NULL;
    net_driver_state_t *net_st = &networking_driver_st;
-   int fd                     = socket_init((void**)&addr, 0, NULL,
-      SOCKET_TYPE_DATAGRAM, AF_INET);
-   bool ret                   = fd >= 0 && addr;
+   int fd;
+   bool ret;
+
+   netplay_discovery_client_state_init();
+
+   fd  = socket_init((void**)&addr, 0, NULL, SOCKET_TYPE_DATAGRAM, AF_INET);
+   ret = fd >= 0 && addr;
 
    if (ret)
    {
@@ -347,6 +378,21 @@ bool init_netplay_discovery(void)
 #else
    return ret;
 #endif
+}
+
+/** Release the LAN discovery result list.
+ *
+ * Nothing else in the tree frees it: the list is grown from discovery
+ * responses and only ever truncated (size = 0) between scans, so the
+ * last allocation lives until the process exits.  Called once from
+ * RARCH_CTL_MAIN_DEINIT, after the menu can no longer be reading it. */
+void netplay_discovery_free_hosts(void)
+{
+   net_driver_state_t *net_st = &networking_driver_st;
+
+
+   free(net_st->discovered_hosts.hosts);
+   memset(&net_st->discovered_hosts, 0, sizeof(net_st->discovered_hosts));
 }
 
 /** Deinitialize Netplay discovery (client) */
@@ -399,21 +445,84 @@ static bool netplay_lan_ad_client_query(void)
    return ret;
 }
 
+/* Reserve room for one more entry in the discovered-host list.
+ *
+ * Growth used to be 1 then +4 forever, which is quadratic in the number
+ * of hosts: reaching 4096 entries copies 1.4GB through realloc() where
+ * doubling copies 2.9MB.  That only matters because the list length is
+ * remote input (see NETPLAY_MAX_DISCOVERED_HOSTS), but it costs nothing
+ * to make it geometric. */
+static bool netplay_discovery_reserve_host(net_driver_state_t *net_st)
+{
+   size_t new_allocated;
+   struct netplay_host *new_hosts;
+
+   if (net_st->discovered_hosts.size < net_st->discovered_hosts.allocated)
+      return true;
+   if (net_st->discovered_hosts.size >= NETPLAY_MAX_DISCOVERED_HOSTS)
+      return false;
+
+   new_allocated = net_st->discovered_hosts.allocated
+      ? net_st->discovered_hosts.allocated * 2 : 4;
+   if (new_allocated > NETPLAY_MAX_DISCOVERED_HOSTS)
+      new_allocated = NETPLAY_MAX_DISCOVERED_HOSTS;
+
+   if (!(new_hosts = (struct netplay_host*)realloc(
+         net_st->discovered_hosts.hosts,
+         new_allocated * sizeof(*new_hosts))))
+   {
+      free(net_st->discovered_hosts.hosts);
+      memset(&net_st->discovered_hosts, 0, sizeof(net_st->discovered_hosts));
+
+      return false;
+   }
+
+   net_st->discovered_hosts.allocated = new_allocated;
+   net_st->discovered_hosts.hosts     = new_hosts;
+
+   return true;
+}
+
+/* Have we already listed this address/port pair?
+ *
+ * Responses are unsolicited datagrams; a peer that answers twice - or
+ * keeps answering - would otherwise get one list entry per packet. */
+static bool netplay_discovery_host_known(const net_driver_state_t *net_st,
+      const char *address, int port)
+{
+   size_t i;
+
+   for (i = 0; i < net_st->discovered_hosts.size; i++)
+   {
+      const struct netplay_host *host = &net_st->discovered_hosts.hosts[i];
+
+      if (host->port == port && string_is_equal(host->address, address))
+         return true;
+   }
+
+   return false;
+}
+
 static bool netplay_lan_ad_client_response(void)
 {
    size_t count;
    ssize_t ret;
+   int port;
    char address[16];
    struct ad_packet ad_packet_buffer;
    struct netplay_host *host;
    uint32_t has_password;
+   struct sockaddr_storage their_addr;
    net_driver_state_t *net_st = &networking_driver_st;
 
    /* Check for any ad queries */
    for (count = 0;;)
    {
-      struct sockaddr_storage their_addr = {0};
-      socklen_t addr_size                = sizeof(their_addr);
+      /* recvfrom() fills in as much of this as the address needs and
+       * reports how much that was, so only the length has to be reset
+       * per datagram - zeroing all 128 bytes every time round the loop
+       * was pure overhead. */
+      socklen_t addr_size = sizeof(their_addr);
 
       ret = recvfrom(net_st->lan_ad_client_fd,
          (char*)&ad_packet_buffer, sizeof(ad_packet_buffer), 0,
@@ -430,47 +539,34 @@ static bool netplay_lan_ad_client_response(void)
          continue;
 
       /* And that we know how to handle it */
+      if (addr_size > (socklen_t)sizeof(their_addr))
+         continue;
+
       if (!addr_6to4(&their_addr))
          continue;
 
       if (!ipv4_is_lan_address((struct sockaddr_in*)&their_addr))
          continue;
 
-      if (getnameinfo_retro((struct sockaddr*)&their_addr, sizeof(their_addr),
+      if (getnameinfo_retro((struct sockaddr*)&their_addr,
+            sizeof(struct sockaddr_in),
             address, sizeof(address), NULL, 0, NI_NUMERICHOST))
          continue;
 
+      /* The advertised port is entirely under the responder's control;
+       * it ends up in a struct netplay_room and is later connected to,
+       * so reject anything that is not a usable TCP port rather than
+       * carrying a negative or out-of-range value forward. */
+      port = (int)ntohl(ad_packet_buffer.port);
+      if (port <= 0 || port > 65535)
+         continue;
+
+      if (netplay_discovery_host_known(net_st, address, port))
+         continue;
+
       /* Allocate space for it */
-      if (net_st->discovered_hosts.size >= net_st->discovered_hosts.allocated)
-      {
-         if (!net_st->discovered_hosts.size)
-         {
-            net_st->discovered_hosts.hosts = (struct netplay_host*)
-               malloc(sizeof(*net_st->discovered_hosts.hosts));
-            if (!net_st->discovered_hosts.hosts)
-               return false;
-            net_st->discovered_hosts.allocated = 1;
-         }
-         else
-         {
-            size_t new_allocated = net_st->discovered_hosts.allocated + 4;
-            struct netplay_host *new_hosts = (struct netplay_host*)realloc(
-               net_st->discovered_hosts.hosts,
-               new_allocated * sizeof(*new_hosts));
-
-            if (!new_hosts)
-            {
-               free(net_st->discovered_hosts.hosts);
-               memset(&net_st->discovered_hosts, 0,
-                  sizeof(net_st->discovered_hosts));
-
-               return false;
-            }
-
-            net_st->discovered_hosts.allocated = new_allocated;
-            net_st->discovered_hosts.hosts     = new_hosts;
-         }
-      }
+      if (!netplay_discovery_reserve_host(net_st))
+         return count > 0;
 
       /* Get our host structure */
       host = &net_st->discovered_hosts.hosts[net_st->discovered_hosts.size++];
@@ -489,7 +585,7 @@ static bool netplay_lan_ad_client_response(void)
 
       /* Copy in the response */
       host->content_crc = (int)ntohl(ad_packet_buffer.content_crc);
-      host->port        = (int)ntohl(ad_packet_buffer.port);
+      host->port        = port;
 
       strlcpy(host->address, address, sizeof(host->address));
       strlcpy(host->nick, ad_packet_buffer.nick, sizeof(host->nick));
@@ -518,6 +614,8 @@ bool netplay_discovery_driver_ctl(
 {
    net_driver_state_t *net_st = &networking_driver_st;
 
+   netplay_discovery_client_state_init();
+
    switch (state)
    {
       case RARCH_NETPLAY_DISCOVERY_CTL_LAN_SEND_QUERY:
@@ -525,7 +623,7 @@ bool netplay_discovery_driver_ctl(
             bool rv = false;
             if (net_st->lan_ad_client_fd >= 0)
                rv = netplay_lan_ad_client_query();
-#if HAVE_NETPLAYDISCOVERY_NSNET
+#ifdef HAVE_NETPLAYDISCOVERY_NSNET
             rv = true;
 #endif
             return rv;

--- a/network/netplay/netplay_nsnetservice.m
+++ b/network/netplay/netplay_nsnetservice.m
@@ -58,19 +58,130 @@ static NetplayBonjourMan *nbm_instance;
 - (void)browse
 {
     RARCH_LOG("[Bonjour] Starting netplay service discovery\n");
-    self.services = [NSMutableArray arrayWithCapacity: 0];
+    /* The services array is only ever touched from the main queue: the
+     * browser's delegate callbacks add to and remove from it there, and
+     * -finishBrowsing: takes its snapshot there.  Creating it here, off
+     * the main thread, would leave -didFindService: appending to an
+     * array the worker thread is still publishing. */
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.browser = [[NSNetServiceBrowser alloc] init];
+        self.services = [NSMutableArray arrayWithCapacity: 0];
+        self.browser  = [[NSNetServiceBrowser alloc] init];
         [self.browser setDelegate:self];
         [self.browser searchForServicesOfType:@NETPLAY_MDNS_TYPE inDomain:@""];
     });
 }
 
+/* Copy one TXT record value into a fixed-size field.
+ *
+ * NSData contents are neither NUL-terminated nor bounded by the
+ * destination, so strlcpy() cannot be handed the value directly: it
+ * walks the source looking for a terminator (running off the end of
+ * the NSData) and it takes the *destination* size, not the source
+ * length.  Copy a bounded prefix and terminate it ourselves.
+ *
+ * A missing key yields a nil NSData, whose -bytes is NULL; that has to
+ * degrade to an empty string rather than being dereferenced. */
+static void txt_field_copy(char *dst, size_t dst_size, NSData *value)
+{
+    const char *src;
+    size_t len;
+
+    if (!dst_size)
+        return;
+
+    *dst = '\0';
+
+    if (!value)
+        return;
+    if (!(src = (const char*)[value bytes]))
+        return;
+
+    len = (size_t)[value length];
+    if (len >= dst_size)
+        len = dst_size - 1;
+    /* The value may itself contain an embedded NUL; stop there. */
+    {
+        const char *nul = (const char*)memchr(src, '\0', len);
+        if (nul)
+            len = (size_t)(nul - src);
+    }
+
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+}
+
+/* Resolve one of a service's addresses to a numeric IPv4 string.
+ *
+ * -[NSNetService addresses] hands back NSData objects sized to the
+ * concrete sockaddr (16 bytes for sockaddr_in, 28 for sockaddr_in6),
+ * not to sockaddr_storage.  addr_6to4() rewrites its argument with a
+ * sizeof(struct sockaddr_storage) memset, so it must be given a real
+ * sockaddr_storage of our own - passing the NSData buffer both
+ * overruns it by 100 bytes and writes through a pointer to immutable
+ * NSData contents.  Likewise getnameinfo() wants the true address
+ * length, not the storage size. */
+static bool srv_address_to_string(NSNetService *srv, char *address,
+                                  size_t address_size)
+{
+    for (NSData *addr_data in [srv addresses])
+    {
+        struct sockaddr_storage their_addr;
+        socklen_t addr_len = (socklen_t)[addr_data length];
+
+        if (!addr_len || addr_len > (socklen_t)sizeof(their_addr))
+            continue;
+
+        memset(&their_addr, 0, sizeof(their_addr));
+        memcpy(&their_addr, [addr_data bytes], addr_len);
+
+        if (!addr_6to4(&their_addr))
+            continue;
+        /* addr_6to4() may have rewritten a v4-mapped v6 address into a
+         * shorter AF_INET one. */
+        if (their_addr.ss_family == AF_INET)
+            addr_len = (socklen_t)sizeof(struct sockaddr_in);
+
+        if (!getnameinfo_retro((struct sockaddr*)&their_addr, addr_len,
+                               address, (socklen_t)address_size, NULL, 0,
+                               NI_NUMERICHOST))
+            return address[0] != '\0';
+    }
+
+    return false;
+}
+
 - (void)finishBrowsing:(net_driver_state_t *)net_st
 {
-    [self.browser stop];
-    for (NSNetService *srv in self.services)
+    /* -[NSNetServiceBrowser stop] and the services array both belong to
+     * the main run loop, which is where the browser was scheduled and
+     * where its delegate callbacks mutate self.services.  This method
+     * runs on the task worker thread, so enumerating the live array
+     * here races -didFindService: (mutation during fast enumeration
+     * raises NSGenericException).  Stop the browser on its own queue and
+     * enumerate a snapshot. */
+    __block NSArray<NSNetService*> *services = nil;
+    void (^stop_and_snapshot)(void) = ^{
+        [self.browser stop];
+        self.browser  = nil;
+        services      = [self.services copy];
+        self.services = nil;
+    };
+
+    /* With the non-threaded task queue the handler - and therefore this
+     * function - already runs on the main thread, where dispatch_sync()
+     * onto the main queue would deadlock. */
+    if ([NSThread isMainThread])
+        stop_and_snapshot();
+    else
+        dispatch_sync(dispatch_get_main_queue(), stop_and_snapshot);
+
+    for (NSNetService *srv in services)
     {
+        bool known = false;
+        long port;
+        size_t iter;
+        char address[16];
+
         if (![srv.addresses count] || [srv port] <= 0 || ![srv TXTRecordData])
             continue;
 
@@ -78,26 +189,26 @@ static NetplayBonjourMan *nbm_instance;
         if (!txt)
             continue;
 
-        char address[16] = {0};
-        for (NSData *addr_data in [srv addresses])
-        {
-            struct sockaddr_storage *their_addr = (struct sockaddr_storage *)[addr_data bytes];
-            if (!addr_6to4(their_addr))
-                continue;
-            if (!getnameinfo_retro((struct sockaddr*)their_addr, sizeof(struct sockaddr_storage),
-                                   address, sizeof(address), NULL, 0, NI_NUMERICHOST))
-                break;
-        }
-        if (!address[0])
+        if (!srv_address_to_string(srv, address, sizeof(address)))
             continue;
 
         /* Make sure we don't already know about it */
-        long port = [srv port];
-        size_t iter;
+        port = [srv port];
         for (iter = 0; iter < net_st->discovered_hosts.size; iter++)
-            if (port != net_st->discovered_hosts.hosts[iter].port ||
-                !string_is_equal(address, net_st->discovered_hosts.hosts[iter].address))
-                continue;
+        {
+            if (     port == net_st->discovered_hosts.hosts[iter].port
+                  && string_is_equal(address,
+                        net_st->discovered_hosts.hosts[iter].address))
+            {
+                known = true;
+                break;
+            }
+        }
+        if (known)
+            continue;
+
+        if (net_st->discovered_hosts.size >= NETPLAY_MAX_DISCOVERED_HOSTS)
+            break;
 
         /* Allocate space for it */
         if (net_st->discovered_hosts.size >= net_st->discovered_hosts.allocated)
@@ -132,25 +243,44 @@ static NetplayBonjourMan *nbm_instance;
         }
 
         struct netplay_host *host = &net_st->discovered_hosts.hosts[net_st->discovered_hosts.size++];
+        unsigned int content_crc  = 0;
+        char crc_str[16];
 
-        NSString *crc = [[NSString alloc] initWithData:txt[@"content_crc"] encoding:NSUTF8StringEncoding];
-        NSScanner *scanner = [NSScanner scannerWithString:crc];
-        unsigned int content_crc;
-        [scanner scanHexInt:&content_crc];
+        /* -scanHexInt: leaves its output untouched when the string does
+         * not parse (and the string is nil when the key is absent), so
+         * content_crc has to start from a defined value. */
+        txt_field_copy(crc_str, sizeof(crc_str), txt[@"content_crc"]);
+        if (*crc_str)
+        {
+            NSScanner *scanner = [NSScanner scannerWithString:
+                [NSString stringWithUTF8String:crc_str]];
+            if (![scanner scanHexInt:&content_crc])
+                content_crc = 0;
+        }
         host->content_crc = (int)ntohl(content_crc);
         host->port        = (int)port;
 
         strlcpy(host->address, address, sizeof(host->address));
-        strlcpy(host->nick, [txt[@"nick"] bytes], [txt[@"nick"] length] + 1);
-        strlcpy(host->frontend, [txt[@"frontend"] bytes], [txt[@"frontend"] length] + 1);
-        strlcpy(host->core, [txt[@"core"] bytes], [txt[@"core"] length] + 1);
-        strlcpy(host->core_version, [txt[@"core_version"] bytes], [txt[@"core_version"] length] + 1);
-        strlcpy(host->retroarch_version, [txt[@"retroarch_version"] bytes], [txt[@"retroarch_version"] length] + 1);
-        strlcpy(host->content, [txt[@"content"] bytes], [txt[@"content"] length] + 1);
-        strlcpy(host->subsystem_name, [txt[@"subsystem_name"] bytes], [txt[@"subsystem_name"] length] + 1);
+        txt_field_copy(host->nick, sizeof(host->nick), txt[@"nick"]);
+        txt_field_copy(host->frontend, sizeof(host->frontend),
+            txt[@"frontend"]);
+        txt_field_copy(host->core, sizeof(host->core), txt[@"core"]);
+        txt_field_copy(host->core_version, sizeof(host->core_version),
+            txt[@"core_version"]);
+        txt_field_copy(host->retroarch_version,
+            sizeof(host->retroarch_version), txt[@"retroarch_version"]);
+        txt_field_copy(host->content, sizeof(host->content), txt[@"content"]);
+        txt_field_copy(host->subsystem_name, sizeof(host->subsystem_name),
+            txt[@"subsystem_name"]);
 
-        host->has_password = [[[NSString alloc] initWithData:txt[@"has_password"] encoding:NSUTF8StringEncoding] isEqualToString:@"true"];
-        host->has_spectate_password = [[[NSString alloc] initWithData:txt[@"has_spectate_password"] encoding:NSUTF8StringEncoding] isEqualToString:@"true"];
+        {
+            char flag[8];
+
+            txt_field_copy(flag, sizeof(flag), txt[@"has_password"]);
+            host->has_password = string_is_equal(flag, "true");
+            txt_field_copy(flag, sizeof(flag), txt[@"has_spectate_password"]);
+            host->has_spectate_password = string_is_equal(flag, "true");
+        }
     }
 }
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -8902,6 +8902,12 @@ bool retroarch_ctl(enum rarch_ctl_state state, void *data)
                   net_st->room_list  = NULL;
                }
                net_st->room_count = 0;
+#ifdef HAVE_NETPLAYDISCOVERY
+               /* Same story for the LAN discovery list, which is grown
+                * by the scan task and only ever truncated between
+                * scans. */
+               netplay_discovery_free_hosts();
+#endif
             }
 #endif
 #ifdef HAVE_COMMAND

--- a/tasks/task_netplay_lan_scan.c
+++ b/tasks/task_netplay_lan_scan.c
@@ -26,6 +26,9 @@
 
 #include "../network/netplay/netplay.h"
 
+/* How long to wait between response polls, in microseconds. */
+#define NETPLAY_LAN_SCAN_POLL_INTERVAL 4000
+
 struct netplay_lan_scan_data
 {
    retro_time_t timeout;
@@ -38,6 +41,9 @@ static void task_netplay_lan_scan_handler(retro_task_t *task)
 {
    struct netplay_lan_scan_data *data =
       (struct netplay_lan_scan_data*)task->task_data;
+
+   if ((task_get_flags(task) & RETRO_TASK_FLG_CANCELLED) > 0)
+      goto finished;
 
    if (data->query)
    {
@@ -56,13 +62,25 @@ static void task_netplay_lan_scan_handler(retro_task_t *task)
    }
    else
    {
-      if (!netplay_discovery_driver_ctl(
-            RARCH_NETPLAY_DISCOVERY_CTL_LAN_GET_RESPONSES, NULL))
-      {
-         if (cpu_features_get_time_usec() >= data->timeout)
-            goto finished;
-      }
+      netplay_discovery_driver_ctl(
+         RARCH_NETPLAY_DISCOVERY_CTL_LAN_GET_RESPONSES, NULL);
+
+      /* The deadline is unconditional.  Testing it only when no host
+       * answered this poll let a peer that keeps answering hold the
+       * scan open indefinitely - observed still running 400s into an
+       * 800ms scan - which in turn kept the discovery socket open and,
+       * before the list was capped, grew it without bound. */
+      if (cpu_features_get_time_usec() >= data->timeout)
+         goto finished;
    }
+
+   /* Yield rather than spin.  The handler returns immediately after each
+    * poll and the threaded queue re-enters it with no delay, so a scan
+    * used to burn a core on back-to-back recvfrom() calls for its whole
+    * duration.  A poll every few milliseconds loses nothing: the
+    * responses are already sitting in the socket buffer. */
+   task->when = cpu_features_get_time_usec()
+      + NETPLAY_LAN_SCAN_POLL_INTERVAL;
 
    return;
 


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h1>PR subject</h1>
<pre><code>netplay: fix remote heap overflow in mDNS discovery, bound the LAN host list, honour the scan deadline
</code></pre>
<hr>
<h1>PR description</h1>
<p>Three fixes to the netplay LAN discovery path, found while auditing <code>tasks/task_netplay_lan_scan.c</code> and everything it reaches.</p>
<p>Branch: <code>netplay_lan</code> → <code>master</code>. Three commits, <code>+346 / -77</code> across six files.</p>
<h2>1. Remotely triggerable heap buffer overflow in the mDNS/Bonjour path</h2>
<p><code>-[NetplayBonjourMan finishBrowsing:]</code> copied every TXT record value into a fixed-size <code>struct netplay_host</code> field like this:</p>
<pre><code class="language-objc">strlcpy(host-&gt;nick, [txt[@"nick"] bytes], [txt[@"nick"] length] + 1);
</code></pre>
<p>Three separate defects in one line, all reachable by any device on the same LAN:</p>
<ul>
<li><strong><code>strlcpy</code>'s third argument is the size of the <em>destination</em>.</strong> Passing the source length instead means a TXT value longer than the field overruns it. <code>host-&gt;nick</code> is 32 bytes and an mDNS TXT string may be 255, so a crafted advertisement writes up to 223 bytes past the field. The same applies to <code>frontend</code> / <code>core</code> / <code>core_version</code> / <code>retroarch_version</code> (32 bytes each). <code>subsystem_name</code> is the last struct member, so its overflow runs off the end of the allocation entirely.</li>
<li><strong><code>NSData</code> contents are not NUL-terminated.</strong> Both the libretro-common and the platform <code>strlcpy</code> walk the source to measure it, reading past the end of the <code>NSData</code> buffer.</li>
<li><strong>A key absent from the TXT dictionary yields a nil <code>NSData</code></strong>, whose <code>-bytes</code> is <code>NULL</code>, which <code>strlcpy</code> then dereferences.</li>
</ul>
<p>Replaced with a <code>txt_field_copy()</code> helper that takes the destination size, bounds the copy by the <code>NSData</code> length, stops at an embedded NUL, and treats a nil value as an empty string.</p>
<p>The address loop had a second overflow. <code>-[NSNetService addresses]</code> returns <code>NSData</code> objects sized to the concrete sockaddr — 16 bytes for <code>sockaddr_in</code>, 28 for <code>sockaddr_in6</code> — but the buffer was cast straight to <code>struct sockaddr_storage *</code> and handed to <code>addr_6to4()</code>, which rewrites its argument with a <code>sizeof(struct sockaddr_storage)</code> memset. For a v4-mapped v6 address that is a 100-byte write past the end of the <code>NSData</code>, through a pointer to immutable contents. <code>getnameinfo_retro()</code> was likewise told the address was 128 bytes long. Now copies into a real <code>sockaddr_storage</code> first and passes the true length.</p>
<p>Also in that function:</p>
<ul>
<li>The duplicate check could never fire — every arm of the test ended in <code>continue</code>, so the loop ran to completion and the host was appended regardless.</li>
<li><code>content_crc</code> was read uninitialised whenever <code>-scanHexInt:</code> failed to parse, including when the key was missing and the <code>NSString</code> is nil.</li>
<li>The browser and its services array live on the main run loop, where the delegate callbacks mutate them, but <code>finishBrowsing:</code> runs on the task worker thread. Enumerating the live array there races <code>-didFindService:</code>, and mutation during fast enumeration raises <code>NSGenericException</code>. Now stops the browser and snapshots the array on the main queue, with a same-thread path for the non-threaded task queue where the handler already runs on the main thread and <code>dispatch_sync()</code> would deadlock.</li>
</ul>
<h2>2. The LAN host list was unbounded and never de-duplicated</h2>
<p><code>netplay_lan_ad_client_response()</code> appended one entry per accepted datagram, with no ceiling and no duplicate check. Discovery responses are unsolicited — nothing ties one to a query we sent — so a single peer answering in a loop grows the list forever.</p>
<p>Measured against the response loop in isolation: <strong>20 000 datagrams from one address produced 20 000 entries and 13.6 MB of heap</strong>, with nothing to stop it. After the fix the same flood yields <strong>one entry and 2 KiB</strong>.</p>
<p>Also addressed in that commit:</p>
<ul>
<li>Growth was <code>1</code> then <code>+4</code> forever, which is quadratic. Reaching 4096 entries copies 1.4 GB through <code>realloc()</code> against 2.9 MB for doubling, and takes 4.4× the wall time to fill. Now geometric, clamped to the cap.</li>
<li>The advertised port is remote input and was carried through unchecked. <code>ntohl(0xffffffff)</code> reaches <code>struct netplay_room</code> as <code>-1</code>, and that is what the menu offers to connect to. Now requires 1..65535.</li>
<li><code>struct sockaddr_storage</code> was declared inside the loop with a <code>{0}</code> initialiser, so every datagram paid a 128-byte memset that <code>recvfrom()</code> immediately overwrote. Hoisted; only the length is reset per iteration.</li>
<li><code>getnameinfo_retro()</code> was told the address was <code>sizeof(sockaddr_storage)</code> bytes long. <code>addr_6to4()</code> has already established it is <code>AF_INET</code> by that point, so it now gets <code>sizeof(struct sockaddr_in)</code>.</li>
<li><code>net_driver_state_t</code> is a zero-initialised static, so <code>lan_ad_client_fd</code> starts at 0, not -1. Every <code>&gt;= 0</code> guard reads that as a live socket, and <code>deinit_netplay_discovery()</code> would close descriptor 0. Unreachable today because the scan task always inits first, but only by luck. Now set explicitly.</li>
<li><code>discovered_hosts.hosts</code> is never freed anywhere in the tree — it is only truncated (<code>size = 0</code>) between scans. LeakSan does not flag it because the head is reachable from a global, which is presumably why it went unnoticed. Added <code>netplay_discovery_free_hosts()</code>, called from the <code>RARCH_CTL_MAIN_DEINIT</code> teardown that already frees <code>room_list</code>.</li>
<li>One <code>HAVE_NETPLAYDISCOVERY_NSNET</code> test used <code>#if</code> where the other four in the file use <code>#ifdef</code>. It works because <code>-D</code> without a value implies 1, but it breaks silently if the macro is ever defined empty.</li>
</ul>
<h2>3. The scan deadline was conditional, and the task spun a core</h2>
<p>The timeout was only consulted when the discovery driver reported that no host had answered:</p>
<pre><code class="language-c">if (!netplay_discovery_driver_ctl(...GET_RESPONSES, NULL))
   if (cpu_features_get_time_usec() &gt;= data-&gt;timeout)
      goto finished;
</code></pre>
<p><code>netplay_lan_ad_client_response()</code> returns true whenever at least one host was added this poll, so a peer answering continuously keeps the scan alive forever. Modelled against the real queue: <strong>still running 400 s into an 800 ms scan.</strong> Commit 2 stops a single peer from being counted repeatedly, but the deadline should not depend on that — it is now tested unconditionally.</p>
<p>The handler also returned immediately after each poll with <code>task-&gt;when</code> left at 0, so the threaded worker re-entered it with no delay at all. That is a full core spent on back-to-back <code>recvfrom()</code> calls for the whole 800 ms of every scan. Now polls every 4 ms; datagrams arriving in between are waiting in the socket buffer, so nothing is missed. (<code>task_cloudsync.c:1369</code> already sets <code>task-&gt;when</code> from inside its handler this way.)</p>
<p>Finally, the handler never looked at <code>RETRO_TASK_FLG_CANCELLED</code>, so <code>task_queue_cancel_task()</code> on a running scan had no effect and the discovery socket stayed open until the deadline.</p>
<h2>Verification</h2>
<p><code>netplay_lan_ad_client_response()</code> and <code>netplay_discovery_driver_ctl()</code> were extracted verbatim into a harness with a scripted socket layer, so the sanitizers saw the shipping code rather than a paraphrase. Cases: well-formed streams across the growth seam, fully unterminated string fields, truncated / oversized datagrams, wrong magic, non-LAN sources, clear-then-refill, and the flood case. A second harness models the task against libretro-common's threaded queue — handler on the worker thread, callback on the main thread, plus the <code>task_queue_deinit(); retroarch_init_task_queue();</code> sequence that content loading performs.</p>

Sweep | Result
-- | --
ASan (strict_string_checks, detect_stack_use_after_return) | clean
UBSan (-fno-sanitize-recover=all) | clean
LeakSan | clean
TSan, all three lifecycle scenarios | clean


<p>Both C files compile warning-clean under <code>-std=gnu89 -Wall -Wextra</code>.</p>
<h2>Caveats</h2>
<ul>
<li>Behavioural verification is against the extracted functions, not the linked binary.</li>
<li><code>NETPLAY_MAX_DISCOVERED_HOSTS</code> is set to 256. That is far above any plausible LAN and the menu is unusable long before it, but it is a judgement call and easy to change.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>