### PR TITLE
Revert "metal: fix lost orientation in TATE mode (issue #19142)"

### DIFF
--- a/gfx/drivers/metal.m
+++ b/gfx/drivers/metal.m
@@ -5265,15 +5265,7 @@ typedef struct MTLALIGN(16)
       memset(&_engine.pass[i].feedback, 0, sizeof(_engine.pass[i].feedback));
    }
 
-   /* Default to the rotated projection matrix. Under a TATE rotation the
-    * final pass swaps width/height (below), which makes its target size
-    * differ from the viewport and sends it down the FBO-allocation branch
-    * rather than the direct-to-screen 'else' that assigns the rotated
-    * matrix -- so without this default the last pass would render with the
-    * unrotated matrix and the image would keep its orientation while only
-    * the aspect ratio changed (issue #19142). This mirrors the D3D11 driver,
-    * which initialises mvp_last_pass to the rotated mvp. */
-   _engine.mvp_last_pass = _context.uniforms->projectionMatrix;
+   _engine.mvp_last_pass = _context.uniformsNoRotate->projectionMatrix;
    int rot = retroarch_get_rotation();
    
    width  = (NSUInteger)_size.width;


### PR DESCRIPTION
This reverts commit ba28fae5304068aaad4ce8c8560c5e1c942edeb9.

## Description

Rotation issues with Metal was specific to Golden Gate Beta. This change affected current and older versions of macOS and iOS. This could end up resolving itself when *OS 27 is released.

#19142 

## Reviewers

@LibretroAdmin @piciji 