### PR TITLE
(cheevos) fix game identification for buffered cue files

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1942,6 +1942,9 @@ bool rcheevos_load(const void *data)
 #endif
 
       {
+#ifdef HAVE_THREADS
+         intptr_t gen;
+#endif
          const uint8_t* data = (const uint8_t*)info->data;
          size_t data_size = info->size;
 
@@ -1964,7 +1967,7 @@ bool rcheevos_load(const void *data)
           * loses information only if HAVE_THREADS is enabled
           * and a generation counter overflows intptr_t, which
           * would require ~2^31 (or ~2^63) load events. */
-         intptr_t gen = (intptr_t)retro_atomic_load_acquire_int(
+         gen = (intptr_t)retro_atomic_load_acquire_int(
                &rcheevos_locals.load_generation);
          rc_client_begin_identify_and_load_game(rcheevos_locals.client, console_id,
             info->path, data, data_size, rcheevos_client_load_game_callback, (void*)gen);

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1942,6 +1942,20 @@ bool rcheevos_load(const void *data)
 #endif
 
       {
+         const uint8_t* data = (const uint8_t*)info->data;
+         size_t data_size = info->size;
+
+         if (data) {
+            const char* ext = path_get_extension(info->path);
+            if (string_is_equal_noncase(ext, "m3u") || string_is_equal_noncase(ext, "cue")) {
+               /* If the core doesn't specify needs_fullpath, the file will be loaded into
+                * memory. For m3u and cue files, we want to call the version of the hasher
+                * that reads files from disk, so pretend the data isn't loaded in memory. */
+               data = NULL;
+               data_size = 0;
+            }
+         }
+
 #ifdef HAVE_THREADS
          /* Capture the current load generation; the callback
           * compares this against the live value to detect a
@@ -1953,12 +1967,10 @@ bool rcheevos_load(const void *data)
          intptr_t gen = (intptr_t)retro_atomic_load_acquire_int(
                &rcheevos_locals.load_generation);
          rc_client_begin_identify_and_load_game(rcheevos_locals.client, console_id,
-            info->path, (const uint8_t*)info->data, info->size,
-            rcheevos_client_load_game_callback, (void*)gen);
+            info->path, data, data_size, rcheevos_client_load_game_callback, (void*)gen);
 #else
          rc_client_begin_identify_and_load_game(rcheevos_locals.client, console_id,
-            info->path, (const uint8_t*)info->data, info->size,
-            rcheevos_client_load_game_callback, NULL);
+            info->path, data, data_size, rcheevos_client_load_game_callback, NULL);
 #endif
       }
    }


### PR DESCRIPTION
## Description

Fixes an issue where attempting to load a Sega CD cue file in the picodrive core reports "unsupported console for buffer hash".

The behavioral override extensions for the PicoDrive core were updated to include "cue" [last November](https://github.com/libretro/picodrive/commit/9e304a66eb3041df45452b79e596fd1c2572cee3#diff-60cdbe462ad5f4c9234d624b8d0503a676f6577f0022d80eee5b04c5e0bf648bR631).

As a result, the frontend uses the needs_fullpath from the [content override data](https://github.com/libretro/RetroArch/blob/8cbd0f1eacf59f263b695fd11baf5a864736cb1e/libretro-common/include/libretro.h#L6215) instead of the needs_fullpath from the [system info](https://github.com/libretro/RetroArch/blob/8cbd0f1eacf59f263b695fd11baf5a864736cb1e/libretro-common/include/libretro.h#L6117), and the content override data does not claim it needs the full path, so the cue file gets buffered and then it attempts to hash the cue file instead of loading the associated disc.

Similarly, the new virtualjaguar core does not set `CONTENT_INFO_FLAG_NEED_FULLPATH`, so the cue file gets buffered when loading a Jaguar CD game, and the hashing code doesn't try to process the contents of the cue.

As these cores support both CD and non-CD games, it's easier to just override the behavior when calling the hasher. That will also handle any other cores that would be similarly affected.

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

@Sanaki