### PR TITLE
SDL3: Always call SDL_Quit on exit

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -6237,15 +6237,14 @@ static void global_free(struct rarch_state *p_rarch)
 #if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX) || defined(HAVE_SDL3)
 static void sdl_exit(void)
 {
-   /* Quit any SDL subsystems, then quit
-    * SDL itself */
-   uint32_t sdl_subsystem_flags = SDL_WasInit(0);
-
-   if (sdl_subsystem_flags != 0)
-   {
-      SDL_QuitSubSystem(sdl_subsystem_flags);
-      SDL_Quit();
-   }
+   /* SDL documents that SDL_Quit() should be called at exit even if
+    * every subsystem was already shut down with SDL_QuitSubSystem()
+    * (which the SDL drivers do on deinit, so SDL_WasInit(0) is
+    * normally 0 by now), and that it is safe to call regardless of
+    * whether anything was ever initialised. It also shuts down any
+    * subsystems still running, so no per-subsystem quits are needed
+    * here. */
+   SDL_Quit();
 }
 #endif
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -6237,13 +6237,10 @@ static void global_free(struct rarch_state *p_rarch)
 #if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX) || defined(HAVE_SDL3)
 static void sdl_exit(void)
 {
-   /* SDL documents that SDL_Quit() should be called at exit even if
-    * every subsystem was already shut down with SDL_QuitSubSystem()
-    * (which the SDL drivers do on deinit, so SDL_WasInit(0) is
-    * normally 0 by now), and that it is safe to call regardless of
-    * whether anything was ever initialised. It also shuts down any
-    * subsystems still running, so no per-subsystem quits are needed
-    * here. */
+   /* SDL_Quit() should be called at exit even if every subsystem
+    * was already shut down with SDL_QuitSubSystem(). It is also
+    * safe to call regardless of whether anything was ever
+    * initialized. */
    SDL_Quit();
 }
 #endif

--- a/retroarch.c
+++ b/retroarch.c
@@ -6234,17 +6234,6 @@ static void global_free(struct rarch_state *p_rarch)
    retroarch_override_setting_free_state();
 }
 
-#if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX) || defined(HAVE_SDL3)
-static void sdl_exit(void)
-{
-   /* SDL_Quit() should be called at exit even if every subsystem
-    * was already shut down with SDL_QuitSubSystem(). It is also
-    * safe to call regardless of whether anything was ever
-    * initialized. */
-   SDL_Quit();
-}
-#endif
-
 /**
  * main_exit:
  *
@@ -6338,7 +6327,7 @@ void main_exit(void *args)
 #endif
 
 #if defined(HAVE_SDL) || defined(HAVE_SDL2) || defined(HAVE_SDL_DINGUX) || defined(HAVE_SDL3)
-   sdl_exit();
+   SDL_Quit();
 #endif
 }
 


### PR DESCRIPTION
It's safe to call `SDL_Quit()` whether or not anything in SDL was initialized. This allows us to clean up everything, and not miss any subsystem. Also saves some code.