### PR TITLE
SDL3: Implement GL `make_current`

### DIFF
--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -324,7 +324,16 @@ static void sdl3_ctx_bind_hw_render(void *data, bool enable)
 /* With threaded video, gl3/gl2 bind the GL context on the video
  * thread around menu/widget texture loads and raster-font teardown.
  * Without this hook those binds are silent no-ops and the textures
- * are created without a current context (black menu icons). */
+ * are created without a current context (black menu icons).
+ *
+ * No locking is needed here, and none of the other ctx drivers that
+ * implement this hook take any either: every caller reaches it from
+ * inside a custom command that video_thread_texture_handle has
+ * dispatched onto the video thread and blocks on, so this runs
+ * serialised with frame rendering rather than alongside it. That is
+ * the same thread sdl3_gl_current is assigned on - the wrapper
+ * handles CMD_INIT from within video_thread_loop, so the ctx init
+ * that sets it already runs on the video thread. */
 static void sdl3_ctx_make_current(bool release)
 {
    if (!sdl3_gl_current || !sdl3_gl_current->win)

--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -54,6 +54,10 @@ static unsigned sdl3_gl_minor = 0;
 static SDL_GLContext sdl3_gl_cached_ctx = NULL;
 static SDL_GLContext sdl3_gl_cached_shared_ctx = NULL;
 
+/* The make_current hook receives no instance pointer, so track the
+ * live instance at file scope (mirrors x_ctx's current_context_data). */
+static gfx_ctx_sdl3_data_t *sdl3_gl_current = NULL;
+
 /* Core-profile context: explicitly requested, or GL 3.1+. */
 static bool sdl3_gl_core_profile(gfx_ctx_sdl3_data_t *sdl)
 {
@@ -100,6 +104,9 @@ static void sdl3_ctx_destroy(void *data)
    if (!sdl3_gl_cached_ctx)
       SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
+   if (sdl3_gl_current == sdl)
+      sdl3_gl_current = NULL;
+
    free(sdl);
 }
 
@@ -128,6 +135,8 @@ static void *sdl3_ctx_init(void *video_driver)
 
    RARCH_LOG("[SDL3 GL] SDL %d.%d.%d gfx context driver initialized.\n",
          SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_MICRO_VERSION);
+
+   sdl3_gl_current = sdl;
 
    return sdl;
 }
@@ -312,6 +321,18 @@ static void sdl3_ctx_bind_hw_render(void *data, bool enable)
       SDL_GL_MakeCurrent(sdl->win, sdl->ctx);
 }
 
+/* With threaded video, gl3/gl2 bind the GL context on the video
+ * thread around menu/widget texture loads and raster-font teardown.
+ * Without this hook those binds are silent no-ops and the textures
+ * are created without a current context (black menu icons). */
+static void sdl3_ctx_make_current(bool release)
+{
+   if (!sdl3_gl_current || !sdl3_gl_current->win)
+      return;
+   SDL_GL_MakeCurrent(sdl3_gl_current->win,
+         release ? NULL : sdl3_gl_current->ctx);
+}
+
 const gfx_ctx_driver_t gfx_ctx_sdl3_gl =
 {
    sdl3_ctx_init,
@@ -344,7 +365,7 @@ const gfx_ctx_driver_t gfx_ctx_sdl3_gl =
    sdl3_ctx_set_flags,
    sdl3_ctx_bind_hw_render,
    NULL, /* get_context_data */
-   NULL, /* make_current */
+   sdl3_ctx_make_current,
    NULL, /* create_surface */
    NULL  /* destroy_surface */
 };

--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -54,8 +54,8 @@ static unsigned sdl3_gl_minor = 0;
 static SDL_GLContext sdl3_gl_cached_ctx = NULL;
 static SDL_GLContext sdl3_gl_cached_shared_ctx = NULL;
 
-/* The make_current hook receives no instance pointer, so track the
- * live instance at file scope (mirrors x_ctx's current_context_data). */
+/* The make_current hook receives no pointer, so track it at
+ * the file scope (same as x_ctx). */
 static gfx_ctx_sdl3_data_t *sdl3_gl_current = NULL;
 
 /* Core-profile context: explicitly requested, or GL 3.1+. */
@@ -322,18 +322,9 @@ static void sdl3_ctx_bind_hw_render(void *data, bool enable)
 }
 
 /* With threaded video, gl3/gl2 bind the GL context on the video
- * thread around menu/widget texture loads and raster-font teardown.
- * Without this hook those binds are silent no-ops and the textures
- * are created without a current context (black menu icons).
- *
- * No locking is needed here, and none of the other ctx drivers that
- * implement this hook take any either: every caller reaches it from
- * inside a custom command that video_thread_texture_handle has
- * dispatched onto the video thread and blocks on, so this runs
- * serialised with frame rendering rather than alongside it. That is
- * the same thread sdl3_gl_current is assigned on - the wrapper
- * handles CMD_INIT from within video_thread_loop, so the ctx init
- * that sets it already runs on the video thread. */
+ * thread. Without this hook those binds don't do anything and
+ * the textures created without a current context, resulting in
+ * black menu icons. */
 static void sdl3_ctx_make_current(bool release)
 {
    if (!sdl3_gl_current || !sdl3_gl_current->win)

--- a/gfx/drivers_context/sdl3_vk_ctx.c
+++ b/gfx/drivers_context/sdl3_vk_ctx.c
@@ -295,10 +295,9 @@ const gfx_ctx_driver_t gfx_ctx_sdl3_vk = {
    sdl3_vk_ctx_set_flags,
    sdl3_vk_ctx_bind_hw_render,
    sdl3_vk_ctx_get_context_data,
-   /* make_current: GL-only. Vulkan has no per-thread current context
-    * to bind, only the GL video drivers ever call the hook, and every
-    * other Vulkan ctx driver (x_vk, w_vk, android_vk, khr_display)
-    * leaves it NULL as well. */
+   /* make_current: GL-only. Vulkan has no per-thread context
+    * to bind. x, wayland, android, and other Vulkan drivers
+    * do the same. */
    NULL,
    NULL, /* create_surface */
    NULL  /* destroy_surface */

--- a/gfx/drivers_context/sdl3_vk_ctx.c
+++ b/gfx/drivers_context/sdl3_vk_ctx.c
@@ -295,7 +295,11 @@ const gfx_ctx_driver_t gfx_ctx_sdl3_vk = {
    sdl3_vk_ctx_set_flags,
    sdl3_vk_ctx_bind_hw_render,
    sdl3_vk_ctx_get_context_data,
-   NULL, /* make_current */
+   /* make_current: GL-only. Vulkan has no per-thread current context
+    * to bind, only the GL video drivers ever call the hook, and every
+    * other Vulkan ctx driver (x_vk, w_vk, android_vk, khr_display)
+    * leaves it NULL as well. */
+   NULL,
    NULL, /* create_surface */
    NULL  /* destroy_surface */
 };


### PR DESCRIPTION
Adds the `make_current` hook for the SDL3 OpenGL context to allow flipping the current context. Takes the same approach as x_ctx, and wayland_ctx.