### PR TITLE
(gl1/gl2) Fix HDR ignoring aspect ratio

### DIFF
--- a/gfx/drivers/gl1.c
+++ b/gfx/drivers/gl1.c
@@ -2293,6 +2293,15 @@ static bool gl1_frame(void *data, const void *frame,
       glEnd();
 
       gl1->scrgb.UseProgram(0);
+
+      /* Restore the aspect-correct viewport the composite just
+       * clobbered. glViewport is context state, not per-FBO, and
+       * gl1_frame only establishes it under GL1_FLAG_SHOULD_RESIZE --
+       * so without this the next frame blits into the offscreen with
+       * the full window viewport still latched and the image is
+       * stretched to fill, ignoring the aspect ratio. Same convention
+       * as the fullscreen menu-texture branch above. */
+      glViewport(gl1->vp.x, gl1->vp.y, gl1->vp.width, gl1->vp.height);
    }
 #endif
 

--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -4178,6 +4178,21 @@ static bool gl2_frame(void *data, const void *frame,
       glDisableVertexAttribArray(0);
       glDisableVertexAttribArray(1);
       glUseProgram(0);
+
+      /* Restore the aspect-correct viewport the composite just
+       * clobbered. glViewport is context state, not per-FBO, and this
+       * driver only re-establishes it on resize (and, for hardware
+       * cores, in the HW_RENDER_FBO_INIT block above) -- so without
+       * this the next frame draws into the offscreen with the full
+       * window viewport still latched and the image is stretched to
+       * fill, ignoring the aspect ratio. Same save/restore convention
+       * as the fullscreen branch of gl2_draw_texture.
+       *
+       * The glcore driver has the same shape here but is unaffected:
+       * its filter chain re-runs glViewport on the final pass every
+       * frame (shader_gl3.cpp), so the leak never survives to a draw.
+       * The gl2 GLSL path has no equivalent choke point. */
+      glViewport(gl->vp.x, gl->vp.y, gl->vp.width, gl->vp.height);
    }
 
    /* Screenshots. */


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>PR title</h1>
<pre><code>(gl1/gl2) Fix HDR ignoring aspect ratio
</code></pre>
<hr>
<h1>PR description</h1>
<h2>Summary</h2>
<p>Under HDR output, the <code>gl1</code> and <code>gl2</code> drivers ignore the configured aspect ratio and stretch the image to fill the window.</p>
<p>The cause is a leaked <code>glViewport</code>. The scRGB composite at the end of the frame binds framebuffer 0 and sets a full-window viewport for its fullscreen quad, then never restores the aspect-correct one. <code>glViewport</code> is context state rather than per-FBO state, so the full-window rect stays latched into the <em>next</em> frame's draw into the SDR offscreen.</p>
<p>The composite itself is correct and is supposed to be full-window — aspect is meant to be baked into the offscreen by the frame draw, and it is, until the leaked viewport overwrites it.</p>
<h2>Symptom</h2>
<p>The first frame after a resize renders correctly; every frame after it is stretched. In practice that reads as "aspect ratio is always ignored", since a correct single frame at startup isn't noticeable.</p>
<h2>Why it reproduces where it does</h2>
<p>Neither driver re-establishes the viewport unconditionally per frame — every establishment point is guarded.</p>
<p><strong><code>gl2_frame</code>:</strong></p>

Site | Guard
-- | --
gl2.c:3866 | #ifdef IOS
gl2.c:3941 | SHOULD_RESIZE && !FBO_INITED
gl2.c:3985 | HW_RENDER_FBO_INIT && !FBO_INITED
gl2.c:1673 | shader-chain final pass


<p>So gl2 needs a software-rendered core, no shader chain, non-iOS. A hardware-rendered core or any shader preset masks it entirely, which is why it can look unreproducible.</p>
<p><strong><code>gl1_frame</code></strong> has exactly one establishment point, the <code>GL1_FLAG_SHOULD_RESIZE</code> block at <code>gl1.c:2013</code>. Nothing masks it — every core and every config is affected.</p>
<p>One gl1 wrinkle worth knowing: the raster font path calls <code>gl1_set_viewport</code> on its non-block exit (<code>gl1.c:1049</code>), so with OSD text or statistics on screen the viewport is re-established mid-frame. That runs <em>before</em> the composite, so it doesn't help the next frame, but it does mean toggling the FPS display perturbs the symptom in ways that don't obviously point at the viewport.</p>
<h2>Fix</h2>
<p>Restore <code>gl-&gt;vp</code> / <code>gl1-&gt;vp</code> after the composite. This matches the save/restore convention already used by the fullscreen branch of <code>gl2_draw_texture</code> (<code>gl2.c:3612</code>) and the fullscreen menu-texture branch in <code>gl1_frame</code> (<code>gl1.c:2184</code>–<code>2187</code>) — the convention existed, the composite just didn't follow it.</p>
<pre><code class="language-c">glViewport(gl-&gt;vp.x, gl-&gt;vp.y, gl-&gt;vp.width, gl-&gt;vp.height);
</code></pre>
<h2>Not affected: glcore</h2>
<p><code>gl3</code> has the same shape in its composite and also does not restore, but the leak never survives to a draw: <code>gl3_filter_chain</code> re-runs <code>glViewport</code> on the final pass every frame (<code>shader_gl3.cpp:1779</code>). No change needed there. The gl2 GLSL path has no equivalent per-frame choke point.</p>
<h2>Ruled out</h2>
<ul>
<li><strong>Offscreen sized wrong.</strong> Both offscreens are allocated at window size (<code>gl-&gt;video_width/height</code>), not viewport size, so pass 2 is not stretching a mis-sized target.</li>
<li><strong>Composite forcing full.</strong> It's meant to be full-window; that part is correct.</li>
<li><strong>gl1 matrix state.</strong> <code>gl1_default_ortho</code> is <code>{0, 1, 0, 1, -1, 1}</code> and the composite draws a <code>-1..1</code> quad without touching the matrix stack. Had the base projection been left at that ortho, the quad would span NDC <code>[-3, +1]</code> and produce a 2× crop rather than a stretch. All 8 <code>glPushMatrix</code> calls are balanced by 8 <code>glPopMatrix</code>, so the base state is identity and the quad is genuinely fullscreen. Only the viewport leaks.</li>
</ul>
<h2>Testing</h2>
<p>Both files build clean and are warning-free under <code>-std=c89 -pedantic</code> with the project's own flag set.</p>
<p>Manual check: software core, no shader preset, HDR on. Resize the window — the first frame lands correct, then stretches on <code>master</code>; stays correct with the patch.</p>
<p>Not run: sanitizer sweep. The change is a single <code>glViewport</code> state restore with no allocation or lifetime impact, and the paths need a real GL context to exercise meaningfully.</p></body></html><!--EndFragment-->
</body>
</html>