### PR TITLE
android: add model info to log

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -575,6 +575,23 @@ void ANativeActivity_onCreate(ANativeActivity* activity,
          savedState, savedStateSize);
 }
 
+void frontend_android_get_manufacturer_model(char *s, size_t len)
+{
+   char manufacturer[PROP_VALUE_MAX] = {0};
+   char model[PROP_VALUE_MAX]        = {0};
+
+   if (!s || len == 0)
+      return;
+
+   __system_property_get("ro.product.manufacturer", manufacturer);
+   __system_property_get("ro.product.model", model);
+
+   if (manufacturer[0])
+      manufacturer[0] = (char)toupper((unsigned char)manufacturer[0]);
+
+   snprintf(s, len, "%s %s", manufacturer, model);
+}
+
 void frontend_android_get_name(char *s, size_t len)
 {
    system_property_get("getprop", "ro.product.model", s, len);

--- a/frontend/drivers/platform_unix.h
+++ b/frontend/drivers/platform_unix.h
@@ -395,6 +395,8 @@ extern struct android_app *g_android;
 
 void frontend_android_get_name(char *s, size_t len);
 
+void frontend_android_get_manufacturer_model(char *s, size_t len);
+
 void frontend_android_get_version(int32_t *major, int32_t *minor, int32_t *rel);
 
 void frontend_android_get_version_sdk(int32_t *sdk);

--- a/retroarch.c
+++ b/retroarch.c
@@ -8447,6 +8447,7 @@ bool retroarch_main_init(int argc, char *argv[])
 #if defined(ANDROID)
       {
          char str_output[128];
+         char manufacturer_model[PROP_VALUE_MAX * 2];
          int32_t major = 0;
          int32_t minor = 0;
          int32_t rel   = 0;
@@ -8457,15 +8458,17 @@ bool retroarch_main_init(int argc, char *argv[])
             "Sideload";
 
          frontend_android_get_version(&major, &minor, &rel);
+         frontend_android_get_manufacturer_model(
+            manufacturer_model, sizeof(manufacturer_model));
 
          snprintf(str_output, sizeof(str_output),
-            FILE_PATH_LOG_INFO " Running on: Android v%d.%d.%d (API %d) (%s)\n",
+            FILE_PATH_LOG_INFO " Running on: Android v%d.%d.%d (%s)\n"
+            FILE_PATH_LOG_INFO " Device: %s\n",
             major,
             minor,
             rel,
-            android_get_device_api_level(),
-            build_type);
-
+            build_type,
+            manufacturer_model);
          RARCH_LOG_OUTPUT("%s", str_output);
       }
 #elif defined(WEBOS)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Add device model to log, useful for Android - google tv issues/phone issues.

Remove API level as Android version is enough.

## Related Issues


## Related Pull Requests


## Reviewers

