### PR TITLE
linux: use subdirectory for cache folder

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2331,10 +2331,10 @@ static void frontend_unix_get_env(int *argc,
        fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_SYSTEM], base_path,
              "system", sizeof(g_defaults.dirs[DEFAULT_DIR_SYSTEM]));
 
-   if (test_permissions("/tmp"))
+   if (test_permissions("/tmp") && path_mkdir("/tmp/retroarch-tmp"))
    {
-      fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CACHE], "/",
-         "tmp", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
+      fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CACHE], "/tmp",
+         "retroarch-tmp", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
    }
    else
    {


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

As a follow up, use a subdirectory in /tmp instead of /tmp itself on linux. Just in case there is a future need for automatic cache clearing in RA.

## Related Issues

## Related Pull Requests

## Reviewers
