### PR TITLE
linux: set cache directory needed for extracting zips over smb

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -222,6 +222,20 @@ int system_property_get(const char *command,
    return __len;
 }
 
+bool test_permissions(const char *path)
+{
+   char buf[PATH_MAX_LENGTH];
+   bool ret                  = false;
+
+   fill_pathname_join_special(buf, path, ".retroarch", sizeof(buf));
+   ret = path_mkdir(buf);
+
+   if (ret)
+      rmdir(buf);
+
+   return ret;
+}
+
 #ifdef ANDROID
 /* forward declaration */
 bool android_run_events(void *data);
@@ -670,7 +684,7 @@ static bool device_is_game_console(const char *name)
    return false;
 }
 
-bool test_permissions(const char *path)
+bool test_permissions_android(const char *path)
 {
    char buf[PATH_MAX_LENGTH];
    bool ret                  = false;
@@ -1933,12 +1947,12 @@ static void frontend_unix_get_env(int *argc,
        * to internal_storage_path */
 
       if (*internal_storage_path &&
-         test_permissions(internal_storage_path))
+         test_permissions_android(internal_storage_path))
       {
          storage_permissions = INTERNAL_STORAGE_WRITABLE;
       }
       else if (*internal_storage_app_path &&
-               test_permissions(internal_storage_app_path))
+               test_permissions_android(internal_storage_app_path))
       {
          storage_permissions = INTERNAL_STORAGE_APPDIR_WRITABLE;
       }
@@ -2316,6 +2330,17 @@ static void frontend_unix_get_env(int *argc,
    else
        fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SYSTEM], base_path,
              "system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
+
+   if (test_permissions("/tmp"))
+   {
+      fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CACHE], "/",
+         "tmp", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
+   }
+   else
+   {
+      fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CACHE], base_path,
+         "cache", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
+   }
 #endif
 
 #ifndef IS_SALAMANDER


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

ZIPs fail to extract when using SMB due to no temporary directory set to extract to on Linux and derivatives.

## Related Issues

## Related Pull Requests

## Reviewers
