### PR TITLE
patch: reject truncated BPS and UPS varints

### DIFF
--- a/tasks/patch_stream.c
+++ b/tasks/patch_stream.c
@@ -14,6 +14,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #include <encodings/crc32.h>
 
@@ -146,26 +147,34 @@ static bool patch_stream_fill(patch_stream_t *ps, size_t at,
 }
 
 /* Variable-length integer, as used by both UPS and BPS. */
-static uint64_t patch_stream_decode(patch_stream_t *ps)
+static bool patch_stream_decode(patch_stream_t *ps, uint64_t *out)
 {
    uint64_t val   = 0;
    uint64_t shift = 1;
 
    for (;;)
    {
-      uint8_t x = (ps->p_off < ps->patch_len) ? ps->patch[ps->p_off] : 0;
+      uint8_t x;
 
-      if (ps->p_off < ps->patch_len)
-         ps->p_off++;
+      if (ps->p_off >= ps->patch_len)
+         return false;
+      x = ps->patch[ps->p_off++];
 
+      if ((uint64_t)(x & 0x7f) > (UINT64_MAX - val) / shift)
+         return false;
       val += (x & 0x7f) * shift;
       if (x & 0x80)
-         break;
+      {
+         *out = val;
+         return true;
+      }
+      if (shift > UINT64_MAX >> 7)
+         return false;
       shift <<= 7;
+      if (val > UINT64_MAX - shift)
+         return false;
       val   += shift;
    }
-
-   return val;
 }
 
 /* --------------------------------------------------------------------
@@ -402,6 +411,8 @@ patch_stream_t *patch_stream_ups_open(const uint8_t *patch, size_t patch_len,
       size_t src_len)
 {
    patch_stream_t *ps;
+   uint64_t declared_src;
+   uint64_t declared_tgt;
 
    if (patch_len < 18 || memcmp(patch, "UPS1", 4))
       return NULL;
@@ -418,9 +429,17 @@ patch_stream_t *patch_stream_ups_open(const uint8_t *patch, size_t patch_len,
    /* The caller's src_len stays authoritative for decoding, exactly as
     * in the whole-buffer applier, but the declared lengths are part of
     * what the trailer is checked against. */
-   ps->ups_declared_src_len = (uint32_t)patch_stream_decode(ps);
-   ps->tgt_len              = (size_t)patch_stream_decode(ps);
-   ps->ups_declared_tgt_len = (uint32_t)ps->tgt_len;
+   if (   !patch_stream_decode(ps, &declared_src)
+       || !patch_stream_decode(ps, &declared_tgt)
+       || declared_src > UINT32_MAX
+       || declared_tgt > UINT32_MAX)
+   {
+      patch_stream_free(ps);
+      return NULL;
+   }
+   ps->ups_declared_src_len = (uint32_t)declared_src;
+   ps->tgt_len              = (size_t)declared_tgt;
+   ps->ups_declared_tgt_len = (uint32_t)declared_tgt;
 
    ps->carry_cap = 65536;
    if (     !(ps->carry = (uint8_t*)malloc(ps->carry_cap))
@@ -474,7 +493,13 @@ static void patch_stream_ups_run(patch_stream_t *ps)
       size_t   save_p = ps->p_off;
       size_t   save_s = ps->s_off;
       size_t   save_t = ps->t_off;
-      uint64_t skip   = patch_stream_decode(ps);
+      uint64_t skip;
+
+      if (!patch_stream_decode(ps, &skip))
+      {
+         ps->failed = 1;
+         return;
+      }
 
       while (skip--)
       {
@@ -656,9 +681,13 @@ patch_stream_t *patch_stream_bps_open(const uint8_t *patch, size_t patch_len,
    ps->src_len   = src_len;
    ps->p_off     = 4;
 
-   decl_src = patch_stream_decode(ps);
-   decl_tgt = patch_stream_decode(ps);
-   markup   = patch_stream_decode(ps);
+   if (   !patch_stream_decode(ps, &decl_src)
+       || !patch_stream_decode(ps, &decl_tgt)
+       || !patch_stream_decode(ps, &markup))
+   {
+      patch_stream_free(ps);
+      return NULL;
+   }
 
    if (     markup   > patch_len - ps->p_off
          || decl_src > src_len
@@ -688,9 +717,16 @@ static void patch_stream_bps_run(patch_stream_t *ps)
       size_t   save_o = ps->t_off;
       size_t   save_s = ps->s_off;
       size_t   save_t = ps->bt_off;
-      uint64_t len    = patch_stream_decode(ps);
-      unsigned mode   = (unsigned)(len & 3);
+      uint64_t len;
+      unsigned mode;
       uint64_t k;
+
+      if (!patch_stream_decode(ps, &len))
+      {
+         ps->failed = 1;
+         return;
+      }
+      mode = (unsigned)(len & 3);
 
       len = (len >> 2) + 1;
 
@@ -742,9 +778,18 @@ static void patch_stream_bps_run(patch_stream_t *ps)
 
          default: /* SourceCopy / TargetCopy */
          {
-            int64_t  raw = (int64_t)patch_stream_decode(ps);
-            int      neg = (int)(raw & 1);
+            uint64_t decoded;
+            int64_t  raw;
+            int      neg;
             int64_t  off;
+
+            if (!patch_stream_decode(ps, &decoded))
+            {
+               ps->failed = 1;
+               return;
+            }
+            raw = (int64_t)decoded;
+            neg = (int)(raw & 1);
 
             raw >>= 1;
             off   = neg ? -raw : raw;

--- a/tasks/task_patch.c
+++ b/tasks/task_patch.c
@@ -20,6 +20,7 @@
 /* TODO/FIXME - turn this into actual task */
 
 #include <stdint.h>
+#include <limits.h>
 #include <string.h>
 
 #include <boolean.h>
@@ -107,33 +108,41 @@ typedef enum patch_error (*patch_func_t)(const uint8_t*, uint64_t,
 static uint8_t bps_read(struct bps_data *bps)
 {
    /* Reads past the end yield zeroes rather than walking off the
-    * buffer: a malformed varint near the trailer could otherwise
-    * drive bps_decode() arbitrarily far past modify_length (the
-    * UPS reader below already guards the same way).  The rolling
-    * per-byte checksum that used to live here is gone - the patch
-    * bytes are one contiguous span, so the modify checksum is
-    * folded in one call at the point it is compared. */
+    * buffer. The rolling per-byte checksum that used to live here is
+    * gone - the patch bytes are one contiguous span, so the modify
+    * checksum is folded in one call at the point it is compared. */
    if (bps->modify_offset < bps->modify_length)
       return bps->modify_data[bps->modify_offset++];
    bps->modify_offset++;
    return 0x00;
 }
 
-static uint64_t bps_decode(struct bps_data *bps)
+static bool bps_decode(struct bps_data *bps, uint64_t *out)
 {
    uint64_t data = 0, shift = 1;
 
    for (;;)
    {
-      uint8_t x  = bps_read(bps);
+      uint8_t x;
+
+      if (bps->modify_offset >= bps->modify_length)
+         return false;
+      x = bps->modify_data[bps->modify_offset++];
+      if ((uint64_t)(x & 0x7f) > (UINT64_MAX - data) / shift)
+         return false;
       data      += (x & 0x7f) * shift;
       if (x & 0x80)
-         break;
+      {
+         *out = data;
+         return true;
+      }
+      if (shift > UINT64_MAX >> 7)
+         return false;
       shift    <<= 7;
+      if (data > UINT64_MAX - shift)
+         return false;
       data      += shift;
    }
-
-   return data;
 }
 
 static enum patch_error bps_apply_patch(
@@ -176,9 +185,14 @@ static enum patch_error bps_apply_patch(
       return PATCH_PATCH_INVALID_HEADER;
 
    {
-      uint64_t raw_source = bps_decode(&bps);
-      uint64_t raw_target = bps_decode(&bps);
-      uint64_t raw_markup = bps_decode(&bps);
+      uint64_t raw_source;
+      uint64_t raw_target;
+      uint64_t raw_markup;
+
+      if (   !bps_decode(&bps, &raw_source)
+          || !bps_decode(&bps, &raw_target)
+          || !bps_decode(&bps, &raw_markup))
+         return PATCH_PATCH_INVALID;
 
       /* All three sizes are decoded from attacker-controlled
        * variable-length integers in the patch file with no
@@ -229,8 +243,14 @@ static enum patch_error bps_apply_patch(
 
    while (bps.modify_offset < bps.modify_length - 12)
    {
-      size_t _len   = bps_decode(&bps);
-      unsigned mode = _len & 3;
+      uint64_t decoded_len;
+      size_t _len;
+      unsigned mode;
+
+      if (!bps_decode(&bps, &decoded_len))
+         return PATCH_PATCH_INVALID;
+      _len = (size_t)decoded_len;
+      mode = _len & 3;
 
       _len          = (_len >> 2) + 1;
 
@@ -278,8 +298,14 @@ static enum patch_error bps_apply_patch(
          case SOURCE_COPY:
          case TARGET_COPY:
          {
-            int    offset = (int)bps_decode(&bps);
-            bool negative = offset & 1;
+            uint64_t decoded_offset;
+            int      offset;
+            bool negative;
+
+            if (!bps_decode(&bps, &decoded_offset))
+               return PATCH_PATCH_INVALID;
+            offset = (int)decoded_offset;
+            negative = offset & 1;
 
             offset >>= 1;
 
@@ -432,21 +458,33 @@ static void ups_copy_run(struct ups_data *data, size_t n)
    data->target_offset += (unsigned)n;
 }
 
-static uint64_t ups_decode(struct ups_data *data)
+static bool ups_decode(struct ups_data *data, uint64_t *out)
 {
    uint64_t offset = 0, shift = 1;
 
    for (;;)
    {
-      uint8_t x = ups_patch_read(data);
+      uint8_t x;
+
+      if (data->patch_offset >= data->patch_length)
+         return false;
+      x = data->patch_data[data->patch_offset++];
+      if ((uint64_t)(x & 0x7f) > (UINT64_MAX - offset) / shift)
+         return false;
       offset   += (x & 0x7f) * shift;
 
       if (x & 0x80)
-         break;
+      {
+         *out = offset;
+         return true;
+      }
+      if (shift > UINT64_MAX >> 7)
+         return false;
       shift <<= 7;
+      if (offset > UINT64_MAX - shift)
+         return false;
       offset += shift;
    }
-   return offset;
 }
 
 static enum patch_error ups_apply_patch(
@@ -456,6 +494,8 @@ static enum patch_error ups_apply_patch(
 {
    size_t i;
    struct ups_data data;
+   uint64_t decoded_source_length;
+   uint64_t decoded_target_length;
    unsigned source_read_length;
    unsigned target_read_length;
    uint32_t patch_result_checksum = 0;
@@ -486,8 +526,13 @@ static enum patch_error ups_apply_patch(
       )
       return PATCH_PATCH_INVALID;
 
-   source_read_length = (unsigned)ups_decode(&data);
-   target_read_length = (unsigned)ups_decode(&data);
+   if (   !ups_decode(&data, &decoded_source_length)
+       || !ups_decode(&data, &decoded_target_length)
+       || decoded_source_length > UINT_MAX
+       || decoded_target_length > UINT_MAX)
+      return PATCH_PATCH_INVALID;
+   source_read_length = (unsigned)decoded_source_length;
+   target_read_length = (unsigned)decoded_target_length;
 
    if (     (data.source_length != source_read_length)
          && (data.source_length != target_read_length))
@@ -510,7 +555,12 @@ static enum patch_error ups_apply_patch(
 
    while (data.patch_offset < data.patch_length - 12)
    {
-      unsigned __len = (unsigned)ups_decode(&data);
+      uint64_t decoded_len;
+      unsigned __len;
+
+      if (!ups_decode(&data, &decoded_len) || decoded_len > UINT_MAX)
+         return PATCH_PATCH_INVALID;
+      __len = (unsigned)decoded_len;
       ups_copy_run(&data, __len);
 
       for (;;)


### PR DESCRIPTION
The BPS and UPS decoders currently continue reading zero bytes after EOF
while looking for a terminating variable-length integer.

A crafted sidecar patch can therefore make content loading spin
indefinitely, consuming CPU until RetroArch is forcibly stopped.

Make streaming and whole-buffer decoders reject truncated or overflowing
varints, and propagate the failure to their callers.