### PR TITLE
SDL3: Fix text input boxes, and Clipboard pasting

### DIFF
--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -620,8 +620,7 @@ static uint16_t sdl3_translate_mod(SDL_Keymod smod)
    return mod;
 }
 
-/* Gets the text in the clipboard, and interprets it as libretro
- * keyboard input. */
+/* Grabs text from the clipboard, and passes it as keyboard input. */
 static void sdl3_paste_clipboard(void)
 {
    char *text      = SDL_GetClipboardText();

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -598,6 +598,7 @@ static void sdl3_poll_touch(sdl3_input_t *sdl)
    sdl->num_touch_devices = num_direct;
 }
 
+/* Translates an SDL_Keymod to a RETROKMOD. */
 static uint16_t sdl3_translate_mod(SDL_Keymod smod)
 {
    uint16_t mod = 0;
@@ -618,6 +619,25 @@ static uint16_t sdl3_translate_mod(SDL_Keymod smod)
       mod |= RETROKMOD_SCROLLOCK;
 
    return mod;
+}
+
+/* Translates control/modifier keys into their ASCII character counterpart. */
+static uint32_t sdl3_translate_control_key(unsigned code, uint16_t mod)
+{
+   switch (code)
+   {
+      case RETROK_BACKSPACE:
+      case RETROK_TAB:
+      case RETROK_RETURN:
+      case RETROK_ESCAPE:
+      case RETROK_DELETE:
+      case RETROK_KP_ENTER:
+         return input_keymaps_translate_rk_to_ascii((enum retro_key)code, (enum retro_mod)mod);
+      default:
+         break;
+   }
+
+   return 0;
 }
 
 /* Grabs text from the clipboard, and passes it as keyboard input. */
@@ -680,12 +700,9 @@ static void sdl3_input_poll(void *data)
             continue;
          }
 
-         /* Character 0: typed characters are delivered separately
-          * through SDL_EVENT_TEXT_INPUT below (mirroring the win32
-          * WM_KEYDOWN / WM_CHAR split), so don't also synthesize one
-          * from the keycode or text entry would double up. */
          input_keyboard_event(event.type == SDL_EVENT_KEY_DOWN,
-               code, 0, mod, RETRO_DEVICE_KEYBOARD);
+               code, sdl3_translate_control_key(code, mod), mod,
+               RETRO_DEVICE_KEYBOARD);
       }
       else if (event.type == SDL_EVENT_TEXT_INPUT)
       {

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -636,8 +636,7 @@ static void sdl3_paste_clipboard(void)
       /* Skip newline and backspace characters, since those would
        * negatively affect the input. */
       if (c >= 0x20 && c != 0x7f)
-         input_keyboard_event(true, RETROK_UNKNOWN, c, 0,
-               RETRO_DEVICE_KEYBOARD);
+         input_keyboard_event(true, RETROK_UNKNOWN, c, 0, RETRO_DEVICE_KEYBOARD);
    }
 
    SDL_free(text);

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -620,6 +620,32 @@ static uint16_t sdl3_translate_mod(SDL_Keymod smod)
    return mod;
 }
 
+/* Feeds the clipboard text through the keyboard-line character path,
+ * one codepoint at a time, as if the user had typed it. Only called
+ * while line input (netplay password, achievement login, search,
+ * on-screen keyboard) is active. */
+static void sdl3_paste_clipboard(void)
+{
+   char *text      = SDL_GetClipboardText();
+   const char *ptr = text;
+
+   if (!text)
+      return;
+
+   while (*ptr)
+   {
+      uint32_t c = utf8_walk(&ptr);
+
+      /* Drop control characters: a pasted newline would submit the
+       * line and DEL/backspace would eat previous input. */
+      if (c >= 0x20 && c != 0x7f)
+         input_keyboard_event(true, RETROK_UNKNOWN, c, 0,
+               RETRO_DEVICE_KEYBOARD);
+   }
+
+   SDL_free(text);
+}
+
 static void sdl3_input_poll(void *data)
 {
    SDL_Event event;
@@ -647,6 +673,20 @@ static void sdl3_input_poll(void *data)
          uint16_t mod  = sdl3_translate_mod(event.key.mod);
          unsigned code = input_keymaps_translate_keysym_to_rk(
                event.key.key);
+
+         /* Ctrl+V pastes the clipboard into an active keyboard line
+          * (Ctrl combinations produce no SDL_EVENT_TEXT_INPUT, so
+          * nothing is double-delivered below). Swallow the key-down
+          * entirely; the matching key-up still goes through and is
+          * ignored by the line editor. */
+         if (     event.type == SDL_EVENT_KEY_DOWN
+               && event.key.key == SDLK_V
+               && (event.key.mod & SDL_KMOD_CTRL)
+               && input_state_get_ptr()->keyboard_line.enabled)
+         {
+            sdl3_paste_clipboard();
+            continue;
+         }
 
          /* Character 0: typed characters are delivered separately
           * through SDL_EVENT_TEXT_INPUT below (mirroring the win32

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -634,7 +634,6 @@ static void sdl3_paste_clipboard(void)
    {
       uint32_t c = utf8_walk(&ptr);
 
-      /* Drop control characters: a pasted newline would submit the
       /* Skip newline and backspace characters, since those would
        * negatively affect the input. */
       if (c >= 0x20 && c != 0x7f)

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -623,7 +623,7 @@ static uint16_t sdl3_translate_mod(SDL_Keymod smod)
 /* Grabs text from the clipboard, and passes it as keyboard input. */
 static void sdl3_paste_clipboard(void)
 {
-   char *text      = SDL_GetClipboardText();
+   char *text = SDL_GetClipboardText();
    const char *ptr = text;
 
    if (!text)

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -620,10 +620,8 @@ static uint16_t sdl3_translate_mod(SDL_Keymod smod)
    return mod;
 }
 
-/* Feeds the clipboard text through the keyboard-line character path,
- * one codepoint at a time, as if the user had typed it. Only called
- * while line input (netplay password, achievement login, search,
- * on-screen keyboard) is active. */
+/* Gets the text in the clipboard, and interprets it as libretro
+ * keyboard input. */
 static void sdl3_paste_clipboard(void)
 {
    char *text      = SDL_GetClipboardText();
@@ -637,7 +635,8 @@ static void sdl3_paste_clipboard(void)
       uint32_t c = utf8_walk(&ptr);
 
       /* Drop control characters: a pasted newline would submit the
-       * line and DEL/backspace would eat previous input. */
+      /* Skip newline and backspace characters, since those would
+       * negatively affect the input. */
       if (c >= 0x20 && c != 0x7f)
          input_keyboard_event(true, RETROK_UNKNOWN, c, 0,
                RETRO_DEVICE_KEYBOARD);
@@ -674,11 +673,7 @@ static void sdl3_input_poll(void *data)
          unsigned code = input_keymaps_translate_keysym_to_rk(
                event.key.key);
 
-         /* Ctrl+V pastes the clipboard into an active keyboard line
-          * (Ctrl combinations produce no SDL_EVENT_TEXT_INPUT, so
-          * nothing is double-delivered below). Swallow the key-down
-          * entirely; the matching key-up still goes through and is
-          * ignored by the line editor. */
+         /* Allow pasting the clipboard. */
          if (     event.type == SDL_EVENT_KEY_DOWN
                && event.key.key == SDLK_V
                && (event.key.mod & SDL_KMOD_CTRL)

--- a/retroarch.c
+++ b/retroarch.c
@@ -8355,6 +8355,20 @@ bool retroarch_main_init(int argc, char *argv[])
       RARCH_ERR("%s: \"%s\"\n",
             msg_hash_to_str(MSG_FATAL_ERROR_RECEIVED_IN),
             global_get_ptr()->error_string);
+#ifdef HAVE_SDL3
+      /* Fatal startup errors otherwise only reach the log; there is
+       * no window yet to display anything in. SDL3 message boxes are
+       * documented to be safe to call at any time, even before
+       * SDL_Init(), so pop up a native dialog for the user. */
+      {
+         char _msg[NAME_MAX_LENGTH + 64];
+         snprintf(_msg, sizeof(_msg), "%s: \"%s\"",
+               msg_hash_to_str(MSG_FATAL_ERROR_RECEIVED_IN),
+               global->error_string);
+         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
+               msg_hash_to_str(MSG_PROGRAM), _msg, NULL);
+      }
+#endif
       goto error;
    }
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -8355,20 +8355,6 @@ bool retroarch_main_init(int argc, char *argv[])
       RARCH_ERR("%s: \"%s\"\n",
             msg_hash_to_str(MSG_FATAL_ERROR_RECEIVED_IN),
             global_get_ptr()->error_string);
-#ifdef HAVE_SDL3
-      /* Fatal startup errors otherwise only reach the log; there is
-       * no window yet to display anything in. SDL3 message boxes are
-       * documented to be safe to call at any time, even before
-       * SDL_Init(), so pop up a native dialog for the user. */
-      {
-         char _msg[NAME_MAX_LENGTH + 64];
-         snprintf(_msg, sizeof(_msg), "%s: \"%s\"",
-               msg_hash_to_str(MSG_FATAL_ERROR_RECEIVED_IN),
-               global->error_string);
-         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
-               msg_hash_to_str(MSG_PROGRAM), _msg, NULL);
-      }
-#endif
       goto error;
    }
 


### PR DESCRIPTION
This does two things for SDL3:

1. Fixes text input, for like entering your username, so you can use backspace, and ENTER to submit it
2. Allows you to paste text from your clipboard

<img width="922" height="626" alt="Screenshot from 2026-08-13 17-01-07" src="https://github.com/user-attachments/assets/32a6bf03-7e34-4ddf-963a-71f456bd3362" />
