### PR TITLE
ci: webos: fix the SDL2 prebuilt download

### DIFF
--- a/.github/workflows/webOS.yml
+++ b/.github/workflows/webOS.yml
@@ -81,6 +81,32 @@ jobs:
           RARCH_VERSION=$(grep -Po '(?<=#define PACKAGE_VERSION ")[^"]+' version.all)
           echo "RARCH_VERSION=$RARCH_VERSION" >> "$GITHUB_ENV"
 
+      - name: Resolve SDL2 prebuilt archive
+        id: sdl2
+        shell: bash
+        run: |
+          URL=$(sed -n 's/^SDL2_PREBUILT_ARCHIVE *?= *//p' Makefile.webos)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$URL")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SDL2 prebuilt
+        id: sdl2-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/sdl2-prebuilt
+          key: sdl2-prebuilt-${{ steps.sdl2.outputs.name }}
+
+      - name: Download SDL2 prebuilt
+        if: steps.sdl2-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          SDL2_URL: ${{ steps.sdl2.outputs.url }}
+          SDL2_NAME: ${{ steps.sdl2.outputs.name }}
+        run: |
+          mkdir -p /tmp/sdl2-prebuilt
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 30 -o "/tmp/sdl2-prebuilt/$SDL2_NAME" "$SDL2_URL"
+
       - name: Compile RA (GLES2, no wayland legacy variant)
         shell: bash
         run: |
@@ -88,12 +114,14 @@ jobs:
           export SDK_PATH=/tmp/arm-webos-linux-gnueabi_sdk-buildroot
           make -f Makefile.webos clean
           make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 \
+          SDL2_PREBUILT_ARCHIVE="file:///tmp/sdl2-prebuilt/${SDL2_NAME}" \
           -j"$(getconf _NPROCESSORS_ONLN)"
           mkdir -p webos/arm
           mv webos/com.retroarch.webos_${RARCH_VERSION}_arm.ipk \
              webos/arm/com.retroarch.webos-legacy-gles2-no-wayland_${RARCH_VERSION}_arm.ipk
         env:
           DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
+          SDL2_NAME: ${{ steps.sdl2.outputs.name }}
 
       - name: Upload GLES2 artifact
         uses: actions/upload-artifact@v7
@@ -110,6 +138,7 @@ jobs:
           make -f Makefile.webos clean
           bash gfx/common/wayland/generate_wayland_protos.sh
           make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=1 \
+          SDL2_PREBUILT_ARCHIVE="file:///tmp/sdl2-prebuilt/${SDL2_NAME}" \
           HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 HAVE_WAYLAND=1 \
           HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1 -j"$(getconf _NPROCESSORS_ONLN)"
           mkdir -p webos/arm
@@ -117,6 +146,7 @@ jobs:
             webos/arm/com.retroarch.webos_${RARCH_VERSION}_arm.ipk
         env:
           DEBUG: ${{ github.event_name == 'release' && '0' || '1' }}
+          SDL2_NAME: ${{ steps.sdl2.outputs.name }}
 
       - name: Upload default artifact
         uses: actions/upload-artifact@v7

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -384,8 +384,8 @@ ifeq ($(ADD_SDL2_LIB), 1)
 		echo "Downloading SDL2 prebuilt"; \
 		rm -rf SDL.tmp SDL2-prebuilt.tar.gz.tmp; \
 		mkdir -p SDL.tmp; \
-		wget --tries=5 --timeout=30 --retry-connrefused \
-			-qO SDL2-prebuilt.tar.gz.tmp $(SDL2_PREBUILT_ARCHIVE) \
+		curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+			-o SDL2-prebuilt.tar.gz.tmp $(SDL2_PREBUILT_ARCHIVE) \
 			|| { echo "error: SDL2 prebuilt download failed: $(SDL2_PREBUILT_ARCHIVE)"; \
 			     rm -rf SDL.tmp SDL2-prebuilt.tar.gz.tmp; exit 1; }; \
 		tar -C SDL.tmp -zxf SDL2-prebuilt.tar.gz.tmp \


### PR DESCRIPTION
The webos CI job was [failing on downloading SDL2 prebuilt](https://github.com/libretro/RetroArch/actions/runs/31450659336/job/93654175518) binaries. This PR does two things to try to fix it...

1. Switches to `curl` to allow use of `--retry-all-errors`
2. Adds a file cache in github actions so that it doesn't have to re-download the prebuilt binaries each time the github actions pipeline run