### PR TITLE
android: fix back button on google tv remote

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1170,9 +1170,13 @@ static INLINE void android_input_poll_event_type_key(
    {
       case AKEY_EVENT_ACTION_UP:
          BIT_CLEAR(buf, keysym);
+         if (keysym == AKEYCODE_BACK)
+            BIT_CLEAR(buf, AKEYCODE_X); /* alias BACK on remote */
          break;
       case AKEY_EVENT_ACTION_DOWN:
          BIT_SET(buf, keysym);
+         if (keysym == AKEYCODE_BACK)
+            BIT_SET(buf, AKEYCODE_X);
          break;
    }
 

--- a/pkg/android/phoenix/AndroidManifest.xml
+++ b/pkg/android/phoenix/AndroidManifest.xml
@@ -28,6 +28,7 @@
         android:banner="@drawable/banner"
         android:extractNativeLibs="true"
         android:requestLegacyExternalStorage="true"
+        android:enableOnBackInvokedCallback="false"
         tools:ignore="UnusedAttribute">
         <activity android:name="com.retroarch.browser.mainmenu.MainMenuActivity" android:exported="true" android:launchMode="singleInstance">
             <intent-filter>


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Fixes back button Google TV remote as per user feedback.

enableOnBackInvokedCallback -> stops also the Google TV UI from intercepting the call.

## Related Issues

## Related Pull Requests

## Reviewers
