### PR TITLE
android: fix smb - android 32-bit, crash when all file access declined, simulator in android 11, log keyb in debug mode

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -1932,18 +1932,22 @@ static void frontend_unix_get_env(int *argc,
       /* set paths depending on the ability to write
        * to internal_storage_path */
 
-      if (*internal_storage_path)
+      if (*internal_storage_path &&
+         test_permissions(internal_storage_path))
       {
-         if (test_permissions(internal_storage_path))
-            storage_permissions = INTERNAL_STORAGE_WRITABLE;
+         storage_permissions = INTERNAL_STORAGE_WRITABLE;
       }
-      else if (*internal_storage_app_path)
+      else if (*internal_storage_app_path &&
+               test_permissions(internal_storage_app_path))
       {
-         if (test_permissions(internal_storage_app_path))
-            storage_permissions = INTERNAL_STORAGE_APPDIR_WRITABLE;
+         storage_permissions = INTERNAL_STORAGE_APPDIR_WRITABLE;
       }
       else
+      {
+         // fallback to private data storage
+         // e.g. /data/user/0/com.retroarch.aarch64 then saves/ etc.
          storage_permissions = INTERNAL_STORAGE_NOT_WRITABLE;
+      }
 
       /* code to populate default paths*/
       if (*app_dir)

--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1374,6 +1374,11 @@ static INLINE void android_input_poll_event_type_key(
    int action   = AKeyEvent_getAction(event);
    int keysym   = keycode;
 
+   int device_id = AInputEvent_getDeviceId(event);
+   RARCH_DBG("android_input_poll_event_type_key: keycode:%d port:%d source:0x%x action:%d device_id:%d is_kbd_id:%d\n",
+      keycode, port, source, action, device_id,
+      android_is_keyboard_id(device_id));
+
    /* Handle 'duplicate' inputs that correspond
     * to the same RETROK_* key */
    switch (keycode)
@@ -1398,7 +1403,10 @@ static INLINE void android_input_poll_event_type_key(
       case AKEY_EVENT_ACTION_DOWN:
          BIT_SET(buf, keysym);
          if (keysym == AKEYCODE_BACK)
+         {
             BIT_SET(buf, AKEYCODE_X);
+            BIT_SET(android_key_state[ANDROID_KEYBOARD_PORT], AKEYCODE_X);
+         }
          break;
    }
 

--- a/libretro-common/vfs/vfs_implementation_smb.c
+++ b/libretro-common/vfs/vfs_implementation_smb.c
@@ -472,7 +472,7 @@ int64_t retro_vfs_file_read_smb(libretro_vfs_implementation_file *stream,
    struct smb2_context *ctx;
    struct smb2fh *fh;
 
-   if (!smb_initialized || !stream || !s || stream->smb_fh < 0)
+   if (!smb_initialized || !stream || !s || !stream->smb_fh)
       return -1;
 
    if (len == 0)
@@ -519,7 +519,7 @@ int64_t retro_vfs_file_write_smb(libretro_vfs_implementation_file *stream,
    struct smb2_context *ctx;
    struct smb2fh *fh;
 
-   if (!smb_initialized || !stream || !s || stream->smb_fh < 0)
+   if (!smb_initialized || !stream || !s || !stream->smb_fh)
       return -1;
 
    if (len == 0)
@@ -622,7 +622,7 @@ int retro_vfs_file_close_smb(libretro_vfs_implementation_file *stream)
    if (!smb_initialized)
       return -1;
 
-   if (!stream || stream->smb_fh < 0)
+   if (!stream || !stream->smb_fh)
       return -1;
 
    ctx = (struct smb2_context *)(void *)(uintptr_t)stream->smb_ctx;

--- a/pkg/android/phoenix/build.gradle
+++ b/pkg/android/phoenix/build.gradle
@@ -90,7 +90,7 @@ android {
       targetSdkVersion 36
       versionCode getPlayStoreVersionCode()
       versionName getPlayStoreVersionName()
-  
+
       resValue "string", "app_name", "RetroArch"
       buildConfigField "boolean", "PLAY_STORE_BUILD", "true"
 

--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -36,9 +36,21 @@ public final class MainMenuActivity extends PreferenceActivity
 
 	public void showMessageOKCancel(String message, DialogInterface.OnClickListener onClickListener)
 	{
-		new AlertDialog.Builder(this).setMessage(message)
-			.setPositiveButton("OK", onClickListener).setCancelable(false)
-			.setNegativeButton("Cancel", null).create().show();
+		new AlertDialog.Builder(this)
+			.setMessage(message)
+			.setPositiveButton("OK", onClickListener)
+			.setCancelable(false)
+			.setNegativeButton("Cancel", new DialogInterface.OnClickListener()
+			{
+				@Override
+				public void onClick(DialogInterface dialog, int which)
+				{
+					checkPermissions = false;
+					finalStartup();
+				}
+			})
+			.create()
+			.show();
 	}
 
 	private boolean addPermission(List<String> permissionsList, String permission)
@@ -79,14 +91,34 @@ public final class MainMenuActivity extends PreferenceActivity
 									Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
 									intent.addCategory("android.intent.category.DEFAULT");
 									intent.setData(Uri.parse(String.format("package:%s", getPackageName())));
+
 									startActivityForResult(intent, REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
 								}
-								catch (Exception e)
+								catch (android.content.ActivityNotFoundException e)
 								{
-									Intent intent = new Intent();
-									intent.setAction(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
-									startActivityForResult(intent, REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
+									try
+									{
+										Intent intent = new Intent(
+											Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+
+										startActivityForResult(
+											intent,
+											REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS);
+									}
+									catch (android.content.ActivityNotFoundException e2)
+									{
+										Log.w("MainMenuActivity",
+											"All files access settings are not available on this device.");
+										// The device does not provide an all files access
+										checkPermissions = false;
+										finalStartup();
+									}
 								}
+							}
+							else
+							{
+								/* User rejected all files access - data written to private storage */
+								finalStartup();
 							}
 						}
 					});
@@ -147,22 +179,6 @@ public final class MainMenuActivity extends PreferenceActivity
 		if (!checkPermissions)
 		{
 			finalStartup();
-		}
-	}
-
-	@Override
-	protected void onResume()
-	{
-		super.onResume();
-
-		// If the user just came back from settings and granted the permission, boot immediately
-		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
-		{
-			if (Environment.isExternalStorageManager() && checkPermissions)
-			{
-				checkPermissions = false;
-				finalStartup();
-			}
 		}
 	}
 
@@ -295,5 +311,17 @@ public final class MainMenuActivity extends PreferenceActivity
 			finalStartup();
 		else
 			checkRuntimePermissions();
+	}
+
+	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data)
+	{
+		super.onActivityResult(requestCode, resultCode, data);
+
+		if (requestCode == REQUEST_CODE_ASK_MULTIPLE_PERMISSIONS)
+		{
+			checkPermissions = false;
+			finalStartup();
+		}
 	}
 }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

1. Fixes smb on 32-bit android
2. Fixes crash when declining all files access.
3. Fixes path to data when declined all files access
4. Logs all keyboard entry when android TV remote is being used (only in debug mode)

## Related Issues


## Related Pull Requests

## Reviewers
