### PR TITLE
File I/O: mapped-view accessor, allocation-free file/buffer comparison, and the stack-safety work that fell out of it

### DIFF
--- a/.github/workflows/Linux-libretro-common-samples.yml
+++ b/.github/workflows/Linux-libretro-common-samples.yml
@@ -67,6 +67,7 @@ jobs:
             rzip_chunk_size_test
             net_ifinfo
             vfs_read_overflow_test
+            vfs_mapped_ptr_test
             cdrom_cuesheet_overflow_test
             cdfs_dir_record_test
             chd_meta_overflow_test
@@ -618,3 +619,22 @@ jobs:
           set -u
           set -o pipefail
           ${{ matrix.qemu }} -L ${{ matrix.sysroot }} ./crc32_test
+
+      - name: Run vfs_mapped_ptr_test without mappings (MMAP=0)
+        shell: bash
+        working-directory: libretro-common/samples/file/vfs
+        run: |
+          set -eu
+          # The default build has HAVE_MMAP, where filestream_matches_buf()
+          # compares against the memory map in a single memcmp and its
+          # windowed fallback never executes - so the window-boundary
+          # cases in the run above assert on code that did not run.
+          # This lane is where that path is actually under test, and it
+          # is also the only coverage the platforms without mappings
+          # get.  Verified to fail here with the window advance off by
+          # one, which the mapped lane does not notice at all.
+          make clean all MMAP=0 SANITIZER=address,undefined
+          ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+             UBSAN_OPTIONS=print_stacktrace=1 timeout 120 \
+             ./vfs_mapped_ptr_test
+          echo "[pass] vfs_mapped_ptr_test (MMAP=0, ASan)"

--- a/.github/workflows/Linux-libretro-common-samples.yml
+++ b/.github/workflows/Linux-libretro-common-samples.yml
@@ -65,6 +65,7 @@ jobs:
             nbio_test
             rpng
             rzip_chunk_size_test
+            rzip_matches_buf_test
             net_ifinfo
             vfs_read_overflow_test
             vfs_mapped_ptr_test

--- a/.github/workflows/Linux-libretro-common-samples.yml
+++ b/.github/workflows/Linux-libretro-common-samples.yml
@@ -66,6 +66,13 @@ jobs:
             rpng
             rzip_chunk_size_test
             rzip_matches_buf_test
+            data_transfer_source_test
+            data_transfer_prefix_test
+            data_transfer_window_test
+            audio_transfer_window_test
+            rjpeg_test
+            r7z_lzma_props_test
+            vcdiff_test
             net_ifinfo
             vfs_read_overflow_test
             vfs_mapped_ptr_test
@@ -89,6 +96,23 @@ jobs:
             retro_atomic_extern_c_linkage_test_cxx
             retro_spsc_test
             audio_mixer_loop_test
+          )
+
+          # Targets that are built but deliberately not executed, each
+          # for a reason that is not "we forgot".  Anything built and
+          # listed in neither this nor RUN_TARGETS is an error below,
+          # because a silent "not in run allowlist" skip is
+          # indistinguishable from an omission - which is how seven
+          # self-contained regression tests came to be compiled every
+          # run and never executed.
+          declare -a NORUN_TARGETS=(
+            # CLI tools that print usage and exit non-zero without
+            # arguments; they have no self-test mode.
+            rzip
+            # Performs real HTTP requests against an external host, so
+            # running it would make this job depend on a third party
+            # being up.
+            http_test
           )
 
           # Per-binary run command (overrides ./<binary> if present).
@@ -170,7 +194,12 @@ jobs:
 
             for t in "${targets[@]}"; do
               if ! is_in "$t" "${RUN_TARGETS[@]}"; then
-                printf '[skip-run] %s/%s (not in run allowlist)\n' "$rel" "$t"
+                if is_in "$t" "${NORUN_TARGETS[@]}"; then
+                  printf '[skip-run] %s/%s (deliberately not run)\n' "$rel" "$t"
+                  continue
+                fi
+                printf '::error title=Target not classified::%s/%s is built but appears in neither RUN_TARGETS nor NORUN_TARGETS. Add it to one of them.\n' "$rel" "$t"
+                fails=$((fails+1))
                 continue
               fi
 

--- a/.github/workflows/Linux-libretro-common-tests.yml
+++ b/.github/workflows/Linux-libretro-common-tests.yml
@@ -65,3 +65,17 @@ jobs:
           # branch broken.  This is the same check at source level, for
           # free, on Linux.
           python3 tools/vfs_backend_parity.py
+
+      - name: Check stack frame budget
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -eu
+          # PSP and GX threads get 8 KiB of stack (STACKSIZE in
+          # rthreads/psp_pthread.h and rthreads/gx_pthread.h).  Nothing
+          # warns when a local buffer outgrows that: it builds
+          # everywhere and overflows only on a target most contributors
+          # cannot build.  config_file_write() carried a 16 KiB stdio
+          # buffer as a local - twice that stack - on a path reached
+          # from a task handler, and nothing noticed.
+          python3 tools/stack_budget.py

--- a/.github/workflows/Linux-libretro-common-tests.yml
+++ b/.github/workflows/Linux-libretro-common-tests.yml
@@ -50,3 +50,18 @@ jobs:
              LIBCHECK_CFLAGS="$(pkg-config --cflags check)" \
              CFLAGS="$(pkg-config --cflags check)"
           echo "[pass] libretro-common unit test suites"
+
+      - name: Check VFS backend symbol parity
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -eu
+          # vfs_implementation_uwp.cpp replaces vfs_implementation.c on
+          # UWP rather than extending it, so a function added to the C
+          # backend and called from the shared file_stream.c compiles
+          # everywhere and fails to link on UWP alone - at the end of a
+          # long MSVC build, on a runner most contributors do not have.
+          # That is how retro_vfs_file_get_mapped_ptr_impl reached the
+          # branch broken.  This is the same check at source level, for
+          # free, on Linux.
+          python3 tools/vfs_backend_parity.py

--- a/libretro-common/encodings/encoding_deflate.c
+++ b/libretro-common/encodings/encoding_deflate.c
@@ -1701,6 +1701,21 @@ struct rdeflate
    uint8_t  dyn_rle[288 + 30];    /* RLE'd (lit+dist) code lengths           */
    uint8_t  dyn_rle_extra[288 + 30];
    int      dyn_rle_n;
+
+   /* Huffman length-generation scratch.  These were locals in
+    * rd_gen_lengths(), which made that a 12768-byte frame - the
+    * two-queue tree needs 2*288 nodes of weight, left, right and
+    * depth, on top of the 288-entry sort arrays.  A frame that size
+    * does not belong on a stack whatever the target: it sits under
+    * whatever called it, and the state struct here is calloc'd once
+    * per stream, so the arrays cost nothing extra to keep. */
+   int      gl_idx[288];
+   uint32_t gl_fr[288];
+   int      gl_lc[288];
+   uint32_t gl_wt[2 * 288];
+   int      gl_left[2 * 288];
+   int      gl_right[2 * 288];
+   int      gl_depth[2 * 288];
 };
 
 /* ------- bit writer (LSB-first) -------
@@ -2528,12 +2543,13 @@ static int rd_emit_block_stored(struct rdeflate *s)
  * always yielding a complete (Kraft-exact) code.  Builds a Huffman tree by
  * repeated lowest-weight sibling merges, reads off depths, then repairs any
  * over-long codes with a Kraft-sum redistribution. */
-static void rd_gen_lengths(const uint32_t *freq, int n, int max_bits,
+static void rd_gen_lengths(struct rdeflate *s,
+      const uint32_t *freq, int n, int max_bits,
       uint8_t *lengths_out)
 {
-   int      idx[288];
-   uint32_t fr[288];
-   int      lc[288];
+   int      *idx = s->gl_idx;
+   uint32_t *fr  = s->gl_fr;
+   int      *lc  = s->gl_lc;
    int      m = 0;
    int      i;
 
@@ -2584,10 +2600,10 @@ static void rd_gen_lengths(const uint32_t *freq, int n, int max_bits,
     * once assigns every depth without the per-leaf parent-chain
     * walk the old code did. */
    {
-      uint32_t wt[2 * 288];
-      int      left[2 * 288];
-      int      right[2 * 288];
-      int      depth[2 * 288];
+      uint32_t *wt    = s->gl_wt;
+      int      *left  = s->gl_left;
+      int      *right = s->gl_right;
+      int      *depth = s->gl_depth;
       int      lq = 0;   /* front of the leaf queue                   */
       int      iq = 288; /* front of the internal queue (base 288)    */
       int      node_used;
@@ -2758,8 +2774,8 @@ static uint32_t rd_build_dynamic(struct rdeflate *s)
    /* the end-of-block symbol (256) always occurs once */
    s->freq_lit[256]++;
 
-   rd_gen_lengths(s->freq_lit, 286, 15, s->dyn_lit_len);
-   rd_gen_lengths(s->freq_dist, 30, 15, s->dyn_dist_len);
+   rd_gen_lengths(s, s->freq_lit, 286, 15, s->dyn_lit_len);
+   rd_gen_lengths(s, s->freq_dist, 30, 15, s->dyn_dist_len);
 
    /* hlit: number of lit/len codes (257..286); hdist: dist codes (1..30) */
    maxlit = 285;
@@ -2777,7 +2793,7 @@ static uint32_t rd_build_dynamic(struct rdeflate *s)
    rd_codes_from_lengths(s->dyn_dist_len, 30, s->dyn_dist_code);
 
    rd_rle_lengths(s, cl_freq);
-   rd_gen_lengths(cl_freq, 19, 7, s->dyn_cl_len);
+   rd_gen_lengths(s, cl_freq, 19, 7, s->dyn_cl_len);
    rd_codes_from_lengths(s->dyn_cl_len, 19, s->dyn_cl_code);
 
    /* hclen: number of CL code lengths present (in clc_order), min 4 */

--- a/libretro-common/encodings/encoding_rzstd.c
+++ b/libretro-common/encodings/encoding_rzstd.c
@@ -3237,13 +3237,22 @@ typedef struct rzstd_seq
 
 /* Emits one block as literals plus sequences, or reports that doing so
  * would not be smaller than storing it. */
+/* 'cts' is three FSE compression tables owned by the caller.  They
+ * were locals, which made this a 9440-byte frame: each table carries
+ * a 1<<accuracy_log entry table plus two 256-entry delta arrays, so
+ * three of them are most of 9 KiB.  A frame that size does not belong
+ * on a stack whatever the target - it sits under whatever called it -
+ * and rzstd_encode() already owns heap scratch for the match finder,
+ * so these go alongside it and are allocated once per call rather
+ * than once per block. */
 static int rzstd_emit_block(uint8_t *dst, size_t dst_cap,
       const uint8_t *src, size_t len, const rzstd_seq_t *seq, size_t nseq,
-      const uint8_t *literals, size_t lit_len, size_t *out_len)
+      const uint8_t *literals, size_t lit_len, size_t *out_len,
+      rzstd_fse_ct_t *cts)
 {
-   rzstd_fse_ct_t ll_ct;
-   rzstd_fse_ct_t ml_ct;
-   rzstd_fse_ct_t of_ct;
+   rzstd_fse_ct_t *ll_ctp = &cts[0];
+   rzstd_fse_ct_t *ml_ctp = &cts[1];
+   rzstd_fse_ct_t *of_ctp = &cts[2];
    rzstd_wbits_t  w;
    size_t         at = 0;
    size_t         i;
@@ -3309,9 +3318,9 @@ static int rzstd_emit_block(uint8_t *dst, size_t dst_cap,
       return RZ_DATA;
    dst[at++] = 0;
 
-   if (rzstd_fse_build_ct(&ll_ct, rzstd_ll_default, 36, 6) != RZ_OK
-    || rzstd_fse_build_ct(&ml_ct, rzstd_ml_default, 53, 6) != RZ_OK
-    || rzstd_fse_build_ct(&of_ct, rzstd_of_default, 29, 5) != RZ_OK)
+   if (rzstd_fse_build_ct(ll_ctp, rzstd_ll_default, 36, 6) != RZ_OK
+    || rzstd_fse_build_ct(ml_ctp, rzstd_ml_default, 53, 6) != RZ_OK
+    || rzstd_fse_build_ct(of_ctp, rzstd_of_default, 29, 5) != RZ_OK)
       return RZ_DATA;
 
    rzstd_wbits_init(&w, dst + at, dst_cap - at);
@@ -3325,9 +3334,9 @@ static int rzstd_emit_block(uint8_t *dst, size_t dst_cap,
       uint32_t ml = rzstd_code_for(rzstd_ml_base, 53, s2->match);
       uint32_t of = rzstd_of_code(s2->offset);
 
-      ml_state = rzstd_fse_ct_begin(&ml_ct, ml);
-      of_state = rzstd_fse_ct_begin(&of_ct, of);
-      ll_state = rzstd_fse_ct_begin(&ll_ct, ll);
+      ml_state = rzstd_fse_ct_begin(ml_ctp, ml);
+      of_state = rzstd_fse_ct_begin(of_ctp, of);
+      ll_state = rzstd_fse_ct_begin(ll_ctp, ll);
 
       rzstd_wbits_add(&w, s2->literals - rzstd_ll_base[ll],
             rzstd_ll_bits[ll]);
@@ -3346,9 +3355,9 @@ static int rzstd_emit_block(uint8_t *dst, size_t dst_cap,
       /* The decoder updates literal length, then match length, then
        * offset. Everything here is written in reverse of the reading
        * order, so they go out the other way about. */
-      of_state = rzstd_fse_ct_encode(&w, of_state, &of_ct, of);
-      ml_state = rzstd_fse_ct_encode(&w, ml_state, &ml_ct, ml);
-      ll_state = rzstd_fse_ct_encode(&w, ll_state, &ll_ct, ll);
+      of_state = rzstd_fse_ct_encode(&w, of_state, of_ctp, of);
+      ml_state = rzstd_fse_ct_encode(&w, ml_state, ml_ctp, ml);
+      ll_state = rzstd_fse_ct_encode(&w, ll_state, ll_ctp, ll);
 
       rzstd_wbits_add(&w, s2->literals - rzstd_ll_base[ll],
             rzstd_ll_bits[ll]);
@@ -3357,9 +3366,9 @@ static int rzstd_emit_block(uint8_t *dst, size_t dst_cap,
       rzstd_wbits_add(&w, s2->offset - ((uint32_t)1 << of), of);
    }
 
-   rzstd_fse_ct_flush(&w, ml_state, &ml_ct);
-   rzstd_fse_ct_flush(&w, of_state, &of_ct);
-   rzstd_fse_ct_flush(&w, ll_state, &ll_ct);
+   rzstd_fse_ct_flush(&w, ml_state, ml_ctp);
+   rzstd_fse_ct_flush(&w, of_state, of_ctp);
+   rzstd_fse_ct_flush(&w, ll_state, ll_ctp);
 
    {
       size_t n = rzstd_wbits_close(&w);
@@ -3388,6 +3397,10 @@ int rzstd_encode(uint8_t *dst, size_t dst_len, const uint8_t *src,
    uint32_t  rep[3];
    uint32_t *hash  = NULL;
    uint32_t *chain = NULL;
+   /* Three FSE compression tables for rzstd_emit_block(), which used
+    * to hold them as locals - see the comment there.  Allocated with
+    * the match-finder scratch and freed with it. */
+   rzstd_fse_ct_t *cts = NULL;
 
    (void)level;
 
@@ -3484,9 +3497,10 @@ int rzstd_encode(uint8_t *dst, size_t dst_len, const uint8_t *src,
              * read. */
             chain = (uint32_t*)calloc((size_t)1 << enc_log,
                   sizeof(uint32_t));
+            cts   = (rzstd_fse_ct_t*)calloc(3, sizeof(*cts));
          }
 
-         if (seq && lits && hash && chain)
+         if (seq && lits && hash && chain && cts)
          {
             size_t   pos      = 0;
             size_t   lit_from = 0;
@@ -3694,9 +3708,9 @@ int rzstd_encode(uint8_t *dst, size_t dst_len, const uint8_t *src,
                lit_len += take - lit_from;
             }
 
-            if (nseq && rzstd_emit_block(dst + at + 3, dst_len - at - 3,
+            if (nseq && cts && rzstd_emit_block(dst + at + 3, dst_len - at - 3,
                      src + in, take, seq, nseq, lits, lit_len,
-                     &produced) == RZ_OK
+                     &produced, cts) == RZ_OK
                   && produced < take)
             {
                rzstd_write_block_header(dst + at, (uint32_t)produced,
@@ -3726,6 +3740,7 @@ int rzstd_encode(uint8_t *dst, size_t dst_len, const uint8_t *src,
 
    free(hash);
    free(chain);
+   free(cts);
 
    if (wrote)
       *wrote = at;

--- a/libretro-common/file/config_file_io.c
+++ b/libretro-common/file/config_file_io.c
@@ -170,14 +170,37 @@ bool config_file_write(config_file_t *conf, const char *path, bool sort)
          config_file_dump(conf, stdout, sort);
       else
       {
-         char buf[0x4000];
+         /* The stdio buffer is heap, not a local.  At 16 KiB it was
+          * twice the whole thread stack on the smallest targets - PSP
+          * and GX threads get 8 KiB, see STACKSIZE in psp_pthread.h
+          * and gx_pthread.h - and this is reached from a task
+          * handler, so it runs on the task thread rather than the
+          * main one whenever the queue is threaded:
+          * input_autoconfigure_connect_handler ->
+          * ..._scan_config_files_external -> ..._index_write ->
+          * here, which is the path a gamepad being plugged in takes.
+          * -fstack-usage put the frame at 16432 bytes.
+          *
+          * C89 has no way to ask setvbuf for a buffer of a given size
+          * without supplying one, so it is allocated here and freed
+          * after fclose - the buffer has to outlive every write
+          * through the stream.  If the allocation fails the C library
+          * default is used, exactly as in
+          * retro_vfs_file_open_impl(): a platform under real memory
+          * pressure gets slower writes rather than no config. */
+         char *buf  = (char*)malloc(0x4000);
          FILE *file = (FILE*)fopen_utf8(path, "wb");
          if (!file)
+         {
+            free(buf);
             return false;
-         setvbuf(file, buf, _IOFBF, sizeof(buf));
+         }
+         if (buf)
+            setvbuf(file, buf, _IOFBF, 0x4000);
          config_file_dump(conf, file, sort);
          if (file != stdout)
             fclose(file);
+         free(buf);
          conf->flags &= ~CONF_FILE_FLG_MODIFIED;
       }
    }

--- a/libretro-common/file/config_file_io.c
+++ b/libretro-common/file/config_file_io.c
@@ -171,9 +171,9 @@ bool config_file_write(config_file_t *conf, const char *path, bool sort)
       else
       {
          /* The stdio buffer is heap, not a local.  At 16 KiB it was
-          * twice the whole thread stack on the smallest targets - PSP
-          * and GX threads get 8 KiB, see STACKSIZE in psp_pthread.h
-          * and gx_pthread.h - and this is reached from a task
+          * twice the whole thread stack on the smallest target -
+          * GEKKO threads get 8 KiB, see STACKSIZE in
+          * rthreads/gx_pthread.h - and this is reached from a task
           * handler, so it runs on the task thread rather than the
           * main one whenever the queue is threaded:
           * input_autoconfigure_connect_handler ->

--- a/libretro-common/formats/json/rjson.c
+++ b/libretro-common/formats/json/rjson.c
@@ -1157,12 +1157,27 @@ enum rjson_type rjson_get_context_type(rjson_t *json)
    return json->stack_top->type;
 }
 
-void rjson_free(rjson_t *json)
+/* Release the two buffers that can outgrow their inline storage.
+ * Split out of rjson_free() because a stack-allocated rjson_t has
+ * the same buffers to release but must not have free() called on
+ * the handle itself. */
+static void _rjson_free_buffers(rjson_t *json)
 {
    if (json->stack != json->inline_stack)
+   {
       free(json->stack);
+      json->stack = json->inline_stack;
+   }
    if (json->string != json->inline_string)
+   {
       free(json->string);
+      json->string = json->inline_string;
+   }
+}
+
+void rjson_free(rjson_t *json)
+{
+   _rjson_free_buffers(json);
    free(json);
 }
 
@@ -1277,12 +1292,27 @@ bool rjson_parse_quick(const char *string, size_t len, void* context, char optio
          start_object_handler, end_object_handler,
          start_array_handler, end_array_handler,
          boolean_handler, null_handler) == RJSON_DONE)
+   {
+      /* The handle is on the stack, but its string and stack buffers
+       * are not: either outgrows its inline storage onto the heap - a
+       * long string token, or deep nesting - and nothing released
+       * them on the way out.  rjson_free() cannot be used here
+       * because it frees the handle too, so the buffer release is
+       * split out.
+       *
+       * The one caller in the tree parses netplay lobby responses,
+       * so the input is a remote server's and the growth is its
+       * choice, up to _RJSON_MAX_SIZE.  That made this leak per
+       * refresh and sized by whatever the other end sent. */
+      _rjson_free_buffers(&json);
       return true;
+   }
    if (error_handler)
       error_handler(context,
             (int)rjson_get_source_line(&json),
             (int)rjson_get_source_column(&json),
             rjson_get_error(&json));
+   _rjson_free_buffers(&json);
    return false;
 }
 

--- a/libretro-common/formats/libchdr/libchdr_chd.c
+++ b/libretro-common/formats/libchdr/libchdr_chd.c
@@ -1380,18 +1380,30 @@ CHD_EXPORT const chd_header *chd_get_header(chd_file *chd)
 CHD_EXPORT chd_error chd_read_header_core_file(core_file *file, chd_header *header)
 {
 	chd_error err;
-	chd_file fake;
+	chd_file *fake;
 
 	/* punt if NULL */
 	if (file == NULL || header == NULL)
 		return CHDERR_INVALID_PARAMETER;
 
 	/* header_read only touches ->file, but hand it a fully zeroed
-	 * struct so that stays true by inspection. */
-	memset(&fake, 0, sizeof(fake));
-	fake.file = file;
+	 * struct so that stays true by inspection.
+	 *
+	 * Heap rather than a local: chd_file embeds the working state of
+	 * every codec it can use - huff, zlib, cdzl, lzma - so as
+	 * 'chd_file fake;' this was a 57504-byte frame, zeroed in full,
+	 * to read a header that reads one member of it. No target with a
+	 * small thread stack builds CHD, so this was not a crash, but a
+	 * frame that size does not belong on any stack: it sits under
+	 * whatever called it, and nothing about "read this file's header"
+	 * suggests it costs 56 KiB to do. */
+	fake = (chd_file *)calloc(1, sizeof(*fake));
+	if (fake == NULL)
+		return CHDERR_OUT_OF_MEMORY;
+	fake->file = file;
 
-	err = header_read(&fake, header);
+	err = header_read(fake, header);
+	free(fake);
 	if (err != CHDERR_NONE)
 		return err;
 

--- a/libretro-common/formats/webp/rwebp.c
+++ b/libretro-common/formats/webp/rwebp.c
@@ -187,30 +187,50 @@ static int vh_next_tbl_bits(const int *count, int len, int root_bits)
 static int vh_build(vh *h, const uint8_t *lens, int ns, int root)
 {
    int count[VH_MAXCL + 1], offset[VH_MAXCL + 1];
-   int sorted[4096];
+   /* Symbol scratch, heap rather than stack.  As int sorted[4096] this
+    * was 16 KiB in one frame - twice the 8 KiB a GEKKO thread gets
+    * (STACKSIZE in rthreads/gx_pthread.h) - and it is reachable from
+    * a task handler, so it runs on a worker rather than the main
+    * thread whenever the task queue is threaded:
+    * task_file_load_handler -> task_image_load_handler ->
+    * task_image_process -> image_transfer_process ->
+    * rwebp_process_image -> ... -> vh_build, and the same via
+    * task_overlay_handler.  Wii and GameCube build HAVE_RWEBP and
+    * HAVE_THREADS both.
+    *
+    * uint16_t rather than int as well: every value here is a symbol
+    * index, bounded by the ns > 4096 rejection below, and every read
+    * of it is already masked with 0xFFFF. */
+   uint16_t *sorted = (uint16_t*)malloc(4096 * sizeof(*sorted));
    int total_size = 1 << root;
    int len, symbol, i, pass;
    uint32_t *t = NULL;
 
-   if (ns > 4096) return -1;
+   if (!sorted)
+      return -1;
+   if (ns > 4096)
+      goto fail;
    memset(count, 0, sizeof(count));
    for (symbol = 0; symbol < ns; symbol++)
    {
-      if (lens[symbol] > VH_MAXCL) return -1;
+      if (lens[symbol] > VH_MAXCL)
+         goto fail;
       count[lens[symbol]]++;
    }
-   if (count[0] == ns) return -1;
+   if (count[0] == ns)
+      goto fail;
 
    offset[1] = 0;
    for (len = 1; len < VH_MAXCL; len++)
    {
-      if (count[len] > (1 << len)) return -1;
+      if (count[len] > (1 << len))
+         goto fail;
       offset[len + 1] = offset[len] + count[len];
    }
    for (symbol = 0; symbol < ns; symbol++)
    {
       int cl = lens[symbol];
-      if (cl > 0) sorted[offset[cl]++] = symbol;
+      if (cl > 0) sorted[offset[cl]++] = (uint16_t)symbol;
    }
 
    /* Single-symbol special case: 0-bit code returns that symbol. */
@@ -218,10 +238,12 @@ static int vh_build(vh *h, const uint8_t *lens, int ns, int root)
    {
       total_size = 1 << root;
       h->t = (uint32_t*)calloc(total_size, sizeof(uint32_t));
-      if (!h->t) return -1;
+      if (!h->t)
+         goto fail;
       h->sz = total_size; h->rb = root;
       for (i = 0; i < total_size; i++)
          h->t[i] = (uint32_t)(sorted[0] & 0xFFFF);
+      free(sorted);
       return 0;
    }
 
@@ -282,12 +304,18 @@ static int vh_build(vh *h, const uint8_t *lens, int ns, int root)
       if (pass == 0)
       {
          t = (uint32_t*)calloc(total_size + 1, sizeof(uint32_t));
-         if (!t) return -1;
+         if (!t)
+            goto fail;
       }
    }
 
    h->t = t; h->sz = total_size; h->rb = root;
+   free(sorted);
    return 0;
+
+fail:
+   free(sorted);
+   return -1;
 }
 
 static INLINE int vh_read(const vh *h, vbr *b)

--- a/libretro-common/hash/lrc_hash.c
+++ b/libretro-common/hash/lrc_hash.c
@@ -498,27 +498,45 @@ void SHA1Digest(const uint8_t* data, size_t len, uint8_t digest[20])
 int sha1_calculate(const char *path, char *result)
 {
    struct sha1_context sha;
-   unsigned char buff[4096];
+   const uint8_t *map = NULL;
+   int64_t        map_len = 0;
+   unsigned char *buff = NULL;
    int rv    = 1;
+   /* Ask for a mapping: where the platform provides one the whole
+    * file is already addressable and there is nothing to copy. */
    RFILE *fd = filestream_open(path,
          RETRO_VFS_FILE_ACCESS_READ,
-         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+         RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS);
 
    if (!fd)
       goto error;
 
-   buff[0] = '\0';
-
    SHA1Reset(&sha);
 
-   do
+   if ((map = filestream_get_mapped_ptr(fd, &map_len)) && map_len >= 0)
+      SHA1Input(&sha, map, (unsigned)map_len);
+   else
    {
-      rv = (int)filestream_read(fd, buff, 4096);
-      if (rv < 0)
+      /* No mapping, so copy a block at a time.  The buffer is heap
+       * rather than a local: as unsigned char buff[4096] this was a
+       * 4304-byte frame, over half of the 8 KiB a GEKKO thread gets
+       * (STACKSIZE in rthreads/gx_pthread.h), and hashing a whole
+       * file dwarfs one allocation either way. */
+      if (!(buff = (unsigned char*)malloc(4096)))
          goto error;
 
-      SHA1Input(&sha, buff, rv);
-   } while (rv);
+      do
+      {
+         rv = (int)filestream_read(fd, buff, 4096);
+         if (rv < 0)
+            goto error;
+
+         SHA1Input(&sha, buff, rv);
+      } while (rv);
+
+      free(buff);
+      buff = NULL;
+   }
 
    if (!SHA1Result(&sha, NULL))
       goto error;
@@ -533,6 +551,7 @@ int sha1_calculate(const char *path, char *result)
    return 0;
 
 error:
+   free(buff);
    if (fd)
       filestream_close(fd);
    return -1;

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -400,6 +400,57 @@ int filestream_cmp(const char *src_path, const char *dst_path);
 const char* filestream_get_path(RFILE *stream);
 
 /**
+ * Borrowed read-only pointer to the entire file, when \c stream is
+ * backed by a memory map.
+ *
+ * Open with \c RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS to ask for
+ * a mapping.  The hint has always produced one, but the map was
+ * reachable only from inside the read path, which copies out of it -
+ * so consumers of the hint paid for a copy of data that was already
+ * addressable.  Use this when the file is to be read rather than
+ * owned: compared against a buffer, hashed, or handed to a parser
+ * that takes a base pointer.
+ *
+ * \c NULL is a normal answer rather than an error - the platform may
+ * have no mapping support, the hint may not have been given, or the
+ * stream may come from a frontend-supplied VFS - so a caller must
+ * keep its ordinary read path and treat this purely as a fast lane.
+ *
+ * @param stream The file to get the mapping of.
+ * @param len Filled with the mapped length, or 0 when there is no
+ * mapping.  May be \c NULL.
+ * @return Pointer to the mapped file, or \c NULL if it is not mapped.
+ * The mapping is owned by \c stream, is valid only until \c stream is
+ * closed, and must not be written or freed by the caller.
+ */
+const uint8_t *filestream_get_mapped_ptr(RFILE *stream, int64_t *len);
+
+/**
+ * Does the file at \c path hold exactly \c len bytes equal to
+ * \c data?
+ *
+ * For the common "has this changed since I last wrote it?" question,
+ * where the answer decides whether to write at all.  Callers used to
+ * answer it by reading the whole file into a fresh allocation,
+ * comparing, and freeing - paying a full-size malloc and a full-file
+ * read even when a size mismatch made the answer free.
+ *
+ * This allocates nothing: it settles a size mismatch without reading,
+ * compares in place against the memory map where the platform offers
+ * one, falls back to a fixed window otherwise, and stops at the first
+ * differing byte.
+ *
+ * @param path The file to compare against.
+ * @param data The buffer to compare with. May be \c NULL only when
+ * \c len is 0.
+ * @param len The number of bytes in \c data.
+ * @return \c true only if the file exists, is exactly \c len bytes,
+ * and every byte matches. A missing or unreadable file is \c false,
+ * not an error - the caller's next step is the same either way.
+ */
+bool filestream_matches_buf(const char *path, const void *data, size_t len);
+
+/**
  * Determines if a file exists at the given path.
  *
  * @param path The path to check for existence.

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -426,6 +426,24 @@ const char* filestream_get_path(RFILE *stream);
 const uint8_t *filestream_get_mapped_ptr(RFILE *stream, int64_t *len);
 
 /**
+ * Size of the buffer filestream_matches_buf() compares through when
+ * the file is not mapped.
+ *
+ * Exposed so a test can aim at the real boundary rather than a
+ * remembered one - a boundary case pointed at the wrong offset is
+ * just another mid-file check under a boundary's name.
+ *
+ * The ceiling is a stack budget, not a throughput one: this buffer is
+ * a local, and the smallest thread stacks in the tree are 8 KiB
+ * (STACKSIZE in psp_pthread.h and gx_pthread.h), with 32 KiB on 3DS
+ * and 64 KiB on Vita. Larger reads are faster - at or above the VFS's
+ * own 64 KiB stdio buffer they bypass it entirely - but the platforms
+ * that take this path are the ones without memory mapping, which are
+ * the same ones with those stacks.
+ */
+#define FILESTREAM_MATCHES_BUF_WINDOW 1024
+
+/**
  * Does the file at \c path hold exactly \c len bytes equal to
  * \c data?
  *

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -434,9 +434,9 @@ const uint8_t *filestream_get_mapped_ptr(RFILE *stream, int64_t *len);
  * just another mid-file check under a boundary's name.
  *
  * The ceiling is a stack budget, not a throughput one: this buffer is
- * a local, and the smallest thread stacks in the tree are 8 KiB
- * (STACKSIZE in psp_pthread.h and gx_pthread.h), with 32 KiB on 3DS
- * and 64 KiB on Vita. Larger reads are faster - at or above the VFS's
+ * a local, and the smallest thread stack in the tree is GEKKO's
+ * 8 KiB (STACKSIZE in rthreads/gx_pthread.h), with 32 KiB on 3DS and
+ * 64 KiB on Vita. Larger reads are faster - at or above the VFS's
  * own 64 KiB stdio buffer they bypass it entirely - but the platforms
  * that take this path are the ones without memory mapping, which are
  * the same ones with those stacks.

--- a/libretro-common/include/streams/file_stream.h
+++ b/libretro-common/include/streams/file_stream.h
@@ -426,6 +426,15 @@ const char* filestream_get_path(RFILE *stream);
 const uint8_t *filestream_get_mapped_ptr(RFILE *stream, int64_t *len);
 
 /**
+ * Size of the window filestream_vscanf() reads and scans at a time,
+ * i.e. the furthest a single conversion can reach.
+ *
+ * Named so a test can drive input either side of it rather than
+ * assume a value, the way the compare window below is.
+ */
+#define FILESTREAM_SCANF_WINDOW 4096
+
+/**
  * Size of the buffer filestream_matches_buf() compares through when
  * the file is not mapped.
  *

--- a/libretro-common/include/streams/rzip_stream.h
+++ b/libretro-common/include/streams/rzip_stream.h
@@ -115,6 +115,14 @@ char* rzipstream_gets(rzipstream_t *stream, char *s, size_t len);
  * Returns false in the event of an error */
 bool rzipstream_read_file(const char *path, void **buf, int64_t *len);
 
+/* Size of the buffer rzipstream_matches_buf() decompresses through.
+ *
+ * Exposed so a test can aim at the real chunk boundary rather than a
+ * remembered one.  Sized like its filestream counterpart, by the
+ * smallest thread stacks in the tree (8 KiB on PSP and GX) rather
+ * than by the decompressor - see FILESTREAM_MATCHES_BUF_WINDOW. */
+#define RZIPSTREAM_MATCHES_BUF_CHUNK 1024
+
 /* Does the file at 'path' hold exactly 'len' bytes equal to 'data'?
  *
  * The rzip counterpart of filestream_matches_buf(), for callers

--- a/libretro-common/include/streams/rzip_stream.h
+++ b/libretro-common/include/streams/rzip_stream.h
@@ -115,6 +115,27 @@ char* rzipstream_gets(rzipstream_t *stream, char *s, size_t len);
  * Returns false in the event of an error */
 bool rzipstream_read_file(const char *path, void **buf, int64_t *len);
 
+/* Does the file at 'path' hold exactly 'len' bytes equal to 'data'?
+ *
+ * The rzip counterpart of filestream_matches_buf(), for callers
+ * deciding whether a write is needed at all.  Settles a size
+ * mismatch from the header before decompressing anything, compares
+ * a chunk at a time, stops at the first difference, and allocates
+ * nothing - where answering this with rzipstream_read_file() meant
+ * decompressing the whole file into a fresh buffer to compare and
+ * free it.
+ *
+ * 'data' may be NULL only when 'len' is 0. A missing or unreadable
+ * file returns false rather than an error: the caller's next step is
+ * the same either way.
+ *
+ * Note one deliberate difference from filestream_matches_buf(): a
+ * zero-byte file never matches here, not even against zero bytes.
+ * It has no rzip header, so it cannot be opened and there is nothing
+ * to compare - and false is the useful answer, since writing then
+ * replaces it with a valid file. */
+bool rzipstream_matches_buf(const char *path, const void *data, size_t len);
+
 /* File Write */
 
 /* Writes 'len' bytes to an RZIP file.

--- a/libretro-common/include/vfs/vfs_implementation.h
+++ b/libretro-common/include/vfs/vfs_implementation.h
@@ -57,6 +57,25 @@ int retro_vfs_file_rename_impl(const char *old_path, const char *new_path);
 
 const char *retro_vfs_file_get_path_impl(libretro_vfs_implementation_file *stream);
 
+/* Borrowed pointer to the whole file, when this stream is backed by a
+ * memory map, else NULL.  Valid until the stream is closed; read-only;
+ * never freed by the caller.
+ *
+ * RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS already maps the file,
+ * but the mapping was reachable only from inside the read path, which
+ * memcpy's out of it - so every consumer of the hint paid for a copy
+ * of data that was already addressable, and the point of asking for
+ * the map was lost.  This hands the map itself to callers that want
+ * to look rather than own: comparing a file against a buffer, hashing
+ * it, or passing it to a parser that takes a base pointer.
+ *
+ * NULL is a normal answer, not an error - no HAVE_MMAP, hint not
+ * given, a write mode, a scheme with no mapping, or a frontend-
+ * supplied VFS - so callers need the copying path anyway and should
+ * treat this as a fast lane, never as the only one. */
+const uint8_t *retro_vfs_file_get_mapped_ptr_impl(
+      libretro_vfs_implementation_file *stream, int64_t *len);
+
 int retro_vfs_stat_impl(const char *path, int32_t *size);
 
 int retro_vfs_stat_64_impl(const char *path, int64_t *size);

--- a/libretro-common/samples/compat/fnmatch/Makefile
+++ b/libretro-common/samples/compat/fnmatch/Makefile
@@ -10,6 +10,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/compat/snprintf/Makefile
+++ b/libretro-common/samples/compat/snprintf/Makefile
@@ -11,6 +11,16 @@ OBJS := $(SOURCES_C:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/encodings/base64/Makefile
+++ b/libretro-common/samples/encodings/base64/Makefile
@@ -11,6 +11,16 @@ OBJS := $(SOURCES_C:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/file/archive_zstd/Makefile
+++ b/libretro-common/samples/file/archive_zstd/Makefile
@@ -6,6 +6,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -O0
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/file/file_path/Makefile
+++ b/libretro-common/samples/file/file_path/Makefile
@@ -19,6 +19,16 @@ COMMON_OBJS := $(COMMON_SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -DRARCH_INTERNAL -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGETS)
 
 %.o: %.c

--- a/libretro-common/samples/file/nbio/Makefile
+++ b/libretro-common/samples/file/nbio/Makefile
@@ -17,6 +17,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/file/vfs/Makefile
+++ b/libretro-common/samples/file/vfs/Makefile
@@ -1,9 +1,9 @@
-TARGET := vfs_read_overflow_test
+TARGET      := vfs_read_overflow_test
+TARGET_TEST := vfs_mapped_ptr_test
 
 LIBRETRO_COMM_DIR := ../../..
 
-SOURCES := \
-	vfs_read_overflow_test.c \
+COMMON_SOURCES := \
 	$(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
 	$(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 	$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
@@ -13,23 +13,47 @@ SOURCES := \
 	$(LIBRETRO_COMM_DIR)/time/rtime.c \
 	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c
 
-OBJS := $(SOURCES:.c=.o)
+COMMON_OBJS := $(COMMON_SOURCES:.c=.o)
+OBJS        := vfs_read_overflow_test.o vfs_mapped_ptr_test.o $(COMMON_OBJS)
 
-# -DHAVE_MMAP is required for the test to exercise the patched
-# code path; without it the implementation falls back to buffered
-# fread and the test becomes a smoke test that can't discriminate
-# the overflow case.
-CFLAGS += -Wall -pedantic -std=gnu99 -g -DHAVE_MMAP -I$(LIBRETRO_COMM_DIR)/include
+# -DHAVE_MMAP is required for vfs_read_overflow_test to exercise the
+# patched code path; without it the implementation falls back to
+# buffered fread and that test becomes a smoke test that can't
+# discriminate the overflow case.
+#
+# vfs_mapped_ptr_test needs BOTH settings to be meaningful, which is
+# why this is a variable rather than a fixed flag.  With mappings on,
+# filestream_matches_buf() compares against the map and its windowed
+# fallback never runs - so the window-boundary cases would be
+# asserting on code that was not executed.  Build with MMAP=0 to put
+# that path under test; the test reports which one it took.
+MMAP ?= 1
+ifeq ($(MMAP),1)
+   CFLAGS += -DHAVE_MMAP
+endif
 
-all: $(TARGET)
+CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
+
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir; without this block the variable was silently ignored
+# here, so these two ran unchecked while the rest of the tree did not.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET) $(TARGET_TEST)
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
 
-$(TARGET): $(OBJS)
+$(TARGET): vfs_read_overflow_test.o $(COMMON_OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+$(TARGET_TEST): vfs_mapped_ptr_test.o $(COMMON_OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:
-	rm -f $(TARGET) $(OBJS)
+	rm -f $(TARGET) $(TARGET_TEST) $(OBJS)
 
 .PHONY: clean

--- a/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
+++ b/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
@@ -173,14 +173,30 @@ int main(void)
             CHECK(memcmp(map, body, len) == 0,
                   "mapped view holds the file's bytes");
             /* The point of the accessor: the same bytes a read would
-             * have copied, without the copy. */
+             * have copied, without the copy.  Checked over the whole
+             * file, not a prefix - consumers hash or compare the
+             * entire mapping (task_cloudsync's MD5 does exactly
+             * that), so a view that agreed only at the start would
+             * silently produce a different digest from the read path
+             * on the same content. */
             {
-               uint8_t probe[4096];
-               int64_t got = filestream_read(f, probe, (int64_t)sizeof(probe));
-               CHECK(got == (int64_t)sizeof(probe),
-                     "read from the same stream still works");
-               CHECK(memcmp(probe, map, sizeof(probe)) == 0,
-                     "read agrees with the mapped view");
+               uint8_t *probe = (uint8_t*)malloc(len);
+               int64_t  got   = 0;
+               size_t   off   = 0;
+
+               while (off < len)
+               {
+                  got = filestream_read(f, probe + off,
+                        (int64_t)(len - off));
+                  if (got <= 0)
+                     break;
+                  off += (size_t)got;
+               }
+               CHECK(off == len,
+                     "sequential read from the same stream reaches EOF");
+               CHECK(off == len && memcmp(probe, map, len) == 0,
+                     "read agrees with the mapped view over the whole file");
+               free(probe);
             }
          }
          else

--- a/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
+++ b/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
@@ -281,12 +281,12 @@ int main(void)
       other[len - 1] ^= 0xff;
 
       /* A window boundary is where an off-by-one would live.  This
-       * must track filestream_matches_buf()'s actual window - it is
-       * 4 KiB, sized by the Vita thread stack rather than by
-       * throughput - because a "boundary" test aimed at the wrong
-       * offset is just another mid-file check wearing the name. */
+       * takes the window straight from the header rather than
+       * repeating the number here.  It has already been resized once,
+       * and a boundary case aimed at the old value is not a boundary
+       * case at all - just another mid-file check wearing the name. */
       {
-         size_t win = 4096;
+         size_t win = FILESTREAM_MATCHES_BUF_WINDOW;
          size_t at[] = { win - 1, win, win + 1, 2 * win, 8 * win };
          size_t k;
          for (k = 0; k < sizeof(at) / sizeof(at[0]); k++)

--- a/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
+++ b/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
@@ -280,17 +280,25 @@ int main(void)
             "matches_buf: difference at the last byte is caught");
       other[len - 1] ^= 0xff;
 
-      /* A window boundary is where an off-by-one would live: the
-       * fallback reads 64 KiB at a time. */
-      other[64 * 1024 - 1] ^= 0xff;
-      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
-            "matches_buf: difference at a window boundary is caught");
-      other[64 * 1024 - 1] ^= 0xff;
-
-      other[64 * 1024] ^= 0xff;
-      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
-            "matches_buf: difference just past a window boundary is caught");
-      other[64 * 1024] ^= 0xff;
+      /* A window boundary is where an off-by-one would live.  This
+       * must track filestream_matches_buf()'s actual window - it is
+       * 4 KiB, sized by the Vita thread stack rather than by
+       * throughput - because a "boundary" test aimed at the wrong
+       * offset is just another mid-file check wearing the name. */
+      {
+         size_t win = 4096;
+         size_t at[] = { win - 1, win, win + 1, 2 * win, 8 * win };
+         size_t k;
+         for (k = 0; k < sizeof(at) / sizeof(at[0]); k++)
+         {
+            if (at[k] >= len)
+               continue;
+            other[at[k]] ^= 0xff;
+            CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
+                  "matches_buf: difference at a window boundary is caught");
+            other[at[k]] ^= 0xff;
+         }
+      }
 
       /* Size disagreements resolve without reading, and must not
        * report a match on a prefix. */

--- a/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
+++ b/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
@@ -1,0 +1,312 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (vfs_mapped_ptr_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Regression test for two things that meet at the same place: what a
+ * stream can tell you about a file before you copy it.
+ *
+ * 1. filestream_read_file() on a file that reports no size.
+ *
+ *    It sized its allocation from filestream_get_size() and read
+ *    exactly that many bytes, so a file stat'ing as zero came back
+ *    empty - with a *success* return, indistinguishable from a
+ *    genuinely empty file.  Every procfs entry stats as zero, so the
+ *    /proc/apm battery probe, the /proc/modules check in cdrom.c and
+ *    the dingux /proc/jz/battery reader all silently read nothing.
+ *    (mem_stats.c reads /proc/meminfo through a raw open() and
+ *    read() precisely to dodge this.)
+ *
+ *    A stat size is a hint, not a contract.  The fix reads to EOF
+ *    when there is no usable hint - and the test asserts on real
+ *    procfs where the platform has it, because a fixture cannot
+ *    reproduce "stats as 0 but yields bytes" on a normal filesystem.
+ *    A genuinely empty file must still read as empty, which is the
+ *    case the fix could plausibly break.
+ *
+ * 2. filestream_get_mapped_ptr(), the borrowed view of a mapped file.
+ *
+ *    RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS has always mmap'd the
+ *    file, but the mapping was reachable only from inside the read
+ *    path, which memcpy's out of it - so asking for a map bought a
+ *    copy of data that was already addressable.  The contract the
+ *    accessor has to keep is narrow and worth pinning: the bytes are
+ *    the file's, the length is the whole file, it is NULL without the
+ *    hint, and it stays consistent with what filestream_read()
+ *    returns from the same stream.
+ *
+ *    NULL is a legal answer everywhere (no HAVE_MMAP, other schemes,
+ *    a frontend VFS), so every check here is conditional on having
+ *    got a pointer at all - a platform without mappings must pass by
+ *    skipping, not by failing.
+ *
+ * Build:  make            (SANITIZER=address,undefined for a checked run)
+ * Run:    ./vfs_mapped_ptr_test
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <boolean.h>
+#include <streams/file_stream.h>
+
+static int test_fails;
+
+#define CHECK(cond, msg) \
+   do { \
+      if (!(cond)) \
+      { \
+         printf("FAIL: %s\n", msg); \
+         test_fails++; \
+      } \
+      else \
+         printf("ok:   %s\n", msg); \
+   } while (0)
+
+#define SKIP(msg) printf("skip: %s\n", (msg))
+
+static void write_file(const char *path, const void *data, size_t len)
+{
+   FILE *f = fopen(path, "wb");
+   if (len)
+      fwrite(data, 1, len, f);
+   fclose(f);
+}
+
+int main(void)
+{
+   /* Big enough to span pages, odd enough to leave a sub-page tail. */
+   size_t   len  = 300 * 1024 + 77;
+   uint8_t *body = (uint8_t*)malloc(len);
+   size_t   i;
+
+   for (i = 0; i < len; i++)
+      body[i] = (uint8_t)(i * 31 + (i >> 8));
+
+   write_file("mapped_fixture.bin", body, len);
+   write_file("mapped_empty.bin", NULL, 0);
+
+   /* ---- 1a: a file that reports no size still reads ---- */
+   {
+      void   *buf = NULL;
+      int64_t got = -1;
+      /* /proc/cpuinfo stats as 0 bytes and yields many; no ordinary
+       * file can stand in for that, so skip where it is absent. */
+      if (filestream_exists("/proc/cpuinfo"))
+      {
+         int64_t rv = filestream_read_file("/proc/cpuinfo", &buf, &got);
+         CHECK(rv == 1, "size-0 file: read reports success");
+         CHECK(got > 0, "size-0 file: bytes actually delivered");
+         CHECK(buf && ((char*)buf)[got] == '\0',
+               "size-0 file: result is NUL-terminated at the length");
+         free(buf);
+      }
+      else
+         SKIP("no procfs on this platform (size-0 read lane)");
+   }
+
+   /* ---- 1b: a genuinely empty file is still empty ---- */
+   {
+      void   *buf = NULL;
+      int64_t got = -1;
+      int64_t rv  = filestream_read_file("mapped_empty.bin", &buf, &got);
+      CHECK(rv == 1, "empty file: read reports success");
+      CHECK(got == 0, "empty file: zero bytes");
+      CHECK(buf && ((char*)buf)[0] == '\0', "empty file: empty string");
+      free(buf);
+   }
+
+   /* ---- 1c: a missing file is still a failure ---- */
+   {
+      void   *buf = NULL;
+      int64_t got = 0;
+      int64_t rv  = filestream_read_file("mapped_missing.bin", &buf, &got);
+      CHECK(rv == 0, "missing file: read reports failure");
+      CHECK(buf == NULL, "missing file: no buffer handed back");
+   }
+
+   /* ---- 1d: an ordinary sized file is unchanged ---- */
+   {
+      void   *buf = NULL;
+      int64_t got = -1;
+      int64_t rv  = filestream_read_file("mapped_fixture.bin", &buf, &got);
+      CHECK(rv == 1 && got == (int64_t)len, "sized file: full length read");
+      CHECK(buf && memcmp(buf, body, len) == 0,
+            "sized file: contents intact");
+      free(buf);
+   }
+
+   /* ---- 2a: the mapped view, with the hint ---- */
+   {
+      RFILE *f = filestream_open("mapped_fixture.bin",
+            RETRO_VFS_FILE_ACCESS_READ,
+            RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS);
+      CHECK(f != NULL, "fixture opens with the mapping hint");
+      if (f)
+      {
+         int64_t        map_len = -1;
+         const uint8_t *map     = filestream_get_mapped_ptr(f, &map_len);
+
+         if (map)
+         {
+            CHECK(map_len == (int64_t)len,
+                  "mapped view spans the whole file");
+            CHECK(memcmp(map, body, len) == 0,
+                  "mapped view holds the file's bytes");
+            /* The point of the accessor: the same bytes a read would
+             * have copied, without the copy. */
+            {
+               uint8_t probe[4096];
+               int64_t got = filestream_read(f, probe, (int64_t)sizeof(probe));
+               CHECK(got == (int64_t)sizeof(probe),
+                     "read from the same stream still works");
+               CHECK(memcmp(probe, map, sizeof(probe)) == 0,
+                     "read agrees with the mapped view");
+            }
+         }
+         else
+            SKIP("no mapping available (mapped-view lane)");
+         filestream_close(f);
+      }
+   }
+
+   /* ---- 2b: no hint, no map ---- */
+   {
+      RFILE *f = filestream_open("mapped_fixture.bin",
+            RETRO_VFS_FILE_ACCESS_READ,
+            RETRO_VFS_FILE_ACCESS_HINT_NONE);
+      CHECK(f != NULL, "fixture opens without the hint");
+      if (f)
+      {
+         int64_t        map_len = -1;
+         const uint8_t *map     = filestream_get_mapped_ptr(f, &map_len);
+         CHECK(map == NULL, "no hint: no mapped view offered");
+         CHECK(map_len == 0, "no hint: length reported as zero");
+         filestream_close(f);
+      }
+   }
+
+   /* ---- 2c: defensive arguments ---- */
+   {
+      const uint8_t *map = filestream_get_mapped_ptr(NULL, NULL);
+      CHECK(map == NULL, "NULL stream answers NULL rather than faulting");
+   }
+
+   /* ---- 2d: an empty file must not hand back a bogus view ---- */
+   {
+      RFILE *f = filestream_open("mapped_empty.bin",
+            RETRO_VFS_FILE_ACCESS_READ,
+            RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS);
+      if (f)
+      {
+         int64_t        map_len = -1;
+         const uint8_t *map     = filestream_get_mapped_ptr(f, &map_len);
+         CHECK(!map || map_len == 0,
+               "empty file: no view, or a view of zero bytes");
+         filestream_close(f);
+      }
+      else
+         SKIP("empty fixture would not open with the hint");
+   }
+
+   /* ---- 3: filestream_matches_buf ---- */
+   {
+      uint8_t *other = (uint8_t*)malloc(len);
+
+      /* Which lane the checks below actually exercise.  With mappings
+       * available the compare runs against the map in one memcmp and
+       * the windowed fallback never executes, so the boundary cases
+       * are only meaningful in an MMAP=0 build - run both. */
+#ifdef HAVE_MMAP
+      printf("info: built with mappings; matches_buf compares in place\n");
+#else
+      printf("info: built without mappings; matches_buf uses the window\n");
+#endif
+
+      memcpy(other, body, len);
+      CHECK(filestream_matches_buf("mapped_fixture.bin", other, len),
+            "matches_buf: identical content matches");
+
+      /* The three places a difference can hide.  A window-at-a-time
+       * compare that mishandled its offsets would pass the first and
+       * fail one of the others. */
+      other[0] ^= 0xff;
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
+            "matches_buf: difference at the first byte is caught");
+      other[0] ^= 0xff;
+
+      other[len / 2] ^= 0xff;
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
+            "matches_buf: difference mid-file is caught");
+      other[len / 2] ^= 0xff;
+
+      other[len - 1] ^= 0xff;
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
+            "matches_buf: difference at the last byte is caught");
+      other[len - 1] ^= 0xff;
+
+      /* A window boundary is where an off-by-one would live: the
+       * fallback reads 64 KiB at a time. */
+      other[64 * 1024 - 1] ^= 0xff;
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
+            "matches_buf: difference at a window boundary is caught");
+      other[64 * 1024 - 1] ^= 0xff;
+
+      other[64 * 1024] ^= 0xff;
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len),
+            "matches_buf: difference just past a window boundary is caught");
+      other[64 * 1024] ^= 0xff;
+
+      /* Size disagreements resolve without reading, and must not
+       * report a match on a prefix. */
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len - 1),
+            "matches_buf: shorter length does not match");
+      CHECK(!filestream_matches_buf("mapped_fixture.bin", other, len + 1),
+            "matches_buf: longer length does not match");
+
+      CHECK(!filestream_matches_buf("mapped_missing.bin", other, len),
+            "matches_buf: missing file does not match");
+      CHECK(!filestream_matches_buf(NULL, other, len),
+            "matches_buf: NULL path answers false rather than faulting");
+
+      /* An empty file against zero bytes is a match, and is the one
+       * case where a NULL data pointer is legal. */
+      CHECK(filestream_matches_buf("mapped_empty.bin", NULL, 0),
+            "matches_buf: empty file matches zero bytes");
+      CHECK(!filestream_matches_buf("mapped_empty.bin", other, len),
+            "matches_buf: empty file does not match a non-empty buffer");
+
+      free(other);
+   }
+
+   free(body);
+   remove("mapped_fixture.bin");
+   remove("mapped_empty.bin");
+
+   if (test_fails)
+   {
+      printf("== %d FAILURES ==\n", test_fails);
+      return 1;
+   }
+   printf("== vfs_mapped_ptr_test: all tests pass ==\n");
+   return 0;
+}

--- a/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
+++ b/libretro-common/samples/file/vfs/vfs_mapped_ptr_test.c
@@ -298,6 +298,86 @@ int main(void)
       free(other);
    }
 
+   /* ---- 4: no stale bytes from a recycled stdio buffer ---- */
+   {
+      /* The VFS hands stdio a per-open buffer and no longer zeroes it
+       * (nothing reads those bytes before stdio writes them, and the
+       * WiiU path never zeroed).  The regression that would introduce
+       * is stale content surfacing through a read - most plausibly on
+       * a short read near EOF, where the buffer is only partly
+       * filled, and on a stream opened right after one that left
+       * different bytes in a recycled allocation.
+       *
+       * So: alternate between two files of different lengths and
+       * distinct fills, reading each to EOF a byte-count at a time
+       * that does not divide either length, and verify every byte.
+       * Under the old zeroing build this passes trivially; it is here
+       * to keep passing without it. */
+      const char *pa = "stale_a.bin";
+      const char *pb = "stale_b.bin";
+      size_t   la    = 40000;
+      size_t   lb    = 9001;
+      uint8_t *ba    = (uint8_t*)malloc(la);
+      uint8_t *bb    = (uint8_t*)malloc(lb);
+      uint8_t *got   = (uint8_t*)malloc(la);
+      int      round;
+      bool     clean = true;
+
+      for (i = 0; i < la; i++)
+         ba[i] = (uint8_t)(0xA0 + (i & 0x0f));
+      for (i = 0; i < lb; i++)
+         bb[i] = (uint8_t)(0x50 + (i & 0x0f));
+      write_file(pa, ba, la);
+      write_file(pb, bb, lb);
+
+      for (round = 0; round < 40 && clean; round++)
+      {
+         const char    *path = (round & 1) ? pb : pa;
+         const uint8_t *want = (round & 1) ? bb : ba;
+         size_t         len2 = (round & 1) ? lb : la;
+         size_t         off  = 0;
+         RFILE         *f    = filestream_open(path,
+               RETRO_VFS_FILE_ACCESS_READ,
+               RETRO_VFS_FILE_ACCESS_HINT_NONE);
+
+         if (!f)
+         {
+            clean = false;
+            break;
+         }
+         /* 4093 is prime, so the final read of each file is short and
+          * the buffer is left partly filled. */
+         while (off < len2)
+         {
+            int64_t n = filestream_read(f, got + off, 4093);
+            if (n <= 0)
+               break;
+            off += (size_t)n;
+         }
+         if (off != len2 || memcmp(got, want, len2) != 0)
+            clean = false;
+         /* Past EOF must deliver nothing rather than buffer residue. */
+         {
+            uint8_t tail[64];
+            memset(tail, 0xCC, sizeof(tail));
+            if (filestream_read(f, tail, (int64_t)sizeof(tail)) > 0)
+               clean = false;
+            for (i = 0; i < sizeof(tail); i++)
+               if (tail[i] != 0xCC)
+                  clean = false;
+         }
+         filestream_close(f);
+      }
+      CHECK(clean,
+            "recycled stdio buffers leak no stale bytes across opens");
+
+      free(ba);
+      free(bb);
+      free(got);
+      remove(pa);
+      remove(pb);
+   }
+
    free(body);
    remove("mapped_fixture.bin");
    remove("mapped_empty.bin");

--- a/libretro-common/samples/file/vfs_cdrom/Makefile
+++ b/libretro-common/samples/file/vfs_cdrom/Makefile
@@ -32,6 +32,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -DHAVE_CDROM -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 LDLIBS += -lm
 
 all: $(TARGET)

--- a/libretro-common/samples/formats/bmp/Makefile
+++ b/libretro-common/samples/formats/bmp/Makefile
@@ -10,6 +10,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/formats/jpeg/Makefile
+++ b/libretro-common/samples/formats/jpeg/Makefile
@@ -11,6 +11,15 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS  += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/formats/json/Makefile
+++ b/libretro-common/samples/formats/json/Makefile
@@ -27,6 +27,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS  += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/formats/json/rjson_test.c
+++ b/libretro-common/samples/formats/json/rjson_test.c
@@ -94,6 +94,72 @@ static void test_parser_happy_path(void)
    printf("[SUCCESS] parser happy path\n");
 }
 
+static void test_parser_deep_nesting_at(size_t depth, bool want_ok,
+      const char *what)
+{
+   size_t i;
+   size_t len   = depth * 2;
+   char  *input = (char*)malloc(len + 1);
+   struct count_ctx ctx;
+   bool   rc;
+
+   if (!input)
+   {
+      printf("[ERROR] %s: OOM\n", what);
+      failures++;
+      return;
+    }
+
+   for (i = 0; i < depth; ++i)
+      input[i] = '[';
+   for (i = 0; i < depth; ++i)
+      input[depth + i] = ']';
+   input[len] = '\0';
+
+   memset(&ctx, 0, sizeof(ctx));
+   rc = rjson_parse_quick(input, len, &ctx, 0,
+         cb_string, cb_string, cb_number,
+         cb_start_obj, cb_ignore_default,
+         cb_start_arr, cb_ignore_default,
+         cb_ignore_bool, cb_ignore_default, NULL);
+   free(input);
+
+   if (rc != want_ok)
+   {
+      printf("[ERROR] %s: parse returned %d, expected %d\n",
+            what, (int)rc, (int)want_ok);
+      failures++;
+      return;
+   }
+   printf("[SUCCESS] %s\n", what);
+}
+
+/* rjson_parse_quick() keeps its handle on the stack but not the two
+ * buffers inside it, and either can outgrow its inline storage onto
+ * the heap: the string buffer above, and the nesting stack here.
+ * Both leaked until _rjson_free_buffers() was split out of
+ * rjson_free().  test_parser_long_string() is what found the string
+ * half; this is the other one, which nothing exercised - the inline
+ * stack holds 10 levels, so anything shallower never allocates and
+ * never shows the leak.
+ *
+ * Both of parse_quick's returns are covered, because both leaked:
+ * 40 levels grows the stack and parses (the success return), and 200
+ * grows it to the 50-level ceiling and then fails (the error
+ * return), which is the path a hostile input takes.
+ *
+ * The only caller in the tree parses netplay lobby responses, so the
+ * nesting depth is a remote server's choice.  Run under
+ * LeakSanitizer to make this meaningful; without it, it only checks
+ * that the depth limit behaves. */
+static void test_parser_deep_nesting(void)
+{
+   test_parser_deep_nesting_at(40, true,
+         "deep nesting parsed and grown stack released");
+   test_parser_deep_nesting_at(200, false,
+         "over-deep nesting refused and grown stack released");
+}
+
 static void test_parser_long_string(void)
 {
    /* Forces multiple _rjson_grow_string growths: start from the
@@ -273,6 +339,7 @@ int main(void)
 {
    test_parser_happy_path();
    test_parser_long_string();
+   test_parser_deep_nesting();
    test_parser_malformed();
    test_writer_happy_path();
    test_writer_negative_len();

--- a/libretro-common/samples/formats/tga/Makefile
+++ b/libretro-common/samples/formats/tga/Makefile
@@ -10,6 +10,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/formats/xml/Makefile
+++ b/libretro-common/samples/formats/xml/Makefile
@@ -19,6 +19,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -DRXML_TEST -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/libretro-common/samples/net/Makefile
+++ b/libretro-common/samples/net/Makefile
@@ -77,6 +77,16 @@ NET_IFINFO_C = \
 
 ifeq ($(platform), win)
 CFLAGS += -liphlpapi -lws2_32
+
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
 endif
 
 NET_IFINFO_OBJS := $(NET_IFINFO_C:.c=.o)

--- a/libretro-common/samples/streams/rzip/Makefile
+++ b/libretro-common/samples/streams/rzip/Makefile
@@ -1,5 +1,6 @@
-TARGET := rzip
-TARGET_TEST := rzip_chunk_size_test
+TARGET       := rzip
+TARGET_TEST  := rzip_chunk_size_test
+TARGET_TEST2 := rzip_matches_buf_test
 
 LIBRETRO_COMM_DIR := ../../..
 LIBRETRO_DEPS_DIR := ../../../../deps
@@ -48,9 +49,11 @@ COMMON_SOURCES := \
 
 SOURCES      := rzip.c $(COMMON_SOURCES)
 SOURCES_TEST := rzip_chunk_size_test.c $(COMMON_SOURCES)
+SOURCES_TEST2 := rzip_matches_buf_test.c $(COMMON_SOURCES)
 
 OBJS      := $(SOURCES:.c=.o)
 OBJS_TEST := $(SOURCES_TEST:.c=.o)
+OBJS_TEST2 := $(SOURCES_TEST2:.c=.o)
 
 INCLUDE_DIRS += -I$(LIBRETRO_COMM_DIR)/include
 CFLAGS += -DHAVE_COMPRESSION -Wall -pedantic -std=gnu99 $(INCLUDE_DIRS)
@@ -64,13 +67,18 @@ ifeq ($(UNAME), MSYS)
 	CFLAGS += -Wno-format
 endif
 
+ifneq ($(SANITIZER),)
+	CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+	LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
 ifeq ($(DEBUG), 1)
 	CFLAGS += -O0 -g -DDEBUG -D_DEBUG
 else
 	CFLAGS += -O2 -DNDEBUG
 endif
 
-all: $(TARGET) $(TARGET_TEST)
+all: $(TARGET) $(TARGET_TEST) $(TARGET_TEST2)
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
@@ -81,7 +89,10 @@ $(TARGET): $(OBJS)
 $(TARGET_TEST): $(OBJS_TEST)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
+$(TARGET_TEST2): $(OBJS_TEST2)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
 clean:
-	rm -f $(TARGET) $(TARGET_TEST) $(OBJS) $(OBJS_TEST)
+	rm -f $(TARGET) $(TARGET_TEST) $(TARGET_TEST2) $(OBJS) $(OBJS_TEST) $(OBJS_TEST2)
 
 .PHONY: clean

--- a/libretro-common/samples/streams/rzip/rzip_matches_buf_test.c
+++ b/libretro-common/samples/streams/rzip/rzip_matches_buf_test.c
@@ -144,12 +144,17 @@ int main(void)
       expect_diff_at(path, probe, len, len - 1,
             "difference at the last byte is caught");
 
-      /* Read-chunk boundaries: the compare reads 64 KiB at a time. */
-      expect_diff_at(path, probe, len, 64 * 1024 - 1,
+      /* Read-chunk boundaries.  Must track rzipstream_matches_buf()'s
+       * actual chunk - 4 KiB, sized by the Vita thread stack rather
+       * than by the decompressor - because a boundary test aimed at
+       * the wrong offset is just another mid-file check. */
+      expect_diff_at(path, probe, len, 4096 - 1,
             "difference at a read-chunk boundary is caught");
-      expect_diff_at(path, probe, len, 64 * 1024,
+      expect_diff_at(path, probe, len, 4096,
             "difference just past a read-chunk boundary is caught");
-      expect_diff_at(path, probe, len, 128 * 1024,
+      expect_diff_at(path, probe, len, 4096 + 1,
+            "difference just after a read-chunk boundary is caught");
+      expect_diff_at(path, probe, len, 64 * 1024,
             "difference at a later read-chunk boundary is caught");
 
       /* rzip's own chunking is independent of the read size, so a

--- a/libretro-common/samples/streams/rzip/rzip_matches_buf_test.c
+++ b/libretro-common/samples/streams/rzip/rzip_matches_buf_test.c
@@ -144,17 +144,17 @@ int main(void)
       expect_diff_at(path, probe, len, len - 1,
             "difference at the last byte is caught");
 
-      /* Read-chunk boundaries.  Must track rzipstream_matches_buf()'s
-       * actual chunk - 4 KiB, sized by the Vita thread stack rather
-       * than by the decompressor - because a boundary test aimed at
-       * the wrong offset is just another mid-file check. */
-      expect_diff_at(path, probe, len, 4096 - 1,
+      /* Read-chunk boundaries, taken from the header rather than
+       * repeated here: the chunk has already been resized once, and a
+       * boundary case aimed at the old value is just another mid-file
+       * check wearing a boundary's name. */
+      expect_diff_at(path, probe, len, RZIPSTREAM_MATCHES_BUF_CHUNK - 1,
             "difference at a read-chunk boundary is caught");
-      expect_diff_at(path, probe, len, 4096,
+      expect_diff_at(path, probe, len, RZIPSTREAM_MATCHES_BUF_CHUNK,
             "difference just past a read-chunk boundary is caught");
-      expect_diff_at(path, probe, len, 4096 + 1,
+      expect_diff_at(path, probe, len, RZIPSTREAM_MATCHES_BUF_CHUNK + 1,
             "difference just after a read-chunk boundary is caught");
-      expect_diff_at(path, probe, len, 64 * 1024,
+      expect_diff_at(path, probe, len, 8 * RZIPSTREAM_MATCHES_BUF_CHUNK,
             "difference at a later read-chunk boundary is caught");
 
       /* rzip's own chunking is independent of the read size, so a

--- a/libretro-common/samples/streams/rzip/rzip_matches_buf_test.c
+++ b/libretro-common/samples/streams/rzip/rzip_matches_buf_test.c
@@ -1,0 +1,204 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rzip_matches_buf_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Regression test for rzipstream_matches_buf().
+ *
+ * The SRAM dirty-check asks "does the file on disk already hold what
+ * is in memory?", and answered it by decompressing the whole save
+ * into a fresh allocation, comparing, and freeing - checking the size
+ * only afterwards, so the one case where the answer is free still
+ * paid a full decompress.  rzipstream_matches_buf() settles the size
+ * from the header first, decompresses a chunk at a time, and stops at
+ * the first difference.
+ *
+ * What makes this worth its own test rather than sharing
+ * filestream_matches_buf's: rzip reads are decompressions, so the
+ * chunk loop is re-entering an inflate stream rather than walking a
+ * buffer, and its boundaries do not line up with the compressor's
+ * chunking.  A difference sitting on a read boundary, an rzip chunk
+ * boundary, or between the two is where an off-by-one lives, and
+ * those are three different offsets.
+ *
+ * rzip is also transparent about uncompressed input, so both file
+ * shapes go through the same entry point and both are checked here -
+ * a save written before compression was enabled must still compare
+ * correctly.
+ *
+ * Build:  make            (SANITIZER=address,undefined for a checked run)
+ * Run:    ./rzip_matches_buf_test
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <boolean.h>
+#include <streams/rzip_stream.h>
+#include <streams/file_stream.h>
+
+static int test_fails;
+
+#define CHECK(cond, msg) \
+   do { \
+      if (!(cond)) \
+      { \
+         printf("FAIL: %s\n", msg); \
+         test_fails++; \
+      } \
+      else \
+         printf("ok:   %s\n", msg); \
+   } while (0)
+
+/* Compressible enough that rzip actually compresses, varied enough
+ * that a misaligned compare cannot pass by accident. */
+static void fill_body(uint8_t *body, size_t len)
+{
+   size_t i;
+   for (i = 0; i < len; i++)
+      body[i] = (uint8_t)((i / 61) ^ (i & 0x3f));
+}
+
+static bool write_rzip(const char *path, const uint8_t *body, size_t len)
+{
+   rzipstream_t *s = rzipstream_open(path, RETRO_VFS_FILE_ACCESS_WRITE);
+   bool ok;
+   if (!s)
+      return false;
+   ok = (rzipstream_write(s, body, (int64_t)len) == (int64_t)len);
+   rzipstream_close(s);
+   return ok;
+}
+
+static void write_plain(const char *path, const uint8_t *body, size_t len)
+{
+   FILE *f = fopen(path, "wb");
+   if (len)
+      fwrite(body, 1, len, f);
+   fclose(f);
+}
+
+/* Flip one byte, assert the mismatch is seen, flip it back. */
+static void expect_diff_at(const char *path, uint8_t *probe, size_t len,
+      size_t at, const char *msg)
+{
+   if (at >= len)
+      return;
+   probe[at] ^= 0xff;
+   CHECK(!rzipstream_matches_buf(path, probe, len), msg);
+   probe[at] ^= 0xff;
+}
+
+int main(void)
+{
+   /* Spans several 64 KiB read chunks and does not end on one. */
+   size_t   len   = 300 * 1024 + 77;
+   uint8_t *body  = (uint8_t*)malloc(len);
+   uint8_t *probe = (uint8_t*)malloc(len);
+   int      pass;
+
+   fill_body(body, len);
+
+   if (!write_rzip("rzip_match.rzip", body, len))
+   {
+      printf("FAIL: could not write the compressed fixture\n");
+      return 1;
+   }
+   write_plain("rzip_match.plain", body, len);
+   write_plain("rzip_match.empty", body, 0);
+
+   /* Both file shapes through the same entry point. */
+   for (pass = 0; pass < 2; pass++)
+   {
+      const char *path = pass ? "rzip_match.plain" : "rzip_match.rzip";
+
+      printf("-- %s input --\n", pass ? "uncompressed" : "compressed");
+      memcpy(probe, body, len);
+
+      CHECK(rzipstream_matches_buf(path, probe, len),
+            "identical content matches");
+
+      expect_diff_at(path, probe, len, 0,
+            "difference at the first byte is caught");
+      expect_diff_at(path, probe, len, len / 2,
+            "difference mid-file is caught");
+      expect_diff_at(path, probe, len, len - 1,
+            "difference at the last byte is caught");
+
+      /* Read-chunk boundaries: the compare reads 64 KiB at a time. */
+      expect_diff_at(path, probe, len, 64 * 1024 - 1,
+            "difference at a read-chunk boundary is caught");
+      expect_diff_at(path, probe, len, 64 * 1024,
+            "difference just past a read-chunk boundary is caught");
+      expect_diff_at(path, probe, len, 128 * 1024,
+            "difference at a later read-chunk boundary is caught");
+
+      /* rzip's own chunking is independent of the read size, so a
+       * difference landing on one is a separate offset to check. */
+      expect_diff_at(path, probe, len, 32 * 1024,
+            "difference at an rzip chunk boundary is caught");
+      expect_diff_at(path, probe, len, 32 * 1024 - 1,
+            "difference just before an rzip chunk boundary is caught");
+
+      /* Size disagreements resolve from the header, and a prefix
+       * must not be reported as a match. */
+      CHECK(!rzipstream_matches_buf(path, probe, len - 1),
+            "shorter length does not match");
+      CHECK(!rzipstream_matches_buf(path, probe, len + 1),
+            "longer length does not match");
+
+      CHECK(!rzipstream_matches_buf(path, probe, 0),
+            "zero length does not match a non-empty file");
+   }
+
+   printf("-- edge cases --\n");
+   CHECK(!rzipstream_matches_buf("rzip_match.missing", probe, len),
+         "missing file does not match");
+   CHECK(!rzipstream_matches_buf(NULL, probe, len),
+         "NULL path answers false rather than faulting");
+   /* Deliberately the opposite of filestream_matches_buf, which
+    * matches an empty file against zero bytes.  An empty file has no
+    * rzip header, so rzipstream_open() cannot open it at all and
+    * there is nothing to compare - and false is the answer that
+    * serves the caller, since "write it" replaces a zero-byte file
+    * with a valid one.  Asserted so the asymmetry stays deliberate
+    * rather than becoming a surprise for anyone switching a call site
+    * between the two. */
+   CHECK(!rzipstream_matches_buf("rzip_match.empty", NULL, 0),
+         "empty file does not match zero bytes (no rzip header to read)");
+   CHECK(!rzipstream_matches_buf("rzip_match.empty", probe, len),
+         "empty file does not match a non-empty buffer");
+
+   free(body);
+   free(probe);
+   remove("rzip_match.rzip");
+   remove("rzip_match.plain");
+   remove("rzip_match.empty");
+
+   if (test_fails)
+   {
+      printf("== %d FAILURES ==\n", test_fails);
+      return 1;
+   }
+   printf("== rzip_matches_buf_test: all tests pass ==\n");
+   return 0;
+}

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -879,16 +879,33 @@ static int fs_scan_wide(const char **pp, const fs_scan_spec_t *sp,
 
 int filestream_vscanf(RFILE *stream, const char *format, va_list *args)
 {
-   char        buf[4096];
+   /* The scan window is heap rather than a local: at char buf[4096]
+    * this was a 4368-byte frame, over half of the 8 KiB a GEKKO
+    * thread gets (STACKSIZE in rthreads/gx_pthread.h).  Shrinking it
+    * instead would have been the cheaper change and the wrong one -
+    * the window is how far a single conversion may reach, so a
+    * smaller one fails differently on long input rather than merely
+    * more slowly.  One allocation per call is nothing beside the read
+    * this function already performs. */
+   char       *buf       = (char*)malloc(FILESTREAM_SCANF_WINDOW);
    va_list     args_copy;
    const char *bufiter;
    const char *fmt      = format;
    int         ret      = 0;
-   int64_t     startpos = filestream_tell(stream);
-   int64_t     maxlen   = filestream_read(stream, buf, sizeof(buf) - 1);
+   int64_t     startpos;
+   int64_t     maxlen;
+
+   if (!buf)
+      return EOF;
+
+   startpos = filestream_tell(stream);
+   maxlen   = filestream_read(stream, buf, FILESTREAM_SCANF_WINDOW - 1);
 
    if (maxlen <= 0)
+   {
+      free(buf);
       return EOF;
+   }
 
    buf[maxlen] = '\0';
 
@@ -1007,9 +1024,12 @@ int filestream_vscanf(RFILE *stream, const char *format, va_list *args)
 
    va_end(args_copy);
 
+   /* Seek before the free: the new position is derived from how far
+    * bufiter walked into buf. */
    filestream_seek(stream, startpos + (bufiter - buf),
          RETRO_VFS_SEEK_POSITION_START);
 
+   free(buf);
    return ret;
 }
 

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -1232,23 +1232,22 @@ bool filestream_matches_buf(const char *path, const void *data, size_t len)
    }
 
    {
-      /* 4 KiB, and the ceiling is a stack budget rather than a
-       * throughput one.  These constructs are libretro-common API, so
-       * any caller can be on a spawned thread, and sthread_create()
-       * gives Vita threads a 0x10000 stack - a 64 KiB window is the
-       * entire stack, which is an overflow rather than a slow path.
+      /* FILESTREAM_MATCHES_BUF_WINDOW, which is sized by the smallest
+       * thread stack in the tree rather than by throughput.  PSP and
+       * GX threads get 8 KiB (STACKSIZE in psp_pthread.h and
+       * gx_pthread.h), 3DS 32 KiB, Vita 64 KiB - and this is
+       * libretro-common API, so a caller on a spawned thread is not
+       * hypothetical.
        *
-       * A larger window does read slightly better, because reads at
-       * or above the VFS's own 64 KiB stdio buffer are handed
-       * straight to the destination instead of being staged through
-       * it: measured on the unchanged case, which reads everything,
-       * 4 KiB against 64 KiB costs 30.9 us vs 27.0 us on a 512 KiB
-       * file and 831 us vs 774 us on 8 MiB.  Seven to fourteen per
-       * cent, and only on this path - the mapped branch above does
-       * not copy at all, so the platforms that pay it are the ones
-       * without mappings, which are also the ones with the small
-       * stacks.  That trade is not close. */
-      uint8_t window[4096];
+       * Bigger reads are faster, and at or above the VFS's own 64 KiB
+       * stdio buffer they skip it entirely: measured on the unchanged
+       * case, which reads every byte, 1 KiB against 4 KiB against
+       * 64 KiB is 1753 / 1432 / 1153 us on an 8 MiB file.  The
+       * platforms paying that are the ones with no memory mapping -
+       * the mapped branch above copies nothing - which are the same
+       * ones with the 8 KiB stacks, and this runs when a save is
+       * written rather than in a frame. */
+      uint8_t window[FILESTREAM_MATCHES_BUF_WINDOW];
       size_t  off = 0;
 
       match = true;

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -1197,6 +1197,96 @@ const char* filestream_get_path(RFILE *stream)
          (libretro_vfs_implementation_file*)stream->hfile);
 }
 
+bool filestream_matches_buf(const char *path, const void *data, size_t len)
+{
+   const uint8_t *mem     = (const uint8_t*)data;
+   const uint8_t *map     = NULL;
+   int64_t        map_len = 0;
+   bool           match   = false;
+   RFILE         *file;
+
+   if (!path || !*path || (len && !data))
+      return false;
+
+   if (!(file = filestream_open(path, RETRO_VFS_FILE_ACCESS_READ,
+               RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS)))
+      return false;
+
+   /* The cheap answer, before a byte moves.  Callers that slurped the
+    * file to memcmp it were paying a full-size allocation and a
+    * full-file read to learn this, and learning it last. */
+   if (filestream_get_size(file) != (int64_t)len)
+      goto done;
+
+   if ((map = filestream_get_mapped_ptr(file, &map_len)))
+   {
+      /* A view that does not span the file would compare the wrong
+       * bytes; fall through to the copying path rather than guess. */
+      if (map_len == (int64_t)len)
+      {
+         match = (len == 0) || (memcmp(map, mem, len) == 0);
+         goto done;
+      }
+      if (filestream_seek(file, 0, RETRO_VFS_SEEK_POSITION_START) != 0)
+         goto done;
+   }
+
+   {
+      /* Window sized to the VFS's own stdio buffer, so each read is
+       * handed straight to the destination rather than staged through
+       * it - below that size this reintroduces the very copy the
+       * mapped path exists to avoid. */
+      uint8_t window[64 * 1024];
+      size_t  off = 0;
+
+      match = true;
+      while (off < len)
+      {
+         int64_t got;
+         size_t  want = len - off;
+
+         if (want > sizeof(window))
+            want = sizeof(window);
+
+         if ((got = filestream_read(file, window, (int64_t)want))
+               != (int64_t)want)
+         {
+            match = false;
+            break;
+         }
+         /* Stop at the first difference: the caller asked a yes/no
+          * question and a 'no' is final. */
+         if (memcmp(window, mem + off, (size_t)got) != 0)
+         {
+            match = false;
+            break;
+         }
+         off += (size_t)got;
+      }
+   }
+
+done:
+   if (filestream_close(file) != 0)
+      free(file);
+   return match;
+}
+
+const uint8_t *filestream_get_mapped_ptr(RFILE *stream, int64_t *len)
+{
+   if (len)
+      *len = 0;
+   if (!stream)
+      return NULL;
+   /* A frontend- or core-supplied VFS is driven entirely through the
+    * callbacks below and has no mapping this side of them, so there
+    * is nothing to hand back.  Answer NULL rather than reaching into
+    * a handle this layer does not own. */
+   if (filestream_read_cb)
+      return NULL;
+   return retro_vfs_file_get_mapped_ptr_impl(
+         (libretro_vfs_implementation_file*)stream->hfile, len);
+}
+
 int64_t filestream_write(RFILE *stream, const void *s, int64_t len)
 {
    int64_t output;
@@ -1267,6 +1357,78 @@ int filestream_close(RFILE *stream)
    return output;
 }
 
+/* Read an already-open stream to EOF, growing the buffer as it goes.
+ *
+ * For the path below that sizes its allocation from
+ * filestream_get_size(), a file reporting zero bytes yields a zero-
+ * byte read - so procfs, whose entries all stat as size 0, came back
+ * as an empty string *and a success return*.  Callers cannot tell
+ * that from a genuinely empty file, and did not: the /proc/apm
+ * battery probe, the /proc/modules sg check in cdrom.c and the
+ * dingux /proc/jz/battery reader all silently saw nothing.  (Which
+ * is also why mem_stats.c reads /proc/meminfo through a raw open()
+ * and read() rather than this helper.)
+ *
+ * A stat size is a hint, not a contract - synthetic filesystems have
+ * no length until they are read, and a growing file's is stale the
+ * moment it is taken - so when there is no usable hint, read until
+ * the stream says stop.  Returns bytes read, or -1.
+ */
+static int64_t filestream_read_file_to_eof(RFILE *file, void **buf)
+{
+   /* One page holds essentially every procfs entry this is used for,
+    * so the doubling below rarely runs at all. */
+   size_t   cap  = 4096;
+   size_t   used = 0;
+   char    *data = (char*)malloc(cap);
+
+   if (!data)
+      return -1;
+
+   for (;;)
+   {
+      int64_t got;
+
+      /* Keep a spare byte for the NUL, and grow before reading so a
+       * read is never issued with zero space. */
+      if (used + 1 >= cap)
+      {
+         char  *tmp;
+         size_t want = cap * 2;
+
+         /* Refuse a doubling that would wrap, rather than allocating
+          * a smaller buffer than the offsets below assume. */
+         if (want < cap)
+         {
+            free(data);
+            return -1;
+         }
+         if (!(tmp = (char*)realloc(data, want)))
+         {
+            free(data);
+            return -1;
+         }
+         data = tmp;
+         cap  = want;
+      }
+
+      if ((got = filestream_read(file, data + used,
+                  (int64_t)(cap - used - 1))) < 0)
+      {
+         free(data);
+         return -1;
+      }
+      if (got == 0)
+         break;
+
+      used += (size_t)got;
+   }
+
+   data[used] = '\0';
+   *buf       = data;
+   return (int64_t)used;
+}
+
 int64_t filestream_read_file(const char *path, void **buf, int64_t *len)
 {
    int64_t ret              = 0;
@@ -1284,6 +1446,22 @@ int64_t filestream_read_file(const char *path, void **buf, int64_t *len)
 
    if ((content_buf_size = filestream_get_size(file)) < 0)
       goto error;
+
+   /* No usable size hint: read to EOF instead of trusting the zero.
+    * See filestream_read_file_to_eof() above. */
+   if (content_buf_size == 0)
+   {
+      if ((ret = filestream_read_file_to_eof(file, &content_buf)) < 0)
+         goto error;
+
+      if (filestream_close(file) != 0)
+         free(file);
+
+      *buf = content_buf;
+      if (len)
+         *len = ret;
+      return 1;
+   }
 
    /* Reject sizes that would not survive the cast to size_t for
     * the malloc below.  Pre-patch the only check here was a

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -1233,11 +1233,14 @@ bool filestream_matches_buf(const char *path, const void *data, size_t len)
 
    {
       /* FILESTREAM_MATCHES_BUF_WINDOW, which is sized by the smallest
-       * thread stack in the tree rather than by throughput.  PSP and
-       * GX threads get 8 KiB (STACKSIZE in psp_pthread.h and
-       * gx_pthread.h), 3DS 32 KiB, Vita 64 KiB - and this is
+       * thread stack in the tree rather than by throughput.  GEKKO
+       * threads get 8 KiB (STACKSIZE in rthreads/gx_pthread.h), 3DS
+       * 32 KiB (ctr_pthread.h) and Vita 64 KiB - and this is
        * libretro-common API, so a caller on a spawned thread is not
-       * hypothetical.
+       * hypothetical.  (psp_pthread.h declares 8 KiB too, but nothing
+       * includes it: rthreads.c reaches for gx_pthread.h under GEKKO
+       * and ctr_pthread.h under _3DS, and PSP falls through to plain
+       * pthreads.  The 8 KiB floor is GEKKO's.)
        *
        * Bigger reads are faster, and at or above the VFS's own 64 KiB
        * stdio buffer they skip it entirely: measured on the unchanged

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -1232,11 +1232,23 @@ bool filestream_matches_buf(const char *path, const void *data, size_t len)
    }
 
    {
-      /* Window sized to the VFS's own stdio buffer, so each read is
-       * handed straight to the destination rather than staged through
-       * it - below that size this reintroduces the very copy the
-       * mapped path exists to avoid. */
-      uint8_t window[64 * 1024];
+      /* 4 KiB, and the ceiling is a stack budget rather than a
+       * throughput one.  These constructs are libretro-common API, so
+       * any caller can be on a spawned thread, and sthread_create()
+       * gives Vita threads a 0x10000 stack - a 64 KiB window is the
+       * entire stack, which is an overflow rather than a slow path.
+       *
+       * A larger window does read slightly better, because reads at
+       * or above the VFS's own 64 KiB stdio buffer are handed
+       * straight to the destination instead of being staged through
+       * it: measured on the unchanged case, which reads everything,
+       * 4 KiB against 64 KiB costs 30.9 us vs 27.0 us on a 512 KiB
+       * file and 831 us vs 774 us on 8 MiB.  Seven to fourteen per
+       * cent, and only on this path - the mapped branch above does
+       * not copy at all, so the platforms that pay it are the ones
+       * without mappings, which are also the ones with the small
+       * stacks.  That trade is not close. */
+      uint8_t window[4096];
       size_t  off = 0;
 
       match = true;

--- a/libretro-common/streams/rzip_stream.c
+++ b/libretro-common/streams/rzip_stream.c
@@ -782,10 +782,13 @@ bool rzipstream_matches_buf(const char *path, const void *data, size_t len)
       goto done;
 
    {
-      /* Chunk rather than window: an rzip read is a decompress, so
-       * this trades a fixed 64 KiB of stack against how many times
-       * the inflate loop is re-entered. */
-      uint8_t chunk[64 * 1024];
+      /* 4 KiB, sized by the stack rather than by the decompressor:
+       * this is libretro-common API, so a caller can be on a spawned
+       * thread, and sthread_create() gives Vita threads a 0x10000
+       * stack - a 64 KiB buffer here is the whole of it.  See the
+       * same ceiling and its measured cost in
+       * filestream_matches_buf(). */
+      uint8_t chunk[4096];
       size_t  off = 0;
 
       match = true;

--- a/libretro-common/streams/rzip_stream.c
+++ b/libretro-common/streams/rzip_stream.c
@@ -784,8 +784,8 @@ bool rzipstream_matches_buf(const char *path, const void *data, size_t len)
    {
       /* RZIPSTREAM_MATCHES_BUF_CHUNK, sized by the stack rather than
        * by the decompressor: this is libretro-common API, so a caller
-       * can be on a spawned thread, and PSP and GX threads get 8 KiB
-       * (STACKSIZE in psp_pthread.h and gx_pthread.h).  See the same
+       * can be on a spawned thread, and GEKKO threads get 8 KiB
+       * (STACKSIZE in rthreads/gx_pthread.h).  See the same
        * ceiling and its measured cost in filestream_matches_buf(). */
       uint8_t chunk[RZIPSTREAM_MATCHES_BUF_CHUNK];
       size_t  off = 0;

--- a/libretro-common/streams/rzip_stream.c
+++ b/libretro-common/streams/rzip_stream.c
@@ -750,6 +750,73 @@ char* rzipstream_gets(rzipstream_t *stream, char *s, size_t len)
    return (s);
 }
 
+/* Does the file at 'path' hold exactly 'len' bytes equal to 'data'?
+ *
+ * The rzip counterpart of filestream_matches_buf(), for the same
+ * "has this changed since I last wrote it?" question, and answering
+ * it the same way: the uncompressed size settles a mismatch before
+ * anything is decompressed, and the comparison stops at the first
+ * differing byte.
+ *
+ * There is no mapped fast path here and there cannot be - the bytes
+ * being compared do not exist on disk in that form - so this always
+ * decompresses into a window.  What it avoids is the whole-file
+ * allocation: callers asked this question by decompressing the
+ * entire file into a fresh buffer, comparing it, and freeing it.
+ *
+ * False for a missing file, a size mismatch, a short or failed read,
+ * or the first difference - all of which mean "write it". */
+bool rzipstream_matches_buf(const char *path, const void *data, size_t len)
+{
+   const uint8_t *mem   = (const uint8_t*)data;
+   bool           match = false;
+   rzipstream_t  *stream;
+
+   if (!path || !*path || (len && !data))
+      return false;
+
+   if (!(stream = rzipstream_open(path, RETRO_VFS_FILE_ACCESS_READ)))
+      return false;
+
+   if (rzipstream_get_size(stream) != (int64_t)len)
+      goto done;
+
+   {
+      /* Chunk rather than window: an rzip read is a decompress, so
+       * this trades a fixed 64 KiB of stack against how many times
+       * the inflate loop is re-entered. */
+      uint8_t chunk[64 * 1024];
+      size_t  off = 0;
+
+      match = true;
+      while (off < len)
+      {
+         int64_t got;
+         size_t  want = len - off;
+
+         if (want > sizeof(chunk))
+            want = sizeof(chunk);
+
+         if ((got = rzipstream_read(stream, chunk, (int64_t)want))
+               != (int64_t)want)
+         {
+            match = false;
+            break;
+         }
+         if (memcmp(chunk, mem + off, (size_t)got) != 0)
+         {
+            match = false;
+            break;
+         }
+         off += (size_t)got;
+      }
+   }
+
+done:
+   rzipstream_close(stream);
+   return match;
+}
+
 /* Reads all data from file specified by 'path' and
  * copies it to 'buf'.
  * - 'buf' will be allocated and must be free()'d manually.

--- a/libretro-common/streams/rzip_stream.c
+++ b/libretro-common/streams/rzip_stream.c
@@ -782,13 +782,12 @@ bool rzipstream_matches_buf(const char *path, const void *data, size_t len)
       goto done;
 
    {
-      /* 4 KiB, sized by the stack rather than by the decompressor:
-       * this is libretro-common API, so a caller can be on a spawned
-       * thread, and sthread_create() gives Vita threads a 0x10000
-       * stack - a 64 KiB buffer here is the whole of it.  See the
-       * same ceiling and its measured cost in
-       * filestream_matches_buf(). */
-      uint8_t chunk[4096];
+      /* RZIPSTREAM_MATCHES_BUF_CHUNK, sized by the stack rather than
+       * by the decompressor: this is libretro-common API, so a caller
+       * can be on a spawned thread, and PSP and GX threads get 8 KiB
+       * (STACKSIZE in psp_pthread.h and gx_pthread.h).  See the same
+       * ceiling and its measured cost in filestream_matches_buf(). */
+      uint8_t chunk[RZIPSTREAM_MATCHES_BUF_CHUNK];
       size_t  off = 0;
 
       match = true;

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -580,11 +580,21 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
        * even that is too much the allocation simply fails and the C
        * library default is used, so a platform under real pressure
        * degrades rather than breaks.  A platform wanting a different
-       * size says so, as the two below do. */
+       * size says so, as the two below do.
+       *
+       * It is malloc rather than calloc because nothing ever reads
+       * these bytes before stdio writes them - the buffer is handed
+       * straight to setvbuf and otherwise only freed, and the WiiU
+       * path below has always used non-zeroing memalign.  Zeroing it
+       * was the single dearest part of opening a small file: 3000
+       * opens of 256-byte files measured 2.9-3.1 us each with the
+       * zeroing and 1.8 us without, so scan-shaped and thumbnail-
+       * shaped workloads - thousands of opens, few bytes each - spent
+       * more time clearing buffers than reading files. */
 #if defined(_3DS)
       if (stream->scheme != VFS_SCHEME_CDROM)
       {
-         stream->buf = (char*)calloc(1, 0x10000);
+         stream->buf = (char*)malloc(0x10000);
          if (stream->fp)
             setvbuf(stream->fp, stream->buf, _IOFBF, 0x10000);
       }
@@ -600,7 +610,7 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(
       if (stream->scheme != VFS_SCHEME_CDROM)
       {
          const int bufsize = 64 * 1024;
-         if ((stream->buf = (char*)calloc(1, bufsize)))
+         if ((stream->buf = (char*)malloc(bufsize)))
          {
             if (stream->fp)
                setvbuf(stream->fp, stream->buf, _IOFBF, bufsize);

--- a/libretro-common/vfs/vfs_implementation.c
+++ b/libretro-common/vfs/vfs_implementation.c
@@ -1113,6 +1113,30 @@ const char *retro_vfs_file_get_path_impl(
    return stream->orig_path;
 }
 
+const uint8_t *retro_vfs_file_get_mapped_ptr_impl(
+      libretro_vfs_implementation_file *stream, int64_t *len)
+{
+   if (len)
+      *len = 0;
+#ifdef HAVE_MMAP
+   /* Gate on the hint as well as the pointer, matching the read and
+    * seek paths: those consult 'mapped' only under the hint, so the
+    * map is authoritative for the file contents only when the hint
+    * put it there. */
+   if (     stream
+         && stream->mapped
+         && (stream->hints & RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS))
+   {
+      if (len)
+         *len = (int64_t)stream->mapsize;
+      return stream->mapped;
+   }
+#else
+   (void)stream;
+#endif
+   return NULL;
+}
+
 int retro_vfs_stat_64_impl(const char *path, int64_t *size)
 {
    int ret                   = RETRO_VFS_STAT_IS_VALID;

--- a/libretro-common/vfs/vfs_implementation_uwp.cpp
+++ b/libretro-common/vfs/vfs_implementation_uwp.cpp
@@ -662,6 +662,27 @@ const char *retro_vfs_file_get_path_impl(libretro_vfs_implementation_file *strea
    return stream->orig_path;
 }
 
+const uint8_t *retro_vfs_file_get_mapped_ptr_impl(
+      libretro_vfs_implementation_file *stream, int64_t *len)
+{
+   /* This backend never maps a file: retro_vfs_file_open_impl() above
+    * nulls 'mapped' and clears
+    * RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS unconditionally.  NULL
+    * is the documented answer for "no mapping here", and every caller
+    * must already handle it - the hint is advisory on every backend -
+    * so there is nothing to implement beyond saying so.
+    *
+    * It has to be said out loud rather than omitted, though:
+    * filestream_get_mapped_ptr() calls this whenever no frontend VFS
+    * is installed, and this file replaces vfs_implementation.c
+    * wholesale on UWP, so leaving it out is a link error rather than
+    * a fallback. */
+   (void)stream;
+   if (len)
+      *len = 0;
+   return NULL;
+}
+
 int retro_vfs_stat_64_impl(const char *path, int64_t *size)
 {
    wchar_t *path_wide;

--- a/samples/tasks/decompress/Makefile
+++ b/samples/tasks/decompress/Makefile
@@ -6,6 +6,16 @@ OBJS := $(SOURCES:.c=.o)
 
 CFLAGS += -Wall -pedantic -std=gnu99 -g -O0
 
+# The samples workflow passes SANITIZER=address,undefined to every
+# sample dir.  Without this block the variable was accepted and
+# ignored, so these targets built unsanitized while the workflow
+# reported them as checked.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+
 all: $(TARGET)
 
 %.o: %.c

--- a/save.c
+++ b/save.c
@@ -601,10 +601,6 @@ static bool content_save_ram_file(unsigned slot, bool compress)
 {
    struct ram_type ram;
    retro_ctx_memory_info_t mem_info;
-#if defined(HAVE_COMPRESSION)
-   int64_t disk_rc;
-   void *disk_buf = NULL;
-#endif
 
    if (!content_get_memory(&mem_info, &ram, slot))
       return false;
@@ -615,48 +611,33 @@ static bool content_save_ram_file(unsigned slot, bool compress)
    if (   ram.path && *ram.path
        &&  path_is_valid(ram.path))
    {
-#if defined(HAVE_COMPRESSION)
-      bool read_ok = rzipstream_read_file(ram.path, &disk_buf, &disk_rc);
-
-      if (read_ok && disk_buf)
-      {
-         bool matches = (disk_rc == (int64_t)mem_info.size)
-            && (memcmp(disk_buf, mem_info.data, mem_info.size) == 0);
-         free(disk_buf);
-         if (matches)
-         {
-            RARCH_LOG("[SRAM] %s \"%s\" (unchanged, skipping write).\n",
-                  msg_hash_to_str(MSG_SAVED_SUCCESSFULLY_TO),
-                  ram.path);
-            return true;
-         }
-      }
-      else if (disk_buf)
-         free(disk_buf);
-#else
-      /* Uncompressed saves are compared in place rather than slurped.
-       * The old path allocated a second copy of the whole save file
+      /* Compared in place rather than slurped, in both lanes.  The
+       * old path allocated a second copy of the whole save file
        * purely to memcmp it and free it, and checked the size only
        * after the read had already happened - so a save that had
        * changed size, the one case where the answer is knowable for
-       * free, still paid a full-size malloc and a full-file read.
-       * Cores with megabytes of save RAM paid that on every save,
-       * against a memory budget that on the handheld targets is the
-       * scarce resource.
+       * free, still paid a full-size allocation and a full-file read
+       * (a full decompress, in the compressed lane).  Cores with
+       * megabytes of save RAM paid that on every save, against a
+       * memory budget that on the handheld targets is the scarce
+       * resource.
        *
-       * Size first, then compare without owning a copy: the mapped
-       * view when the platform gives one, a fixed window otherwise.
-       * Either way the comparison stops at the first differing byte,
-       * which is the case that goes on to write. */
+       * Size first, then compare without owning a copy, stopping at
+       * the first differing byte - which is the case that goes on to
+       * write. */
+#if defined(HAVE_COMPRESSION)
+      if (rzipstream_matches_buf(ram.path, mem_info.data,
+               mem_info.size))
+#else
       if (filestream_matches_buf(ram.path, mem_info.data,
                mem_info.size))
+#endif
       {
          RARCH_LOG("[SRAM] %s \"%s\" (unchanged, skipping write).\n",
                msg_hash_to_str(MSG_SAVED_SUCCESSFULLY_TO),
                ram.path);
          return true;
       }
-#endif
    }
 
    RARCH_LOG("[SRAM] %s #%u %s \"%s\".\n",

--- a/save.c
+++ b/save.c
@@ -601,8 +601,10 @@ static bool content_save_ram_file(unsigned slot, bool compress)
 {
    struct ram_type ram;
    retro_ctx_memory_info_t mem_info;
+#if defined(HAVE_COMPRESSION)
    int64_t disk_rc;
    void *disk_buf = NULL;
+#endif
 
    if (!content_get_memory(&mem_info, &ram, slot))
       return false;
@@ -615,9 +617,7 @@ static bool content_save_ram_file(unsigned slot, bool compress)
    {
 #if defined(HAVE_COMPRESSION)
       bool read_ok = rzipstream_read_file(ram.path, &disk_buf, &disk_rc);
-#else
-      bool read_ok = filestream_read_file(ram.path, &disk_buf, &disk_rc);
-#endif
+
       if (read_ok && disk_buf)
       {
          bool matches = (disk_rc == (int64_t)mem_info.size)
@@ -633,6 +633,30 @@ static bool content_save_ram_file(unsigned slot, bool compress)
       }
       else if (disk_buf)
          free(disk_buf);
+#else
+      /* Uncompressed saves are compared in place rather than slurped.
+       * The old path allocated a second copy of the whole save file
+       * purely to memcmp it and free it, and checked the size only
+       * after the read had already happened - so a save that had
+       * changed size, the one case where the answer is knowable for
+       * free, still paid a full-size malloc and a full-file read.
+       * Cores with megabytes of save RAM paid that on every save,
+       * against a memory budget that on the handheld targets is the
+       * scarce resource.
+       *
+       * Size first, then compare without owning a copy: the mapped
+       * view when the platform gives one, a fixed window otherwise.
+       * Either way the comparison stops at the first differing byte,
+       * which is the case that goes on to write. */
+      if (filestream_matches_buf(ram.path, mem_info.data,
+               mem_info.size))
+      {
+         RARCH_LOG("[SRAM] %s \"%s\" (unchanged, skipping write).\n",
+               msg_hash_to_str(MSG_SAVED_SUCCESSFULLY_TO),
+               ram.path);
+         return true;
+      }
+#endif
    }
 
    RARCH_LOG("[SRAM] %s #%u %s \"%s\".\n",

--- a/tasks/task_cloudsync.c
+++ b/tasks/task_cloudsync.c
@@ -568,40 +568,69 @@ static INLINE int task_cloud_sync_key_cmp(struct item_file *left, struct item_fi
 
 static char *task_cloud_sync_md5_rfile(RFILE *file)
 {
-   int rv;
    MD5_CTX md5;
-   /* 256 KB reads, same reasoning as intfstream_get_crc: hashing a
-    * large savestate at 4 KB a call is call overhead, not hashing.
-    * Heap once per file; this is a background sync path. */
-   size_t buf_len = 256 * 1024;
-   unsigned char *buf;
-   unsigned char digest[16];
-   libretro_vfs_implementation_file *hfile = filestream_get_vfs_handle(file);
-   char *hash = (char*)malloc(33);
+   unsigned char  digest[16];
+   const uint8_t *map     = NULL;
+   int64_t        map_len = 0;
+   char          *hash    = (char*)malloc(33);
 
    if (!hash)
       return NULL;
 
-   if (!(buf = (unsigned char*)malloc(buf_len)))
-   {
-      free(hash);
-      return NULL;
-   }
-
    MD5_Init(&md5);
 
-   if (hfile && hfile->mapped)
-      MD5_Update(&md5, hfile->mapped, hfile->size);
+   /* Hash the whole file, from the start, whichever path is taken.
+    * The mapped branch below always covered the entire file while the
+    * read branch started wherever the stream happened to be, and one
+    * caller hands this a stream it got from a fetch callback rather
+    * than one it just opened - so on a platform with mappings and a
+    * non-zero position the two branches hashed different bytes and
+    * produced different manifest entries for the same content.  A
+    * partial hash is not a useful answer to "what is this file", so
+    * the read path is squared up with the mapped one rather than the
+    * other way round. */
+   filestream_seek(file, 0, RETRO_VFS_SEEK_POSITION_START);
+
+   /* The files are opened with HINT_FREQUENT_ACCESS, so where the
+    * platform maps them the whole file is already addressable and
+    * there is nothing to copy.  This used to read the mapping out of
+    * the VFS handle directly - the only place in the tree that did -
+    * which meant a task reaching past filestream into a struct it
+    * does not own, and getting no answer at all from a
+    * frontend-supplied VFS.  filestream_get_mapped_ptr() answers the
+    * same question through the layer that owns it, and NULL is a
+    * normal answer, so the read loop below stays the general case. */
+   if ((map = filestream_get_mapped_ptr(file, &map_len)) && map_len > 0)
+      MD5_Update(&md5, map, (size_t)map_len);
    else
    {
+      /* 256 KB reads, same reasoning as intfstream_get_crc: hashing a
+       * large savestate at 4 KB a call is call overhead, not hashing.
+       * Heap once per file; this is a background sync path.
+       *
+       * Allocated here rather than before the branch above, where it
+       * was malloc'd and freed on every mapped hash as well without a
+       * byte of it ever being touched. */
+      size_t         buf_len = 256 * 1024;
+      unsigned char *buf     = (unsigned char*)malloc(buf_len);
+      int            rv;
+
+      if (!buf)
+      {
+         free(hash);
+         return NULL;
+      }
+
       do
       {
          rv = (int)filestream_read(file, buf, (int64_t)buf_len);
          if (rv > 0)
             MD5_Update(&md5, buf, rv);
       } while (rv > 0);
+
+      free(buf);
    }
-   free(buf);
+
    MD5_Final(digest, &md5);
 
    snprintf(hash, 33, "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Fail on libretro-common functions whose stack frame would not fit a
+console thread stack.
+
+The smallest thread stacks in the tree are 8 KiB - STACKSIZE in
+rthreads/psp_pthread.h and rthreads/gx_pthread.h - with 32 KiB on 3DS
+and 0x10000 on Vita. Nothing warns when a local buffer outgrows them:
+it builds everywhere, and overflows only on a target most contributors
+cannot build, at whatever moment that code first runs on a task
+thread.
+
+That is not hypothetical. config_file_write() carried a 16 KiB stdio
+buffer as a local, twice an 8 KiB stack, and is reached from
+input_autoconfigure_connect_handler - a task handler, so it runs off
+the main thread whenever the task queue is threaded, on the path a
+gamepad being plugged in takes.
+
+Frames are measured with -fstack-usage under -DPSP, because
+PATH_MAX_LENGTH is 512 on those targets rather than 2048 and a
+host-shaped measurement overstates every function that holds a path
+buffer - several archive functions look like 6 KiB on a desktop build
+and are under 4 KiB there.
+
+The budget is deliberately well under 8 KiB: a frame is not alone on
+the stack, it sits under whatever called it.
+"""
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT       = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INCLUDE    = os.path.join(ROOT, 'libretro-common', 'include')
+SRC_ROOT   = os.path.join(ROOT, 'libretro-common')
+
+# Bytes. Leaves the majority of an 8 KiB stack for callers.
+BUDGET     = 2048
+
+# Frames that already exceeded the budget when this check was written,
+# with the size measured then. They are recorded rather than fixed:
+# almost all are codec and compression inner loops (rvp9, rh264, raac,
+# ropus, rflac, rzstd, rvorbis) and chd, whose working sets are large
+# by nature and whose call graphs have not been traced to a task
+# thread on PSP or GX - and several of those codecs may not be built
+# for those targets at all.
+#
+# So this list is unaudited, and says so. The check is a ratchet: it
+# does not claim these are safe, it stops the list growing. Removing
+# an entry is always welcome; adding one is a decision someone has to
+# write down.
+#
+# The value is the size at the time of writing, so a frame that grows
+# past its recorded size is caught even while allowlisted.
+ALLOWLIST  = {
+    'cdfs_find_file.constprop': 2160,
+    'config_file_dump': 4208,
+    'filestream_vscanf': 4368,
+    'flac_decoder_decode_interleaved': 4816,
+    'map_read': 8320,
+    'mem_stats_proc_meminfo.constprop': 2160,
+    'raac_decode_ics': 4448,
+    'raac_filterbank': 16496,
+    'raac_imdct': 4240,
+    'rchd_decompress': 28736,
+    'rchd_map_v5': 2768,
+    'rd_gen_lengths': 12768,
+    'rflac__alloc_raw': 4320,
+    'rflac_open_with_metadata_private.constprop': 4464,
+    'rh264_cabac_decode_islice.constprop.isra': 2240,
+    'rh264_cabac_decode_mb_ctx.isra': 2112,
+    'rh264_cabac_decode_pslice.constprop.isra': 2608,
+    'rh264_video_decode_inter': 7520,
+    'rhuff_dec_build': 4240,
+    'rhuff_read_tree_packed': 2288,
+    'ropus_deinterleave_hadamard': 4160,
+    'ropus_deinterleave_hadamard_q': 2112,
+    'ropus_interleave_hadamard': 4160,
+    'ropus_interleave_hadamard_q': 2112,
+    'ropus_silk2_decode': 6480,
+    'rvp9_build_inter_pred.isra': 25840,
+    'rvp9_build_inter_pred_hbd.isra': 51456,
+    'rvp9_convolve8.constprop': 8752,
+    'rvp9_convolve8_hbd.constprop': 17392,
+    'rvp9_iht_add.isra': 4496,
+    'rvp9_iht_add_hbd.isra': 4496,
+    'rzstd_emit_block.constprop': 9440,
+    'rzstd_huf_read_bmi2': 2368,
+    'rzstd_huf_read_sse': 2368,
+    'sha1_calculate': 4304,
+    'vh_build': 16784,
+    'vorbis_decode_packet_rest.isra': 2672,
+}
+
+
+def stack_usage(path, workdir):
+    """Compile one TU and return [(func, bytes)] from its .su file.
+
+    gcc writes the .su alongside the object named by -o, not alongside
+    the source, so the name has to be derived from the object.  Getting
+    that wrong is silent: the file simply is not there, every TU
+    reports no frames, and the check passes while measuring nothing.
+    It did, until a deliberately oversized buffer failed to trip it.
+    """
+    obj = os.path.join(workdir, 'o.o')
+    su  = os.path.join(workdir, 'o.su')
+    if os.path.exists(su):
+        os.remove(su)
+    cmd = ['gcc', '-O2', '-DPSP', '-DHAVE_COMPRESSION',
+           '-I' + INCLUDE, '-fstack-usage', '-c', path, '-o', obj]
+    r = subprocess.run(cmd, cwd=workdir, capture_output=True)
+    if not os.path.exists(su):
+        # Did not compile on this host (platform-specific TU, missing
+        # dependency).  Report it rather than counting it as scanned.
+        return None
+    out = []
+    with open(su) as f:
+        for line in f:
+            parts = line.rstrip('\n').split('\t')
+            if len(parts) < 2:
+                continue
+            name = re.sub(r'^.*:', '', parts[0])
+            try:
+                out.append((name, int(parts[1])))
+            except ValueError:
+                pass
+    return out
+
+
+def main():
+    over    = []
+    scanned = 0
+    skipped = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        for dirpath, _, files in os.walk(SRC_ROOT):
+            parts = dirpath.split(os.sep)
+            # Shipped code only: samples, tools and tests are
+            # host programs, not console builds, and their
+            # frames are irrelevant to a PSP thread stack.
+            if ({'samples', 'tools', 'test', 'tests'} & set(parts)):
+                continue
+            for fn in sorted(files):
+                if not fn.endswith('.c'):
+                    continue
+                frames = stack_usage(os.path.join(dirpath, fn), tmp)
+                if frames is None:
+                    skipped += 1
+                    continue
+                scanned += 1
+                for name, size in frames:
+                    if size <= BUDGET:
+                        continue
+                    # Allowlisted, but only at the size recorded: a
+                    # frame that has grown since is a new problem.
+                    if name in ALLOWLIST and size <= ALLOWLIST[name]:
+                        continue
+                    over.append((size, name, fn))
+
+    # A run that measured nothing is a broken check, not a clean tree.
+    if scanned == 0:
+        print('error: no translation unit yielded stack data; the '
+              'check is not measuring anything', file=sys.stderr)
+        return 2
+
+    if over:
+        print('error: stack frames over %d bytes, against an 8 KiB '
+              'thread stack on PSP and GX:' % BUDGET, file=sys.stderr)
+        for size, name, fn in sorted(over, reverse=True):
+            print('   %7d  %s  (%s)' % (size, name, fn), file=sys.stderr)
+        print('\nMove the buffer to the heap, shrink it, or - if it '
+              'genuinely cannot reach a thread on those targets - add '
+              'it to ALLOWLIST in %s with the reason.'
+              % os.path.basename(__file__), file=sys.stderr)
+        return 1
+
+    print('stack budget: %d translation units measured (%d did not '
+          'build on this host), no frame over %d bytes'
+          % (scanned, skipped, BUDGET))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -62,6 +62,7 @@ BUDGET     = 2048
 #   rd_gen_lengths               12768 ->  352  scratch into struct rdeflate
 #   rzstd_emit_block              9440 ->    0  FSE tables into encoder scratch
 #   sha1_calculate                4304 ->  224  mapped view, else heap buffer
+#   filestream_vscanf             4368 ->  272  scan window to the heap
 #
 # What is left is mostly codec inner loops (rvp9, rh264, raac, ropus,
 # rflac, rzstd, rvorbis) whose working sets are large by nature. Large
@@ -80,7 +81,6 @@ BUDGET     = 2048
 ALLOWLIST  = {
     'cdfs_find_file.constprop': 2160,
     'config_file_dump': 4208,
-    'filestream_vscanf': 4368,
     'flac_decoder_decode_interleaved': 4816,
     'map_read': 8320,
     'mem_stats_proc_meminfo.constprop': 2160,

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -40,33 +40,38 @@ SRC_ROOT   = os.path.join(ROOT, 'libretro-common')
 # Bytes. Leaves the majority of an 8 KiB stack for callers.
 BUDGET     = 2048
 
-# Frames that already exceeded the budget when this check was written,
-# with the size measured then. They are recorded rather than fixed:
-# almost all are codec and compression inner loops (rvp9, rh264, raac,
-# ropus, rflac, rzstd, rvorbis) and chd, whose working sets are large
-# by nature.
+# Frames that exceeded the budget when this check was written, with
+# the size measured then.
 #
-# That exemption was originally an assumption - that those call graphs
-# do not reach a task thread on the small-stack targets, and that
-# several of the codecs are not built there at all. It has since been
-# checked with tools/stack_chain.py against the feature sets those
-# targets really use, taken from 'make -f Makefile.griffin platform=wii
-# -n' and Makefile.ctr rather than guessed:
+# THE RULE: an entry here is debt, not an exemption. "It is not built
+# on a small-stack target" and "nothing reaches it from a task thread"
+# are both statements about today, and both have already been wrong
+# once - config_file_write() was exempt on exactly that reasoning
+# until its caller turned out to be a task handler. Platforms gain
+# features, call graphs gain edges, and a frame that is fine now is
+# fine only until someone connects it to something. So the question
+# for an entry is not "can this overflow today" but "does this need
+# to be on the stack at all", and the answer is usually no: the
+# fixable ones are a struct or a scratch array that could live on the
+# heap or in a state object that is already allocated once.
 #
-#   wii  (8 KiB threads, GEKKO):  2 of 37 entries reachable from a task
-#                                 handler - config_file_dump and
-#                                 vh_build. The rest are not compiled.
-#   ctr  (32 KiB threads):        3 of 37 - the same two plus
-#                                 mem_stats_proc_meminfo.
+# Fixed under that rule rather than argued about:
+#   vh_build                     16784 -> 400   scratch to the heap
+#   config_file_write            16432 ->   48  stdio buffer to the heap
+#   chd_read_header_core_file    57504 ->   32  whole chd_file to the heap
+#   rd_gen_lengths               12768 ->  352  scratch into struct rdeflate
 #
-# So the assumption holds for the codec entries, on those two targets,
-# in those configurations. It is not a general claim: indirect calls
-# are invisible to that analysis, and a target built with a different
-# feature set can reach further.
+# What is left is mostly codec inner loops (rvp9, rh264, raac, ropus,
+# rflac, rzstd, rvorbis) whose working sets are large by nature. Large
+# by nature is not the same as necessarily-on-the-stack: most of them
+# could hold their scratch in the decoder state, which is allocated
+# once per stream. They are recorded rather than fixed because that is
+# per-codec work with real regression risk, not because they are safe.
 #
-# The check remains a ratchet: it does not claim these are safe, it
-# stops the list growing. Removing an entry is always welcome; adding
-# one is a decision someone has to write down.
+# The check is a ratchet: it stops the list growing. Removing an entry
+# is always welcome; adding one is a decision someone has to write
+# down, and "not reachable on the targets I checked" is not one of the
+# reasons that counts.
 #
 # The value is the size at the time of writing, so a frame that grows
 # past its recorded size is caught even while allowlisted.
@@ -82,7 +87,6 @@ ALLOWLIST  = {
     'raac_imdct': 4240,
     'rchd_decompress': 28736,
     'rchd_map_v5': 2768,
-    'rd_gen_lengths': 12768,
     'rflac__alloc_raw': 4320,
     'rflac_open_with_metadata_private.constprop': 4464,
     'rh264_cabac_decode_islice.constprop.isra': 2240,
@@ -123,7 +127,15 @@ def stack_usage(path, workdir):
     su  = os.path.join(workdir, 'o.su')
     if os.path.exists(su):
         os.remove(su)
-    cmd = ['gcc', '-O2', '-DPSP', '-DHAVE_COMPRESSION',
+    # The define set has to be at least as wide as a real build, or
+    # the check measures code no target compiles and misses code every
+    # target does. HAVE_7ZIP is the case that proved it: without it
+    # libchdr_chd.c's largest frame is 8320 bytes, with it 57504 - a
+    # seven-fold difference in shipped code, under a define that wii,
+    # ctr and every desktop build set.
+    cmd = ['gcc', '-O2', '-DPSP', '-DHAVE_COMPRESSION', '-DHAVE_7ZIP',
+           '-DHAVE_CHD', '-DHAVE_RPNG', '-DHAVE_RJPEG', '-DHAVE_RBMP',
+           '-DHAVE_RTGA', '-DHAVE_RWEBP', '-DHAVE_RDDS', '-DHAVE_RWAV',
            '-I' + INCLUDE, '-fstack-usage', '-c', path, '-o', obj]
     r = subprocess.run(cmd, cwd=workdir, capture_output=True)
     if not os.path.exists(su):

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -61,6 +61,7 @@ BUDGET     = 2048
 #   chd_read_header_core_file    57504 ->   32  whole chd_file to the heap
 #   rd_gen_lengths               12768 ->  352  scratch into struct rdeflate
 #   rzstd_emit_block              9440 ->    0  FSE tables into encoder scratch
+#   sha1_calculate                4304 ->  224  mapped view, else heap buffer
 #
 # What is left is mostly codec inner loops (rvp9, rh264, raac, ropus,
 # rflac, rzstd, rvorbis) whose working sets are large by nature. Large
@@ -109,7 +110,6 @@ ALLOWLIST  = {
     'rvp9_iht_add_hbd.isra': 4496,
     'rzstd_huf_read_bmi2': 2368,
     'rzstd_huf_read_sse': 2368,
-    'sha1_calculate': 4304,
     'vorbis_decode_packet_rest.isra': 2672,
 }
 

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -44,14 +44,29 @@ BUDGET     = 2048
 # with the size measured then. They are recorded rather than fixed:
 # almost all are codec and compression inner loops (rvp9, rh264, raac,
 # ropus, rflac, rzstd, rvorbis) and chd, whose working sets are large
-# by nature and whose call graphs have not been traced to a task
-# thread on PSP or GX - and several of those codecs may not be built
-# for those targets at all.
+# by nature.
 #
-# So this list is unaudited, and says so. The check is a ratchet: it
-# does not claim these are safe, it stops the list growing. Removing
-# an entry is always welcome; adding one is a decision someone has to
-# write down.
+# That exemption was originally an assumption - that those call graphs
+# do not reach a task thread on the small-stack targets, and that
+# several of the codecs are not built there at all. It has since been
+# checked with tools/stack_chain.py against the feature sets those
+# targets really use, taken from 'make -f Makefile.griffin platform=wii
+# -n' and Makefile.ctr rather than guessed:
+#
+#   wii  (8 KiB threads, GEKKO):  2 of 37 entries reachable from a task
+#                                 handler - config_file_dump and
+#                                 vh_build. The rest are not compiled.
+#   ctr  (32 KiB threads):        3 of 37 - the same two plus
+#                                 mem_stats_proc_meminfo.
+#
+# So the assumption holds for the codec entries, on those two targets,
+# in those configurations. It is not a general claim: indirect calls
+# are invisible to that analysis, and a target built with a different
+# feature set can reach further.
+#
+# The check remains a ratchet: it does not claim these are safe, it
+# stops the list growing. Removing an entry is always welcome; adding
+# one is a decision someone has to write down.
 #
 # The value is the size at the time of writing, so a frame that grows
 # past its recorded size is caught even while allowlisted.
@@ -91,7 +106,6 @@ ALLOWLIST  = {
     'rzstd_huf_read_bmi2': 2368,
     'rzstd_huf_read_sse': 2368,
     'sha1_calculate': 4304,
-    'vh_build': 16784,
     'vorbis_decode_packet_rest.isra': 2672,
 }
 

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -2,9 +2,12 @@
 """Fail on libretro-common functions whose stack frame would not fit a
 console thread stack.
 
-The smallest thread stacks in the tree are 8 KiB - STACKSIZE in
-rthreads/psp_pthread.h and rthreads/gx_pthread.h - with 32 KiB on 3DS
-and 0x10000 on Vita. Nothing warns when a local buffer outgrows them:
+The smallest thread stack in the tree is GEKKO's 8 KiB - STACKSIZE in
+rthreads/gx_pthread.h - with 32 KiB on 3DS (ctr_pthread.h) and 0x10000
+on Vita. (rthreads/psp_pthread.h names 8 KiB as well, but nothing
+includes it: rthreads.c takes gx_pthread.h under GEKKO and
+ctr_pthread.h under _3DS, and PSP falls through to plain pthreads. The
+floor is GEKKO's.) Nothing warns when a local buffer outgrows them:
 it builds everywhere, and overflows only on a target most contributors
 cannot build, at whatever moment that code first runs on a task
 thread.

--- a/tools/stack_budget.py
+++ b/tools/stack_budget.py
@@ -60,6 +60,7 @@ BUDGET     = 2048
 #   config_file_write            16432 ->   48  stdio buffer to the heap
 #   chd_read_header_core_file    57504 ->   32  whole chd_file to the heap
 #   rd_gen_lengths               12768 ->  352  scratch into struct rdeflate
+#   rzstd_emit_block              9440 ->    0  FSE tables into encoder scratch
 #
 # What is left is mostly codec inner loops (rvp9, rh264, raac, ropus,
 # rflac, rzstd, rvorbis) whose working sets are large by nature. Large
@@ -106,7 +107,6 @@ ALLOWLIST  = {
     'rvp9_convolve8_hbd.constprop': 17392,
     'rvp9_iht_add.isra': 4496,
     'rvp9_iht_add_hbd.isra': 4496,
-    'rzstd_emit_block.constprop': 9440,
     'rzstd_huf_read_bmi2': 2368,
     'rzstd_huf_read_sse': 2368,
     'sha1_calculate': 4304,

--- a/tools/stack_chain.py
+++ b/tools/stack_chain.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Worst-case cumulative stack per call chain, from a set of roots.
+
+tools/stack_budget.py checks one frame at a time, which is necessary
+and not sufficient: a frame does not run alone, it runs on top of
+everything that called it. config_file_write() was caught by that
+check only because the offending 16 KiB was in its own frame. Ten
+1.5 KiB frames in a row pass every per-frame check ever written and
+still overflow an 8 KiB thread stack.
+
+This walks the call graph GCC emits with -fcallgraph-info=su and sums
+frames along it, reporting the deepest chain from each root. Task
+handlers are the roots that matter: retro_task_regular_gather() runs
+them on the main thread, but a threaded task queue runs them on a
+worker, and on GEKKO that worker has 8 KiB (STACKSIZE in
+rthreads/gx_pthread.h).
+
+WHAT THIS IS NOT
+
+A verdict. Three things keep it a screening tool rather than a proof:
+
+  - The deepest path may be infeasible. Nothing here knows that two
+    branches are mutually exclusive, so the sum can describe a chain
+    that cannot occur.
+  - Indirect calls are invisible to the call graph, so a real chain
+    can be deeper than anything reported here. The number is not an
+    upper bound either.
+  - It measures what the *given* build configuration compiles. Run
+    with a host config.h and it will sum codecs the target never
+    builds - the same roots measure 73 KiB with everything enabled
+    and 20 KiB with a console-shaped feature set, and neither figure
+    describes a platform nobody built.
+
+So it is deliberately not wired into CI: it would report numbers that
+need a real target configuration to mean anything, and a check that
+cries wolf gets an allowlist and then gets ignored. Point it at a
+tree configured for the target you care about, and read the chains
+rather than the totals.
+
+USAGE
+
+  # emit call graphs for the translation units of interest
+  mkdir ci && cd ci
+  gcc -O2 -DGEKKO -fcallgraph-info=su -c <sources> -I... -include config.h
+
+  # roots: one symbol per line
+  tools/stack_chain.py ci roots.txt
+
+A roots file can be built from the task handlers with:
+
+  grep -rhoE '(\\.|->)handler[[:space:]]*=[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*' \\
+      tasks/*.c *.c menu/*.c | sed 's/.*=[[:space:]]*//' | sort -u
+"""
+import collections
+import glob
+import os
+import re
+import sys
+
+NODE = re.compile(r'node:\s*\{\s*title:\s*"([^"]+)"\s*label:\s*"([^"]*?)"', re.S)
+EDGE = re.compile(r'edge:\s*\{\s*sourcename:\s*"([^"]+)"\s*targetname:\s*"([^"]+)"')
+SIZE = re.compile(r'(\d+)\s+bytes')
+# GCC suffixes clones; the roots file names the original.
+CLONE = re.compile(r'\.(isra|constprop|part|cold|lto_priv)[0-9.]*$')
+
+
+def load(ci_dir):
+    """size[node], edges[node] -> set(node), byname[symbol] -> [node...]"""
+    size = {}
+    edges = collections.defaultdict(set)
+    byname = collections.defaultdict(list)
+
+    files = glob.glob(os.path.join(ci_dir, '*.ci'))
+    if not files:
+        print('error: no .ci files in %s - was -fcallgraph-info=su passed?'
+              % ci_dir, file=sys.stderr)
+        sys.exit(2)
+
+    for path in files:
+        with open(path, encoding='utf-8', errors='replace') as f:
+            text = f.read()
+        for title, label in NODE.findall(text):
+            m = SIZE.search(label)
+            if not m:
+                continue           # declaration only, no body here
+            size[title] = int(m.group(1))
+            byname[CLONE.sub('', title.split(':')[-1])].append(title)
+        for src, dst in EDGE.findall(text):
+            edges[src].add(dst)
+    return size, edges, byname
+
+
+def analyse(size, edges, byname, roots, top):
+    def targets(node):
+        """Resolve a node's callees, including cross-TU ones.
+
+        A call to a function defined in another translation unit is
+        emitted as a bare symbol, so it has to be matched back to
+        whichever node defines it."""
+        out = set()
+        for dst in edges.get(node, ()):
+            if dst in size:
+                out.add(dst)
+            else:
+                out.update(byname.get(CLONE.sub('', dst.split(':')[-1]), ()))
+        return out
+
+    memo = {}
+
+    def worst(node, on_stack):
+        # Recursion is reported rather than summed: its depth is a
+        # runtime property this cannot see.
+        if node in on_stack:
+            return 0, ['<recursion>']
+        if node in memo:
+            return memo[node]
+        best, best_path = 0, []
+        for dst in targets(node):
+            cost, path = worst(dst, on_stack | {node})
+            if cost > best:
+                best, best_path = cost, path
+        result = (size.get(node, 0) + best,
+                  [CLONE.sub('', node.split(':')[-1])] + best_path)
+        memo[node] = result
+        return result
+
+    found = []
+    for root in roots:
+        for node in byname.get(root, ()):
+            total, path = worst(node, frozenset())
+            found.append((total, root, path))
+
+    if not found:
+        print('error: none of the given roots were found in the call graph',
+              file=sys.stderr)
+        return 2
+
+    for total, root, path in sorted(found, reverse=True)[:top]:
+        print('%7d  %s' % (total, root))
+        print('         %s' % ' -> '.join(path[:8]))
+    return 0
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    ci_dir = sys.argv[1]
+    with open(sys.argv[2]) as f:
+        roots = [l.strip() for l in f if l.strip()]
+    top = int(sys.argv[3]) if len(sys.argv) > 3 else 15
+    size, edges, byname = load(ci_dir)
+    print('call graph: %d nodes with frames, %d roots requested\n'
+          % (len(size), len(roots)))
+    return analyse(size, edges, byname, roots, top)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/vfs_backend_parity.py
+++ b/tools/vfs_backend_parity.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Check that every VFS backend defines the same retro_vfs_*_impl set.
+
+vfs_implementation_uwp.cpp does not extend vfs_implementation.c, it
+replaces it: the UWP project compiles the .cpp and not the .c.  So a
+function added to the C backend and called from file_stream.c - which
+both builds share - compiles fine everywhere and fails to link on UWP
+only, at the end of a long build, on a runner most contributors do not
+have.  That is how retro_vfs_file_get_mapped_ptr_impl shipped broken.
+
+This compares the two backends by symbol and fails on any function the
+C backend defines and the UWP backend does not.  It is a source-level
+check, so it costs nothing and runs on Linux.
+
+A backend that genuinely cannot support a call still has to say so -
+returning a documented "not available" value, the way the UWP mapping
+accessor returns NULL - because a missing definition is a link error,
+not a fallback.
+"""
+import re
+import sys
+
+C_BACKEND   = 'libretro-common/vfs/vfs_implementation.c'
+UWP_BACKEND = 'libretro-common/vfs/vfs_implementation_uwp.cpp'
+
+# Definitions only: a return type (possibly with const/*/ws) then the
+# name then '(' at the start of a line.  Calls are indented, so
+# anchoring to column 0 keeps them out.
+DEF = re.compile(
+    r'^(?:const\s+|static\s+|struct\s+)*[\w\*\s]*?\b(retro_vfs_\w+_impl)\s*\(',
+    re.M)
+
+
+def defined_in(path):
+    with open(path, encoding='utf-8', errors='replace') as f:
+        return set(DEF.findall(f.read()))
+
+
+def main():
+    c   = defined_in(C_BACKEND)
+    uwp = defined_in(UWP_BACKEND)
+
+    if not c or not uwp:
+        print('error: parsed no symbols from a backend; the regex or the '
+              'file layout has drifted', file=sys.stderr)
+        return 2
+
+    missing = sorted(c - uwp)
+    if missing:
+        print('error: defined in %s but missing from %s:' %
+              (C_BACKEND, UWP_BACKEND), file=sys.stderr)
+        for m in missing:
+            print('   %s' % m, file=sys.stderr)
+        print('\nAdd each to the UWP backend.  If it cannot be supported '
+              'there, define it anyway and return the documented '
+              '"unavailable" value - a missing definition is a link '
+              'error, not a fallback.', file=sys.stderr)
+        return 1
+
+    print('vfs backend parity: %d symbols, both backends agree' % len(c))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h1>Subject</h1>
<pre><code>File I/O: mapped-view accessor, allocation-free file/buffer comparison, and the stack-safety work that fell out of it
</code></pre>
<hr>
<h1>Description</h1>
<p>Started as a file I/O audit of <code>libretro-common</code> and the task layer. Two new constructs came out of it, along with three correctness fixes, two CI gaps, and — once there was a tool for measuring it — a run of oversized stack frames that could not survive on a console thread.</p>
<p>The branch drifts from its title about halfway through, and deliberately so: the stack work was found by the file I/O work, one thread at a time. Each commit stands alone and can be dropped without disturbing the others.</p>
<h2>New constructs</h2>
<p><strong><code>filestream_get_mapped_ptr()</code></strong> — a borrowed read-only view of a memory-mapped file.</p>
<p><code>RETRO_VFS_FILE_ACCESS_HINT_FREQUENT_ACCESS</code> has always <code>mmap</code>'d the file, but the mapping was reachable only from inside <code>retro_vfs_file_read_impl()</code>, which <code>memcpy</code>s out of it. Asking for a map bought a copy of data that was already addressable, and the point of the hint was lost. Two call sites in the whole tree used it.</p>
<p><code>NULL</code> is a normal answer — no <code>HAVE_MMAP</code>, no hint, a write mode, a frontend-supplied VFS — so every caller keeps its copying path and treats this as a fast lane. Three consumers so far: <code>task_cloudsync</code>'s MD5, <code>sha1_calculate()</code>, and the comparison below.</p>
<p><strong><code>filestream_matches_buf()</code> / <code>rzipstream_matches_buf()</code></strong> — does this file hold exactly these bytes?</p>
<p>For the "has this changed since I last wrote it?" question, where the answer decides whether to write at all. Settles a size mismatch without reading, compares in place against the mapping where there is one, falls back to a fixed window otherwise, stops at the first differing byte, and allocates nothing.</p>
<p><code>save.c</code>'s SRAM dirty-check is the first consumer. It used to read the whole save into a fresh allocation purely to <code>memcmp</code> and free it — and checked the size only afterwards, so a save that had changed size, the one case where the answer is free, still paid a full-size allocation and a full-file read (a full decompress, in the compressed lane).</p>

SRAM | unchanged | changed | peak extra heap
-- | -- | -- | --
128 KiB | −50% | −66% | 128 KiB → 0
2 MiB | −47% | −94% | 2 MiB → 0
8 MiB | −49% | −99% | 8 MiB → 0
32 MiB | −80% | −100% | 32 MiB → 0


<p><code>vh_build</code> is the one that mattered most: it sits under two task handlers (<code>task_file_load_handler</code> and <code>task_overlay_handler</code>) via WebP decode, and Wii and GameCube build <code>HAVE_RWEBP</code> and <code>HAVE_THREADS</code> both. Worst-case chains from those handlers went 19976 → 7064 and 18568 → 5656 bytes, measured against the real wii feature set taken from <code>make -f Makefile.griffin platform=wii -n</code>.</p>
<p>The governing rule, now written into <code>tools/stack_budget.py</code>: <strong>an allowlist entry is debt, not an exemption.</strong> "It is not built on a small-stack target" and "nothing reaches it from a task thread" are statements about today, and both have already been wrong once. The question is not whether a frame can overflow today but whether it needs to be on the stack at all.</p>
<h2>CI</h2>
<p>Two gaps where CI reported coverage it did not have.</p>
<p><strong>Sixteen sample Makefiles had no <code>SANITIZER</code> opt-in block.</strong> The workflow passes <code>SANITIZER=address,undefined</code> to every sample directory, so the variable was accepted and ignored — including for <code>rbmp_test</code> and <code>cdrom_cuesheet_overflow_test</code>, which the workflow's own comment names among the tests that use ASan as the regression discriminator for the bound-check they verify. Adding the block is what surfaced the <code>rjson</code> leak above.</p>
<p><strong>Nine sample targets were built and never run.</strong> Seven are self-contained regression tests that pass; two should not run (a CLI tool, and one that performs real HTTP requests). The mechanism mattered more than the seven: <code>[skip-run] not in run allowlist</code> reads identically whether the omission was deliberate or forgotten. Targets are now classified explicitly and an unclassified one fails the job.</p>
<h2>Tooling</h2>
<ul>
<li><code>tools/vfs_backend_parity.py</code> — <code>vfs_implementation_uwp.cpp</code> replaces <code>vfs_implementation.c</code> on UWP rather than extending it, so a function added to the C backend and called from the shared <code>file_stream.c</code> compiles everywhere and fails to link on UWP alone. That is how the mapped-ptr accessor first reached this branch broken. Source-level check, runs on Linux, costs nothing.</li>
<li><code>tools/stack_budget.py</code> — per-frame ratchet with the allowlist and the rule above.</li>
<li><code>tools/stack_chain.py</code> — sums frames along the call graph from task-handler roots, because per-frame checking is necessary and not sufficient: <code>config_file_write</code> was caught only because its own frame held the 16 KiB, and its caller measures 1488 bytes. Deliberately <strong>not</strong> wired into CI — the same roots measure 73 KiB with a host <code>config.h</code> and 20 KiB with a console-shaped feature set, and a check reporting numbers that need a real target configuration to interpret earns an allowlist and then gets ignored.</li>
</ul>
<h2>Testing</h2>
<p>New oracles, all in the samples tree and wired into CI:</p>
<ul>
<li><code>samples/file/vfs/vfs_mapped_ptr_test</code> — the size-0 read, the mapped view, and <code>filestream_matches_buf</code>. Runs in two lanes (<code>MMAP=1</code> and <code>MMAP=0</code>) because with mappings available the comparison never executes its windowed fallback, so the boundary cases would be asserting on code that did not run.</li>
<li><code>samples/streams/rzip/rzip_matches_buf_test</code> — rzip reads are decompressions, so a difference on a read boundary, on an rzip chunk boundary, and between them are three different offsets. Both compressed and uncompressed input, since rzip accepts both through the same entry point.</li>
<li><code>samples/formats/json/rjson_test</code> — gained deep-nesting coverage for the stack half of the leak fix; the inline stack holds 10 levels, so every existing case was too shallow to allocate.</li>
</ul>
<p>For changes with no oracle to hang off, behaviour was diffed before and after rather than smoke-tested:</p>
<ul>
<li><strong>zstd</strong> — 40 inputs, five content shapes across eight lengths, compressed output byte-identical in every case, every one decoding back to source.</li>
<li><strong>SHA-1</strong> — 25 cases straddling the 4096 block; digests identical with mappings on, with mappings off, and the two lanes agree with each other.</li>
<li><strong>scanf</strong> — conversion kinds and input shapes either side of the scan window; return codes, parsed values and resulting stream position identical throughout.</li>
<li><strong>WebP</strong> — the <code>image_decode_fuzz</code> lane decodes identically before and after (259 attempts, 69 decoded).</li>
</ul>
<p>Every commit: full build and link, <code>griffin</code>-shape single-TU compile where relevant, ASan/UBSan/LeakSan and TSan on the touched oracles, and C89 <code>-pedantic -Wdeclaration-after-statement</code> checked against a pre-change baseline rather than in isolation.</p>
<h2>Known gaps</h2>
<ul>
<li>All measurements were taken in a Linux container with a warm page cache. Ratios are the signal; the absolute microseconds are floors. A profile on real hardware — particularly a scan-shaped workload — would be worth having before trusting the throughput figures.</li>
<li>32 allowlist entries remain, mostly codec inner loops (<code>rvp9</code>, <code>raac</code>, <code>rh264</code>, <code>ropus</code>, <code>rflac</code>). <code>rvp9_build_inter_pred_hbd</code> at 51456 is the largest thing on the list, but nothing in the tree decodes VP9 video in a test, and changing a decoder inner loop with no way to check the output is how silent corruption ships. They are recorded as debt, not as safe.</li>
<li><code>task_overlay_handler</code> is at 7064 bytes of GEKKO's 8192 and <code>input_autoconfigure_connect_handler</code> at 5800. Neither is a bug today; neither has much headroom, and nothing in CI will say when that runs out.</li>
<li>The hint gate in <code>retro_vfs_file_get_mapped_ptr_impl()</code> is redundant by construction — <code>mapped</code> is only ever set under the hint — so the oracle does not discriminate it. Kept to match the read and seek paths.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>