### PR TITLE
sdl3: Fix mouse wheel expecting SDL 3.2.12+

### DIFF
--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -659,8 +659,8 @@ static void sdl3_input_poll(void *data)
       }
       else if (event.type == SDL_EVENT_MOUSE_WHEEL)
       {
-         Sint32 wx = event.wheel.integer_x;
-         Sint32 wy = event.wheel.integer_y;
+         float wx = event.wheel.x;
+         float wy = event.wheel.y;
 
          /* FLIPPED = "natural" scrolling: SDL delivers inverted
           * signs and expects the caller to negate them. */


### PR DESCRIPTION
The integer_x and integer_y is only available with 3.2.12+, so this switches back to using the `float`s to allow compatibility with other SDL3 versions.

Fixes #19335
