### PR TITLE
Windows: Improve DPI scaling on modern OS versions

### DIFF
--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -214,6 +214,7 @@ typedef struct DISPLAYCONFIG_PATH_INFO_CUSTOM
 
 typedef LONG (WINAPI *QUERYDISPLAYCONFIG)(UINT32, UINT32*, DISPLAYCONFIG_PATH_INFO_CUSTOM*, UINT32*, DISPLAYCONFIG_MODE_INFO_CUSTOM*, UINT32*);
 typedef LONG (WINAPI *GETDISPLAYCONFIGBUFFERSIZES)(UINT32, UINT32*, UINT32*);
+typedef HRESULT (WINAPI *GETSCALEFACTOR)(HMONITOR, int*);
 
 static void *win32_display_server_init(void)
 {
@@ -897,13 +898,34 @@ static bool win32_display_server_get_metrics(void *data,
          *value = (float)GetDeviceCaps(monitor, VERTSIZE);
          break;
       case DISPLAY_METRIC_DPI:
-         /* 25.4 mm in an inch. */
          {
-            int pixels_x       = GetDeviceCaps(monitor, HORZRES);
-            int physical_width = GetDeviceCaps(monitor, HORZSIZE);
-            *value = (physical_width > 0)
-               ? (float)(254 * pixels_x) / (float)(physical_width * 10)
-               : 0.0f;
+            static float dpi;
+
+            if (dpi == 0.0f)
+            {
+               HMODULE shcore = LoadLibraryA("shcore.dll");
+               GETSCALEFACTOR get_scale_factor = NULL;
+               int scale;
+
+               if (shcore)
+                  get_scale_factor = (GETSCALEFACTOR)GetProcAddress(
+                        shcore, "GetScaleFactorForMonitor");
+
+               if (  get_scale_factor
+                  && get_scale_factor(MonitorFromWindow(
+                        win32_get_window(), MONITOR_DEFAULTTONEAREST), &scale) == S_OK)
+                  dpi = 96.0f * scale / 100.0f;
+               else
+               {
+                  /* 25.4 mm in an inch. */
+                  int pixels_x       = GetDeviceCaps(monitor, HORZRES);
+                  int physical_width = GetDeviceCaps(monitor, HORZSIZE);
+                  dpi = (physical_width > 0)
+                     ? (float)(254 * pixels_x) / (float)(physical_width * 10)
+                     : 0.0f;
+               }
+            }
+            *value = dpi;
          }
          break;
       default:


### PR DESCRIPTION
## Description

In the current RetroArch master on Windows, the DPI metrics used for scaling widgets and UI elements for certain menu drivers (Ozone and MaterialUI) are based on the physical size/resolution of the screen (HORZRES and HORZSIZE), calculated through the `GetDeviceCaps()` function. This calculation does not take into account the user-defined DPI scaling as set in Windows itself.

As a consequence of this, when using RA on a Windows device that might be connected to 2+ screens having the same resolution but different DPI values (such as in my use-case, an handheld PC with a 7-inch 1080p internal screen that is occasionally docked to a bigger 1080p screen), the UI scaling will end up differing greatly between one screen and another. 
This forces users to adjust the scaling factor in the menu every single time the screen is switched around...

This PR proposes a more accurate form of DPI awareness, derived from the shcore.dll library and the `GetScaleFactorForMonitor()` function. On Windows versions 8.1 and above, this lets us calculate the DPI value that was actually set for the chosen monitor in the OS, preserving the UI scale between same-res screens with different DPI values.
The original GetDeviceCaps() method is kept as a fallback approach for older Windows systems, where the shcore library or the newer DPI awareness systems might not be available (Windows 7 and below).

## Reviewers

@LibretroAdmin 