### PR TITLE
android: increase ram available during packaging

### DIFF
--- a/pkg/android/phoenix/gradle.properties
+++ b/pkg/android/phoenix/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-Xms512m -Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms1024m -Xmx4096m -Dfile.encoding=UTF-8
 android.defaults.buildfeatures.resvalues=true

--- a/pkg/android/phoenix/module_template/build.gradle
+++ b/pkg/android/phoenix/module_template/build.gradle
@@ -11,7 +11,7 @@ android {
     targetSdkVersion 36
   }
 
-  ndkVersion "27.3.13750724"
+  ndkVersion "29.0.14206865"
 
   flavorDimensions "variant"
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Signing plus version:

```
Caused by: java.lang.IllegalArgumentException: Self-suppression not permitted
	at com.android.zipflinger.StreamSource.<init>(StreamSource.java:54)
	at com.android.zipflinger.Sources.from(Sources.java:61)
	at com.android.zipflinger.Sources.from(Sources.java:56)
	at com.android.builder.internal.packaging.AabFlinger$writeZip$1.call(AabFlinger.kt:95)
	at com.android.builder.internal.packaging.AabFlinger$writeZip$1.call(AabFlinger.kt:92)
Caused by: java.lang.OutOfMemoryError: Java heap space
```

Also set correct NDK that was used.

## Related Issues

## Related Pull Requests

## Reviewers
