### PR TITLE
android: reduce RAM usage in packaging to 4GB max

### DIFF
--- a/pkg/android/phoenix/gradle.properties
+++ b/pkg/android/phoenix/gradle.properties
@@ -1,2 +1,2 @@
-org.gradle.jvmargs=-Xms1024m -Xmx8192m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms1024m -Xmx4096m -Dfile.encoding=UTF-8
 android.defaults.buildfeatures.resvalues=true


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

8gb was not needed, only 4gb for plus in the end. Reduce in case someone wants to compile RA locally and doesn't have that much RAM.

## Related Issues

## Related Pull Requests

## Reviewers
