### PR TITLE
smb2: ensure smb settings initalized earlier, also log failures

### DIFF
--- a/libretro-common/vfs/vfs_implementation_smb.c
+++ b/libretro-common/vfs/vfs_implementation_smb.c
@@ -169,9 +169,22 @@ static bool smb_init(void)
       return false;
 
    if (!smb_cfg || (!smb_cfg->server_address || !*smb_cfg->server_address))
+   {
+      fprintf(stderr, "smb_init - error - config not initialized\n");
       return false;
+   }
 
    unsigned max_smb_contexts = smb_cfg->num_contexts;
+   unsigned timeout = smb_cfg->timeout;
+   unsigned auth_mode = smb_cfg->auth_mode;
+
+   // this should always be a positive number 1 or more
+   if (max_smb_contexts == 0)
+      max_smb_contexts = RETRO_SMB2_DEFAULT_MAX_CLIENTS;
+
+   if (timeout == 0)
+      timeout = RETRO_SMB2_DEFAULT_CLIENT_TIMEOUT;
+
    smb_context_pool = calloc(max_smb_contexts, sizeof(struct smb2_context *));
 
    if (!smb_context_pool)
@@ -183,6 +196,7 @@ static bool smb_init(void)
 
       if (!smb_context)
       {
+         fprintf(stderr, "smb_init: error - no smb_context for %d\n", i);
          reset(max_context_configured);
          return false;
       }
@@ -208,20 +222,22 @@ static bool smb_init(void)
          share[0] = '\0';
 
       /* set timeout */
-      smb2_set_timeout(smb_context, smb_cfg->timeout);
+      smb2_set_timeout(smb_context, timeout);
 
       /* SMB2_SEC_ defines missing on system headers but provided with latest libsmb2 */
-      switch(smb_cfg->auth_mode)
+      switch(auth_mode)
       {
          case RETRO_SMB2_SEC_NTLMSSP:
             smb2_set_security_mode(smb_context, RETRO_SMB2_SEC_NTLMSSP);
             smb2_set_authentication(smb_context, RETRO_SMB2_SEC_NTLMSSP);
             resolved_auth_mode = RETRO_SMB2_SEC_NTLMSSP;
+            auth_mode = resolved_auth_mode;
             break;
          case RETRO_SMB2_SEC_KRB5:
             smb2_set_security_mode(smb_context, RETRO_SMB2_SEC_KRB5);
             smb2_set_authentication(smb_context, RETRO_SMB2_SEC_KRB5);
             resolved_auth_mode = RETRO_SMB2_SEC_KRB5;
+            auth_mode = resolved_auth_mode;
             break;
          case RETRO_SMB2_SEC_UNDEFINED:
          default:
@@ -247,28 +263,45 @@ static bool smb_init(void)
 
                if (!smb_context)
                {
+                  fprintf(stderr, "smb_init - error - no context\n");
                   reset(max_context_configured);
                   return false;
                }
 
-               smb2_set_user(smb_context, username);
+               /* reset credentials */
+               if (smb_cfg->username && *smb_cfg->username)
+               {
+                  username = (char*)smb_cfg->username;
+                  smb2_set_user(smb_context, username);
+               }
+
                if (smb_cfg->password && *smb_cfg->password)
                   smb2_set_password(smb_context, smb_cfg->password);
+
                if (smb_cfg->workgroup && *smb_cfg->workgroup)
                   smb2_set_domain(smb_context, smb_cfg->workgroup);
-               smb2_set_timeout(smb_context, smb_cfg->timeout);
+
+               if (smb_cfg->share && *smb_cfg->share)
+                  strlcpy(share, smb_cfg->share, sizeof(share));
+               else
+                  share[0] = '\0';
+
+               smb2_set_timeout(smb_context, timeout);
             }
 
             /* if that fails, try SMB2_SEC_KRB5 in fallthrough */
             smb2_set_security_mode(smb_context, RETRO_SMB2_SEC_NTLMSSP);
             smb2_set_authentication(smb_context, RETRO_SMB2_SEC_NTLMSSP);
+
+            // attempt RETRO_SMB2_SEC_NTLMSSP as RETRO_SMB2_SEC_KRB5 did not work
             resolved_auth_mode = RETRO_SMB2_SEC_NTLMSSP;
-            break;
+            auth_mode = resolved_auth_mode;
       }
 
       /* Connect to share */
       if ((error_no = smb2_connect_share(smb_context, server, share, username)) < 0)
       {
+         fprintf(stderr, "smb_init: error - failed to connect - error_no: %d\n", error_no);
          smb2_destroy_context(smb_context);
          reset(max_context_configured);
          return false;
@@ -727,7 +760,10 @@ int retro_vfs_stat_smb(const char *path, int64_t *size)
 
    smb_context = get_smb_context();
    if (!smb_context)
+   {
+      fprintf(stderr, "retro_vfs_stat_smb: no smb_context!\n");
       return 0;
+   }
 
    if (smb2_stat(smb_context, rel_path, &st) < 0)
    {

--- a/libretro-common/vfs/vfs_implementation_smb.h
+++ b/libretro-common/vfs/vfs_implementation_smb.h
@@ -14,6 +14,8 @@ extern "C" {
 #define RETRO_SMB2_SEC_UNDEFINED 0
 #define RETRO_SMB2_SEC_NTLMSSP 1
 #define RETRO_SMB2_SEC_KRB5 2
+#define RETRO_SMB2_DEFAULT_MAX_CLIENTS 4
+#define RETRO_SMB2_DEFAULT_CLIENT_TIMEOUT 5
 
 struct smb_settings {
    const char *server_address;

--- a/retroarch.c
+++ b/retroarch.c
@@ -6514,6 +6514,10 @@ int rarch_main(int argc, char *argv[], void *data)
 
    runloop_msg_queue_init();
 
+#ifdef HAVE_SMBCLIENT
+   retroarch_smb_init();
+#endif
+
    if (frontend_state_get_ptr()->current_frontend_ctx)
    {
       content_ctx_info_t info;
@@ -6534,10 +6538,6 @@ int rarch_main(int argc, char *argv[], void *data)
    }
 
    settings = config_get_ptr();
-
-#ifdef HAVE_SMBCLIENT
-   retroarch_smb_init();
-#endif
 
    ui_companion_driver_init_first(
 #ifdef HAVE_QT


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

hatari seems to be requesting smb2 before its finished initializing in rarch_main, so move retro vfs init up higher to ensure it is setup first.

also fixes auto mode.

## Related Issues

## Related Pull Requests

## Reviewers