### PR TITLE
SDL3: Add Audio Driver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - ANDROID: Enable network commands
 - ANDROID: Fix dual-motor rumble for USB-connected DS4 and DualSense controllers
 - AUDIO: ASIO driver for Windows platforms
+- AUDIO: SDL3 audio and microphone drivers
 - AUDIO/MICROPHONE: Fix resampling, apple drivers
 - APPLE: Use coreaudio3 resampling
 - APPLE: Add coreaudio3 driver to iOS/TVOS

--- a/Makefile.common
+++ b/Makefile.common
@@ -1671,7 +1671,8 @@ ifeq ($(HAVE_SDL3), 1)
    OBJ += input/drivers_joypad/sdl3_joypad.o \
           input/drivers/sdl3_input.o \
           gfx/drivers/sdl3_gfx.o \
-          gfx/common/sdl3_common.o
+          gfx/common/sdl3_common.o \
+          audio/drivers/sdl3_audio.o
 
    ifneq ($(filter 1,$(HAVE_OPENGL) $(HAVE_OPENGL1) $(HAVE_OPENGL_CORE) $(HAVE_OPENGLES)),)
       OBJ += gfx/drivers_context/sdl3_gl_ctx.o

--- a/audio/audio_driver.c
+++ b/audio/audio_driver.c
@@ -200,6 +200,9 @@ audio_driver_t *audio_drivers[] = {
 #if defined(HAVE_SDL) || defined(HAVE_SDL2)
    &audio_sdl,
 #endif
+#ifdef HAVE_SDL3
+   &audio_sdl3,
+#endif
 #ifdef HAVE_PULSE
    &audio_pulse,
 #endif
@@ -276,6 +279,9 @@ microphone_driver_t *microphone_drivers[] = {
 #endif
 #ifdef HAVE_SDL2
       &microphone_sdl, /* Microphones are not supported in SDL 1 */
+#endif
+#ifdef HAVE_SDL3
+      &microphone_sdl3,
 #endif
 #ifdef HAVE_PIPEWIRE
       &microphone_pipewire,

--- a/audio/audio_driver.h
+++ b/audio/audio_driver.h
@@ -529,6 +529,7 @@ extern audio_driver_t audio_openal;
 extern audio_driver_t audio_opensl;
 extern audio_driver_t audio_jack;
 extern audio_driver_t audio_sdl;
+extern audio_driver_t audio_sdl3;
 extern audio_driver_t audio_xa;
 extern audio_driver_t audio_pulse;
 extern audio_driver_t audio_pipewire;

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -24,7 +24,6 @@
 #include <boolean.h>
 #include <retro_inline.h>
 #include <retro_math.h>
-#include <queues/fifo_queue.h>
 #include <lists/string_list.h>
 #include <string/stdstring.h>
 
@@ -34,17 +33,25 @@
 #include "../../configuration.h"
 #include "../../verbosity.h"
 
-/* The drivers below use a pull architecture: RetroArch pushes into a
- * FIFO owned by the driver, and SDL's stream get-callback pulls from
- * that FIFO each device period (the microphone mirrors this with the
- * put-callback).  The FIFO and its condition variable share one
- * mutex, so blocking reads/writes need no timeouts or sleeps and
- * can't miss a wakeup.  SDL's own synchronization primitives are
- * used instead of rthreads, so the driver behaves identically with
- * or without HAVE_THREADS; SDL3 provides them on every platform it
- * supports.  The lock order is always SDL's stream lock -> ours
- * (callbacks run under the stream lock), never the reverse: the
- * RetroArch side makes no SDL stream calls while holding our mutex. */
+/* The drivers below feed SDL3 audio streams directly: RetroArch puts
+ * samples into the playback stream and gets them from the recording
+ * stream on its own thread, while SDL's device threads handle the
+ * other end.  SDL_AudioStream is internally locked and buffers any
+ * amount of queued audio, so it doubles as the FIFO and the drivers
+ * keep no buffers, locks or condition variables of their own.
+ * Blocking writes and reads poll the stream's fill level at a short
+ * interval instead of waiting on a callback signal: a device that
+ * stops making progress (unplugged, stalled driver) can then only
+ * ever cost the stall timeout below, never park the core's thread
+ * for good. */
+
+/* How long a blocking write/read keeps polling without making any
+ * progress before giving up on the device. */
+#define SDL3_AUDIO_STALL_TIMEOUT_MS 256
+
+/* Poll interval while a blocking write/read waits on the device;
+ * device periods are several times longer than this. */
+#define SDL3_AUDIO_POLL_INTERVAL_NS SDL_NS_PER_MS
 
 static INLINE int sdl3_audio_find_num_frames(int rate, int latency)
 {
@@ -59,6 +66,7 @@ static INLINE int sdl3_audio_find_num_frames(int rate, int latency)
 static SDL_AudioDeviceID sdl3_audio_find_device(const char *device, bool recording)
 {
    int i;
+   bool found                 = false;
    int count                  = 0;
    SDL_AudioDeviceID *devices = NULL;
    SDL_AudioDeviceID devid    = recording
@@ -72,21 +80,25 @@ static SDL_AudioDeviceID sdl3_audio_find_device(const char *device, bool recordi
       ? SDL_GetAudioRecordingDevices(&count)
       : SDL_GetAudioPlaybackDevices(&count);
 
-   if (devices)
+   if (!devices)
    {
-      for (i = 0; i < count; i++)
-      {
-         if (string_is_equal(SDL_GetAudioDeviceName(devices[i]), device))
-         {
-            devid = devices[i];
-            break;
-         }
-      }
-      SDL_free(devices);
+      RARCH_WARN("[SDL3 audio] Failed to enumerate %s devices: %s.\n",
+            recording ? "recording" : "playback", SDL_GetError());
+      return devid;
    }
 
-   if (      devid == SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK
-         ||  devid == SDL_AUDIO_DEVICE_DEFAULT_RECORDING)
+   for (i = 0; i < count; i++)
+   {
+      if (string_is_equal(SDL_GetAudioDeviceName(devices[i]), device))
+      {
+         devid = devices[i];
+         found = true;
+         break;
+      }
+   }
+   SDL_free(devices);
+
+   if (!found)
       RARCH_WARN("[SDL3 audio] Requested %s device \"%s\" not found, using the default device.\n",
             recording ? "recording" : "playback", device);
 
@@ -129,72 +141,18 @@ static struct string_list *sdl3_audio_device_list(bool recording)
 
 typedef struct sdl3_audio
 {
-   /* Guards speaker_buffer and pairs with cond; the stream
-    * get-callback takes it too, so FIFO fill checks and waits
-    * are race-free. */
-   SDL_Mutex *lock;
-   SDL_Condition *cond;
-   /**
-    * The queue used to store outgoing samples to be played by the driver.
-    * Audio from the core ultimately makes its way here,
-    * the last stop before the get-callback pulls it into the device.
-    */
-   fifo_buffer_t *speaker_buffer;
-   size_t buffer_size;
-   /* Staging area for FIFO -> stream copies inside the callback. */
-   uint8_t *scratch;
-   size_t scratch_size;
-   /* The device stream; samples are put into it only by the callback. */
+   /* The device stream.  SDL_AudioStream is internally locked and
+    * buffers queued audio itself, so it doubles as the FIFO between
+    * RetroArch and the device. */
    SDL_AudioStream *stream;
    /* The format samples are put in (SDL converts to the device format). */
    SDL_AudioSpec spec;
-   /* Bytes per frame on the device side, for converting the
-    * callback's byte counts into our put-side units. */
-   size_t out_frame_size;
-   size_t in_frame_size;
+   /* Cap on queued audio, in bytes of our put-side format; writes
+    * block (or bail, when nonblocking) once this much is queued. */
+   size_t buffer_size;
    bool nonblock;
    bool is_paused;
 } sdl3_audio_t;
-
-/**
- * Runs on SDL's device thread each period, before the device reads
- * from the stream: pulls however much the device needs out of the
- * FIFO.  If the FIFO can't cover it, the stream runs short and SDL
- * plays silence for the remainder (the underrun case).
- */
-static void SDLCALL sdl3_audio_stream_cb(void *userdata,
-      SDL_AudioStream *stream, int additional_amount, int total_amount)
-{
-   sdl3_audio_t *sdl = (sdl3_audio_t*)userdata;
-   /* additional_amount is in device-format bytes; convert to ours. */
-   size_t needed     = (size_t)((additional_amount + (int)sdl->out_frame_size - 1)
-         / (int)sdl->out_frame_size) * sdl->in_frame_size;
-
-   SDL_LockMutex(sdl->lock);
-
-   while (needed > 0)
-   {
-      size_t avail = FIFO_READ_AVAIL(sdl->speaker_buffer);
-      size_t chunk = (needed > sdl->scratch_size) ? sdl->scratch_size : needed;
-
-      if (chunk > avail)
-         chunk = avail;
-      if (chunk == 0)
-         break;
-
-      fifo_read(sdl->speaker_buffer, sdl->scratch, chunk);
-      /* This callback already holds the stream's recursive lock,
-       * so putting from here can't deadlock. */
-      SDL_PutAudioStreamData(stream, sdl->scratch, (int)chunk);
-      needed -= chunk;
-   }
-
-   /* Signal while holding the mutex, so the wakeup can't slip
-    * between a writer's fill check and its wait. */
-   SDL_SignalCondition(sdl->cond);
-
-   SDL_UnlockMutex(sdl->lock);
-}
 
 static void sdl3_audio_free(void *data)
 {
@@ -202,20 +160,9 @@ static void sdl3_audio_free(void *data)
 
    if (sdl)
    {
-      /* Destroying the stream also closes the device.  Do this
-       * before freeing anything else, since the stream callback
-       * uses the FIFO, the scratch buffer and the locks. */
+      /* Destroying the stream also closes the device. */
       if (sdl->stream)
          SDL_DestroyAudioStream(sdl->stream);
-
-      if (sdl->speaker_buffer)
-         fifo_free(sdl->speaker_buffer);
-      free(sdl->scratch);
-
-      if (sdl->cond)
-         SDL_DestroyCondition(sdl->cond);
-      if (sdl->lock)
-         SDL_DestroyMutex(sdl->lock);
 
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
    }
@@ -228,14 +175,14 @@ static void *sdl3_audio_init(const char *device,
 {
    int frames;
    char frames_str[16];
-   size_t min_size;
-   const char *device_name  = NULL;
-   void *tmp                = NULL;
-   SDL_AudioDeviceID devid  = 0;
+   size_t frame_size, min_size;
+   const char *device_name   = NULL;
+   void *tmp                 = NULL;
+   SDL_AudioDeviceID devid   = 0;
    SDL_AudioSpec device_spec = {0};
-   int device_sample_frames = 0;
-   sdl3_audio_t *sdl        = NULL;
-   settings_t *settings     = config_get_ptr();
+   int device_sample_frames  = 0;
+   sdl3_audio_t *sdl         = NULL;
+   settings_t *settings      = config_get_ptr();
 
    /* Subsystem initialization is reference-counted in SDL3, so
     * initialize unconditionally; every init is balanced by the
@@ -263,7 +210,7 @@ static void *sdl3_audio_init(const char *device,
       device_spec.freq = rate;
 
    /* Request a device period of roughly a quarter of the total
-    * latency; the rest of the budget stays queued in the FIFO. */
+    * latency; the rest of the budget stays queued in the stream. */
    frames = sdl3_audio_find_num_frames(device_spec.freq, latency / 4);
    snprintf(frames_str, sizeof(frames_str), "%d", frames);
    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
@@ -276,7 +223,11 @@ static void *sdl3_audio_init(const char *device,
          ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
    sdl->spec.channels = 2;
 
-   if (!(sdl->stream = SDL_OpenAudioDeviceStream(devid, &sdl->spec, NULL, NULL)))
+   sdl->stream = SDL_OpenAudioDeviceStream(devid, &sdl->spec, NULL, NULL);
+   /* The hint is process-global; clear it now that the open has
+    * consumed it so later SDL audio opens aren't affected. */
+   SDL_ResetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES);
+   if (!sdl->stream)
    {
       RARCH_ERR("[SDL3 audio] Failed to open SDL audio output device: %s.\n",
             SDL_GetError());
@@ -284,37 +235,18 @@ static void *sdl3_audio_init(const char *device,
    }
 
    /* See what SDL actually opened (sample_frames honours the hint). */
-   sdl->in_frame_size  = SDL_AUDIO_FRAMESIZE(sdl->spec);
-   sdl->out_frame_size = sdl->in_frame_size;
-   if (SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(sdl->stream),
+   if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(sdl->stream),
          &device_spec, &device_sample_frames))
-   {
-      if (SDL_AUDIO_FRAMESIZE(device_spec) > 0)
-         sdl->out_frame_size = SDL_AUDIO_FRAMESIZE(device_spec);
-   }
-   else
       device_sample_frames = frames;
 
    /* Buffer the requested latency's worth of audio, with at least
     * two device periods to avoid underruns. */
+   frame_size       = SDL_AUDIO_FRAMESIZE(sdl->spec);
    sdl->buffer_size = (size_t)((uint64_t)sdl->spec.freq * latency / 1000)
-         * sdl->in_frame_size;
-   min_size         = (size_t)(2 * device_sample_frames) * sdl->in_frame_size;
+         * frame_size;
+   min_size         = (size_t)(2 * device_sample_frames) * frame_size;
    if (sdl->buffer_size < min_size)
       sdl->buffer_size = min_size;
-
-   /* The staging buffer covers one device period per copy;
-    * the callback loops if it ever needs more. */
-   sdl->scratch_size = (size_t)device_sample_frames * sdl->in_frame_size;
-   if (sdl->scratch_size < 1024)
-      sdl->scratch_size = 1024;
-
-   sdl->speaker_buffer = fifo_new(sdl->buffer_size);
-   sdl->scratch        = (uint8_t*)malloc(sdl->scratch_size);
-   sdl->lock           = SDL_CreateMutex();
-   sdl->cond           = SDL_CreateCondition();
-   if (!sdl->speaker_buffer || !sdl->scratch || !sdl->lock || !sdl->cond)
-      goto error;
 
    *new_rate = sdl->spec.freq;
 
@@ -330,18 +262,16 @@ static void *sdl3_audio_init(const char *device,
          SDL_AUDIO_ISFLOAT(sdl->spec.format) ? "floating-point" : "integer");
    RARCH_LOG("[SDL3 audio] Requested %u ms latency for output device, using %d ms.\n",
          latency,
-         (int)((sdl->buffer_size / sdl->in_frame_size + device_sample_frames)
+         (int)((sdl->buffer_size / frame_size + device_sample_frames)
             * 1000 / sdl->spec.freq));
 
-   /* Prefill the FIFO with silence so playback starts with a
+   /* Prefill the stream with silence so playback starts with a
     * full latency budget instead of an immediate underrun. */
    if ((tmp = calloc(1, sdl->buffer_size)))
    {
-      fifo_write(sdl->speaker_buffer, tmp, sdl->buffer_size);
+      SDL_PutAudioStreamData(sdl->stream, tmp, (int)sdl->buffer_size);
       free(tmp);
    }
-
-   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
 
    /* Device streams open in a paused state. */
    SDL_ResumeAudioStreamDevice(sdl->stream);
@@ -355,36 +285,52 @@ error:
 
 static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 {
-   size_t _len      = 0;
+   size_t _len       = 0;
+   Uint64 deadline   = 0;
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
-   SDL_LockMutex(sdl->lock);
+   if (!sdl)
+      return -1;
 
    while (_len < len)
    {
-      size_t avail = FIFO_WRITE_AVAIL(sdl->speaker_buffer);
+      int queued   = SDL_GetAudioStreamQueued(sdl->stream);
+      size_t avail = (queued >= 0 && (size_t)queued < sdl->buffer_size)
+            ? sdl->buffer_size - (size_t)queued : 0;
 
       /* If the outgoing sample queue is full... */
       if (avail == 0)
       {
+         Uint64 now;
          if (sdl->nonblock)
             break; /* If the queue was full... well, too bad. */
-         /* Block until the stream callback pulls samples out of the
-          * FIFO.  It signals under this same mutex, so the wakeup
-          * can't be lost between the check above and this wait. */
-         SDL_WaitCondition(sdl->cond, sdl->lock);
+         /* Poll until the device drains the stream.  Bounded: if
+          * the device stops making progress, give up after the
+          * stall timeout instead of blocking the core's thread
+          * forever. */
+         now = SDL_GetTicks();
+         if (deadline == 0)
+            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_MS;
+         else if (now >= deadline)
+            break;
+         SDL_DelayNS(SDL3_AUDIO_POLL_INTERVAL_NS);
       }
       else
       {
          /* Enqueue as many samples as we have available without
-          * overflowing the queue. */
+          * exceeding the latency cap. */
          size_t write_amt = (len - _len > avail) ? avail : len - _len;
-         fifo_write(sdl->speaker_buffer, (const char*)s + _len, write_amt);
-         _len += write_amt;
+         if (!SDL_PutAudioStreamData(sdl->stream,
+               (const char*)s + _len, (int)write_amt))
+         {
+            RARCH_ERR("[SDL3 audio] Failed to write to audio stream: %s.\n",
+                  SDL_GetError());
+            break;
+         }
+         _len    += write_amt;
+         deadline = 0; /* Progress was made; reset the stall clock. */
       }
    }
-
-   SDL_UnlockMutex(sdl->lock);
 
    return _len;
 }
@@ -392,7 +338,9 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 static bool sdl3_audio_stop(void *data)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
-   sdl->is_paused    = true;
+   if (!sdl)
+      return false;
+   sdl->is_paused = true;
    return SDL_PauseAudioStreamDevice(sdl->stream);
 }
 
@@ -407,7 +355,9 @@ static bool sdl3_audio_alive(void *data)
 static bool sdl3_audio_start(void *data, bool is_shutdown)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
-   sdl->is_paused    = false;
+   if (!sdl)
+      return false;
+   sdl->is_paused = false;
    return SDL_ResumeAudioStreamDevice(sdl->stream);
 }
 
@@ -421,24 +371,30 @@ static void sdl3_audio_set_nonblock_state(void *data, bool state)
 static bool sdl3_audio_use_float(void *data)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
-   return SDL_AUDIO_ISFLOAT(sdl->spec.format) ? true : false;
+   if (!sdl)
+      return false;
+   return SDL_AUDIO_ISFLOAT(sdl->spec.format) != 0;
 }
 
 static size_t sdl3_audio_write_avail(void *data)
 {
-   size_t avail;
+   int queued;
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
-   SDL_LockMutex(sdl->lock);
-   avail = FIFO_WRITE_AVAIL(sdl->speaker_buffer);
-   SDL_UnlockMutex(sdl->lock);
+   if (!sdl)
+      return 0;
 
-   return avail;
+   queued = SDL_GetAudioStreamQueued(sdl->stream);
+   if (queued < 0 || (size_t)queued >= sdl->buffer_size)
+      return 0;
+   return sdl->buffer_size - (size_t)queued;
 }
 
 static size_t sdl3_audio_buffer_size(void *data)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   if (!sdl)
+      return 0;
    return sdl->buffer_size;
 }
 
@@ -482,54 +438,30 @@ typedef struct sdl3_microphone
 
 typedef struct sdl3_microphone_handle
 {
-   /* Guards sample_buffer and pairs with cond (see sdl3_audio). */
-   SDL_Mutex *lock;
-   SDL_Condition *cond;
-   /**
-    * The queue used to store incoming samples from the driver.
-    * The stream put-callback drains the device stream into it.
-    */
-   fifo_buffer_t *sample_buffer;
-   size_t buffer_size;
-   /* Staging area for stream -> FIFO copies inside the callback. */
-   uint8_t *scratch;
-   size_t scratch_size;
-   /* The device stream; samples are read from it only by the callback. */
+   /* The device stream.  Internally locked and buffering, so it
+    * doubles as the FIFO between the device and RetroArch. */
    SDL_AudioStream *stream;
    /* The format samples are read in (SDL converts from the device format). */
    SDL_AudioSpec spec;
+   /* Cap on buffered capture, in bytes of our get-side format;
+    * the put-callback drops the backlog once it grows past this. */
+   size_t buffer_size;
 } sdl3_microphone_handle_t;
 
 /**
  * Runs on SDL's device thread each period, after the device puts
- * recorded samples into the stream: drains the stream into the FIFO.
- * If the FIFO is almost full, whatever doesn't fit is dropped, which
- * keeps capture latency bounded when nothing is reading.
+ * recorded samples into the stream.  Its only job is to bound the
+ * backlog: if nothing has been reading for a while, drop the stale
+ * audio wholesale so the next read resumes with fresh samples and
+ * capture latency stays bounded.
  */
 static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)
 {
-   int got;
    sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)userdata;
 
-   /* Always drain the stream completely, even when the FIFO can't
-    * take it all, so unread samples never pile up inside SDL. */
-   while ((got = SDL_GetAudioStreamData(stream,
-         mic->scratch, (int)mic->scratch_size)) > 0)
-   {
-      size_t avail, write_amt;
-
-      SDL_LockMutex(mic->lock);
-      avail     = FIFO_WRITE_AVAIL(mic->sample_buffer);
-      write_amt = ((size_t)got > avail) ? avail : (size_t)got;
-      fifo_write(mic->sample_buffer, mic->scratch, write_amt);
-      /* Signal under the mutex; the wakeup can't be lost. */
-      SDL_SignalCondition(mic->cond);
-      SDL_UnlockMutex(mic->lock);
-
-      if (got < (int)mic->scratch_size)
-         break;
-   }
+   if (SDL_GetAudioStreamAvailable(stream) > (int)mic->buffer_size)
+      SDL_ClearAudioStream(stream);
 }
 
 static void *sdl3_microphone_init(void)
@@ -538,7 +470,11 @@ static void *sdl3_microphone_init(void)
 
    /* Reference-counted; balanced by SDL_QuitSubSystem in free. */
    if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
+   {
+      RARCH_ERR("[SDL3 mic] Failed to initialize audio subsystem: %s.\n",
+            SDL_GetError());
       return NULL;
+   }
 
    if (!(sdl = (sdl3_microphone_t*)calloc(1, sizeof(*sdl))))
    {
@@ -564,20 +500,9 @@ static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
 
    if (mic)
    {
-      /* Destroying the stream also closes the device.  Do this
-       * before freeing anything else, since the stream callback
-       * uses the FIFO, the scratch buffer and the locks. */
+      /* Destroying the stream also closes the device. */
       if (mic->stream)
          SDL_DestroyAudioStream(mic->stream);
-
-      if (mic->sample_buffer)
-         fifo_free(mic->sample_buffer);
-      free(mic->scratch);
-
-      if (mic->cond)
-         SDL_DestroyCondition(mic->cond);
-      if (mic->lock)
-         SDL_DestroyMutex(mic->lock);
 
       RARCH_LOG("[SDL3 mic] Freed microphone.\n");
       free(mic);
@@ -591,7 +516,6 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
    char frames_str[16];
    size_t frame_size, min_size;
    const char *device_name       = NULL;
-   void *tmp                     = NULL;
    SDL_AudioDeviceID devid       = 0;
    SDL_AudioSpec device_spec     = {0};
    int device_sample_frames      = 0;
@@ -650,7 +574,11 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
 
    /* Device streams open in a paused state;
     * the frontend starts them with start_mic. */
-   if (!(mic->stream = SDL_OpenAudioDeviceStream(devid, &mic->spec, NULL, NULL)))
+   mic->stream = SDL_OpenAudioDeviceStream(devid, &mic->spec, NULL, NULL);
+   /* The hint is process-global; clear it now that the open has
+    * consumed it so later SDL audio opens aren't affected. */
+   SDL_ResetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES);
+   if (!mic->stream)
    {
       RARCH_ERR("[SDL3 mic] Failed to open SDL audio input device: %s.\n",
             SDL_GetError());
@@ -662,32 +590,13 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       device_sample_frames = frames;
 
    /* Buffer up to double the latency budget (with a floor of four
-    * device periods) before new samples start getting dropped. */
-   frame_size        = SDL_AUDIO_FRAMESIZE(mic->spec);
-   mic->buffer_size  = (size_t)((uint64_t)mic->spec.freq * latency / 1000)
+    * device periods) before the backlog starts getting dropped. */
+   frame_size       = SDL_AUDIO_FRAMESIZE(mic->spec);
+   mic->buffer_size = (size_t)((uint64_t)mic->spec.freq * latency / 1000)
          * frame_size * 2;
-   min_size          = (size_t)(4 * device_sample_frames) * frame_size;
+   min_size         = (size_t)(4 * device_sample_frames) * frame_size;
    if (mic->buffer_size < min_size)
       mic->buffer_size = min_size;
-
-   mic->scratch_size = (size_t)device_sample_frames * frame_size;
-   if (mic->scratch_size < 1024)
-      mic->scratch_size = 1024;
-
-   mic->sample_buffer = fifo_new(mic->buffer_size);
-   mic->scratch       = (uint8_t*)malloc(mic->scratch_size);
-   mic->lock          = SDL_CreateMutex();
-   mic->cond          = SDL_CreateCondition();
-   if (!mic->sample_buffer || !mic->scratch || !mic->lock || !mic->cond)
-      goto error;
-
-   /* Prefill half the FIFO with silence, so the first blocking
-    * reads have a latency cushion to draw from. */
-   if ((tmp = calloc(1, mic->buffer_size / 2)))
-   {
-      fifo_write(mic->sample_buffer, tmp, mic->buffer_size / 2);
-      free(tmp);
-   }
 
    SDL_SetAudioStreamPutCallback(mic->stream, sdl3_microphone_stream_cb, mic);
 
@@ -704,10 +613,9 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
    RARCH_DBG("[SDL3 mic] Microphone audio format: %u-bit %s.\n",
          SDL_AUDIO_BITSIZE(mic->spec.format),
          SDL_AUDIO_ISFLOAT(mic->spec.format) ? "floating-point" : "integer");
-   RARCH_LOG("[SDL3 mic] Requested %u ms latency for input device, using %d ms.\n",
+   RARCH_LOG("[SDL3 mic] Requested %u ms latency for input device, capping the backlog at %d ms.\n",
          latency,
-         (int)((mic->buffer_size / 2 / frame_size + device_sample_frames)
-            * 1000 / mic->spec.freq));
+         (int)((mic->buffer_size / frame_size) * 1000 / mic->spec.freq));
 
    return mic;
 
@@ -762,40 +670,49 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
       void *s, size_t len)
 {
    size_t _len                   = 0;
+   Uint64 deadline               = 0;
    sdl3_microphone_t *sdl        = (sdl3_microphone_t*)driver_context;
    sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
 
    if (!sdl || !mic || !s)
       return -1;
 
-   SDL_LockMutex(mic->lock);
-
    /* Until we've given the caller as much data as they've asked for... */
    while (_len < len)
    {
-      size_t avail = FIFO_READ_AVAIL(mic->sample_buffer);
+      int got = SDL_GetAudioStreamData(mic->stream,
+            (char*)s + _len, (int)(len - _len));
 
-      /* If the incoming sample queue is empty... */
-      if (avail == 0)
+      if (got < 0)
       {
-         if (sdl->nonblock)
-            break;
-         /* Block until the stream callback puts samples into the
-          * FIFO.  It signals under this same mutex, so the wakeup
-          * can't be lost between the check above and this wait. */
-         SDL_WaitCondition(mic->cond, mic->lock);
+         RARCH_ERR("[SDL3 mic] Failed to read from microphone stream: %s.\n",
+               SDL_GetError());
+         if (_len == 0)
+            return -1;
+         break;
+      }
+
+      if (got > 0)
+      {
+         _len    += (size_t)got;
+         deadline = 0; /* Progress was made; reset the stall clock. */
       }
       else
       {
-         /* Read as many samples as we have available without
-          * underflowing the queue. */
-         size_t read_amt = (len - _len > avail) ? avail : len - _len;
-         fifo_read(mic->sample_buffer, (char*)s + _len, read_amt);
-         _len += read_amt;
+         Uint64 now;
+         if (sdl->nonblock)
+            break;
+         /* Poll until the device puts more samples into the stream.
+          * Bounded: if the device stops making progress, give up
+          * after the stall timeout instead of blocking forever. */
+         now = SDL_GetTicks();
+         if (deadline == 0)
+            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_MS;
+         else if (now >= deadline)
+            break;
+         SDL_DelayNS(SDL3_AUDIO_POLL_INTERVAL_NS);
       }
    }
-
-   SDL_UnlockMutex(mic->lock);
 
    return (int)_len;
 }
@@ -803,7 +720,9 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
 static bool sdl3_microphone_mic_use_float(const void *driver_context, const void *mic_context)
 {
    const sdl3_microphone_handle_t *mic = (const sdl3_microphone_handle_t*)mic_context;
-   return SDL_AUDIO_ISFLOAT(mic->spec.format) ? true : false;
+   if (!mic)
+      return false;
+   return SDL_AUDIO_ISFLOAT(mic->spec.format) != 0;
 }
 
 static struct string_list *sdl3_microphone_device_list_new(const void *driver_context)

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -42,14 +42,14 @@
 
 /* Context for an audio device. Covered by three different states:
  * 1. Output Driver, used for playback
- * 2. Input Driver, used for recoring, like from a microphone
+ * 2. Input Driver, used for recording, like from a microphone
  * 3. Microphone Device, holds the state for each individual microphone */
 typedef struct sdl3_audio
 {
-   SDL_AudioStream *stream; /** The device stream. */
-   SDL_AudioSpec spec; /** The format for the given audio sample. */
-   size_t buffer_size; /** Cap in bytes on queued audio: writes block past it, capture backlog is dropped past it. */
-   bool nonblock; /** When true, drop samples instead of waiting for the device to clear. */
+   SDL_AudioStream *stream; /**< The device stream. */
+   SDL_AudioSpec spec; /**< The format for the given audio sample. */
+   size_t buffer_size; /**< Cap in bytes on queued audio: writes block past it, capture backlog is dropped past it. */
+   bool nonblock; /**< When true, drop samples instead of waiting for the device to clear. */
 } sdl3_audio_t;
 
 /**
@@ -158,7 +158,10 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
    if (!SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames) || device_spec.freq <= 0)
       device_spec.freq = rate;
 
-   frames = (int)((uint64_t)device_spec.freq * (latency / 4) / 1000);
+   /* Aim for a device period of a quarter of the requested latency. */
+   frames = (int)((uint64_t)device_spec.freq * latency / 4000);
+   if (frames < 1)
+      frames = 1;
    snprintf(frames_str, sizeof(frames_str), "%d", frames);
    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
 
@@ -303,7 +306,7 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 
          /* When the queue is full, and we can't wait on the
           * process for the queue to clear a bit, we're unable
-          * to do anything, so skip it the rest. */
+          * to do anything, so skip the rest. */
          if (sdl->nonblock)
             break;
          now = SDL_GetTicksNS();
@@ -321,6 +324,8 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
          if (!SDL_PutAudioStreamData(sdl->stream, (const char*)s + size, (int)write_amt))
          {
             RARCH_ERR("[SDL3 audio] Failed to write to audio stream: %s.\n", SDL_GetError());
+            if (size == 0)
+               return -1;
             break;
          }
          size += write_amt;
@@ -447,7 +452,8 @@ static void sdl3_microphone_free(void *driver_context)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)driver_context;
 
-   if (sdl) {
+   if (sdl)
+   {
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
       free(sdl);
    }

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -31,37 +31,26 @@
 #include "../../configuration.h"
 #include "../../verbosity.h"
 
-/* The drivers below feed SDL3 audio streams directly: RetroArch puts
- * samples into the playback stream and gets them from the recording
- * stream on its own thread, while SDL's device threads handle the
- * other end.  SDL_AudioStream is internally locked and buffers any
- * amount of queued audio, so it doubles as the FIFO and the drivers
- * keep no buffers, locks or condition variables of their own.
- * Blocking writes and reads poll the stream's fill level at a short
- * interval instead of waiting on a callback signal: a device that
- * stops making progress (unplugged, stalled driver) can then only
- * ever cost the stall timeout below, never park the core's thread
- * for good. */
+/* SDL3 Audio Driver */
 
-/* How long a blocking write/read keeps polling without making any
- * progress before giving up on the device. */
+/* The duration of time to continue polling in order to give up
+ * on a device. */
 #define SDL3_AUDIO_STALL_TIMEOUT_MS 256
 
-/* Poll interval while a blocking write/read waits on the device;
- * device periods are several times longer than this. */
+/* The number of nanoseconds to wait between device polls. */
 #define SDL3_AUDIO_POLL_INTERVAL_NS SDL_NS_PER_MS
 
 /**
  * Looks up an audio device by name, returning the default
- * device if the name is empty or not found.
+ * device ID if the name is empty or not found.
  */
 static SDL_AudioDeviceID sdl3_audio_find_device(const char *device, bool recording)
 {
    int i;
-   bool found                 = false;
-   int count                  = 0;
+   bool found = false;
+   int count = 0;
    SDL_AudioDeviceID *devices = NULL;
-   SDL_AudioDeviceID devid    = recording
+   SDL_AudioDeviceID devid = recording
       ? SDL_AUDIO_DEVICE_DEFAULT_RECORDING
       : SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
 
@@ -98,16 +87,20 @@ static SDL_AudioDeviceID sdl3_audio_find_device(const char *device, bool recordi
 }
 
 /**
- * Enumerates the available audio devices of either direction
- * into a newly allocated string list.
+ * Builds a list of strings from the available audio devices.
+ *
+ * @param recording Whether or not to grab recording devices, or
+ *   just playback.
+ * @return The list of audio device names, which must be freed with
+ *   \c string_list_free() when complete.
  */
 static struct string_list *sdl3_audio_device_list(bool recording)
 {
    int i;
    union string_list_elem_attr attr;
-   int count                  = 0;
+   int count = 0;
    SDL_AudioDeviceID *devices = NULL;
-   struct string_list *sl     = string_list_new();
+   struct string_list *sl = string_list_new();
 
    if (!sl)
       return NULL;
@@ -132,12 +125,10 @@ static struct string_list *sdl3_audio_device_list(bool recording)
 }
 
 /**
- * Shared device-open path for both directions: looks up the device,
- * probes its preferred format so the pipeline runs at the device
- * rate (RetroArch resamples to it exactly once and SDL does no rate
- * conversion of its own), requests a device period of roughly a
- * quarter of the total latency, opens the stream in the negotiated
- * format, and reports the period the device actually uses.
+ * Opens the given audio device.
+ *
+ * It is configured to match native hardware rates to avoid
+ * resampling, and sets low-latency buffer periods.
  */
 static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
       bool recording, unsigned rate, unsigned latency, int channels,
@@ -145,38 +136,35 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
 {
    int frames;
    char frames_str[16];
-   const char *device_name   = NULL;
-   SDL_AudioStream *stream   = NULL;
+   const char *device_name = NULL;
+   SDL_AudioStream *stream = NULL;
    SDL_AudioSpec device_spec = {0};
-   int device_sample_frames  = 0;
-   const char *tag           = recording ? "mic" : "audio";
-   SDL_AudioDeviceID devid   = sdl3_audio_find_device(device, recording);
-   settings_t *settings      = config_get_ptr();
+   int device_sample_frames = 0;
+   SDL_AudioDeviceID devid = sdl3_audio_find_device(device, recording);
+   settings_t *settings = config_get_ptr();
 
-   if (   !SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames)
-       || device_spec.freq <= 0)
+   if (!SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames) || device_spec.freq <= 0)
       device_spec.freq = rate;
 
    frames = (int)((uint64_t)device_spec.freq * (latency / 4) / 1000);
    snprintf(frames_str, sizeof(frames_str), "%d", frames);
    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
 
-   spec->freq     = device_spec.freq;
-   /* SDL3 converts transparently if the device's native format
-    * differs; honour the negotiation hint for what we produce. */
-   spec->format   = (settings->uints.audio_format_negotiation
+   spec->freq = device_spec.freq;
+   /* SDL3 converts the format transparently if needed. */
+   spec->format = (settings->uints.audio_format_negotiation
          == AUDIO_FORMAT_NEGOTIATION_INT16)
          ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
    spec->channels = channels;
 
    stream = SDL_OpenAudioDeviceStream(devid, spec, NULL, NULL);
-   /* The hint is process-global; clear it now that the open has
-    * consumed it so later SDL audio opens aren't affected. */
+
+   /* Audio hints are global, so clear it now that we've used it. */
    SDL_ResetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES);
    if (!stream)
    {
-      RARCH_ERR("[SDL3 %s] Failed to open SDL audio %s device: %s.\n",
-            tag, recording ? "input" : "output", SDL_GetError());
+      RARCH_ERR("[SDL3 audio] failed to open SDL audio %s device: %s.\n",
+            recording ? "input" : "output", SDL_GetError());
       return NULL;
    }
 
@@ -187,10 +175,10 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
    *period_frames = device_sample_frames;
 
    device_name = SDL_GetAudioDeviceName(devid);
-   RARCH_DBG("[SDL3 %s] Opened SDL audio %s device \"%s\": "
+   RARCH_DBG("[SDL3 audio] Opened %s device \"%s\": "
          "%u-bit %s, requested %u Hz / %d frame periods, "
          "received %d Hz / %d frame periods.\n",
-         tag, recording ? "input" : "out",
+         recording ? "input" : "output",
          device_name ? device_name : "(default)",
          SDL_AUDIO_BITSIZE(spec->format),
          SDL_AUDIO_ISFLOAT(spec->format) ? "floating-point" : "integer",
@@ -474,7 +462,7 @@ static void *sdl3_microphone_init(void)
    /* Reference-counted; balanced by SDL_QuitSubSystem in free. */
    if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
    {
-      RARCH_ERR("[SDL3 mic] Failed to initialize audio subsystem: %s.\n",
+      RARCH_ERR("[SDL3 audio] Failed to initialize microphone subsystem: %s.\n",
             SDL_GetError());
       return NULL;
    }
@@ -507,7 +495,7 @@ static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
       if (mic->stream)
          SDL_DestroyAudioStream(mic->stream);
 
-      RARCH_LOG("[SDL3 mic] Freed microphone.\n");
+      RARCH_LOG("[SDL3 audio] Freed microphone.\n");
       free(mic);
    }
 }
@@ -521,7 +509,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
 
    if (!SDL_WasInit(SDL_INIT_AUDIO))
    {
-      RARCH_ERR("[SDL3 mic] Attempted to initialize input device before initializing the audio subsystem.\n");
+      RARCH_ERR("[SDL3 audio] Attempted to initialize input device before initializing the audio subsystem.\n");
       return NULL;
    }
 
@@ -535,10 +523,10 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       if (sl)
       {
          size_t i;
-         RARCH_DBG("[SDL3 mic] %u audio capture devices found:\n",
+         RARCH_DBG("[SDL3 audio] %u input devices found:\n",
                (unsigned)sl->size);
          for (i = 0; i < sl->size; i++)
-            RARCH_DBG("[SDL3 mic]    - %s\n", sl->elems[i].data);
+            RARCH_DBG("[SDL3 audio]    - %s\n", sl->elems[i].data);
          string_list_free(sl);
       }
    }
@@ -564,7 +552,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
    if (new_rate)
       *new_rate = mic->spec.freq;
 
-   RARCH_LOG("[SDL3 mic] Requested %u ms latency for input device, capping the backlog at %d ms.\n",
+   RARCH_LOG("[SDL3 audio] Requested %u ms latency for input device, capping the backlog at %d ms.\n",
          latency,
          (int)((mic->buffer_size / frame_size) * 1000 / mic->spec.freq));
 
@@ -590,10 +578,10 @@ static bool sdl3_microphone_start_mic(void *driver_context, void *mic_context)
       return false;
    if (!SDL_ResumeAudioStreamDevice(mic->stream))
    {
-      RARCH_ERR("[SDL3 mic] Failed to start microphone: %s.\n", SDL_GetError());
+      RARCH_ERR("[SDL3 audio] Failed to start microphone: %s.\n", SDL_GetError());
       return false;
    }
-   RARCH_DBG("[SDL3 mic] Started microphone.\n");
+   RARCH_DBG("[SDL3 audio] Started microphone.\n");
    return true;
 }
 
@@ -604,7 +592,7 @@ static bool sdl3_microphone_stop_mic(void *driver_context, void *mic_context)
       return false;
    if (!SDL_PauseAudioStreamDevice(mic->stream))
    {
-      RARCH_ERR("[SDL3 mic] Failed to pause microphone: %s.\n", SDL_GetError());
+      RARCH_ERR("[SDL3 audio] Failed to pause microphone: %s.\n", SDL_GetError());
       return false;
    }
    return true;
@@ -635,7 +623,7 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
 
       if (got < 0)
       {
-         RARCH_ERR("[SDL3 mic] Failed to read from microphone stream: %s.\n",
+         RARCH_ERR("[SDL3 audio] Failed to read from microphone stream: %s.\n",
                SDL_GetError());
          if (_len == 0)
             return -1;

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -1,0 +1,836 @@
+/*  RetroArch - A frontend for libretro.
+ *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
+ *  Copyright (C) 2011-2017 - Daniel De Matteis
+ *  Copyright (C)      2026 - Rob Loach
+ *
+ *  RetroArch is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  RetroArch is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with RetroArch.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <boolean.h>
+#include <retro_inline.h>
+#include <retro_math.h>
+#include <queues/fifo_queue.h>
+#include <lists/string_list.h>
+#include <string/stdstring.h>
+
+#include <SDL3/SDL.h>
+
+#include "../audio_driver.h"
+#include "../../configuration.h"
+#include "../../verbosity.h"
+
+/* The drivers below use a pull architecture: RetroArch pushes into a
+ * FIFO owned by the driver, and SDL's stream get-callback pulls from
+ * that FIFO each device period (the microphone mirrors this with the
+ * put-callback).  The FIFO and its condition variable share one
+ * mutex, so blocking reads/writes need no timeouts or sleeps and
+ * can't miss a wakeup.  SDL's own synchronization primitives are
+ * used instead of rthreads, so the driver behaves identically with
+ * or without HAVE_THREADS; SDL3 provides them on every platform it
+ * supports.  The lock order is always SDL's stream lock -> ours
+ * (callbacks run under the stream lock), never the reverse: the
+ * RetroArch side makes no SDL stream calls while holding our mutex. */
+
+static INLINE int sdl3_audio_find_num_frames(int rate, int latency)
+{
+   /* Keep the buffer size to 2^n. */
+   return next_pow2((rate * latency) / 1000);
+}
+
+/**
+ * Looks up an audio device by name, returning the default
+ * device if the name is empty or not found.
+ */
+static SDL_AudioDeviceID sdl3_audio_find_device(const char *device, bool recording)
+{
+   int i;
+   int count                  = 0;
+   SDL_AudioDeviceID *devices = NULL;
+   SDL_AudioDeviceID devid    = recording
+      ? SDL_AUDIO_DEVICE_DEFAULT_RECORDING
+      : SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
+
+   if (string_is_empty(device))
+      return devid;
+
+   devices = recording
+      ? SDL_GetAudioRecordingDevices(&count)
+      : SDL_GetAudioPlaybackDevices(&count);
+
+   if (devices)
+   {
+      for (i = 0; i < count; i++)
+      {
+         if (string_is_equal(SDL_GetAudioDeviceName(devices[i]), device))
+         {
+            devid = devices[i];
+            break;
+         }
+      }
+      SDL_free(devices);
+   }
+
+   if (      devid == SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK
+         ||  devid == SDL_AUDIO_DEVICE_DEFAULT_RECORDING)
+      RARCH_WARN("[SDL3 audio] Requested %s device \"%s\" not found, using the default device.\n",
+            recording ? "recording" : "playback", device);
+
+   return devid;
+}
+
+/**
+ * Enumerates the available audio devices of either direction
+ * into a newly allocated string list.
+ */
+static struct string_list *sdl3_audio_device_list(bool recording)
+{
+   int i;
+   union string_list_elem_attr attr;
+   int count                  = 0;
+   SDL_AudioDeviceID *devices = NULL;
+   struct string_list *sl     = string_list_new();
+
+   if (!sl)
+      return NULL;
+
+   attr.i  = 0;
+   devices = recording
+      ? SDL_GetAudioRecordingDevices(&count)
+      : SDL_GetAudioPlaybackDevices(&count);
+
+   if (devices)
+   {
+      for (i = 0; i < count; i++)
+      {
+         const char *name = SDL_GetAudioDeviceName(devices[i]);
+         if (name)
+            string_list_append(sl, name, attr);
+      }
+      SDL_free(devices);
+   }
+
+   return sl;
+}
+
+typedef struct sdl3_audio
+{
+   /* Guards speaker_buffer and pairs with cond; the stream
+    * get-callback takes it too, so FIFO fill checks and waits
+    * are race-free. */
+   SDL_Mutex *lock;
+   SDL_Condition *cond;
+   /**
+    * The queue used to store outgoing samples to be played by the driver.
+    * Audio from the core ultimately makes its way here,
+    * the last stop before the get-callback pulls it into the device.
+    */
+   fifo_buffer_t *speaker_buffer;
+   size_t buffer_size;
+   /* Staging area for FIFO -> stream copies inside the callback. */
+   uint8_t *scratch;
+   size_t scratch_size;
+   /* The device stream; samples are put into it only by the callback. */
+   SDL_AudioStream *stream;
+   /* The format samples are put in (SDL converts to the device format). */
+   SDL_AudioSpec spec;
+   /* Bytes per frame on the device side, for converting the
+    * callback's byte counts into our put-side units. */
+   size_t out_frame_size;
+   size_t in_frame_size;
+   bool nonblock;
+   bool is_paused;
+} sdl3_audio_t;
+
+/**
+ * Runs on SDL's device thread each period, before the device reads
+ * from the stream: pulls however much the device needs out of the
+ * FIFO.  If the FIFO can't cover it, the stream runs short and SDL
+ * plays silence for the remainder (the underrun case).
+ */
+static void SDLCALL sdl3_audio_stream_cb(void *userdata,
+      SDL_AudioStream *stream, int additional_amount, int total_amount)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)userdata;
+   /* additional_amount is in device-format bytes; convert to ours. */
+   size_t needed     = (size_t)((additional_amount + (int)sdl->out_frame_size - 1)
+         / (int)sdl->out_frame_size) * sdl->in_frame_size;
+
+   SDL_LockMutex(sdl->lock);
+
+   while (needed > 0)
+   {
+      size_t avail = FIFO_READ_AVAIL(sdl->speaker_buffer);
+      size_t chunk = (needed > sdl->scratch_size) ? sdl->scratch_size : needed;
+
+      if (chunk > avail)
+         chunk = avail;
+      if (chunk == 0)
+         break;
+
+      fifo_read(sdl->speaker_buffer, sdl->scratch, chunk);
+      /* This callback already holds the stream's recursive lock,
+       * so putting from here can't deadlock. */
+      SDL_PutAudioStreamData(stream, sdl->scratch, (int)chunk);
+      needed -= chunk;
+   }
+
+   /* Signal while holding the mutex, so the wakeup can't slip
+    * between a writer's fill check and its wait. */
+   SDL_SignalCondition(sdl->cond);
+
+   SDL_UnlockMutex(sdl->lock);
+}
+
+static void sdl3_audio_free(void *data)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+
+   if (sdl)
+   {
+      /* Destroying the stream also closes the device.  Do this
+       * before freeing anything else, since the stream callback
+       * uses the FIFO, the scratch buffer and the locks. */
+      if (sdl->stream)
+         SDL_DestroyAudioStream(sdl->stream);
+
+      if (sdl->speaker_buffer)
+         fifo_free(sdl->speaker_buffer);
+      free(sdl->scratch);
+
+      if (sdl->cond)
+         SDL_DestroyCondition(sdl->cond);
+      if (sdl->lock)
+         SDL_DestroyMutex(sdl->lock);
+
+      SDL_QuitSubSystem(SDL_INIT_AUDIO);
+   }
+   free(sdl);
+}
+
+static void *sdl3_audio_init(const char *device,
+      unsigned rate, unsigned latency,
+      unsigned block_frames, unsigned *new_rate)
+{
+   int frames;
+   char frames_str[16];
+   size_t min_size;
+   const char *device_name  = NULL;
+   void *tmp                = NULL;
+   SDL_AudioDeviceID devid  = 0;
+   SDL_AudioSpec device_spec = {0};
+   int device_sample_frames = 0;
+   sdl3_audio_t *sdl        = NULL;
+   settings_t *settings     = config_get_ptr();
+
+   /* Subsystem initialization is reference-counted in SDL3, so
+    * initialize unconditionally; every init is balanced by the
+    * SDL_QuitSubSystem call in sdl3_audio_free. */
+   if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
+   {
+      RARCH_ERR("[SDL3 audio] Failed to initialize audio subsystem: %s.\n",
+            SDL_GetError());
+      return NULL;
+   }
+
+   if (!(sdl = (sdl3_audio_t*)calloc(1, sizeof(*sdl))))
+   {
+      SDL_QuitSubSystem(SDL_INIT_AUDIO);
+      return NULL;
+   }
+
+   devid = sdl3_audio_find_device(device, false);
+
+   /* Ask SDL for the device's preferred format so the whole pipeline
+    * can run at the device rate; RetroArch resamples to it exactly
+    * once and SDL does no rate conversion of its own. */
+   if (   !SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames)
+       || device_spec.freq <= 0)
+      device_spec.freq = rate;
+
+   /* Request a device period of roughly a quarter of the total
+    * latency; the rest of the budget stays queued in the FIFO. */
+   frames = sdl3_audio_find_num_frames(device_spec.freq, latency / 4);
+   snprintf(frames_str, sizeof(frames_str), "%d", frames);
+   SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
+
+   sdl->spec.freq     = device_spec.freq;
+   /* SDL3 converts transparently if the device's native format
+    * differs; honour the negotiation hint for what we produce. */
+   sdl->spec.format   = (settings->uints.audio_format_negotiation
+         == AUDIO_FORMAT_NEGOTIATION_INT16)
+         ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
+   sdl->spec.channels = 2;
+
+   if (!(sdl->stream = SDL_OpenAudioDeviceStream(devid, &sdl->spec, NULL, NULL)))
+   {
+      RARCH_ERR("[SDL3 audio] Failed to open SDL audio output device: %s.\n",
+            SDL_GetError());
+      goto error;
+   }
+
+   /* See what SDL actually opened (sample_frames honours the hint). */
+   sdl->in_frame_size  = SDL_AUDIO_FRAMESIZE(sdl->spec);
+   sdl->out_frame_size = sdl->in_frame_size;
+   if (SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(sdl->stream),
+         &device_spec, &device_sample_frames))
+   {
+      if (SDL_AUDIO_FRAMESIZE(device_spec) > 0)
+         sdl->out_frame_size = SDL_AUDIO_FRAMESIZE(device_spec);
+   }
+   else
+      device_sample_frames = frames;
+
+   /* Buffer the requested latency's worth of audio, with at least
+    * two device periods to avoid underruns. */
+   sdl->buffer_size = (size_t)((uint64_t)sdl->spec.freq * latency / 1000)
+         * sdl->in_frame_size;
+   min_size         = (size_t)(2 * device_sample_frames) * sdl->in_frame_size;
+   if (sdl->buffer_size < min_size)
+      sdl->buffer_size = min_size;
+
+   /* The staging buffer covers one device period per copy;
+    * the callback loops if it ever needs more. */
+   sdl->scratch_size = (size_t)device_sample_frames * sdl->in_frame_size;
+   if (sdl->scratch_size < 1024)
+      sdl->scratch_size = 1024;
+
+   sdl->speaker_buffer = fifo_new(sdl->buffer_size);
+   sdl->scratch        = (uint8_t*)malloc(sdl->scratch_size);
+   sdl->lock           = SDL_CreateMutex();
+   sdl->cond           = SDL_CreateCondition();
+   if (!sdl->speaker_buffer || !sdl->scratch || !sdl->lock || !sdl->cond)
+      goto error;
+
+   *new_rate = sdl->spec.freq;
+
+   device_name = SDL_GetAudioDeviceName(devid);
+   RARCH_DBG("[SDL3 audio] Opened SDL audio out device \"%s\".\n",
+         device_name ? device_name : "(default)");
+   RARCH_DBG("[SDL3 audio] Requested a speaker frequency of %u Hz, received %d Hz.\n",
+         rate, sdl->spec.freq);
+   RARCH_DBG("[SDL3 audio] Requested a device period of %d frames, received %d frames.\n",
+         frames, device_sample_frames);
+   RARCH_DBG("[SDL3 audio] Speaker audio format: %u-bit %s.\n",
+         SDL_AUDIO_BITSIZE(sdl->spec.format),
+         SDL_AUDIO_ISFLOAT(sdl->spec.format) ? "floating-point" : "integer");
+   RARCH_LOG("[SDL3 audio] Requested %u ms latency for output device, using %d ms.\n",
+         latency,
+         (int)((sdl->buffer_size / sdl->in_frame_size + device_sample_frames)
+            * 1000 / sdl->spec.freq));
+
+   /* Prefill the FIFO with silence so playback starts with a
+    * full latency budget instead of an immediate underrun. */
+   if ((tmp = calloc(1, sdl->buffer_size)))
+   {
+      fifo_write(sdl->speaker_buffer, tmp, sdl->buffer_size);
+      free(tmp);
+   }
+
+   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
+
+   /* Device streams open in a paused state. */
+   SDL_ResumeAudioStreamDevice(sdl->stream);
+
+   return sdl;
+
+error:
+   sdl3_audio_free(sdl);
+   return NULL;
+}
+
+static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
+{
+   size_t _len      = 0;
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+
+   SDL_LockMutex(sdl->lock);
+
+   while (_len < len)
+   {
+      size_t avail = FIFO_WRITE_AVAIL(sdl->speaker_buffer);
+
+      /* If the outgoing sample queue is full... */
+      if (avail == 0)
+      {
+         if (sdl->nonblock)
+            break; /* If the queue was full... well, too bad. */
+         /* Block until the stream callback pulls samples out of the
+          * FIFO.  It signals under this same mutex, so the wakeup
+          * can't be lost between the check above and this wait. */
+         SDL_WaitCondition(sdl->cond, sdl->lock);
+      }
+      else
+      {
+         /* Enqueue as many samples as we have available without
+          * overflowing the queue. */
+         size_t write_amt = (len - _len > avail) ? avail : len - _len;
+         fifo_write(sdl->speaker_buffer, (const char*)s + _len, write_amt);
+         _len += write_amt;
+      }
+   }
+
+   SDL_UnlockMutex(sdl->lock);
+
+   return _len;
+}
+
+static bool sdl3_audio_stop(void *data)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   sdl->is_paused    = true;
+   return SDL_PauseAudioStreamDevice(sdl->stream);
+}
+
+static bool sdl3_audio_alive(void *data)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   if (!sdl)
+      return false;
+   return !sdl->is_paused;
+}
+
+static bool sdl3_audio_start(void *data, bool is_shutdown)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   sdl->is_paused    = false;
+   return SDL_ResumeAudioStreamDevice(sdl->stream);
+}
+
+static void sdl3_audio_set_nonblock_state(void *data, bool state)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   if (sdl)
+      sdl->nonblock = state;
+}
+
+static bool sdl3_audio_use_float(void *data)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   return SDL_AUDIO_ISFLOAT(sdl->spec.format) ? true : false;
+}
+
+static size_t sdl3_audio_write_avail(void *data)
+{
+   size_t avail;
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+
+   SDL_LockMutex(sdl->lock);
+   avail = FIFO_WRITE_AVAIL(sdl->speaker_buffer);
+   SDL_UnlockMutex(sdl->lock);
+
+   return avail;
+}
+
+static size_t sdl3_audio_buffer_size(void *data)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+   return sdl->buffer_size;
+}
+
+static void *sdl3_audio_list_new(void *u)
+{
+   return sdl3_audio_device_list(false);
+}
+
+static void sdl3_audio_list_free(void *u, void *slp)
+{
+   struct string_list *sl = (struct string_list*)slp;
+
+   if (sl)
+      string_list_free(sl);
+}
+
+audio_driver_t audio_sdl3 = {
+   sdl3_audio_init,
+   sdl3_audio_write,
+   sdl3_audio_stop,
+   sdl3_audio_start,
+   sdl3_audio_alive,
+   sdl3_audio_set_nonblock_state,
+   sdl3_audio_free,
+   sdl3_audio_use_float,
+   "sdl3",
+   sdl3_audio_list_new,
+   sdl3_audio_list_free,
+   sdl3_audio_write_avail,
+   sdl3_audio_buffer_size,
+   NULL  /* write_raw */
+};
+
+#ifdef HAVE_MICROPHONE
+#include "../microphone_driver.h"
+
+typedef struct sdl3_microphone
+{
+   bool nonblock;
+} sdl3_microphone_t;
+
+typedef struct sdl3_microphone_handle
+{
+   /* Guards sample_buffer and pairs with cond (see sdl3_audio). */
+   SDL_Mutex *lock;
+   SDL_Condition *cond;
+   /**
+    * The queue used to store incoming samples from the driver.
+    * The stream put-callback drains the device stream into it.
+    */
+   fifo_buffer_t *sample_buffer;
+   size_t buffer_size;
+   /* Staging area for stream -> FIFO copies inside the callback. */
+   uint8_t *scratch;
+   size_t scratch_size;
+   /* The device stream; samples are read from it only by the callback. */
+   SDL_AudioStream *stream;
+   /* The format samples are read in (SDL converts from the device format). */
+   SDL_AudioSpec spec;
+} sdl3_microphone_handle_t;
+
+/**
+ * Runs on SDL's device thread each period, after the device puts
+ * recorded samples into the stream: drains the stream into the FIFO.
+ * If the FIFO is almost full, whatever doesn't fit is dropped, which
+ * keeps capture latency bounded when nothing is reading.
+ */
+static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
+      SDL_AudioStream *stream, int additional_amount, int total_amount)
+{
+   int got;
+   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)userdata;
+
+   /* Always drain the stream completely, even when the FIFO can't
+    * take it all, so unread samples never pile up inside SDL. */
+   while ((got = SDL_GetAudioStreamData(stream,
+         mic->scratch, (int)mic->scratch_size)) > 0)
+   {
+      size_t avail, write_amt;
+
+      SDL_LockMutex(mic->lock);
+      avail     = FIFO_WRITE_AVAIL(mic->sample_buffer);
+      write_amt = ((size_t)got > avail) ? avail : (size_t)got;
+      fifo_write(mic->sample_buffer, mic->scratch, write_amt);
+      /* Signal under the mutex; the wakeup can't be lost. */
+      SDL_SignalCondition(mic->cond);
+      SDL_UnlockMutex(mic->lock);
+
+      if (got < (int)mic->scratch_size)
+         break;
+   }
+}
+
+static void *sdl3_microphone_init(void)
+{
+   sdl3_microphone_t *sdl = NULL;
+
+   /* Reference-counted; balanced by SDL_QuitSubSystem in free. */
+   if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
+      return NULL;
+
+   if (!(sdl = (sdl3_microphone_t*)calloc(1, sizeof(*sdl))))
+   {
+      SDL_QuitSubSystem(SDL_INIT_AUDIO);
+      return NULL;
+   }
+   return sdl;
+}
+
+static void sdl3_microphone_free(void *driver_context)
+{
+   sdl3_microphone_t *sdl = (sdl3_microphone_t*)driver_context;
+
+   if (sdl)
+      SDL_QuitSubSystem(SDL_INIT_AUDIO);
+   free(sdl);
+   /* NOTE: The microphone frontend should've closed the mics by now */
+}
+
+static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
+{
+   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+
+   if (mic)
+   {
+      /* Destroying the stream also closes the device.  Do this
+       * before freeing anything else, since the stream callback
+       * uses the FIFO, the scratch buffer and the locks. */
+      if (mic->stream)
+         SDL_DestroyAudioStream(mic->stream);
+
+      if (mic->sample_buffer)
+         fifo_free(mic->sample_buffer);
+      free(mic->scratch);
+
+      if (mic->cond)
+         SDL_DestroyCondition(mic->cond);
+      if (mic->lock)
+         SDL_DestroyMutex(mic->lock);
+
+      RARCH_LOG("[SDL3 mic] Freed microphone.\n");
+      free(mic);
+   }
+}
+
+static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
+      unsigned rate, unsigned latency, unsigned *new_rate)
+{
+   int frames;
+   char frames_str[16];
+   size_t frame_size, min_size;
+   const char *device_name       = NULL;
+   void *tmp                     = NULL;
+   SDL_AudioDeviceID devid       = 0;
+   SDL_AudioSpec device_spec     = {0};
+   int device_sample_frames      = 0;
+   sdl3_microphone_handle_t *mic = NULL;
+   settings_t *settings          = config_get_ptr();
+
+   /* If the audio subsystem wasn't initialized yet... */
+   if (!SDL_WasInit(SDL_INIT_AUDIO))
+   {
+      RARCH_ERR("[SDL3 mic] Attempted to initialize input device before initializing the audio subsystem.\n");
+      return NULL;
+   }
+
+   if (!(mic = (sdl3_microphone_handle_t*)calloc(1, sizeof(*mic))))
+      return NULL;
+
+   /* Only print SDL audio devices if verbose logging is enabled */
+   if (verbosity_is_enabled())
+   {
+      int i;
+      int count                  = 0;
+      SDL_AudioDeviceID *devices = SDL_GetAudioRecordingDevices(&count);
+
+      RARCH_DBG("[SDL3 mic] %d audio capture devices found:\n", count);
+      if (devices)
+      {
+         for (i = 0; i < count; i++)
+         {
+            const char *name = SDL_GetAudioDeviceName(devices[i]);
+            RARCH_DBG("[SDL3 mic]    - %s\n", name ? name : "(unknown)");
+         }
+         SDL_free(devices);
+      }
+   }
+
+   devid = sdl3_audio_find_device(device, true);
+
+   /* Run the capture path at the device's preferred rate so SDL
+    * does no rate conversion; the mic frontend resamples once. */
+   if (   !SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames)
+       || device_spec.freq <= 0)
+      device_spec.freq = rate;
+
+   frames = sdl3_audio_find_num_frames(device_spec.freq, latency / 4);
+   snprintf(frames_str, sizeof(frames_str), "%d", frames);
+   SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
+
+   mic->spec.freq     = device_spec.freq;
+   /* The int16 negotiation hint keeps the whole capture path integer
+    * instead of converting a float stream back down; SDL converts
+    * transparently if the device's native format differs. */
+   mic->spec.format   = (settings->uints.audio_format_negotiation
+         == AUDIO_FORMAT_NEGOTIATION_INT16)
+         ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
+   mic->spec.channels = 1; /* Microphones only usually provide input in mono */
+
+   /* Device streams open in a paused state;
+    * the frontend starts them with start_mic. */
+   if (!(mic->stream = SDL_OpenAudioDeviceStream(devid, &mic->spec, NULL, NULL)))
+   {
+      RARCH_ERR("[SDL3 mic] Failed to open SDL audio input device: %s.\n",
+            SDL_GetError());
+      goto error;
+   }
+
+   if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(mic->stream),
+         &device_spec, &device_sample_frames))
+      device_sample_frames = frames;
+
+   /* Buffer up to double the latency budget (with a floor of four
+    * device periods) before new samples start getting dropped. */
+   frame_size        = SDL_AUDIO_FRAMESIZE(mic->spec);
+   mic->buffer_size  = (size_t)((uint64_t)mic->spec.freq * latency / 1000)
+         * frame_size * 2;
+   min_size          = (size_t)(4 * device_sample_frames) * frame_size;
+   if (mic->buffer_size < min_size)
+      mic->buffer_size = min_size;
+
+   mic->scratch_size = (size_t)device_sample_frames * frame_size;
+   if (mic->scratch_size < 1024)
+      mic->scratch_size = 1024;
+
+   mic->sample_buffer = fifo_new(mic->buffer_size);
+   mic->scratch       = (uint8_t*)malloc(mic->scratch_size);
+   mic->lock          = SDL_CreateMutex();
+   mic->cond          = SDL_CreateCondition();
+   if (!mic->sample_buffer || !mic->scratch || !mic->lock || !mic->cond)
+      goto error;
+
+   /* Prefill half the FIFO with silence, so the first blocking
+    * reads have a latency cushion to draw from. */
+   if ((tmp = calloc(1, mic->buffer_size / 2)))
+   {
+      fifo_write(mic->sample_buffer, tmp, mic->buffer_size / 2);
+      free(tmp);
+   }
+
+   SDL_SetAudioStreamPutCallback(mic->stream, sdl3_microphone_stream_cb, mic);
+
+   if (new_rate)
+      *new_rate = mic->spec.freq;
+
+   device_name = SDL_GetAudioDeviceName(devid);
+   RARCH_DBG("[SDL3 mic] Opened SDL audio input device \"%s\".\n",
+         device_name ? device_name : "(default)");
+   RARCH_DBG("[SDL3 mic] Requested a microphone frequency of %u Hz, received %d Hz.\n",
+         rate, mic->spec.freq);
+   RARCH_DBG("[SDL3 mic] Requested a device period of %d frames, received %d frames.\n",
+         frames, device_sample_frames);
+   RARCH_DBG("[SDL3 mic] Microphone audio format: %u-bit %s.\n",
+         SDL_AUDIO_BITSIZE(mic->spec.format),
+         SDL_AUDIO_ISFLOAT(mic->spec.format) ? "floating-point" : "integer");
+   RARCH_LOG("[SDL3 mic] Requested %u ms latency for input device, using %d ms.\n",
+         latency,
+         (int)((mic->buffer_size / 2 / frame_size + device_sample_frames)
+            * 1000 / mic->spec.freq));
+
+   return mic;
+
+error:
+   sdl3_microphone_close_mic(driver_context, mic);
+   return NULL;
+}
+
+static bool sdl3_microphone_mic_alive(const void *driver_context, const void *mic_context)
+{
+   const sdl3_microphone_handle_t *mic = (const sdl3_microphone_handle_t*)mic_context;
+   if (!mic)
+      return false;
+   return !SDL_AudioStreamDevicePaused(mic->stream);
+}
+
+static bool sdl3_microphone_start_mic(void *driver_context, void *mic_context)
+{
+   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+   if (!mic)
+      return false;
+   if (!SDL_ResumeAudioStreamDevice(mic->stream))
+   {
+      RARCH_ERR("[SDL3 mic] Failed to start microphone: %s.\n", SDL_GetError());
+      return false;
+   }
+   RARCH_DBG("[SDL3 mic] Started microphone.\n");
+   return true;
+}
+
+static bool sdl3_microphone_stop_mic(void *driver_context, void *mic_context)
+{
+   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+   if (!mic)
+      return false;
+   if (!SDL_PauseAudioStreamDevice(mic->stream))
+   {
+      RARCH_ERR("[SDL3 mic] Failed to pause microphone: %s.\n", SDL_GetError());
+      return false;
+   }
+   return true;
+}
+
+static void sdl3_microphone_set_nonblock_state(void *driver_context, bool nonblock)
+{
+   sdl3_microphone_t *sdl = (sdl3_microphone_t*)driver_context;
+   if (sdl)
+      sdl->nonblock = nonblock;
+}
+
+static int sdl3_microphone_read(void *driver_context, void *mic_context,
+      void *s, size_t len)
+{
+   size_t _len                   = 0;
+   sdl3_microphone_t *sdl        = (sdl3_microphone_t*)driver_context;
+   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+
+   if (!sdl || !mic || !s)
+      return -1;
+
+   SDL_LockMutex(mic->lock);
+
+   /* Until we've given the caller as much data as they've asked for... */
+   while (_len < len)
+   {
+      size_t avail = FIFO_READ_AVAIL(mic->sample_buffer);
+
+      /* If the incoming sample queue is empty... */
+      if (avail == 0)
+      {
+         if (sdl->nonblock)
+            break;
+         /* Block until the stream callback puts samples into the
+          * FIFO.  It signals under this same mutex, so the wakeup
+          * can't be lost between the check above and this wait. */
+         SDL_WaitCondition(mic->cond, mic->lock);
+      }
+      else
+      {
+         /* Read as many samples as we have available without
+          * underflowing the queue. */
+         size_t read_amt = (len - _len > avail) ? avail : len - _len;
+         fifo_read(mic->sample_buffer, (char*)s + _len, read_amt);
+         _len += read_amt;
+      }
+   }
+
+   SDL_UnlockMutex(mic->lock);
+
+   return (int)_len;
+}
+
+static bool sdl3_microphone_mic_use_float(const void *driver_context, const void *mic_context)
+{
+   const sdl3_microphone_handle_t *mic = (const sdl3_microphone_handle_t*)mic_context;
+   return SDL_AUDIO_ISFLOAT(mic->spec.format) ? true : false;
+}
+
+static struct string_list *sdl3_microphone_device_list_new(const void *driver_context)
+{
+   return sdl3_audio_device_list(true);
+}
+
+static void sdl3_microphone_device_list_free(const void *driver_context,
+      struct string_list *devices)
+{
+   if (devices)
+      string_list_free(devices);
+}
+
+microphone_driver_t microphone_sdl3 = {
+   sdl3_microphone_init,
+   sdl3_microphone_free,
+   sdl3_microphone_read,
+   sdl3_microphone_set_nonblock_state,
+   "sdl3",
+   sdl3_microphone_device_list_new,
+   sdl3_microphone_device_list_free,
+   sdl3_microphone_open_mic,
+   sdl3_microphone_close_mic,
+   sdl3_microphone_mic_alive,
+   sdl3_microphone_start_mic,
+   sdl3_microphone_stop_mic,
+   sdl3_microphone_mic_use_float,
+};
+#endif /* HAVE_MICROPHONE */

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -35,7 +35,7 @@
 
 /* The duration of time to continue polling in order to give up
  * on a device. */
-#define SDL3_AUDIO_STALL_TIMEOUT_MS 256
+#define SDL3_AUDIO_STALL_TIMEOUT_NS SDL_MS_TO_NS(256)
 
 /* The number of nanoseconds to wait between device polls. */
 #define SDL3_AUDIO_POLL_INTERVAL_NS SDL_NS_PER_MS
@@ -168,7 +168,7 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
       return NULL;
    }
 
-   /* See what SDL actually opened (sample_frames honours the hint). */
+   /* Retrieve the device information to set the period_frames. */
    if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(stream),
          &device_spec, &device_sample_frames))
       device_sample_frames = frames;
@@ -189,16 +189,10 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
 
 typedef struct sdl3_audio
 {
-   /* The device stream.  SDL_AudioStream is internally locked and
-    * buffers queued audio itself, so it doubles as the FIFO between
-    * RetroArch and the device. */
-   SDL_AudioStream *stream;
-   /* The format samples are put in (SDL converts to the device format). */
-   SDL_AudioSpec spec;
-   /* Cap on queued audio, in bytes of our put-side format; writes
-    * block (or bail, when nonblocking) once this much is queued. */
-   size_t buffer_size;
-   bool nonblock;
+   SDL_AudioStream *stream; /** The device stream. */
+   SDL_AudioSpec spec; /** The format for the given audio sample. */
+   size_t buffer_size; /** The maximum bytes of the queued audio buffer. */
+   bool nonblock; /** When true, drop samples instead of waiting for the device to clear. */
 } sdl3_audio_t;
 
 static void sdl3_audio_free(void *data)
@@ -221,17 +215,13 @@ static void *sdl3_audio_init(const char *device,
       unsigned block_frames, unsigned *new_rate)
 {
    size_t frame_size, min_size;
-   void *tmp                = NULL;
+   void *tmp = NULL;
    int device_sample_frames = 0;
-   sdl3_audio_t *sdl        = NULL;
+   sdl3_audio_t *sdl = NULL;
 
-   /* Subsystem initialization is reference-counted in SDL3, so
-    * initialize unconditionally; every init is balanced by the
-    * SDL_QuitSubSystem call in sdl3_audio_free. */
    if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
    {
-      RARCH_ERR("[SDL3 audio] Failed to initialize audio subsystem: %s.\n",
-            SDL_GetError());
+      RARCH_ERR("[SDL3 audio] Failed to initialize audio subsystem: %s.\n", SDL_GetError());
       return NULL;
    }
 
@@ -261,8 +251,7 @@ static void *sdl3_audio_init(const char *device,
          (int)((sdl->buffer_size / frame_size + device_sample_frames)
             * 1000 / sdl->spec.freq));
 
-   /* Prefill the stream with silence so playback starts with a
-    * full latency budget instead of an immediate underrun. */
+   /* Prefill the stream with silence. */
    if ((tmp = calloc(1, sdl->buffer_size)))
    {
       SDL_PutAudioStreamData(sdl->stream, tmp, (int)sdl->buffer_size);
@@ -295,8 +284,8 @@ static size_t sdl3_audio_write_avail(void *data)
 
 static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 {
-   size_t _len       = 0;
-   Uint64 deadline   = 0;
+   size_t _len = 0;
+   Uint64 deadline = 0;
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
    if (!sdl)
@@ -309,23 +298,23 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
       if (avail == 0)
       {
          Uint64 now;
+
+         /* When the queue is full, and we can't wait on the
+          * process for the queue to clear a bit, we're unable
+          * to do anything, so skip it. */
          if (sdl->nonblock)
-            break; /* If the queue was full... well, too bad. */
-         /* Poll until the device drains the stream.  Bounded: if
-          * the device stops making progress, give up after the
-          * stall timeout instead of blocking the core's thread
-          * forever. */
-         now = SDL_GetTicks();
+            break;
+         now = SDL_GetTicksNS();
          if (deadline == 0)
-            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_MS;
+            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_NS;
          else if (now >= deadline)
             break;
          SDL_DelayNS(SDL3_AUDIO_POLL_INTERVAL_NS);
       }
       else
       {
-         /* Enqueue as many samples as we have available without
-          * exceeding the latency cap. */
+         /* Add as many samples as we are able to without hitting
+          * the maximum limit. */
          size_t write_amt = MIN(len - _len, avail);
          if (!SDL_PutAudioStreamData(sdl->stream,
                (const char*)s + _len, (int)write_amt))
@@ -334,7 +323,7 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
                   SDL_GetError());
             break;
          }
-         _len    += write_amt;
+         _len += write_amt;
          deadline = 0; /* Progress was made; reset the stall clock. */
       }
    }
@@ -429,8 +418,7 @@ typedef struct sdl3_microphone
 
 typedef struct sdl3_microphone_handle
 {
-   /* The device stream.  Internally locked and buffering, so it
-    * doubles as the FIFO between the device and RetroArch. */
+   /* The device stream. */
    SDL_AudioStream *stream;
    /* The format samples are read in (SDL converts from the device format). */
    SDL_AudioSpec spec;
@@ -643,9 +631,9 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
          /* Poll until the device puts more samples into the stream.
           * Bounded: if the device stops making progress, give up
           * after the stall timeout instead of blocking forever. */
-         now = SDL_GetTicks();
+         now = SDL_GetTicksNS();
          if (deadline == 0)
-            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_MS;
+            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_NS;
          else if (now >= deadline)
             break;
          SDL_DelayNS(SDL3_AUDIO_POLL_INTERVAL_NS);

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -40,6 +40,18 @@
 /* The number of nanoseconds to wait between device polls. */
 #define SDL3_AUDIO_POLL_INTERVAL_NS SDL_NS_PER_MS
 
+/* Context for an audio device. Covered by three different states:
+ * 1. Output Driver, used for playback
+ * 2. Input Driver, used for recoring, like from a microphone
+ * 3. Microphone Device, holds the state for each individual microphone */
+typedef struct sdl3_audio
+{
+   SDL_AudioStream *stream; /** The device stream. */
+   SDL_AudioSpec spec; /** The format for the given audio sample. */
+   size_t buffer_size; /** Cap in bytes on queued audio: writes block past it, capture backlog is dropped past it. */
+   bool nonblock; /** When true, drop samples instead of waiting for the device to clear. */
+} sdl3_audio_t;
+
 /**
  * Looks up an audio device by name, returning the default
  * device ID if the name is empty or not found.
@@ -187,14 +199,6 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
    return stream;
 }
 
-typedef struct sdl3_audio
-{
-   SDL_AudioStream *stream; /** The device stream. */
-   SDL_AudioSpec spec; /** The format for the given audio sample. */
-   size_t buffer_size; /** The maximum bytes of the queued audio buffer. */
-   bool nonblock; /** When true, drop samples instead of waiting for the device to clear. */
-} sdl3_audio_t;
-
 static void sdl3_audio_free(void *data)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
@@ -237,10 +241,9 @@ static void *sdl3_audio_init(const char *device,
 
    /* Buffer the requested latency's worth of audio, with at least
     * two device periods to avoid underruns. */
-   frame_size       = SDL_AUDIO_FRAMESIZE(sdl->spec);
-   sdl->buffer_size = (size_t)((uint64_t)sdl->spec.freq * latency / 1000)
-         * frame_size;
-   min_size         = (size_t)(2 * device_sample_frames) * frame_size;
+   frame_size = SDL_AUDIO_FRAMESIZE(sdl->spec);
+   sdl->buffer_size = (size_t)((uint64_t)sdl->spec.freq * latency / 1000) * frame_size;
+   min_size = (size_t)(2 * device_sample_frames) * frame_size;
    if (sdl->buffer_size < min_size)
       sdl->buffer_size = min_size;
 
@@ -284,14 +287,14 @@ static size_t sdl3_audio_write_avail(void *data)
 
 static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 {
-   size_t _len = 0;
+   size_t size = 0;
    Uint64 deadline = 0;
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
    if (!sdl)
       return -1;
 
-   while (_len < len)
+   while (size < len)
    {
       size_t avail = sdl3_audio_write_avail(sdl);
 
@@ -301,7 +304,7 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 
          /* When the queue is full, and we can't wait on the
           * process for the queue to clear a bit, we're unable
-          * to do anything, so skip it. */
+          * to do anything, so skip it the rest. */
          if (sdl->nonblock)
             break;
          now = SDL_GetTicksNS();
@@ -315,20 +318,20 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
       {
          /* Add as many samples as we are able to without hitting
           * the maximum limit. */
-         size_t write_amt = MIN(len - _len, avail);
+         size_t write_amt = MIN(len - size, avail);
          if (!SDL_PutAudioStreamData(sdl->stream,
-               (const char*)s + _len, (int)write_amt))
+               (const char*)s + size, (int)write_amt))
          {
             RARCH_ERR("[SDL3 audio] Failed to write to audio stream: %s.\n",
                   SDL_GetError());
             break;
          }
-         _len += write_amt;
+         size += write_amt;
          deadline = 0; /* Progress was made; reset the stall clock. */
       }
    }
 
-   return _len;
+   return size;
 }
 
 static bool sdl3_audio_stop(void *data)
@@ -411,33 +414,14 @@ audio_driver_t audio_sdl3 = {
 #ifdef HAVE_MICROPHONE
 #include "../microphone_driver.h"
 
-typedef struct sdl3_microphone
-{
-   bool nonblock;
-} sdl3_microphone_t;
-
-typedef struct sdl3_microphone_handle
-{
-   /* The device stream. */
-   SDL_AudioStream *stream;
-   /* The format samples are read in (SDL converts from the device format). */
-   SDL_AudioSpec spec;
-   /* Cap on buffered capture, in bytes of our get-side format;
-    * the put-callback drops the backlog once it grows past this. */
-   size_t buffer_size;
-} sdl3_microphone_handle_t;
-
 /**
- * Runs on SDL's device thread each period, after the device puts
- * recorded samples into the stream.  Its only job is to bound the
- * backlog: if nothing has been reading for a while, drop the stale
- * audio wholesale so the next read resumes with fresh samples and
- * capture latency stays bounded.
+ * Stream callback for the microphone to drop stale audio to allow
+ * space within the buffer.
  */
 static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)
 {
-   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)userdata;
+   sdl3_audio_t *mic = (sdl3_audio_t*)userdata;
 
    if (SDL_GetAudioStreamAvailable(stream) > (int)mic->buffer_size)
       SDL_ClearAudioStream(stream);
@@ -445,7 +429,7 @@ static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
 
 static void *sdl3_microphone_init(void)
 {
-   sdl3_microphone_t *sdl = NULL;
+   sdl3_audio_t *sdl = NULL;
 
    /* Reference-counted; balanced by SDL_QuitSubSystem in free. */
    if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
@@ -455,7 +439,7 @@ static void *sdl3_microphone_init(void)
       return NULL;
    }
 
-   if (!(sdl = (sdl3_microphone_t*)calloc(1, sizeof(*sdl))))
+   if (!(sdl = (sdl3_audio_t*)calloc(1, sizeof(*sdl))))
    {
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
       return NULL;
@@ -465,27 +449,27 @@ static void *sdl3_microphone_init(void)
 
 static void sdl3_microphone_free(void *driver_context)
 {
-   sdl3_microphone_t *sdl = (sdl3_microphone_t*)driver_context;
+   sdl3_audio_t *sdl = (sdl3_audio_t*)driver_context;
 
-   if (sdl)
+   if (sdl) {
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
-   free(sdl);
-   /* NOTE: The microphone frontend should've closed the mics by now */
+      free(sdl);
+   }
 }
 
 static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
 {
-   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+   sdl3_audio_t *mic = (sdl3_audio_t*)mic_context;
 
-   if (mic)
-   {
-      /* Destroying the stream also closes the device. */
-      if (mic->stream)
-         SDL_DestroyAudioStream(mic->stream);
+   if (!mic)
+      return;
 
-      RARCH_LOG("[SDL3 audio] Freed microphone.\n");
-      free(mic);
-   }
+   /* Destroying the stream also closes the device. */
+   if (mic->stream)
+      SDL_DestroyAudioStream(mic->stream);
+
+   RARCH_LOG("[SDL3 audio] Freed microphone.\n");
+   free(mic);
 }
 
 static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
@@ -493,7 +477,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
 {
    size_t frame_size, min_size;
    int device_sample_frames      = 0;
-   sdl3_microphone_handle_t *mic = NULL;
+   sdl3_audio_t *mic = NULL;
 
    if (!SDL_WasInit(SDL_INIT_AUDIO))
    {
@@ -501,7 +485,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       return NULL;
    }
 
-   if (!(mic = (sdl3_microphone_handle_t*)calloc(1, sizeof(*mic))))
+   if (!(mic = (sdl3_audio_t*)calloc(1, sizeof(*mic))))
       return NULL;
 
    /* Only print SDL audio devices if verbose logging is enabled */
@@ -528,7 +512,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
 
    /* Buffer up to double the latency budget (with a floor of four
     * device periods) before the backlog starts getting dropped. */
-   frame_size       = SDL_AUDIO_FRAMESIZE(mic->spec);
+   frame_size = SDL_AUDIO_FRAMESIZE(mic->spec);
    mic->buffer_size = (size_t)((uint64_t)mic->spec.freq * latency / 1000)
          * frame_size * 2;
    min_size         = (size_t)(4 * device_sample_frames) * frame_size;
@@ -553,7 +537,7 @@ error:
 
 static bool sdl3_microphone_mic_alive(const void *driver_context, const void *mic_context)
 {
-   const sdl3_microphone_handle_t *mic = (const sdl3_microphone_handle_t*)mic_context;
+   const sdl3_audio_t *mic = (const sdl3_audio_t*)mic_context;
    if (!mic)
       return false;
    return !SDL_AudioStreamDevicePaused(mic->stream);
@@ -561,7 +545,7 @@ static bool sdl3_microphone_mic_alive(const void *driver_context, const void *mi
 
 static bool sdl3_microphone_start_mic(void *driver_context, void *mic_context)
 {
-   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+   sdl3_audio_t *mic = (sdl3_audio_t*)mic_context;
    if (!mic)
       return false;
    if (!SDL_ResumeAudioStreamDevice(mic->stream))
@@ -575,7 +559,7 @@ static bool sdl3_microphone_start_mic(void *driver_context, void *mic_context)
 
 static bool sdl3_microphone_stop_mic(void *driver_context, void *mic_context)
 {
-   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+   sdl3_audio_t *mic = (sdl3_audio_t*)mic_context;
    if (!mic)
       return false;
    if (!SDL_PauseAudioStreamDevice(mic->stream))
@@ -588,7 +572,7 @@ static bool sdl3_microphone_stop_mic(void *driver_context, void *mic_context)
 
 static void sdl3_microphone_set_nonblock_state(void *driver_context, bool nonblock)
 {
-   sdl3_microphone_t *sdl = (sdl3_microphone_t*)driver_context;
+   sdl3_audio_t *sdl = (sdl3_audio_t*)driver_context;
    if (sdl)
       sdl->nonblock = nonblock;
 }
@@ -596,31 +580,30 @@ static void sdl3_microphone_set_nonblock_state(void *driver_context, bool nonblo
 static int sdl3_microphone_read(void *driver_context, void *mic_context,
       void *s, size_t len)
 {
-   size_t _len                   = 0;
-   Uint64 deadline               = 0;
-   sdl3_microphone_t *sdl        = (sdl3_microphone_t*)driver_context;
-   sdl3_microphone_handle_t *mic = (sdl3_microphone_handle_t*)mic_context;
+   size_t size = 0;
+   Uint64 deadline = 0;
+   sdl3_audio_t *sdl = (sdl3_audio_t*)driver_context;
+   sdl3_audio_t *mic = (sdl3_audio_t*)mic_context;
 
    if (!sdl || !mic || !s)
       return -1;
 
-   while (_len < len)
+   while (size < len)
    {
-      int got = SDL_GetAudioStreamData(mic->stream,
-            (char*)s + _len, (int)(len - _len));
+      int got = SDL_GetAudioStreamData(mic->stream, (char*)s + size, (int)(len - size));
 
       if (got < 0)
       {
          RARCH_ERR("[SDL3 audio] Failed to read from microphone stream: %s.\n",
                SDL_GetError());
-         if (_len == 0)
+         if (size == 0)
             return -1;
          break;
       }
 
       if (got > 0)
       {
-         _len    += (size_t)got;
+         size += (size_t)got;
          deadline = 0; /* Progress was made; reset the stall clock. */
       }
       else
@@ -640,12 +623,12 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
       }
    }
 
-   return (int)_len;
+   return (int)size;
 }
 
 static bool sdl3_microphone_mic_use_float(const void *driver_context, const void *mic_context)
 {
-   const sdl3_microphone_handle_t *mic = (const sdl3_microphone_handle_t*)mic_context;
+   const sdl3_audio_t *mic = (const sdl3_audio_t*)mic_context;
    if (!mic)
       return false;
    return SDL_AUDIO_ISFLOAT(mic->spec.format) != 0;

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -251,15 +251,13 @@ static void *sdl3_audio_init(const char *device,
    *new_rate = sdl->spec.freq;
 
    device_name = SDL_GetAudioDeviceName(devid);
-   RARCH_DBG("[SDL3 audio] Opened SDL audio out device \"%s\".\n",
-         device_name ? device_name : "(default)");
-   RARCH_DBG("[SDL3 audio] Requested a speaker frequency of %u Hz, received %d Hz.\n",
-         rate, sdl->spec.freq);
-   RARCH_DBG("[SDL3 audio] Requested a device period of %d frames, received %d frames.\n",
-         frames, device_sample_frames);
-   RARCH_DBG("[SDL3 audio] Speaker audio format: %u-bit %s.\n",
+   RARCH_DBG("[SDL3 audio] Opened SDL audio out device \"%s\": "
+         "%u-bit %s, requested %u Hz / %d frame periods, "
+         "received %d Hz / %d frame periods.\n",
+         device_name ? device_name : "(default)",
          SDL_AUDIO_BITSIZE(sdl->spec.format),
-         SDL_AUDIO_ISFLOAT(sdl->spec.format) ? "floating-point" : "integer");
+         SDL_AUDIO_ISFLOAT(sdl->spec.format) ? "floating-point" : "integer",
+         rate, frames, sdl->spec.freq, device_sample_frames);
    RARCH_LOG("[SDL3 audio] Requested %u ms latency for output device, using %d ms.\n",
          latency,
          (int)((sdl->buffer_size / frame_size + device_sample_frames)
@@ -604,15 +602,13 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       *new_rate = mic->spec.freq;
 
    device_name = SDL_GetAudioDeviceName(devid);
-   RARCH_DBG("[SDL3 mic] Opened SDL audio input device \"%s\".\n",
-         device_name ? device_name : "(default)");
-   RARCH_DBG("[SDL3 mic] Requested a microphone frequency of %u Hz, received %d Hz.\n",
-         rate, mic->spec.freq);
-   RARCH_DBG("[SDL3 mic] Requested a device period of %d frames, received %d frames.\n",
-         frames, device_sample_frames);
-   RARCH_DBG("[SDL3 mic] Microphone audio format: %u-bit %s.\n",
+   RARCH_DBG("[SDL3 mic] Opened SDL audio input device \"%s\": "
+         "%u-bit %s, requested %u Hz / %d frame periods, "
+         "received %d Hz / %d frame periods.\n",
+         device_name ? device_name : "(default)",
          SDL_AUDIO_BITSIZE(mic->spec.format),
-         SDL_AUDIO_ISFLOAT(mic->spec.format) ? "floating-point" : "integer");
+         SDL_AUDIO_ISFLOAT(mic->spec.format) ? "floating-point" : "integer",
+         rate, frames, mic->spec.freq, device_sample_frames);
    RARCH_LOG("[SDL3 mic] Requested %u ms latency for input device, capping the backlog at %d ms.\n",
          latency,
          (int)((mic->buffer_size / frame_size) * 1000 / mic->spec.freq));

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -21,8 +21,7 @@
 #include <stdlib.h>
 
 #include <boolean.h>
-#include <retro_inline.h>
-#include <retro_math.h>
+#include <retro_miscellaneous.h>
 #include <lists/string_list.h>
 #include <string/stdstring.h>
 
@@ -51,12 +50,6 @@
 /* Poll interval while a blocking write/read waits on the device;
  * device periods are several times longer than this. */
 #define SDL3_AUDIO_POLL_INTERVAL_NS SDL_NS_PER_MS
-
-static INLINE int sdl3_audio_find_num_frames(int rate, int latency)
-{
-   /* Keep the buffer size to 2^n. */
-   return next_pow2((rate * latency) / 1000);
-}
 
 /**
  * Looks up an audio device by name, returning the default
@@ -138,6 +131,74 @@ static struct string_list *sdl3_audio_device_list(bool recording)
    return sl;
 }
 
+/**
+ * Shared device-open path for both directions: looks up the device,
+ * probes its preferred format so the pipeline runs at the device
+ * rate (RetroArch resamples to it exactly once and SDL does no rate
+ * conversion of its own), requests a device period of roughly a
+ * quarter of the total latency, opens the stream in the negotiated
+ * format, and reports the period the device actually uses.
+ */
+static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
+      bool recording, unsigned rate, unsigned latency, int channels,
+      SDL_AudioSpec *spec, int *period_frames)
+{
+   int frames;
+   char frames_str[16];
+   const char *device_name   = NULL;
+   SDL_AudioStream *stream   = NULL;
+   SDL_AudioSpec device_spec = {0};
+   int device_sample_frames  = 0;
+   const char *tag           = recording ? "mic" : "audio";
+   SDL_AudioDeviceID devid   = sdl3_audio_find_device(device, recording);
+   settings_t *settings      = config_get_ptr();
+
+   if (   !SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames)
+       || device_spec.freq <= 0)
+      device_spec.freq = rate;
+
+   frames = (int)((uint64_t)device_spec.freq * (latency / 4) / 1000);
+   snprintf(frames_str, sizeof(frames_str), "%d", frames);
+   SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
+
+   spec->freq     = device_spec.freq;
+   /* SDL3 converts transparently if the device's native format
+    * differs; honour the negotiation hint for what we produce. */
+   spec->format   = (settings->uints.audio_format_negotiation
+         == AUDIO_FORMAT_NEGOTIATION_INT16)
+         ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
+   spec->channels = channels;
+
+   stream = SDL_OpenAudioDeviceStream(devid, spec, NULL, NULL);
+   /* The hint is process-global; clear it now that the open has
+    * consumed it so later SDL audio opens aren't affected. */
+   SDL_ResetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES);
+   if (!stream)
+   {
+      RARCH_ERR("[SDL3 %s] Failed to open SDL audio %s device: %s.\n",
+            tag, recording ? "input" : "output", SDL_GetError());
+      return NULL;
+   }
+
+   /* See what SDL actually opened (sample_frames honours the hint). */
+   if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(stream),
+         &device_spec, &device_sample_frames))
+      device_sample_frames = frames;
+   *period_frames = device_sample_frames;
+
+   device_name = SDL_GetAudioDeviceName(devid);
+   RARCH_DBG("[SDL3 %s] Opened SDL audio %s device \"%s\": "
+         "%u-bit %s, requested %u Hz / %d frame periods, "
+         "received %d Hz / %d frame periods.\n",
+         tag, recording ? "input" : "out",
+         device_name ? device_name : "(default)",
+         SDL_AUDIO_BITSIZE(spec->format),
+         SDL_AUDIO_ISFLOAT(spec->format) ? "floating-point" : "integer",
+         rate, frames, spec->freq, device_sample_frames);
+
+   return stream;
+}
+
 typedef struct sdl3_audio
 {
    /* The device stream.  SDL_AudioStream is internally locked and
@@ -150,7 +211,6 @@ typedef struct sdl3_audio
     * block (or bail, when nonblocking) once this much is queued. */
    size_t buffer_size;
    bool nonblock;
-   bool is_paused;
 } sdl3_audio_t;
 
 static void sdl3_audio_free(void *data)
@@ -172,16 +232,10 @@ static void *sdl3_audio_init(const char *device,
       unsigned rate, unsigned latency,
       unsigned block_frames, unsigned *new_rate)
 {
-   int frames;
-   char frames_str[16];
    size_t frame_size, min_size;
-   const char *device_name   = NULL;
-   void *tmp                 = NULL;
-   SDL_AudioDeviceID devid   = 0;
-   SDL_AudioSpec device_spec = {0};
-   int device_sample_frames  = 0;
-   sdl3_audio_t *sdl         = NULL;
-   settings_t *settings      = config_get_ptr();
+   void *tmp                = NULL;
+   int device_sample_frames = 0;
+   sdl3_audio_t *sdl        = NULL;
 
    /* Subsystem initialization is reference-counted in SDL3, so
     * initialize unconditionally; every init is balanced by the
@@ -199,44 +253,9 @@ static void *sdl3_audio_init(const char *device,
       return NULL;
    }
 
-   devid = sdl3_audio_find_device(device, false);
-
-   /* Ask SDL for the device's preferred format so the whole pipeline
-    * can run at the device rate; RetroArch resamples to it exactly
-    * once and SDL does no rate conversion of its own. */
-   if (   !SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames)
-       || device_spec.freq <= 0)
-      device_spec.freq = rate;
-
-   /* Request a device period of roughly a quarter of the total
-    * latency; the rest of the budget stays queued in the stream. */
-   frames = sdl3_audio_find_num_frames(device_spec.freq, latency / 4);
-   snprintf(frames_str, sizeof(frames_str), "%d", frames);
-   SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
-
-   sdl->spec.freq     = device_spec.freq;
-   /* SDL3 converts transparently if the device's native format
-    * differs; honour the negotiation hint for what we produce. */
-   sdl->spec.format   = (settings->uints.audio_format_negotiation
-         == AUDIO_FORMAT_NEGOTIATION_INT16)
-         ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
-   sdl->spec.channels = 2;
-
-   sdl->stream = SDL_OpenAudioDeviceStream(devid, &sdl->spec, NULL, NULL);
-   /* The hint is process-global; clear it now that the open has
-    * consumed it so later SDL audio opens aren't affected. */
-   SDL_ResetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES);
-   if (!sdl->stream)
-   {
-      RARCH_ERR("[SDL3 audio] Failed to open SDL audio output device: %s.\n",
-            SDL_GetError());
+   if (!(sdl->stream = sdl3_audio_open_stream(device, false, rate, latency,
+         2, &sdl->spec, &device_sample_frames)))
       goto error;
-   }
-
-   /* See what SDL actually opened (sample_frames honours the hint). */
-   if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(sdl->stream),
-         &device_spec, &device_sample_frames))
-      device_sample_frames = frames;
 
    /* Buffer the requested latency's worth of audio, with at least
     * two device periods to avoid underruns. */
@@ -249,14 +268,6 @@ static void *sdl3_audio_init(const char *device,
 
    *new_rate = sdl->spec.freq;
 
-   device_name = SDL_GetAudioDeviceName(devid);
-   RARCH_DBG("[SDL3 audio] Opened SDL audio out device \"%s\": "
-         "%u-bit %s, requested %u Hz / %d frame periods, "
-         "received %d Hz / %d frame periods.\n",
-         device_name ? device_name : "(default)",
-         SDL_AUDIO_BITSIZE(sdl->spec.format),
-         SDL_AUDIO_ISFLOAT(sdl->spec.format) ? "floating-point" : "integer",
-         rate, frames, sdl->spec.freq, device_sample_frames);
    RARCH_LOG("[SDL3 audio] Requested %u ms latency for output device, using %d ms.\n",
          latency,
          (int)((sdl->buffer_size / frame_size + device_sample_frames)
@@ -280,6 +291,20 @@ error:
    return NULL;
 }
 
+static size_t sdl3_audio_write_avail(void *data)
+{
+   int queued;
+   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
+
+   if (!sdl)
+      return 0;
+
+   queued = SDL_GetAudioStreamQueued(sdl->stream);
+   if (queued < 0 || (size_t)queued >= sdl->buffer_size)
+      return 0;
+   return sdl->buffer_size - (size_t)queued;
+}
+
 static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 {
    size_t _len       = 0;
@@ -291,11 +316,8 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 
    while (_len < len)
    {
-      int queued   = SDL_GetAudioStreamQueued(sdl->stream);
-      size_t avail = (queued >= 0 && (size_t)queued < sdl->buffer_size)
-            ? sdl->buffer_size - (size_t)queued : 0;
+      size_t avail = sdl3_audio_write_avail(sdl);
 
-      /* If the outgoing sample queue is full... */
       if (avail == 0)
       {
          Uint64 now;
@@ -316,7 +338,7 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
       {
          /* Enqueue as many samples as we have available without
           * exceeding the latency cap. */
-         size_t write_amt = (len - _len > avail) ? avail : len - _len;
+         size_t write_amt = MIN(len - _len, avail);
          if (!SDL_PutAudioStreamData(sdl->stream,
                (const char*)s + _len, (int)write_amt))
          {
@@ -337,7 +359,6 @@ static bool sdl3_audio_stop(void *data)
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
    if (!sdl)
       return false;
-   sdl->is_paused = true;
    return SDL_PauseAudioStreamDevice(sdl->stream);
 }
 
@@ -346,7 +367,7 @@ static bool sdl3_audio_alive(void *data)
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
    if (!sdl)
       return false;
-   return !sdl->is_paused;
+   return !SDL_AudioStreamDevicePaused(sdl->stream);
 }
 
 static bool sdl3_audio_start(void *data, bool is_shutdown)
@@ -354,7 +375,6 @@ static bool sdl3_audio_start(void *data, bool is_shutdown)
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
    if (!sdl)
       return false;
-   sdl->is_paused = false;
    return SDL_ResumeAudioStreamDevice(sdl->stream);
 }
 
@@ -371,20 +391,6 @@ static bool sdl3_audio_use_float(void *data)
    if (!sdl)
       return false;
    return SDL_AUDIO_ISFLOAT(sdl->spec.format) != 0;
-}
-
-static size_t sdl3_audio_write_avail(void *data)
-{
-   int queued;
-   sdl3_audio_t *sdl = (sdl3_audio_t*)data;
-
-   if (!sdl)
-      return 0;
-
-   queued = SDL_GetAudioStreamQueued(sdl->stream);
-   if (queued < 0 || (size_t)queued >= sdl->buffer_size)
-      return 0;
-   return sdl->buffer_size - (size_t)queued;
 }
 
 static size_t sdl3_audio_buffer_size(void *data)
@@ -509,17 +515,10 @@ static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
 static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       unsigned rate, unsigned latency, unsigned *new_rate)
 {
-   int frames;
-   char frames_str[16];
    size_t frame_size, min_size;
-   const char *device_name       = NULL;
-   SDL_AudioDeviceID devid       = 0;
-   SDL_AudioSpec device_spec     = {0};
    int device_sample_frames      = 0;
    sdl3_microphone_handle_t *mic = NULL;
-   settings_t *settings          = config_get_ptr();
 
-   /* If the audio subsystem wasn't initialized yet... */
    if (!SDL_WasInit(SDL_INIT_AUDIO))
    {
       RARCH_ERR("[SDL3 mic] Attempted to initialize input device before initializing the audio subsystem.\n");
@@ -532,59 +531,24 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
    /* Only print SDL audio devices if verbose logging is enabled */
    if (verbosity_is_enabled())
    {
-      int i;
-      int count                  = 0;
-      SDL_AudioDeviceID *devices = SDL_GetAudioRecordingDevices(&count);
-
-      RARCH_DBG("[SDL3 mic] %d audio capture devices found:\n", count);
-      if (devices)
+      struct string_list *sl = sdl3_audio_device_list(true);
+      if (sl)
       {
-         for (i = 0; i < count; i++)
-         {
-            const char *name = SDL_GetAudioDeviceName(devices[i]);
-            RARCH_DBG("[SDL3 mic]    - %s\n", name ? name : "(unknown)");
-         }
-         SDL_free(devices);
+         size_t i;
+         RARCH_DBG("[SDL3 mic] %u audio capture devices found:\n",
+               (unsigned)sl->size);
+         for (i = 0; i < sl->size; i++)
+            RARCH_DBG("[SDL3 mic]    - %s\n", sl->elems[i].data);
+         string_list_free(sl);
       }
    }
 
-   devid = sdl3_audio_find_device(device, true);
-
-   /* Run the capture path at the device's preferred rate so SDL
-    * does no rate conversion; the mic frontend resamples once. */
-   if (   !SDL_GetAudioDeviceFormat(devid, &device_spec, &device_sample_frames)
-       || device_spec.freq <= 0)
-      device_spec.freq = rate;
-
-   frames = sdl3_audio_find_num_frames(device_spec.freq, latency / 4);
-   snprintf(frames_str, sizeof(frames_str), "%d", frames);
-   SDL_SetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES, frames_str);
-
-   mic->spec.freq     = device_spec.freq;
-   /* The int16 negotiation hint keeps the whole capture path integer
-    * instead of converting a float stream back down; SDL converts
-    * transparently if the device's native format differs. */
-   mic->spec.format   = (settings->uints.audio_format_negotiation
-         == AUDIO_FORMAT_NEGOTIATION_INT16)
-         ? SDL_AUDIO_S16 : SDL_AUDIO_F32;
-   mic->spec.channels = 1; /* Microphones only usually provide input in mono */
-
    /* Device streams open in a paused state;
-    * the frontend starts them with start_mic. */
-   mic->stream = SDL_OpenAudioDeviceStream(devid, &mic->spec, NULL, NULL);
-   /* The hint is process-global; clear it now that the open has
-    * consumed it so later SDL audio opens aren't affected. */
-   SDL_ResetHint(SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES);
-   if (!mic->stream)
-   {
-      RARCH_ERR("[SDL3 mic] Failed to open SDL audio input device: %s.\n",
-            SDL_GetError());
+    * the frontend starts them with start_mic.
+    * Microphones usually provide mono input. */
+   if (!(mic->stream = sdl3_audio_open_stream(device, true, rate, latency,
+         1, &mic->spec, &device_sample_frames)))
       goto error;
-   }
-
-   if (!SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(mic->stream),
-         &device_spec, &device_sample_frames))
-      device_sample_frames = frames;
 
    /* Buffer up to double the latency budget (with a floor of four
     * device periods) before the backlog starts getting dropped. */
@@ -600,14 +564,6 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
    if (new_rate)
       *new_rate = mic->spec.freq;
 
-   device_name = SDL_GetAudioDeviceName(devid);
-   RARCH_DBG("[SDL3 mic] Opened SDL audio input device \"%s\": "
-         "%u-bit %s, requested %u Hz / %d frame periods, "
-         "received %d Hz / %d frame periods.\n",
-         device_name ? device_name : "(default)",
-         SDL_AUDIO_BITSIZE(mic->spec.format),
-         SDL_AUDIO_ISFLOAT(mic->spec.format) ? "floating-point" : "integer",
-         rate, frames, mic->spec.freq, device_sample_frames);
    RARCH_LOG("[SDL3 mic] Requested %u ms latency for input device, capping the backlog at %d ms.\n",
          latency,
          (int)((mic->buffer_size / frame_size) * 1000 / mic->spec.freq));
@@ -672,7 +628,6 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
    if (!sdl || !mic || !s)
       return -1;
 
-   /* Until we've given the caller as much data as they've asked for... */
    while (_len < len)
    {
       int got = SDL_GetAudioStreamData(mic->stream,

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -19,7 +19,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <boolean.h>
 #include <retro_inline.h>

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -239,8 +239,7 @@ static void *sdl3_audio_init(const char *device,
          2, &sdl->spec, &device_sample_frames)))
       goto error;
 
-   /* Buffer the requested latency's worth of audio, with at least
-    * two device periods to avoid underruns. */
+   /* Buffer the requested latency's worth of audio. */
    frame_size = SDL_AUDIO_FRAMESIZE(sdl->spec);
    sdl->buffer_size = (size_t)((uint64_t)sdl->spec.freq * latency / 1000) * frame_size;
    min_size = (size_t)(2 * device_sample_frames) * frame_size;
@@ -319,15 +318,13 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
          /* Add as many samples as we are able to without hitting
           * the maximum limit. */
          size_t write_amt = MIN(len - size, avail);
-         if (!SDL_PutAudioStreamData(sdl->stream,
-               (const char*)s + size, (int)write_amt))
+         if (!SDL_PutAudioStreamData(sdl->stream, (const char*)s + size, (int)write_amt))
          {
-            RARCH_ERR("[SDL3 audio] Failed to write to audio stream: %s.\n",
-                  SDL_GetError());
+            RARCH_ERR("[SDL3 audio] Failed to write to audio stream: %s.\n", SDL_GetError());
             break;
          }
          size += write_amt;
-         deadline = 0; /* Progress was made; reset the stall clock. */
+         deadline = 0; /* Reset the stall clock. */
       }
    }
 
@@ -431,7 +428,6 @@ static void *sdl3_microphone_init(void)
 {
    sdl3_audio_t *sdl = NULL;
 
-   /* Reference-counted; balanced by SDL_QuitSubSystem in free. */
    if (!SDL_InitSubSystem(SDL_INIT_AUDIO))
    {
       RARCH_ERR("[SDL3 audio] Failed to initialize microphone subsystem: %s.\n",
@@ -481,7 +477,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
 
    if (!SDL_WasInit(SDL_INIT_AUDIO))
    {
-      RARCH_ERR("[SDL3 audio] Attempted to initialize input device before initializing the audio subsystem.\n");
+      RARCH_ERR("[SDL3 audio] Attempted to initialize input device before the audio subsystem.\n");
       return NULL;
    }
 
@@ -495,27 +491,23 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       if (sl)
       {
          size_t i;
-         RARCH_DBG("[SDL3 audio] %u input devices found:\n",
-               (unsigned)sl->size);
+         RARCH_DBG("[SDL3 audio] %d input devices found:\n", (int)sl->size);
          for (i = 0; i < sl->size; i++)
             RARCH_DBG("[SDL3 audio]    - %s\n", sl->elems[i].data);
          string_list_free(sl);
       }
    }
 
-   /* Device streams open in a paused state;
-    * the frontend starts them with start_mic.
-    * Microphones usually provide mono input. */
+   /* Device streams open in a paused state. The frontend starts
+    * them with start_mic. Microphones usually provide mono input. */
    if (!(mic->stream = sdl3_audio_open_stream(device, true, rate, latency,
          1, &mic->spec, &device_sample_frames)))
       goto error;
 
-   /* Buffer up to double the latency budget (with a floor of four
-    * device periods) before the backlog starts getting dropped. */
+   /* Buffer up to double the latency budget. */
    frame_size = SDL_AUDIO_FRAMESIZE(mic->spec);
-   mic->buffer_size = (size_t)((uint64_t)mic->spec.freq * latency / 1000)
-         * frame_size * 2;
-   min_size         = (size_t)(4 * device_sample_frames) * frame_size;
+   mic->buffer_size = (size_t)((uint64_t)mic->spec.freq * latency / 1000) * frame_size * 2;
+   min_size = (size_t)(4 * device_sample_frames) * frame_size;
    if (mic->buffer_size < min_size)
       mic->buffer_size = min_size;
 
@@ -591,20 +583,17 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
    while (size < len)
    {
       int got = SDL_GetAudioStreamData(mic->stream, (char*)s + size, (int)(len - size));
-
       if (got < 0)
       {
-         RARCH_ERR("[SDL3 audio] Failed to read from microphone stream: %s.\n",
-               SDL_GetError());
+         RARCH_ERR("[SDL3 audio] Failed to read from microphone stream: %s.\n", SDL_GetError());
          if (size == 0)
             return -1;
          break;
       }
-
       if (got > 0)
       {
          size += (size_t)got;
-         deadline = 0; /* Progress was made; reset the stall clock. */
+         deadline = 0; /* Reset the stall clock. */
       }
       else
       {

--- a/audio/microphone_driver.h
+++ b/audio/microphone_driver.h
@@ -655,6 +655,11 @@ extern microphone_driver_t microphone_alsathread;
 extern microphone_driver_t microphone_sdl;
 
 /**
+ * The SDL3-backed microphone driver.
+ */
+extern microphone_driver_t microphone_sdl3;
+
+/**
  * The WASAPI-backed microphone driver.
  */
 extern microphone_driver_t microphone_wasapi;

--- a/configuration.c
+++ b/configuration.c
@@ -151,6 +151,7 @@ enum audio_driver_enum
    AUDIO_JACK,
    AUDIO_SDL,
    AUDIO_SDL2,
+   AUDIO_SDL3,
    AUDIO_XAUDIO,
    AUDIO_PULSE,
    AUDIO_EXT,
@@ -177,6 +178,7 @@ enum microphone_driver_enum
    MICROPHONE_ALSA = AUDIO_NULL + 1,
    MICROPHONE_ALSATHREAD,
    MICROPHONE_SDL2,
+   MICROPHONE_SDL3,
    MICROPHONE_WASAPI,
    MICROPHONE_PIPEWIRE,
    MICROPHONE_COREAUDIO,
@@ -573,6 +575,8 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_RWEBAUDIO;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL;
 #elif defined(HAVE_SDL2)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL2;
+#elif defined(HAVE_SDL3)
+static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL3;
 #elif defined(HAVE_RSOUND)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_RSOUND;
 #elif defined(HAVE_ROAR)
@@ -599,6 +603,8 @@ static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_
 #elif defined(HAVE_SDL2)
 /* The default fallback driver is SDL2, if available. */
 static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_SDL2;
+#elif defined(HAVE_SDL3)
+static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_SDL3;
 #else
 static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_NULL;
 #endif
@@ -960,6 +966,8 @@ const char *config_get_default_audio(void)
          return "sdl";
       case AUDIO_SDL2:
          return "sdl2";
+      case AUDIO_SDL3:
+         return "sdl3";
       case AUDIO_DSOUND:
          return "dsound";
       case AUDIO_WASAPI:
@@ -1035,6 +1043,8 @@ const char *config_get_default_microphone(void)
          return "wasapi";
       case MICROPHONE_SDL2:
          return "sdl2";
+      case MICROPHONE_SDL3:
+         return "sdl3";
       case MICROPHONE_COREAUDIO:
          return "coreaudio";
       case MICROPHONE_NULL:

--- a/configuration.c
+++ b/configuration.c
@@ -491,12 +491,12 @@ static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_CTR;
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SWITCH;
 #elif defined(HAVE_XVIDEO)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_XVIDEO;
+#elif defined(HAVE_SDL3)
+static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL3;
 #elif defined(HAVE_SDL) && !defined(HAVE_SDL_DINGUX)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL;
 #elif defined(HAVE_SDL2)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL2;
-#elif defined(HAVE_SDL3)
-static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL3;
 #elif defined(HAVE_SDL_DINGUX)
 #if defined(RS90) || defined(MIYOO)
 static const enum video_driver_enum VIDEO_DEFAULT_DRIVER = VIDEO_SDL_RS90;
@@ -571,12 +571,12 @@ static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SL;
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_AUDIOWORKLET;
 #elif defined(HAVE_RWEBAUDIO)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_RWEBAUDIO;
+#elif defined(HAVE_SDL3)
+static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL3;
 #elif defined(HAVE_SDL)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL;
 #elif defined(HAVE_SDL2)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL2;
-#elif defined(HAVE_SDL3)
-static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_SDL3;
 #elif defined(HAVE_RSOUND)
 static const enum audio_driver_enum AUDIO_DEFAULT_DRIVER = AUDIO_RSOUND;
 #elif defined(HAVE_ROAR)
@@ -600,11 +600,11 @@ static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_
 static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_PIPEWIRE;
 #elif defined(HAVE_COREAUDIO)
 static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_COREAUDIO;
+#elif defined(HAVE_SDL3)
+static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_SDL3;
 #elif defined(HAVE_SDL2)
 /* The default fallback driver is SDL2, if available. */
 static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_SDL2;
-#elif defined(HAVE_SDL3)
-static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_SDL3;
 #else
 static const enum microphone_driver_enum MICROPHONE_DEFAULT_DRIVER = MICROPHONE_NULL;
 #endif

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -983,6 +983,7 @@ AUDIO
 #include "../input/drivers/sdl3_input.c"
 #include "../gfx/drivers/sdl3_gfx.c"
 #include "../gfx/common/sdl3_common.c"
+#include "../audio/drivers/sdl3_audio.c"
 #if defined(HAVE_OPENGL) || defined(HAVE_OPENGL1) || defined(HAVE_OPENGL_CORE) || defined(HAVE_OPENGLES)
 #include "../gfx/drivers_context/sdl3_gl_ctx.c"
 #endif

--- a/retroarch.c
+++ b/retroarch.c
@@ -6843,7 +6843,7 @@ static void retroarch_print_features(void)
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_SDL2,            "SDL2",            "SDL2 input/audio/video drivers");
 #endif
 #ifdef HAVE_SDL3
-   _len += _PSUPP_BUF(buf, _len, SUPPORTS_SDL3,            "SDL3",            "SDL3 input/video drivers");
+   _len += _PSUPP_BUF(buf, _len, SUPPORTS_SDL3,            "SDL3",            "SDL3 input/audio/video drivers");
 #endif
 #ifdef HAVE_X11
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_X11,             "X11",             "X11 input/video drivers");


### PR DESCRIPTION
This adds the audio driver for SDL3, with support for both output playback and input with a microphone.

Tested with https://github.com/libretro/libretro-samples/pull/34