### PR TITLE
smb: add important information for windows 10+ users regarding userna…

### DIFF
--- a/intl/msg_hash_us.h
+++ b/intl/msg_hash_us.h
@@ -36150,11 +36150,11 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SMB_CLIENT_SUBDIR,
-   "SMB Sub directory (optional)"
+   "SMB Sub directory"
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SMB_CLIENT_SUBDIR,
-   "Sub directory path on the share."
+   "Sub directory path on the share. Optional."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SMB_CLIENT_USERNAME,
@@ -36162,7 +36162,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SMB_CLIENT_USERNAME,
-   "Username for authentication."
+   "Username for authentication. This is optional when guest access is enabled on the server. Windows 10 and above: guest access is disabled by default, so a username is required here."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SMB_CLIENT_PASSWORD,
@@ -36170,7 +36170,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SMB_CLIENT_PASSWORD,
-   "Password for authentication."
+   "Password for authentication. This is optional when guest access is enabled on the server. Windows 10 and above: guest access is disabled by default, so a password is required here."
    )
 MSG_HASH(
    MENU_ENUM_LABEL_VALUE_SMB_CLIENT_WORKGROUP,
@@ -36178,7 +36178,7 @@ MSG_HASH(
    )
 MSG_HASH(
    MENU_ENUM_SUBLABEL_SMB_CLIENT_WORKGROUP,
-   "Workgroup or domain name."
+   "Workgroup or domain name. Optional in some setups."
    )
 /* GENERATED REGION: SMB client authentication group (see settings_def_smb_client_auth.h). */
 #define SETTINGS_DEF_STRINGS_PASS


### PR DESCRIPTION
…me/password being required

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Add a note for smb users that a username/password is required for Windows 10 (and above) normally.

## Related Issues


## Related Pull Requests

## Reviewers
