### PR TITLE
SDL3: Add `get_metrics` for GL/Vulkan contexts

### DIFF
--- a/gfx/common/sdl3_common.c
+++ b/gfx/common/sdl3_common.c
@@ -459,30 +459,31 @@ void sdl3_ctx_check_window(void *data, bool *quit, bool *resize,
 bool sdl3_ctx_get_metrics(void *data,
       enum display_metric_types type, float *value)
 {
+   float scale;
    SDL_Window *win       = sdl3_ctx_window(data);
    SDL_DisplayID display = win
          ? SDL_GetDisplayForWindow(win)
          : SDL_GetPrimaryDisplay();
 
-   switch (type)
+   /* DPI is the only metric this can answer. Of the rest, MM_WIDTH
+    * and MM_HEIGHT are asked for (System Information) but SDL3
+    * exposes no physical display size to answer them with, and
+    * PIXEL_WIDTH / PIXEL_HEIGHT are only ever queried through the
+    * display server interface, never through a context driver. */
+   if (type != DISPLAY_METRIC_DPI)
    {
-      case DISPLAY_METRIC_DPI:
-         {
-            /* SDL3 only exposes the desktop scale factor, not the
-             * physical DPI, so report it relative to the 96 DPI
-             * baseline (X11: Xft.dpi, Wayland: compositor scale). */
-            float scale = SDL_GetDisplayContentScale(display);
-            if (scale <= 0.0f)
-               return false;
-            *value = scale * 96.0f;
-         }
-         return true;
-      default:
-         break;
+      *value = 0.0f;
+      return false;
    }
 
-   *value = 0.0f;
-   return false;
+   /* SDL3 only exposes the desktop scale factor, not the physical
+    * DPI, so report it relative to the 96 DPI baseline (X11:
+    * Xft.dpi, Wayland: compositor scale). */
+   if ((scale = SDL_GetDisplayContentScale(display)) <= 0.0f)
+      return false;
+
+   *value = scale * 96.0f;
+   return true;
 }
 
 void sdl3_show_mouse(void *data, bool state)

--- a/gfx/common/sdl3_common.c
+++ b/gfx/common/sdl3_common.c
@@ -460,16 +460,12 @@ bool sdl3_ctx_get_metrics(void *data,
       enum display_metric_types type, float *value)
 {
    float scale;
-   SDL_Window *win       = sdl3_ctx_window(data);
+   SDL_Window *win = sdl3_ctx_window(data);
    SDL_DisplayID display = win
          ? SDL_GetDisplayForWindow(win)
          : SDL_GetPrimaryDisplay();
 
-   /* DPI is the only metric this can answer. Of the rest, MM_WIDTH
-    * and MM_HEIGHT are asked for (System Information) but SDL3
-    * exposes no physical display size to answer them with, and
-    * PIXEL_WIDTH / PIXEL_HEIGHT are only ever queried through the
-    * display server interface, never through a context driver. */
+   /* This currently only reports on the display's metric DPI. */
    if (type != DISPLAY_METRIC_DPI)
    {
       *value = 0.0f;
@@ -477,8 +473,8 @@ bool sdl3_ctx_get_metrics(void *data,
    }
 
    /* SDL3 only exposes the desktop scale factor, not the physical
-    * DPI, so report it relative to the 96 DPI baseline (X11:
-    * Xft.dpi, Wayland: compositor scale). */
+    * DPI, so use a 96 DPI baseline. For reference, X11 has Xft.dpi,
+    * and Wayland uses the compositor scale. */
    if ((scale = SDL_GetDisplayContentScale(display)) <= 0.0f)
       return false;
 

--- a/gfx/common/sdl3_common.c
+++ b/gfx/common/sdl3_common.c
@@ -460,10 +460,7 @@ bool sdl3_ctx_get_metrics(void *data,
       enum display_metric_types type, float *value)
 {
    float scale;
-   SDL_Window *win = sdl3_ctx_window(data);
-   SDL_DisplayID display = win
-         ? SDL_GetDisplayForWindow(win)
-         : SDL_GetPrimaryDisplay();
+   SDL_Window *win;
 
    /* This currently only reports on the display's metric DPI. */
    if (type != DISPLAY_METRIC_DPI)
@@ -472,11 +469,21 @@ bool sdl3_ctx_get_metrics(void *data,
       return false;
    }
 
+   /* Find the scale from the window, or the primary display if the
+    * window doesn't exist yet. */
+   if ((win = sdl3_ctx_window(data)))
+      scale = SDL_GetWindowDisplayScale(win);
+   else
+      scale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
+
    /* SDL3 only exposes the desktop scale factor, not the physical
     * DPI, so use a 96 DPI baseline. For reference, X11 has Xft.dpi,
     * and Wayland uses the compositor scale. */
-   if ((scale = SDL_GetDisplayContentScale(display)) <= 0.0f)
+   if (scale <= 0.0f)
+   {
+      *value = 0.0f;
       return false;
+   }
 
    *value = scale * 96.0f;
    return true;

--- a/gfx/common/sdl3_common.c
+++ b/gfx/common/sdl3_common.c
@@ -456,6 +456,35 @@ void sdl3_ctx_check_window(void *data, bool *quit, bool *resize,
       sdl3_window_get_video_size(win, width, height);
 }
 
+bool sdl3_ctx_get_metrics(void *data,
+      enum display_metric_types type, float *value)
+{
+   SDL_Window *win       = sdl3_ctx_window(data);
+   SDL_DisplayID display = win
+         ? SDL_GetDisplayForWindow(win)
+         : SDL_GetPrimaryDisplay();
+
+   switch (type)
+   {
+      case DISPLAY_METRIC_DPI:
+         {
+            /* SDL3 only exposes the desktop scale factor, not the
+             * physical DPI, so report it relative to the 96 DPI
+             * baseline (X11: Xft.dpi, Wayland: compositor scale). */
+            float scale = SDL_GetDisplayContentScale(display);
+            if (scale <= 0.0f)
+               return false;
+            *value = scale * 96.0f;
+         }
+         return true;
+      default:
+         break;
+   }
+
+   *value = 0.0f;
+   return false;
+}
+
 void sdl3_show_mouse(void *data, bool state)
 {
    if (state)

--- a/gfx/common/sdl3_common.h
+++ b/gfx/common/sdl3_common.h
@@ -115,11 +115,8 @@ bool sdl3_ctx_has_focus(void *data);
 void sdl3_ctx_check_window(void *data, bool *quit, bool *resize,
       unsigned *width, unsigned *height);
 
-/* Reports DISPLAY_METRIC_DPI derived from the display content scale
- * (scale * 96 DPI). Every other metric returns false: SDL3 exposes
- * no physical display size for MM_WIDTH/MM_HEIGHT, and the
- * PIXEL_WIDTH/PIXEL_HEIGHT pair is never asked of a context
- * driver. */
+/* Retrieve the DISPLAY_METRIC_DPI for the display content scale.
+ * This usually ends up being scale * 96 DPI, or false otherwise. */
 bool sdl3_ctx_get_metrics(void *data, enum display_metric_types type,
       float *value);
 

--- a/gfx/common/sdl3_common.h
+++ b/gfx/common/sdl3_common.h
@@ -115,7 +115,7 @@ bool sdl3_ctx_has_focus(void *data);
 void sdl3_ctx_check_window(void *data, bool *quit, bool *resize,
       unsigned *width, unsigned *height);
 
-/* Retrieve the DISPLAY_METRIC_DPI for the display content scale.
+/* Retrieve the DISPLAY_METRIC_DPI for the window's display scale.
  * This usually ends up being scale * 96 DPI, or false otherwise. */
 bool sdl3_ctx_get_metrics(void *data, enum display_metric_types type,
       float *value);

--- a/gfx/common/sdl3_common.h
+++ b/gfx/common/sdl3_common.h
@@ -116,8 +116,10 @@ void sdl3_ctx_check_window(void *data, bool *quit, bool *resize,
       unsigned *width, unsigned *height);
 
 /* Reports DISPLAY_METRIC_DPI derived from the display content scale
- * (scale * 96 DPI). SDL3 exposes no physical display size, so the
- * MM_WIDTH/MM_HEIGHT metrics are unavailable and return false. */
+ * (scale * 96 DPI). Every other metric returns false: SDL3 exposes
+ * no physical display size for MM_WIDTH/MM_HEIGHT, and the
+ * PIXEL_WIDTH/PIXEL_HEIGHT pair is never asked of a context
+ * driver. */
 bool sdl3_ctx_get_metrics(void *data, enum display_metric_types type,
       float *value);
 

--- a/gfx/common/sdl3_common.h
+++ b/gfx/common/sdl3_common.h
@@ -115,6 +115,12 @@ bool sdl3_ctx_has_focus(void *data);
 void sdl3_ctx_check_window(void *data, bool *quit, bool *resize,
       unsigned *width, unsigned *height);
 
+/* Reports DISPLAY_METRIC_DPI derived from the display content scale
+ * (scale * 96 DPI). SDL3 exposes no physical display size, so the
+ * MM_WIDTH/MM_HEIGHT metrics are unavailable and return false. */
+bool sdl3_ctx_get_metrics(void *data, enum display_metric_types type,
+      float *value);
+
 /* Shows or hides the mouse cursor. */
 void sdl3_show_mouse(void *data, bool state);
 

--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -325,7 +325,7 @@ const gfx_ctx_driver_t gfx_ctx_sdl3_gl =
    NULL, /* get_video_output_size */
    NULL, /* get_video_output_prev */
    NULL, /* get_video_output_next */
-   NULL, /* get_metrics */
+   sdl3_ctx_get_metrics,
    NULL, /* translate_aspect */
    sdl3_ctx_update_title,
    sdl3_ctx_check_window,

--- a/gfx/drivers_context/sdl3_vk_ctx.c
+++ b/gfx/drivers_context/sdl3_vk_ctx.c
@@ -276,7 +276,7 @@ const gfx_ctx_driver_t gfx_ctx_sdl3_vk = {
    NULL, /* get_video_output_size */
    NULL, /* get_video_output_prev */
    NULL, /* get_video_output_next */
-   NULL, /* get_metrics */
+   sdl3_ctx_get_metrics,
    NULL, /* translate_aspect */
    sdl3_ctx_update_title,
    sdl3_vk_ctx_check_window,


### PR DESCRIPTION
This allows the SDL3 GL and Vulkan contexts to grab the display metrics. It uses the window if it exists, or assumes the primary display otherwise.

Thanks to @Ryunam for opening up the other DPI scaling PR, which reminded me I had to do this.