### PR TITLE
android: fallback to media when all access to files declined

### DIFF
--- a/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
+++ b/pkg/android/phoenix/src/com/retroarch/browser/mainmenu/MainMenuActivity.java
@@ -269,8 +269,14 @@ public final class MainMenuActivity extends PreferenceActivity
 		retro.putExtra("APK", dataSourcePath);
 
 		String external;
-		if (BuildConfig.PLAY_STORE_BUILD)
+
+		boolean hasFullStorageAccess = true;
+		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R)
+			hasFullStorageAccess = Environment.isExternalStorageManager();
+
+		if (BuildConfig.PLAY_STORE_BUILD || !hasFullStorageAccess)
 		{
+			// use the scoped external media directory
 			File[] mediaDirs = ctx.getExternalMediaDirs();
 			if (mediaDirs != null && mediaDirs.length > 0 && mediaDirs[0] != null)
 			{
@@ -281,13 +287,14 @@ public final class MainMenuActivity extends PreferenceActivity
 			}
 			else
 			{
-				// Fallback: external media unavailable
+				// fallback: external media unavailable - use private data storage
 				external = Environment.getExternalStorageDirectory().getAbsolutePath()
 						+ "/Android/data/" + PACKAGE_NAME + "/files";
 			}
 		}
 		else
 		{
+			// full "all files access" granted (or pre-R) - use the real SD root /RetroArch
 			external = Environment.getExternalStorageDirectory().getAbsolutePath();
 		}
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

This PR unifies storage locations in Android on sideload.

If a user agrees to all file access, storage will now be:

- /RetroArch (unchanged)

If a user declines all file access, storage will now be:

- mtp://xx/Internal%20storage/Android/media/com.retroarch.xx/RetroArch

If /media does not exist (old Android versions), it will fall back to:

- mtp://xx/Internal%20storage/Android/data/com.retroarch.xx/files/RetroArch

## Related Issues


## Related Pull Requests


## Reviewers
