### PR TITLE
(cheevos) show message when chd fails to open

### DIFF
--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -106,6 +106,7 @@ static rcheevos_locals_t rcheevos_locals =
    0,    /* menuitem_capacity */
    0,    /* menuitem_count */
 #endif
+   NULL, /* hash_error */
    true, /* hardcore_allowed */
    false,/* hardcore_requires_reload */
    false,/* hardcore_being_enabled */
@@ -1201,7 +1202,13 @@ bool rcheevos_get_support_cheevos(void)
 const char* rcheevos_get_hash(void)
 {
    const rc_client_game_t* game = rc_client_get_game_info(rcheevos_locals.client);
-   return game ? game->hash : msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE);
+   if (game)
+      return game->hash;
+
+   if (rcheevos_locals.hash_error)
+      return rcheevos_locals.hash_error;
+
+   return msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NOT_AVAILABLE);
 }
 
 /* hooks for rc_hash library */
@@ -1270,6 +1277,10 @@ static void* rc_hash_handle_chd_open_track(
       CHEEVOS_FREE(file);
       cdfs_close_track(cdfs_track); /* ASSERT: this free()s cdfs_track */
    }
+   else
+   {
+      rcheevos_locals.hash_error = "Could not open CHD file (check log for detail)";
+   }
 
    return NULL;
 }
@@ -1330,6 +1341,7 @@ static void* rc_hash_handle_cd_open_track(
 
       return rc_hash_handle_chd_open_track(path, track);
 #else
+      rcheevos_locals.hash_error = "No CHD support";
       CHEEVOS_LOG(RCHEEVOS_TAG "Cannot generate hash from CHD without HAVE_CHD compile flag\n");
       return NULL;
 #endif
@@ -1711,6 +1723,7 @@ static void rcheevos_client_load_game_callback(int result,
       {
          CHEEVOS_LOG(RCHEEVOS_TAG "Game not recognized, pausing hardcore\n");
          rcheevos_pause_hardcore();
+         rcheevos_locals.hash_error = "Unrecognized";
 
          if (!settings->bools.cheevos_verbose_enable)
             return;
@@ -1726,6 +1739,11 @@ static void rcheevos_client_load_game_callback(int result,
             error_message = "Unknown error";
 
          CHEEVOS_LOG(RCHEEVOS_TAG "Game load failed: %s\n", error_message);
+
+         if (rcheevos_locals.hash_error)
+            error_message = rcheevos_locals.hash_error;
+         else
+            rcheevos_locals.hash_error = rc_error_str(result);
 
          if (result == RC_LOGIN_REQUIRED)
          {
@@ -1882,6 +1900,7 @@ bool rcheevos_load(const void *data)
       rcheevos_client_download_placeholder_badge();
    }
 
+   rcheevos_locals.hash_error = NULL;
    rc_client_set_hardcore_enabled(rcheevos_locals.client, settings->bools.cheevos_hardcore_mode_enable);
    rc_client_set_unofficial_enabled(rcheevos_locals.client, settings->bools.cheevos_test_unofficial);
    rc_client_set_encore_mode_enabled(rcheevos_locals.client, settings->bools.cheevos_start_active);

--- a/cheevos/cheevos.c
+++ b/cheevos/cheevos.c
@@ -1279,7 +1279,7 @@ static void* rc_hash_handle_chd_open_track(
    }
    else
    {
-      rcheevos_locals.hash_error = "Could not open CHD file (check log for detail)";
+      rcheevos_locals.hash_error = "Could not open CHD file";
    }
 
    return NULL;

--- a/cheevos/cheevos_locals.h
+++ b/cheevos/cheevos_locals.h
@@ -117,6 +117,8 @@ typedef struct rcheevos_locals_t
    unsigned menuitem_count;           /* current number of items in the menuitems array */
 #endif
 
+   const char* hash_error;            /* message to display if an error occurred identifying the game */
+
    bool hardcore_allowed;             /* prevents enabling hardcore if illegal settings detected */
    bool hardcore_requires_reload;     /* prevents enabling hardcore until the core is reloaded */
    bool hardcore_being_enabled;       /* allows callers to detect hardcore mode while it's being enabled */

--- a/config.features.h
+++ b/config.features.h
@@ -284,6 +284,12 @@
 #define SUPPORTS_ZLIB false
 #endif
 
+#ifdef HAVE_CHD
+#define SUPPORTS_CHD true
+#else
+#define SUPPORTS_CHD false
+#endif
+
 #ifdef HAVE_7ZIP
 #define SUPPORTS_7ZIP true
 #else

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -27,8 +27,6 @@
 #include <boolean.h>
 #include <compat/strl.h>
 
-#include "../../verbosity.h"
-
 #include <streams/chd_stream.h>
 #include <retro_endianness.h>
 #ifdef HAVE_RCHD
@@ -580,10 +578,8 @@ chdstream_t *chdstream_open(const char *path, int32_t track)
    chdstream_t *stream     = NULL;
    chd_file *chd           = NULL;
    chd_error err           = chd_open(path, CHD_OPEN_READ, NULL, &chd);
-   if (err != CHDERR_NONE) {
-      RARCH_LOG("[CHD] %s\n", chd_error_string(err));
+   if (err != CHDERR_NONE)
       return NULL;
-   }
    if (!chdstream_find_track(chd, track, &meta))
       goto error;
    stream                  = (chdstream_t*)malloc(sizeof(*stream));

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -26,7 +26,8 @@
 
 #include <boolean.h>
 #include <compat/strl.h>
-#include <verbosity.h>
+
+#include "../../verbosity.h"
 
 #include <streams/chd_stream.h>
 #include <retro_endianness.h>

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -26,6 +26,7 @@
 
 #include <boolean.h>
 #include <compat/strl.h>
+#include <verbosity.h>
 
 #include <streams/chd_stream.h>
 #include <retro_endianness.h>

--- a/libretro-common/streams/chd_stream.c
+++ b/libretro-common/streams/chd_stream.c
@@ -578,8 +578,10 @@ chdstream_t *chdstream_open(const char *path, int32_t track)
    chdstream_t *stream     = NULL;
    chd_file *chd           = NULL;
    chd_error err           = chd_open(path, CHD_OPEN_READ, NULL, &chd);
-   if (err != CHDERR_NONE)
+   if (err != CHDERR_NONE) {
+      RARCH_LOG("[CHD] %s\n", chd_error_string(err));
       return NULL;
+   }
    if (!chdstream_find_track(chd, track, &meta))
       goto error;
    stream                  = (chdstream_t*)malloc(sizeof(*stream));

--- a/retroarch.c
+++ b/retroarch.c
@@ -6940,6 +6940,9 @@ static void retroarch_print_features(void)
 #ifdef HAVE_XAUDIO
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_XAUDIO,          "XAudio2",         "Audio driver");
 #endif
+#ifdef HAVE_CHD
+   _len += _PSUPP_BUF(buf, _len, SUPPORTS_CHD,             "CHD",             "CHD support");
+#endif
 #ifdef HAVE_7ZIP
    _len += _PSUPP_BUF(buf, _len, SUPPORTS_7ZIP,            "7zip",            "7zip support");
 #endif


### PR DESCRIPTION
## Description

Changes the error message from "hash generation failed" to "Could not open CHD file" when trying to open the CHD file fails.

<img width="612" height="50" alt="image" src="https://github.com/user-attachments/assets/8a3e9496-f797-409f-8dd1-b343ffb07fa9" />

This message also appears in the info dialog (instead of N/A as reported [here](https://github.com/libretro/RetroArch/pull/19046#issuecomment-5027143794))
<img width="775" height="72" alt="image" src="https://github.com/user-attachments/assets/77fb8216-76ef-45f7-a4c5-e5cad6a2a8f2" />

Also adds a log message with the CHD error (which happens to be `unsupported format` for #19370 - unfortunately I couldn't capture exactly which format was unsupported in the log message).

```
[INFO] [RCHEEVOS] Trying console 12
[INFO] [CHD] unsupported format
[INFO] [RCHEEVOS] Could not open track
```

## Related Issues

n/a

## Related Pull Requests

n/a

## Reviewers

[If possible @mention all the people that should review your pull request]
