### PR TITLE
Fix the open flags in the SMB implementation of the VFS open function

### DIFF
--- a/libretro-common/vfs/vfs_implementation_smb.c
+++ b/libretro-common/vfs/vfs_implementation_smb.c
@@ -412,9 +412,9 @@ bool retro_vfs_file_open_smb(libretro_vfs_implementation_file *stream,
       flags = O_WRONLY;
    }
 
-   if ((mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING) &&
+   if (!(mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING) &&
        (mode & RETRO_VFS_FILE_ACCESS_WRITE))
-      flags |= O_CREAT;
+      flags |= O_CREAT | O_TRUNC;
 
    fh = smb2_open(smb_context, full_path, flags);
    if (!fh)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

There are some problems with the SMB implementation of the VFS open function. Please consult the following table to see the original behavior and the new behavior I have changed it to:

| | File already exists | File doesn't exist |
|-|-|-|
| `RETRO_VFS_FILE_ACCESS_READ` | Open the file from the beginning without deleting its contents | Return `NULL` without creating the file |
| `RETRO_VFS_FILE_ACCESS_WRITE` | <ul><li>**Old behavior:** Open the file from the beginning without deleting its contents</li><li>**New behavior:** Delete the contents of the file before opening it</li></ul> | <ul><li>**Old behavior:** Return `NULL` without creating the file</li><li>**New behavior:** Create the file and then open it</li></ul> |
| `RETRO_VFS_FILE_ACCESS_READ_WRITE` | <ul><li>**Old behavior:** Open the file from the beginning without deleting its contents</li><li>**New behavior:** Delete the contents of the file before opening it</li></ul> | <ul><li>**Old behavior:** Return `NULL` without creating the file</li><li>**New behavior:** Create the file and then open it</li></ul> |
| `RETRO_VFS_FILE_ACCESS_WRITE` \| `RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING` | Open the file from the beginning without deleting its contents | <ul><li>**Old behavior:** Create the file and then open it</li><li>**New behavior:** Return `NULL` without creating the file</li></ul> |
| `RETRO_VFS_FILE_ACCESS_READ_WRITE` \| `RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING` | Open the file from the beginning without deleting its contents | <ul><li>**Old behavior:** Create the file and then open it</li><li>**New behavior:** Return `NULL` without creating the file</li></ul> |
