### PR TITLE
Fix a bug in the SAF implementation of the VFS mkdir function

### DIFF
--- a/libretro-common/vfs/saf/src/com/libretro/common/vfs/VfsImplementationSaf.java
+++ b/libretro-common/vfs/saf/src/com/libretro/common/vfs/VfsImplementationSaf.java
@@ -280,8 +280,7 @@ public final class VfsImplementationSaf
       path = normalizePath(path);
       if (isDocument(treeUri))
          return -1;
-      path = path.length() == 1 ? DocumentsContract.getTreeDocumentId(treeUri) : DocumentsContract.getTreeDocumentId(treeUri) + path;
-      final Uri directoryUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, path);
+      final Uri directoryUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, path.length() == 1 ? DocumentsContract.getTreeDocumentId(treeUri) : DocumentsContract.getTreeDocumentId(treeUri) + path);
       Cursor cursor = null;
       try
       {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

The SAF implementation of the VFS mkdir function previously had a bug that caused it to always failed to create a directory. This fixes the implementation.