### PR TITLE
Make the manual content scan non-blocking: budgeted BEGIN/END states, resumable dir walk, I/O-free DAT parser

### DIFF
--- a/.github/workflows/Linux-samples-tasks.yml
+++ b/.github/workflows/Linux-samples-tasks.yml
@@ -434,6 +434,68 @@ jobs:
              ./image_decode_slice_test
           echo "[pass] image_decode_slice_test (ASan)"
 
+      - name: Build and run scan_begin_budget_test (plain, ASan + UBSan, TSan)
+        shell: bash
+        working-directory: samples/tasks/database
+        run: |
+          set -eu
+          # Pacing + throughput oracle for the manual content scanner's
+          # BEGIN/END split in tasks/task_database.c, compiled from the
+          # tree so it exercises the shipping translation units.
+          #
+          # The regression it pins: MANUAL_SCAN_BEGIN used to perform
+          # the entire recursive directory walk, the whole DAT load and
+          # the playlist setup in one handler invocation, and
+          # MANUAL_SCAN_END flushed every accumulated result (each add
+          # a linear playlist_entry_exists probe) plus a sort and a
+          # write in another - 166 ms measured for the 5000-file
+          # fixture, a hard frame freeze whenever Threaded Tasks is
+          # off.  Both are now sequences of sub-states under the shared
+          # per-frame I/O window (tasks/task_nbio_slice.c, the same
+          # window the file-transfer spine uses), with completed
+          # sub-states collapsing into one gather so small libraries
+          # keep single-tick latency.
+          #
+          # Three wall-clock assertions guard the plain build, because
+          # any one alone can be satisfied by a scanner that is worse:
+          # pacing (no gather over the window plus bounded slack),
+          # first feedback within two frames of the push, and total
+          # scan time within a factor of the blocking walk + DAT parse
+          # it replaced - a scanner that no longer freezes but takes
+          # twice as long fails the third lane.  Playlist parity (every
+          # fixture file present exactly once) is asserted in every
+          # mode.
+          #
+          # The sanitizer runs use the 'sanitize' mode, which runs
+          # every lane but skips the wall-clock assertions a sanitized
+          # build cannot honestly meet.  Those lanes are where the
+          # in-flight resources the split introduced - an open
+          # directory iterator, an open DAT stream over a half-filled
+          # buffer, an open flush playlist - are made to die at every
+          # phase: a 14-point cancellation sweep lands a cancel in
+          # setup, mid-walk, mid-DAT-read, content iteration and
+          # mid-flush, and LeakSanitizer decides whether the teardown
+          # released everything (it already found one 16-byte-per-scan
+          # leak that predates the split).  The threaded lane runs the
+          # same scan under the threaded queue and is the TSan target:
+          # the shared window deliberately opts threaded queues out of
+          # its static state, and this is where a mistake in that
+          # opt-out would surface.
+          make clean all
+          test -x scan_begin_budget_test
+          timeout 600 ./scan_begin_budget_test
+          echo "[pass] scan_begin_budget_test"
+          make clean all SANITIZER=address,undefined
+          ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+             UBSAN_OPTIONS=print_stacktrace=1 timeout 900 \
+             ./scan_begin_budget_test sanitize
+          echo "[pass] scan_begin_budget_test (ASan)"
+          make clean all SANITIZER=thread
+          TSAN_OPTIONS=halt_on_error=1 timeout 900 \
+             ./scan_begin_budget_test sanitize
+          make clean
+          echo "[pass] scan_begin_budget_test (TSan)"
+
       - name: Build and run save_state_io_test (ASan + UBSan, TSan)
         shell: bash
         working-directory: samples/tasks/save_state
@@ -604,7 +666,13 @@ jobs:
                    tasks/task_pl_thumbnail_download.c \
                    tasks/task_core_backup.c \
                    core_backup.c \
-                   libretro-common/streams/interface_stream.c; do
+                   libretro-common/streams/interface_stream.c \
+                   tasks/task_file_transfer.c \
+                   tasks/task_nbio_slice.c \
+                   libretro-common/lists/dir_list.c \
+                   libretro-common/formats/logiqx_dat/logiqx_dat.c \
+                   libretro-common/formats/xml/rxml.c \
+                   database_info.c; do
             if gcc -fsyntax-only $C89 $INC $DEF "$f"; then
               echo "[pass] C89 $f"
             else

--- a/Makefile.common
+++ b/Makefile.common
@@ -265,6 +265,7 @@ OBJ += \
        tasks/task_save.o \
        tasks/task_movie.o \
        tasks/task_file_transfer.o \
+       tasks/task_nbio_slice.o \
        tasks/task_content_prefetch.o \
        tasks/task_image.o \
        tasks/task_playlist_manager.o \

--- a/database_info.c
+++ b/database_info.c
@@ -809,6 +809,26 @@ database_info_handle_t *database_info_dir_init(const char *dir,
    return db;
 }
 
+database_info_handle_t *database_info_dir_init_from_list(
+      enum database_type type, struct string_list *list)
+{
+   database_info_handle_t *db = (database_info_handle_t*)
+      malloc(sizeof(*db));
+
+   if (!db)
+      return NULL;
+
+   /* dir list prioritize - same cue/gdi ordering as
+    * database_info_dir_init() */
+   qsort(list->elems, list->size, sizeof(*list->elems),
+         dir_entry_compare);
+
+   db->status = DATABASE_STATUS_ITERATE;
+   db->type   = type;
+
+   return db;
+}
+
 database_info_handle_t *database_info_file_init(const char *path,
       enum database_type type, retro_task_t *task, struct string_list **content_list)
 {

--- a/database_info.h
+++ b/database_info.h
@@ -226,6 +226,15 @@ database_info_handle_t *database_info_dir_init(const char *dir,
       bool show_hidden_files, bool recursive, bool include_archive, 
       struct string_list **content_list);
 
+/* As database_info_dir_init(), but over a content list the caller has
+ * already built (e.g. incrementally via dir_list_iter_step() so the
+ * walk could be spread across task gathers).  Applies the same
+ * cue/gdi-prioritising sort the directory variant applies and borrows
+ * @list without taking ownership.  Returns NULL only on allocation
+ * failure. */
+database_info_handle_t *database_info_dir_init_from_list(
+      enum database_type type, struct string_list *list);
+
 database_info_handle_t *database_info_file_init(const char *path,
       enum database_type type, retro_task_t *task, struct string_list **content_list);
 

--- a/griffin/griffin.c
+++ b/griffin/griffin.c
@@ -1418,6 +1418,7 @@ DATA RUNLOOP
 #include "../tasks/task_content_prefetch.c"
 #include "../tasks/task_image.c"
 #include "../tasks/task_file_transfer.c"
+#include "../tasks/task_nbio_slice.c"
 #include "../tasks/task_playlist_manager.c"
 #include "../tasks/task_core_backup.c"
 #ifdef HAVE_TRANSLATE

--- a/libretro-common/formats/logiqx_dat/logiqx_dat.c
+++ b/libretro-common/formats/logiqx_dat/logiqx_dat.c
@@ -20,7 +20,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <file/file_path.h>
 #include <string/stdstring.h>
 #include <formats/rxml.h>
 
@@ -66,30 +65,6 @@ const char *logiqx_dat_html_code_list[][2] = {
 };
 
 #define LOGIQX_DAT_HTML_CODE_LIST_SIZE 5
-
-/* Validation */
-
-/* Returns true if @path carries a file extension a
- * Logiqx XML DAT file may legitimately have (.dat or
- * .xml, case-insensitive).  A pure string check -
- * no file system access.  Existence and size checks
- * are the caller's job; this module performs no I/O. */
-bool logiqx_dat_extension_is_valid(const char *path)
-{
-   const char *file_ext = NULL;
-
-   if (!path || !*path)
-      return false;
-
-   /* Check file extension */
-   file_ext = path_get_extension(path);
-
-   if (!file_ext || !*file_ext)
-      return false;
-
-   return    string_is_equal_noncase(file_ext, "dat")
-          || string_is_equal_noncase(file_ext, "xml");
-}
 
 /* Initialisation/de-initialisation */
 

--- a/libretro-common/formats/logiqx_dat/logiqx_dat.c
+++ b/libretro-common/formats/logiqx_dat/logiqx_dat.c
@@ -42,13 +42,11 @@ struct logiqx_dat
    rxml_document_t *data;
    rxml_node_t *current_node;
    /* Lazy search index, built on the first logiqx_dat_search() and
-    * sorted by name for binary search.  logiqx_dat_search() used to
-    * walk every child of the root per call; the manual content
-    * scanner calls it once per content file, which made a DAT-backed
-    * scan O(files x games) - 29% of a 5000-file scan's wall time
-    * under gprof, and quadratic into MAME-sized lists.  On any
-    * allocation failure index_failed is set and the linear walk
-    * remains the answer. */
+    * sorted by name for binary search: without it every search
+    * walks every child of the root, which is O(files x games) for
+    * the scanner's per-file label lookups and quadratic into
+    * MAME-sized lists.  On any allocation failure index_failed is
+    * set and the linear walk remains the answer. */
    logiqx_dat_index_entry_t *index;
    size_t index_size;
    bool index_failed;

--- a/libretro-common/formats/logiqx_dat/logiqx_dat.c
+++ b/libretro-common/formats/logiqx_dat/logiqx_dat.c
@@ -26,11 +26,33 @@
 
 #include <formats/logiqx_dat.h>
 
+/* One entry of the lazy search index: a game node keyed by its
+ * 'name' attribute, with its position in the document so ties
+ * between duplicate names resolve to the first occurrence - the
+ * same answer the linear scan gives. */
+typedef struct
+{
+   const char *name;   /* points into the document's own storage */
+   rxml_node_t *node;
+   size_t seq;
+} logiqx_dat_index_entry_t;
+
 /* Holds all internal DAT file data */
 struct logiqx_dat
 {
    rxml_document_t *data;
    rxml_node_t *current_node;
+   /* Lazy search index, built on the first logiqx_dat_search() and
+    * sorted by name for binary search.  logiqx_dat_search() used to
+    * walk every child of the root per call; the manual content
+    * scanner calls it once per content file, which made a DAT-backed
+    * scan O(files x games) - 29% of a 5000-file scan's wall time
+    * under gprof, and quadratic into MAME-sized lists.  On any
+    * allocation failure index_failed is set and the linear walk
+    * remains the answer. */
+   logiqx_dat_index_entry_t *index;
+   size_t index_size;
+   bool index_failed;
 };
 
 /* List of HTML formatting codes that must
@@ -143,6 +165,12 @@ void logiqx_dat_free(logiqx_dat_t *dat_file)
       return;
 
    dat_file->current_node = NULL;
+
+   if (dat_file->index)
+   {
+      free(dat_file->index);
+      dat_file->index = NULL;
+   }
 
    if (dat_file->data)
    {
@@ -405,6 +433,84 @@ bool logiqx_dat_get_next(
 /* Fetches information for the specified game.
  * Returns false if game does not exist, or arguments
  * are invalid. */
+/* qsort comparator for the search index: by name, then by document
+ * position, so equal names keep document order and the leftmost
+ * match is the first occurrence. */
+static int logiqx_dat_index_compare(const void *a_, const void *b_)
+{
+   const logiqx_dat_index_entry_t *a = (const logiqx_dat_index_entry_t*)a_;
+   const logiqx_dat_index_entry_t *b = (const logiqx_dat_index_entry_t*)b_;
+   int cmp = strcmp(a->name, b->name);
+   if (cmp)
+      return cmp;
+   if (a->seq < b->seq)
+      return -1;
+   if (a->seq > b->seq)
+      return 1;
+   return 0;
+}
+
+/* Build the sorted name index over every game node that carries a
+ * non-empty 'name' attribute.  Nodes without one are exactly the
+ * nodes the linear scan could never match (the matcher rejects
+ * them), so leaving them out changes no answer. */
+static void logiqx_dat_index_build(logiqx_dat_t *dat_file)
+{
+   rxml_node_t *root_node = NULL;
+   rxml_node_t *game_node = NULL;
+   size_t count           = 0;
+
+   dat_file->index_failed = true;   /* cleared on success */
+
+   if (!(root_node = rxml_root_node(dat_file->data)))
+      return;
+
+   for (game_node = root_node->children; game_node; game_node = game_node->next)
+   {
+      if (logiqx_dat_is_game_node(game_node))
+      {
+         const char *name = rxml_node_attrib(game_node, "name");
+         if (name && *name)
+            count++;
+      }
+   }
+
+   if (!count)
+   {
+      /* An empty index is a valid one: every search misses, which
+       * is what the linear scan would conclude too. */
+      dat_file->index_size   = 0;
+      dat_file->index_failed = false;
+      return;
+   }
+
+   if (!(dat_file->index = (logiqx_dat_index_entry_t*)
+         malloc(count * sizeof(*dat_file->index))))
+      return;
+
+   count = 0;
+   for (game_node = root_node->children; game_node; game_node = game_node->next)
+   {
+      if (logiqx_dat_is_game_node(game_node))
+      {
+         const char *name = rxml_node_attrib(game_node, "name");
+         if (name && *name)
+         {
+            dat_file->index[count].name = name;
+            dat_file->index[count].node = game_node;
+            dat_file->index[count].seq  = count;
+            count++;
+         }
+      }
+   }
+
+   qsort(dat_file->index, count, sizeof(*dat_file->index),
+         logiqx_dat_index_compare);
+
+   dat_file->index_size   = count;
+   dat_file->index_failed = false;
+}
+
 bool logiqx_dat_search(
       logiqx_dat_t *dat_file, const char *game_name,
       logiqx_dat_game_info_t *game_info)
@@ -417,6 +523,34 @@ bool logiqx_dat_search(
 
    if (!dat_file->data)
       return false;
+
+   /* Build the name index on first use; on failure fall through to
+    * the linear walk below, which remains authoritative. */
+   if (!dat_file->index && !dat_file->index_size && !dat_file->index_failed)
+      logiqx_dat_index_build(dat_file);
+
+   if (!dat_file->index_failed)
+   {
+      /* Binary search for the leftmost entry with this name: lower
+       * bound over (name, seq)-sorted entries. */
+      size_t lo = 0;
+      size_t hi = dat_file->index_size;
+
+      while (lo < hi)
+      {
+         size_t mid = lo + ((hi - lo) >> 1);
+         if (strcmp(dat_file->index[mid].name, game_name) < 0)
+            lo = mid + 1;
+         else
+            hi = mid;
+      }
+
+      if (   lo < dat_file->index_size
+          && string_is_equal(dat_file->index[lo].name, game_name))
+         return logiqx_dat_parse_game_node(dat_file->index[lo].node,
+               game_info);
+      return false;
+   }
 
    /* Get root node */
    root_node = rxml_root_node(dat_file->data);

--- a/libretro-common/formats/logiqx_dat/logiqx_dat.c
+++ b/libretro-common/formats/logiqx_dat/logiqx_dat.c
@@ -47,17 +47,14 @@ const char *logiqx_dat_html_code_list[][2] = {
 
 /* Validation */
 
-/* Performs rudimentary validation of the specified
- * Logiqx XML DAT file path (not rigorous - just
- * enough to prevent obvious errors).
- * Also provides access to file size (DAT files can
- * be very large, so it is useful to have this information
- * on hand - i.e. so we can check that the system has
- * enough free memory to load the file). */
-bool logiqx_dat_path_is_valid(const char *path, uint64_t *file_size)
+/* Returns true if @path carries a file extension a
+ * Logiqx XML DAT file may legitimately have (.dat or
+ * .xml, case-insensitive).  A pure string check -
+ * no file system access.  Existence and size checks
+ * are the caller's job; this module performs no I/O. */
+bool logiqx_dat_extension_is_valid(const char *path)
 {
    const char *file_ext = NULL;
-   int64_t file_size_int;
 
    if (!path || !*path)
       return false;
@@ -68,50 +65,42 @@ bool logiqx_dat_path_is_valid(const char *path, uint64_t *file_size)
    if (!file_ext || !*file_ext)
       return false;
 
-   if (   !string_is_equal_noncase(file_ext, "dat")
-       && !string_is_equal_noncase(file_ext, "xml"))
-      return false;
-
-   /* Ensure file exists */
-   if (!path_is_valid(path))
-      return false;
-
-   /* Get file size */
-   file_size_int = path_get_size(path);
-
-   if (file_size_int <= 0)
-      return false;
-
-   if (file_size)
-      *file_size = (uint64_t)file_size_int;
-
-   return true;
+   return    string_is_equal_noncase(file_ext, "dat")
+          || string_is_equal_noncase(file_ext, "xml");
 }
 
-/* File initialisation/de-initialisation */
+/* Initialisation/de-initialisation */
 
-/* Loads specified Logiqx XML DAT file from disk.
- * Returned logiqx_dat_t object must be free'd using
- * logiqx_dat_free().
- * Returns NULL if file is invalid or a read error
- * occurs. */
-logiqx_dat_t *logiqx_dat_init(const char *path)
+/* Parses the specified Logiqx XML DAT document held in
+ * memory.  Takes ownership of @xml_data (heap, len + 1
+ * bytes, NUL-terminated at len); it is released by
+ * logiqx_dat_free(), or here on failure.  Reading the
+ * document from disk is the caller's job - this module
+ * performs no file I/O.
+ * Returns NULL if the document is not valid Logiqx/MAME
+ * XML. */
+logiqx_dat_t *logiqx_dat_init_owned(char *xml_data, size_t len)
 {
    logiqx_dat_t *dat_file = NULL;
    rxml_node_t *root_node = NULL;
 
-   /* Check file path */
-   if (!logiqx_dat_path_is_valid(path, NULL))
-      goto error;
+   if (!xml_data)
+      return NULL;
 
-   /* Create logiqx_dat_t object */
-   dat_file = (logiqx_dat_t*)calloc(1, sizeof(*dat_file));
+   /* Create logiqx_dat_t object.  On this one failure
+    * path the buffer has not yet been handed to rxml,
+    * so it is freed here to honour the ownership
+    * contract. */
+   if (!(dat_file = (logiqx_dat_t*)calloc(1, sizeof(*dat_file))))
+   {
+      free(xml_data);
+      return NULL;
+   }
 
-   if (!dat_file)
-      goto error;
-
-   /* Read file from disk */
-   dat_file->data = rxml_load_document(path);
+   /* Parse document.  rxml_load_document_owned takes
+    * the buffer: the tree points into it on success,
+    * and it is freed on failure. */
+   dat_file->data = rxml_load_document_owned(xml_data, len);
 
    if (!dat_file->data)
       goto error;

--- a/libretro-common/formats/xml/rxml.c
+++ b/libretro-common/formats/xml/rxml.c
@@ -1688,6 +1688,16 @@ rxml_document_t *rxml_load_document_string_opts(const char *str,
    return rxml_parse_owned(buf, len, opts, err);
 }
 
+rxml_document_t *rxml_load_document_owned(char *buf, size_t len)
+{
+   if (!buf)
+      return NULL;
+   /* The contract mirrors the tail of rxml_load_document: the caller
+    * hands over a NUL-terminated heap buffer and rxml_parse_owned
+    * either gives it to the document or frees it on failure. */
+   return rxml_parse_owned(buf, len, 0, NULL);
+}
+
 rxml_document_t *rxml_load_document_string(const char *str)
 {
    return rxml_load_document_string_opts(str, 0, NULL);

--- a/libretro-common/include/formats/logiqx_dat.h
+++ b/libretro-common/include/formats/logiqx_dat.h
@@ -60,23 +60,36 @@ typedef struct
 
 /* Validation */
 
-/* Performs rudimentary validation of the specified
- * Logiqx XML DAT file path (not rigorous - just
- * enough to prevent obvious errors).
- * Also provides access to file size (DAT files can
- * be very large, so it is useful to have this information
- * on hand - i.e. so we can check that the system has
- * enough free memory to load the file). */
-bool logiqx_dat_path_is_valid(const char *path, uint64_t *file_size);
+/* Returns true if @path carries a file extension a
+ * Logiqx XML DAT file may legitimately have (.dat or
+ * .xml, case-insensitive).  A pure string check: it
+ * does not touch the file system.  Callers wanting
+ * full path validation (existence, size - e.g. for
+ * free-memory checks against very large DAT files)
+ * should combine this with path_is_valid() and
+ * path_get_size() themselves; this module performs
+ * no I/O of any kind. */
+bool logiqx_dat_extension_is_valid(const char *path);
 
-/* File initialisation/de-initialisation */
+/* Initialisation/de-initialisation */
 
-/* Loads specified Logiqx XML DAT file from disk.
+/* Parses the specified Logiqx XML DAT document held
+ * in memory.  Takes ownership of @xml_data - a heap
+ * allocation of at least @len + 1 bytes with
+ * xml_data[len] == '\0' - which is kept for the
+ * lifetime of the returned object and released by
+ * logiqx_dat_free(); on failure it is freed here
+ * before NULL is returned, so the caller must not
+ * touch it again either way.
+ * Reading the document from disk is the caller's
+ * job (see e.g. the chunked, budgeted read in
+ * tasks/task_database.c); this module performs no
+ * file I/O.
  * Returned logiqx_dat_t object must be free'd using
  * logiqx_dat_free().
- * Returns NULL if file is invalid or a read error
- * occurs. */
-logiqx_dat_t *logiqx_dat_init(const char *path);
+ * Returns NULL if the document is not valid
+ * Logiqx/MAME XML. */
+logiqx_dat_t *logiqx_dat_init_owned(char *xml_data, size_t len);
 
 /* Frees specified DAT file */
 void logiqx_dat_free(logiqx_dat_t *dat_file);

--- a/libretro-common/include/formats/logiqx_dat.h
+++ b/libretro-common/include/formats/logiqx_dat.h
@@ -58,19 +58,6 @@ typedef struct
    bool is_runnable;
 } logiqx_dat_game_info_t;
 
-/* Validation */
-
-/* Returns true if @path carries a file extension a
- * Logiqx XML DAT file may legitimately have (.dat or
- * .xml, case-insensitive).  A pure string check: it
- * does not touch the file system.  Callers wanting
- * full path validation (existence, size - e.g. for
- * free-memory checks against very large DAT files)
- * should combine this with path_is_valid() and
- * path_get_size() themselves; this module performs
- * no I/O of any kind. */
-bool logiqx_dat_extension_is_valid(const char *path);
-
 /* Initialisation/de-initialisation */
 
 /* Parses the specified Logiqx XML DAT document held

--- a/libretro-common/include/formats/rxml.h
+++ b/libretro-common/include/formats/rxml.h
@@ -83,6 +83,17 @@ typedef struct rxml_parse_error
 rxml_document_t *rxml_load_document(const char *path);
 rxml_document_t *rxml_load_document_string(const char *str);
 
+/* As rxml_load_document_string, but takes ownership of @buf - a heap
+ * allocation of at least @len + 1 bytes with buf[len] == '\0' -
+ * instead of copying it.  The document keeps the buffer alive for its
+ * whole lifetime (the tree points into it) and releases it in
+ * rxml_free_document; on failure the buffer is freed here before NULL
+ * is returned, so the caller must not touch it again either way.
+ * For large inputs this halves peak memory against the copying string
+ * entry point, which is what callers that already hold the document
+ * bytes (e.g. a task that read the file itself) should care about. */
+rxml_document_t *rxml_load_document_owned(char *buf, size_t len);
+
 /* As rxml_load_document_string, with parse options; on failure, *err
  * (when non-NULL) receives the position the parser stopped at. */
 rxml_document_t *rxml_load_document_string_opts(const char *str,

--- a/libretro-common/include/lists/dir_list.h
+++ b/libretro-common/include/lists/dir_list.h
@@ -64,6 +64,72 @@ bool dir_list_append(struct string_list *list, const char *dir, const char *ext,
 struct string_list *dir_list_new(const char *dir, const char *ext,
       bool include_dirs, bool include_hidden, bool include_compressed, bool recursive);
 
+/* Resumable directory walk.
+ *
+ * Produces, incrementally, exactly the listing dir_list_new() builds
+ * in one blocking call: same entries, same filters, same order,
+ * including the post-order append of directories when @include_dirs
+ * is set and the silent skip of unreadable subdirectories.  It exists
+ * so a task handler can spread a large recursive walk across gathers
+ * under a time budget instead of freezing the frame that starts it -
+ * and it is the only walk: entries land in the caller's list as they
+ * are read, nothing is enumerated twice.  See dir_list_iter_step()
+ * for the yielding contract. */
+typedef struct dir_list_iter dir_list_iter_t;
+
+/**
+ * dir_list_iter_new:
+ * @dir                : directory path.
+ * @ext                : allowed extensions of file directory entries to include.
+ * @include_dirs       : include directories as part of the finished directory listing?
+ * @include_hidden     : include hidden files and directories as part of the finished directory listing?
+ * @include_compressed : include compressed files, even when not part of ext.
+ * @recursive          : list directory contents recursively
+ * @list               : the string list entries are appended to.  Borrowed:
+ *                       the caller keeps ownership and must keep it alive
+ *                       until the iterator is freed.
+ *
+ * Begin a resumable directory walk equivalent to
+ * dir_list_append(list, dir, ...).
+ *
+ * @return iterator on success, NULL if @dir cannot be opened (the
+ * same condition under which dir_list_new() returns NULL) or on
+ * allocation failure.  Has to be freed with dir_list_iter_free().
+ **/
+dir_list_iter_t *dir_list_iter_new(const char *dir, const char *ext,
+      bool include_dirs, bool include_hidden, bool include_compressed,
+      bool recursive, struct string_list *list);
+
+/**
+ * dir_list_iter_step:
+ * @iter          : iterator from dir_list_iter_new().
+ * @within_budget : optional; consulted between entries, return false
+ *                  to make the step yield.  NULL runs to completion.
+ * @userdata      : passed to @within_budget.
+ *
+ * Advance the walk, appending entries to the list given at creation.
+ * At least one entry is always processed per call (the floor: a queue
+ * whose budget is already spent still makes progress), after which
+ * @within_budget is consulted before each further entry.
+ *
+ * @return 1 when the walk has completed (the list now equals what
+ * dir_list_new() would have produced, pre-sort), 0 when yielding with
+ * work remaining, -1 on allocation failure (the walk is abandoned;
+ * free the iterator).
+ **/
+int dir_list_iter_step(dir_list_iter_t *iter,
+      bool (*within_budget)(void *userdata), void *userdata);
+
+/**
+ * dir_list_iter_free:
+ * @iter : iterator, may be NULL.
+ *
+ * Release the iterator, closing any directory handles still open.
+ * Safe to call at any point of the walk; the entries already appended
+ * to the caller's list remain valid.
+ **/
+void dir_list_iter_free(dir_list_iter_t *iter);
+
 /**
  * dir_list_initialize:
  *

--- a/libretro-common/lists/dir_list.c
+++ b/libretro-common/lists/dir_list.c
@@ -310,6 +310,304 @@ static int dir_list_read_ctx(size_t dir_len, struct dir_list_ctx *ctx)
    return 0;
 }
 
+/* Resumable directory walk ------------------------------------------
+ *
+ * dir_list_read_ctx() above is a depth-first recursion over a shared
+ * path-prefix buffer.  The iterator below is the same walk with the
+ * recursion made explicit - a frame per open directory - so it can
+ * stop between any two entries and resume later.  Every filtering
+ * decision is a transliteration of the recursive body, and the
+ * equivalence is pinned by the parity lane of
+ * samples/tasks/database/scan_begin_budget_test.c, which diffs the
+ * iterator's output against dir_list_new() on the same tree.
+ *
+ * Two behaviours of the recursion that read like accidents are
+ * contract here and preserved deliberately:
+ *  - the return value of the recursive call is ignored, so an
+ *    unreadable subdirectory is skipped silently while the walk
+ *    continues, and
+ *  - a directory itself is appended (under include_dirs) after its
+ *    contents, i.e. post-order, because the append sits after the
+ *    recursive call. */
+
+struct dir_list_iter_frame
+{
+   struct RDIR *entry;    /* open directory handle for this level    */
+   size_t       dir_len;  /* prefix length children append at        */
+   size_t       pend_len; /* path length of the dir itself, for the  *
+                           * post-order append on pop (root: unused) */
+   bool         pend_append; /* append this dir on pop?              */
+};
+
+struct dir_list_iter
+{
+   struct string_list *list;             /* borrowed                 */
+   struct string_list  ext_list;         /* owned storage...         */
+   struct string_list *ext_list_ptr;     /* ...NULL when no filter   */
+   char               *path;             /* shared prefix buffer     */
+   struct dir_list_iter_frame *stack;
+   size_t              depth;            /* frames in use            */
+   size_t              cap;              /* frames allocated         */
+   bool                include_dirs;
+   bool                include_hidden;
+   bool                include_compressed;
+   bool                recursive;
+   bool                done;
+   bool                failed;
+};
+
+static bool dir_list_iter_push(dir_list_iter_t *iter,
+      struct RDIR *entry, size_t dir_len, size_t pend_len,
+      bool pend_append)
+{
+   struct dir_list_iter_frame *frame;
+   if (iter->depth == iter->cap)
+   {
+      size_t new_cap = iter->cap ? (iter->cap * 2) : 8;
+      struct dir_list_iter_frame *new_stack =
+            (struct dir_list_iter_frame*)realloc(iter->stack,
+                  new_cap * sizeof(*new_stack));
+      if (!new_stack)
+         return false;
+      iter->stack = new_stack;
+      iter->cap   = new_cap;
+   }
+   frame              = &iter->stack[iter->depth++];
+   frame->entry       = entry;
+   frame->dir_len     = dir_len;
+   frame->pend_len    = pend_len;
+   frame->pend_append = pend_append;
+   return true;
+}
+
+dir_list_iter_t *dir_list_iter_new(const char *dir, const char *ext,
+      bool include_dirs, bool include_hidden, bool include_compressed,
+      bool recursive, struct string_list *list)
+{
+   dir_list_iter_t *iter;
+   struct RDIR *entry;
+   size_t dir_len;
+
+   if (!dir || !list)
+      return NULL;
+
+   if (!(iter = (dir_list_iter_t*)calloc(1, sizeof(*iter))))
+      return NULL;
+
+   if (!(iter->path = (char*)malloc(PATH_MAX_LENGTH)))
+   {
+      free(iter);
+      return NULL;
+   }
+
+   if (ext)
+   {
+      string_list_initialize(&iter->ext_list);
+      string_split_noalloc(&iter->ext_list, ext, "|");
+      iter->ext_list_ptr    = &iter->ext_list;
+   }
+
+   iter->list               = list;
+   iter->include_dirs       = include_dirs;
+   iter->include_hidden     = include_hidden;
+   iter->include_compressed = include_compressed;
+   iter->recursive          = recursive;
+
+   dir_len = strlcpy(iter->path, dir, PATH_MAX_LENGTH);
+
+   /* A root that cannot be opened is the condition under which
+    * dir_list_new() fails outright - unlike a child, which is
+    * skipped. */
+   entry   = retro_opendir_include_hidden(iter->path, include_hidden);
+   if (!entry)
+      goto error;
+   if (retro_dirent_error(entry))
+   {
+      retro_closedir(entry);
+      goto error;
+   }
+   if (!dir_list_iter_push(iter, entry, dir_len, 0, false))
+   {
+      retro_closedir(entry);
+      goto error;
+   }
+   return iter;
+
+error:
+   dir_list_iter_free(iter);
+   return NULL;
+}
+
+int dir_list_iter_step(dir_list_iter_t *iter,
+      bool (*within_budget)(void *userdata), void *userdata)
+{
+   char *path;
+   bool first = true;
+
+   if (!iter || iter->failed)
+      return -1;
+   if (iter->done)
+      return 1;
+
+   path = iter->path;
+
+   while (iter->depth)
+   {
+      struct dir_list_iter_frame *frame = &iter->stack[iter->depth - 1];
+      struct RDIR *entry                = frame->entry;
+      size_t dir_len                    = frame->dir_len;
+      const char *name;
+      size_t _len;
+      union string_list_elem_attr attr;
+
+      /* The floor: one entry per call regardless of the budget, so a
+       * spent window still makes progress.  After it, yield between
+       * any two entries. */
+      if (!first && within_budget && !within_budget(userdata))
+         return 0;
+      first = false;
+
+      if (!retro_readdir(entry))
+      {
+         /* Level exhausted: close, pop, and perform the parent's
+          * pending post-order append of the directory itself (the
+          * code after the recursive call in dir_list_read_ctx). */
+         bool pend_append = frame->pend_append;
+         size_t pend_len  = frame->pend_len;
+
+         retro_closedir(entry);
+         iter->depth--;
+
+         if (pend_append)
+         {
+            path[pend_len] = '\0';
+            attr.i         = RARCH_DIRECTORY;
+            if (!string_list_append(iter->list, path, attr))
+               goto fail;
+         }
+         continue;
+      }
+
+      name = retro_dirent_get_name(entry);
+
+      if (name[0] == '.' || name[0] == '$')
+      {
+         /* Do not include hidden files and directories */
+         if (!iter->include_hidden)
+            continue;
+         /* char-wise comparisons to avoid string comparison */
+         /* Do not include current dir */
+         if (name[1] == '\0')
+            continue;
+         /* Do not include parent dir */
+         if (name[1] == '.' && name[2] == '\0')
+            continue;
+      }
+
+      /* Append @name to the prefix instead of rebuilding the whole
+       * path: the prefix is already in place from the parent level. */
+      _len = dir_len;
+      if (_len && path[_len - 1] != '/' && path[_len - 1] != '\\')
+         path[_len++] = '/';
+      _len += strlcpy(path + _len, name, PATH_MAX_LENGTH - _len);
+
+      if (retro_dirent_is_dir(entry, NULL))
+      {
+         /* Exclude this frequent hidden dir on platforms which can not handle hidden attribute */
+         if (!iter->include_hidden && strcmp(name, "System Volume Information") == 0)
+            continue;
+
+#if defined(IOS) || defined(OSX)
+         {
+            size_t name_len = strlen(name);
+            if (name_len >= 10
+                  && !memcmp(name + name_len - 10, ".framework", 10))
+            {
+               attr.i = RARCH_PLAIN_FILE;
+               if (!string_list_append(iter->list, path, attr))
+                  goto fail;
+               continue;
+            }
+         }
+#endif
+         if (iter->recursive)
+         {
+            /* Descend.  A child that cannot be opened is skipped
+             * silently - the recursion ignored the child call's
+             * return value - but the post-order append it owed
+             * still happens, so perform it here directly. */
+            struct RDIR *child = retro_opendir_include_hidden(path,
+                  iter->include_hidden);
+
+            if (child && retro_dirent_error(child))
+            {
+               retro_closedir(child);
+               child = NULL;
+            }
+
+            if (child)
+            {
+               if (!dir_list_iter_push(iter, child, _len, _len,
+                        iter->include_dirs))
+               {
+                  retro_closedir(child);
+                  goto fail;
+               }
+               continue;
+            }
+
+            path[_len] = '\0';
+         }
+
+         if (!iter->include_dirs)
+            continue;
+         attr.i = RARCH_DIRECTORY;
+      }
+      else
+      {
+         const char *file_ext    = path_get_extension(name);
+
+         attr.i                  = RARCH_FILETYPE_UNSET;
+
+         if (string_list_find_elem_prefix(iter->ext_list_ptr, ".", file_ext))
+            attr.i            = RARCH_PLAIN_FILE;
+         else
+         {
+            bool is_compressed_file;
+            if ((is_compressed_file = path_is_compressed_file(path)))
+               attr.i               = RARCH_COMPRESSED_ARCHIVE;
+
+            if (iter->ext_list_ptr &&
+                  (!is_compressed_file || !iter->include_compressed))
+               continue;
+         }
+      }
+
+      if (!string_list_append(iter->list, path, attr))
+         goto fail;
+   }
+
+   iter->done = true;
+   return 1;
+
+fail:
+   iter->failed = true;
+   return -1;
+}
+
+void dir_list_iter_free(dir_list_iter_t *iter)
+{
+   size_t i;
+   if (!iter)
+      return;
+   for (i = 0; i < iter->depth; i++)
+      retro_closedir(iter->stack[i].entry);
+   free(iter->stack);
+   free(iter->path);
+   string_list_deinitialize(&iter->ext_list);
+   free(iter);
+}
+
 /**
  * dir_list_append:
  * @list               : existing list to append to.

--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -1591,6 +1591,91 @@ bool manual_content_scan_get_task_config(
  * content directory
  * > Returns NULL in the event of failure
  * > Returned string list must be free()'d */
+/* Shared policy for both content-list builders below:
+ * whether extension filtering applies and whether
+ * compressed files must be listed. */
+static void manual_content_scan_content_list_policy(
+      manual_content_scan_task_config_t *task_config,
+      bool *filter_exts, bool *include_compressed)
+{
+   /* Check whether files should be filtered by
+    * extension */
+   *filter_exts = *task_config->file_exts;
+
+   /* Check whether compressed files should be
+    * included in the directory list
+    * > If compressed files are already listed in
+    *   the 'file_exts' string, they will be included
+    *   automatically
+    * > If we don't have a 'file_exts' list, then all
+    *   files must be included regardless of type
+    * > If user has enabled 'search inside archives',
+    *   then compressed files must of course be included */
+   *include_compressed = (!*filter_exts || task_config->search_archives);
+}
+
+bool manual_content_scan_content_list_iter_new(
+      manual_content_scan_task_config_t *task_config,
+      struct string_list **list, dir_list_iter_t **iter)
+{
+   bool filter_exts;
+   bool include_compressed;
+
+   if (list)
+      *list = NULL;
+   if (iter)
+      *iter = NULL;
+
+   /* Sanity check */
+   if (!task_config || !*task_config->content_dir || !list || !iter)
+      return false;
+
+   manual_content_scan_content_list_policy(task_config,
+         &filter_exts, &include_compressed);
+
+   if (path_is_directory(task_config->content_dir))
+   {
+      if (!(*list = string_list_new()))
+         return false;
+
+      /* Same parameters as the blocking getter's
+       * dir_list_new() call: exclude directories and
+       * hidden files */
+      *iter = dir_list_iter_new(
+            task_config->content_dir,
+            filter_exts ? task_config->file_exts : NULL,
+            false, /* include_dirs */
+            false, /* include_hidden */ /* todo: obey global settings? */
+            include_compressed,
+            task_config->search_recursively,
+            *list);
+
+      if (!*iter)
+      {
+         string_list_free(*list);
+         *list = NULL;
+         return false;
+      }
+      return true;
+   }
+
+   /* A plain-file content dir needs no walk: the list
+    * is complete here and *iter stays NULL. */
+   if (!(*list = string_list_new()))
+      return false;
+   {
+      union string_list_elem_attr attr;
+      attr.i = 0;
+      if (!string_list_append(*list, task_config->content_dir, attr))
+      {
+         string_list_free(*list);
+         *list = NULL;
+         return false;
+      }
+   }
+   return true;
+}
+
 struct string_list *manual_content_scan_get_content_list(
       manual_content_scan_task_config_t *task_config)
 {
@@ -1602,20 +1687,8 @@ struct string_list *manual_content_scan_get_content_list(
    if (!task_config || !*task_config->content_dir)
       return NULL;
 
-   /* Check whether files should be filtered by
-    * extension */
-   filter_exts = *task_config->file_exts;
-
-   /* Check whether compressed files should be
-    * included in the directory list
-    * > If compressed files are already listed in
-    *   the 'file_exts' string, they will be included
-    *   automatically
-    * > If we don't have a 'file_exts' list, then all
-    *   files must be included regardless of type
-    * > If user has enabled 'search inside archives',
-    *   then compressed files must of course be included */
-   include_compressed = (!filter_exts || task_config->search_archives);
+   manual_content_scan_content_list_policy(task_config,
+         &filter_exts, &include_compressed);
 
    if (path_is_directory(task_config->content_dir))
    {

--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -267,18 +267,30 @@ void manual_content_scan_scrub_file_exts_custom(void)
  * to prevent obvious errors), optionally returning the
  * file size (DAT files can be very large, so callers
  * use it for free-memory checks).
- * This used to live in logiqx_dat.c as
- * logiqx_dat_path_is_valid(); the parser is now
- * I/O-free, so the extension whitelist stays with it
- * (logiqx_dat_extension_is_valid()) while the file
- * system checks live with the caller, here. */
-static bool content_scan_dat_path_is_valid(
+ * This subsumes what logiqx_dat.c used to do in
+ * logiqx_dat_path_is_valid(): the parser is fully
+ * path-agnostic now - bytes in, structs out - so both
+ * the extension whitelist and the file system checks
+ * live with the scan configuration that owns the
+ * path. */
+bool manual_content_scan_dat_path_is_valid(
       const char *path, uint64_t *file_size)
 {
+   const char *file_ext = NULL;
    int64_t file_size_int;
 
-   /* Check file extension */
-   if (!logiqx_dat_extension_is_valid(path))
+   if (!path || !*path)
+      return false;
+
+   /* Check file extension (.dat / .xml, the extensions
+    * a Logiqx XML DAT may legitimately carry) */
+   file_ext = path_get_extension(path);
+
+   if (!file_ext || !*file_ext)
+      return false;
+
+   if (   !string_is_equal_noncase(file_ext, "dat")
+       && !string_is_equal_noncase(file_ext, "xml"))
       return false;
 
    /* Ensure file exists */
@@ -311,7 +323,7 @@ enum manual_content_scan_dat_file_path_status
       uint64_t file_size;
 
       /* Check if path itself is valid */
-      if (content_scan_dat_path_is_valid(scan_dat_file_path, &file_size))
+      if (manual_content_scan_dat_path_is_valid(scan_dat_file_path, &file_size))
       {
          uint64_t free_memory = mem_stats_free();
          dat_file_path_status = MANUAL_CONTENT_SCAN_DAT_FILE_OK;
@@ -1560,7 +1572,7 @@ bool manual_content_scan_get_task_config(
        || scan_settings.db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE)
        && *scan_dat_file_path)
    {
-      if (!content_scan_dat_path_is_valid(scan_dat_file_path, NULL))
+      if (!manual_content_scan_dat_path_is_valid(scan_dat_file_path, NULL))
          return false;
       strlcpy(
             task_config->dat_file_path,

--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -267,12 +267,10 @@ void manual_content_scan_scrub_file_exts_custom(void)
  * to prevent obvious errors), optionally returning the
  * file size (DAT files can be very large, so callers
  * use it for free-memory checks).
- * This subsumes what logiqx_dat.c used to do in
- * logiqx_dat_path_is_valid(): the parser is fully
- * path-agnostic now - bytes in, structs out - so both
- * the extension whitelist and the file system checks
- * live with the scan configuration that owns the
- * path. */
+ * The parser (logiqx_dat.c) is path-agnostic - bytes
+ * in, structs out - so both the extension whitelist
+ * and the file system checks live here, with the scan
+ * configuration that owns the path. */
 bool manual_content_scan_dat_path_is_valid(
       const char *path, uint64_t *file_size)
 {

--- a/manual_content_scan.c
+++ b/manual_content_scan.c
@@ -262,6 +262,41 @@ void manual_content_scan_scrub_file_exts_custom(void)
    manual_content_scan_scrub_file_exts(scan_file_exts_custom);
 }
 
+/* Performs rudimentary validation of the specified
+ * Logiqx XML DAT file path (not rigorous - just enough
+ * to prevent obvious errors), optionally returning the
+ * file size (DAT files can be very large, so callers
+ * use it for free-memory checks).
+ * This used to live in logiqx_dat.c as
+ * logiqx_dat_path_is_valid(); the parser is now
+ * I/O-free, so the extension whitelist stays with it
+ * (logiqx_dat_extension_is_valid()) while the file
+ * system checks live with the caller, here. */
+static bool content_scan_dat_path_is_valid(
+      const char *path, uint64_t *file_size)
+{
+   int64_t file_size_int;
+
+   /* Check file extension */
+   if (!logiqx_dat_extension_is_valid(path))
+      return false;
+
+   /* Ensure file exists */
+   if (!path_is_valid(path))
+      return false;
+
+   /* Get file size */
+   file_size_int = path_get_size(path);
+
+   if (file_size_int <= 0)
+      return false;
+
+   if (file_size)
+      *file_size = (uint64_t)file_size_int;
+
+   return true;
+}
+
 /* Checks 'dat_file_path' string and resets it
  * if invalid */
 enum manual_content_scan_dat_file_path_status
@@ -276,7 +311,7 @@ enum manual_content_scan_dat_file_path_status
       uint64_t file_size;
 
       /* Check if path itself is valid */
-      if (logiqx_dat_path_is_valid(scan_dat_file_path, &file_size))
+      if (content_scan_dat_path_is_valid(scan_dat_file_path, &file_size))
       {
          uint64_t free_memory = mem_stats_free();
          dat_file_path_status = MANUAL_CONTENT_SCAN_DAT_FILE_OK;
@@ -1525,7 +1560,7 @@ bool manual_content_scan_get_task_config(
        || scan_settings.db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE)
        && *scan_dat_file_path)
    {
-      if (!logiqx_dat_path_is_valid(scan_dat_file_path, NULL))
+      if (!content_scan_dat_path_is_valid(scan_dat_file_path, NULL))
          return false;
       strlcpy(
             task_config->dat_file_path,

--- a/manual_content_scan.h
+++ b/manual_content_scan.h
@@ -29,6 +29,7 @@
 #include <boolean.h>
 
 #include <lists/string_list.h>
+#include <lists/dir_list.h>
 #include <formats/logiqx_dat.h>
 
 #include "playlist.h"
@@ -327,6 +328,24 @@ bool manual_content_scan_get_task_config(
  * > Returned string list must be free()'d */
 struct string_list *manual_content_scan_get_content_list(
       manual_content_scan_task_config_t *task_config);
+
+/* Resumable counterpart of
+ * manual_content_scan_get_content_list(): creates
+ * @*list and, when the content dir is a directory, a
+ * dir_list_iter_t in @*iter that fills it under the
+ * caller's budget via dir_list_iter_step().  The same
+ * extension / compressed-file policy is applied.  A
+ * content dir that is a plain file fills the list here
+ * and leaves *iter NULL.  When the walk completes the
+ * caller owes the list the same treatment the blocking
+ * getter applied: reject it when empty, then
+ * dir_list_sort(list, true).
+ * > Returns false (leaving *list / *iter NULL) if
+ *   config is invalid or the directory cannot be
+ *   opened */
+bool manual_content_scan_content_list_iter_new(
+      manual_content_scan_task_config_t *task_config,
+      struct string_list **list, dir_list_iter_t **iter);
 
 /* Adds specified content to playlist, if not already
  * present */

--- a/manual_content_scan.h
+++ b/manual_content_scan.h
@@ -322,6 +322,16 @@ bool manual_content_scan_get_task_config(
       const char *path_dir_playlist
       );
 
+/* Performs rudimentary validation of a Logiqx XML DAT
+ * file path: extension whitelist (.dat / .xml,
+ * case-insensitive), existence, size > 0, with the
+ * size optionally returned for free-memory checks.
+ * The parser itself (logiqx_dat.c) is path-agnostic
+ * and performs no validation or I/O; every consumer
+ * of a DAT path goes through this one predicate. */
+bool manual_content_scan_dat_path_is_valid(const char *path,
+      uint64_t *file_size);
+
 /* Creates a list of all valid content in the specified
  * content directory
  * > Returns NULL in the event of failure

--- a/samples/tasks/database/Makefile
+++ b/samples/tasks/database/Makefile
@@ -188,6 +188,11 @@ INDEX_TEST_MAIN   := $(CORE_DIR)/samples/tasks/database/database_index_test.o
 INDEX_TEST_OBJECTS = $(filter-out $(CORE_DIR)/samples/tasks/database/main.o,$(OBJECTS)) \
 	$(INDEX_TEST_MAIN)
 
+BEGIN_TEST        := scan_begin_budget_test
+BEGIN_TEST_MAIN   := $(CORE_DIR)/samples/tasks/database/scan_begin_budget_test.o
+BEGIN_TEST_OBJECTS = $(filter-out $(CORE_DIR)/samples/tasks/database/main.o,$(OBJECTS)) \
+	$(BEGIN_TEST_MAIN)
+
 OBJOUT   = -o
 LINKOUT  = -o
 
@@ -214,9 +219,15 @@ $(INDEX_TEST)$(EXE_EXT): $(INDEX_TEST_OBJECTS)
 $(SCAN_TEST)$(EXE_EXT): $(SCAN_TEST_OBJECTS)
 	$(LD)  $(LINKOUT)$@ $(SHARED) $(SCAN_TEST_OBJECTS) $(LDFLAGS) $(LIBS)
 
-check: $(INDEX_TEST)$(EXE_EXT) $(SCAN_TEST)$(EXE_EXT)
+# Builds its own content tree + DAT, so it needs nothing but a
+# writable dir (honours TMPDIR).
+$(BEGIN_TEST)$(EXE_EXT): $(BEGIN_TEST_OBJECTS)
+	$(LD)  $(LINKOUT)$@ $(SHARED) $(BEGIN_TEST_OBJECTS) $(LDFLAGS) $(LIBS)
+
+check: $(INDEX_TEST)$(EXE_EXT) $(SCAN_TEST)$(EXE_EXT) $(BEGIN_TEST)$(EXE_EXT)
 	./$(INDEX_TEST)$(EXE_EXT)
 	./$(SCAN_TEST)$(EXE_EXT)
+	./$(BEGIN_TEST)$(EXE_EXT)
 
 %.o: %.c
 	$(CC) $(INCFLAGS) $(CFLAGS) -c $(OBJOUT)$@ $<

--- a/samples/tasks/database/Makefile
+++ b/samples/tasks/database/Makefile
@@ -208,7 +208,12 @@ else
 	LD = $(CC)
 endif
 
-all: $(TARGET)$(EXE_EXT)
+# The budget oracle is part of all: the CI step for it (and anyone
+# typing plain make) does `make clean all` and then expects the
+# binary, and `all` producing only database_task left that step
+# probing for a binary the build never made - masked locally by a
+# stale binary from an earlier explicit `make scan_begin_budget_test`.
+all: $(TARGET)$(EXE_EXT) $(BEGIN_TEST)$(EXE_EXT)
 $(TARGET)$(EXE_EXT): $(OBJECTS)
 	$(LD)  $(LINKOUT)$@ $(SHARED) $(OBJECTS) $(LDFLAGS) $(LIBS)
 

--- a/samples/tasks/database/Makefile
+++ b/samples/tasks/database/Makefile
@@ -91,6 +91,7 @@ SOURCES_C := \
 	$(CORE_DIR)/samples/tasks/database/main.c \
 	$(LIBRETRO_COMM_DIR)/memory/mem_stats.c \
 	$(CORE_DIR)/tasks/task_database.c \
+	$(CORE_DIR)/tasks/task_nbio_slice.c \
 	$(CORE_DIR)/tasks/task_database_cue.c \
 	$(CORE_DIR)/database_info.c \
 	$(CORE_DIR)/core_info.c \

--- a/samples/tasks/database/Makefile
+++ b/samples/tasks/database/Makefile
@@ -208,11 +208,6 @@ else
 	LD = $(CC)
 endif
 
-# The budget oracle is part of all: the CI step for it (and anyone
-# typing plain make) does `make clean all` and then expects the
-# binary, and `all` producing only database_task left that step
-# probing for a binary the build never made - masked locally by a
-# stale binary from an earlier explicit `make scan_begin_budget_test`.
 all: $(TARGET)$(EXE_EXT) $(BEGIN_TEST)$(EXE_EXT)
 $(TARGET)$(EXE_EXT): $(OBJECTS)
 	$(LD)  $(LINKOUT)$@ $(SHARED) $(OBJECTS) $(LDFLAGS) $(LIBS)
@@ -224,8 +219,6 @@ $(INDEX_TEST)$(EXE_EXT): $(INDEX_TEST_OBJECTS)
 $(SCAN_TEST)$(EXE_EXT): $(SCAN_TEST_OBJECTS)
 	$(LD)  $(LINKOUT)$@ $(SHARED) $(SCAN_TEST_OBJECTS) $(LDFLAGS) $(LIBS)
 
-# Builds its own content tree + DAT, so it needs nothing but a
-# writable dir (honours TMPDIR).
 $(BEGIN_TEST)$(EXE_EXT): $(BEGIN_TEST_OBJECTS)
 	$(LD)  $(LINKOUT)$@ $(SHARED) $(BEGIN_TEST_OBJECTS) $(LDFLAGS) $(LIBS)
 

--- a/samples/tasks/database/scan_begin_budget_test.c
+++ b/samples/tasks/database/scan_begin_budget_test.c
@@ -54,6 +54,27 @@
 #define CONTENT_DIRS  50
 #define CONTENT_FILES 5000
 
+/* Per-gather cost for the pacing lane is measured in thread CPU
+ * time, not wall time.  The property under test is how much work the
+ * scanner chooses to do in one gather; on a shared CI runner a cheap
+ * gather can be preempted mid-flight and charged tens of wall-clock
+ * milliseconds it never spent, which fails the lane spuriously,
+ * while the regression the lane exists for - the pre-split tree
+ * doing the whole walk+load+flush in one invocation - burns its
+ * >160 ms as CPU and is caught either way.  Wall time remains the
+ * clock for the total/throughput and first-feedback lanes, where
+ * elapsed time is the property. */
+static retro_time_t thread_cpu_usec(void)
+{
+#if defined(CLOCK_THREAD_CPUTIME_ID)
+   struct timespec ts;
+   if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0)
+      return (retro_time_t)ts.tv_sec * 1000000
+           + (retro_time_t)(ts.tv_nsec / 1000);
+#endif
+   return cpu_features_get_time_usec();
+}
+
 /* Slack multiplier over the shared window for the pacing assertion.
  * The window bounds the work the scanner *chooses* to start in a
  * gather; a single readdir()/stat() that straddles the deadline, plus
@@ -335,9 +356,9 @@ static bool run_scan(const char *content_dir, const char *dat_path,
          }
       }
 
-      g0 = cpu_features_get_time_usec();
+      g0 = thread_cpu_usec();
       task_queue_check();
-      g1 = cpu_features_get_time_usec();
+      g1 = thread_cpu_usec();
 
       m->gathers++;
       if (g1 - g0 > m->max_gather_usec)
@@ -590,7 +611,7 @@ int main(int argc, char *argv[])
       goto out_queue;
 
    fprintf(stderr,
-         "[metrics] files=%u total=%.1fms max_gather=%.2fms "
+         "[metrics] files=%u total=%.1fms max_gather_cpu=%.2fms "
          "first_feedback=%.2fms gathers=%u walk_ref=%.1fms dat_ref=%.1fms\n",
          (unsigned)CONTENT_FILES,
          m.total_usec      / 1000.0,
@@ -614,7 +635,7 @@ int main(int argc, char *argv[])
       if (m.max_gather_usec > limit)
       {
          fprintf(stderr,
-               "FAIL pacing: max gather %.2fms exceeds %.2fms budget\n",
+               "FAIL pacing: max gather %.2fms CPU exceeds %.2fms budget\n",
                m.max_gather_usec / 1000.0, limit / 1000.0);
          goto out_queue;
       }

--- a/samples/tasks/database/scan_begin_budget_test.c
+++ b/samples/tasks/database/scan_begin_budget_test.c
@@ -1,0 +1,693 @@
+/* Pacing + throughput oracle for the manual content scanner's BEGIN
+ * path in tasks/task_database.c, compiled from the tree so it
+ * exercises the shipping translation unit.
+ *
+ * Two properties are asserted, because either one alone can be
+ * satisfied by a scanner that is worse:
+ *
+ *  1. Pacing.  Under the regular (non-threaded) task queue, no single
+ *     task_queue_check() attributable to the scanner may exceed the
+ *     shared I/O window by more than bounded slack.  Before the
+ *     BEGIN split, the first gather of a large scan performed the
+ *     entire recursive directory walk, the whole DAT load and the
+ *     playlist setup in one handler invocation - a multi-hundred-
+ *     millisecond freeze that this lane fails on the pre-split tree.
+ *
+ *  2. Throughput.  The total wall-clock time for the same fixed scan
+ *     must stay within a small factor of the blocking dir_list_new()
+ *     walk plus the DAT parse it replaces.  A scanner that no longer
+ *     freezes the UI but takes twice as long is a regression, so the
+ *     budget lane cannot pass on pacing alone.
+ *
+ * The tree is built here - CONTENT_FILES content files spread over
+ * CONTENT_DIRS subdirectories, plus a Logiqx DAT naming each entry -
+ * so the test needs nothing but a writable directory.
+ *
+ * Run with: make scan_begin_budget_test SANITIZER=address,undefined
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+
+#include <queues/task_queue.h>
+#include <lists/dir_list.h>
+#include <lists/string_list.h>
+#include <retro_timers.h>
+#include <streams/file_stream.h>
+#include <file/file_path.h>
+#include <features/features_cpu.h>
+#include <formats/logiqx_dat.h>
+
+#include "../../../core_info.h"
+#include "../../../list_special.h"
+#include "../../../tasks/tasks_internal.h"
+#include "../../../manual_content_scan.h"
+#include "../../../playlist.h"
+#include "../../../configuration.h"
+#include "../../../verbosity.h"
+
+#define SCAN_TIMEOUT_SECONDS 300
+
+#define CONTENT_DIRS  50
+#define CONTENT_FILES 5000
+
+/* Slack multiplier over the shared window for the pacing assertion.
+ * The window bounds the work the scanner *chooses* to start in a
+ * gather; a single readdir()/stat() that straddles the deadline, plus
+ * qsort of the final list, plus task-queue bookkeeping, land on top.
+ * 4x the 4ms window is still an order of magnitude below the
+ * pre-split freeze (>200ms on the same tree, debug build), so the
+ * discriminator stays sharp while absorbing CI jitter. */
+#define PACING_SLACK_MULTIPLIER 4
+
+/* Throughput guard: incremental scan total time must stay within
+ * this factor of (blocking walk + DAT parse + per-entry floor).
+ * Measured locally the ratio is ~1.0; the margin absorbs shared-
+ * runner noise without admitting a 2x regression. */
+#define THROUGHPUT_FACTOR 1.60
+
+/* ------------------------------------------------------------------ */
+/* Stubs (same set as database_scan_test.c - see rationale there)     */
+/* ------------------------------------------------------------------ */
+
+int msg_hash_get_help_us_enum(enum msg_hash_enums msg, char *s, size_t len)
+{
+   (void)msg;
+   if (s && len)
+      s[0] = '\0';
+   return 0;
+}
+
+const char *msg_hash_to_str_us(enum msg_hash_enums msg)
+{
+   (void)msg;
+   return "";
+}
+
+void msg_hash_us_index_init(void)
+{
+}
+
+settings_t *config_get_ptr(void)
+{
+   static settings_t settings;
+   return &settings;
+}
+
+void runloop_msg_queue_push(const char *msg, size_t len,
+      unsigned prio, unsigned duration,
+      bool flush, char *title, unsigned icon, unsigned category)
+{
+   (void)msg; (void)len; (void)prio; (void)duration;
+   (void)flush; (void)title; (void)icon; (void)category;
+}
+
+bool retroarch_override_setting_is_set(unsigned enum_idx, void *data)
+{
+   (void)enum_idx; (void)data;
+   return false;
+}
+
+struct string_list *dir_list_new_special(const char *input_dir,
+      enum dir_list_type type, const char *filter, bool show_hidden_files)
+{
+   (void)filter;
+   if (type == DIR_LIST_DATABASES)
+      return dir_list_new(input_dir, "rdb", false, show_hidden_files,
+            false, false);
+   return NULL;
+}
+
+static void msgq_push(retro_task_t *task, const char *msg,
+      unsigned prio, unsigned duration, bool flush)
+{
+   (void)task; (void)msg; (void)prio; (void)duration; (void)flush;
+}
+
+void ui_companion_driver_notify_refresh(void)
+{
+}
+
+void task_window_progress_cb(retro_task_t *task)
+{
+   (void)task;
+}
+
+/* ------------------------------------------------------------------ */
+/* Fixture                                                            */
+/* ------------------------------------------------------------------ */
+
+static char fixture_root[4096];
+
+static void rm_rf(const char *path)
+{
+   char cmd[4352];
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", path);
+   if (system(cmd) != 0) { /* best effort */ }
+}
+
+static bool write_text_file(const char *path, const char *text)
+{
+   RFILE *f = filestream_open(path,
+         RETRO_VFS_FILE_ACCESS_WRITE, RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   int64_t len;
+   if (!f)
+      return false;
+   len = (int64_t)strlen(text);
+   if (filestream_write(f, text, len) != len)
+   {
+      filestream_close(f);
+      return false;
+   }
+   filestream_close(f);
+   return true;
+}
+
+/* Build CONTENT_FILES small .bin files across CONTENT_DIRS subdirs,
+ * and a Logiqx DAT that names each one, into root (created here). */
+static bool build_fixture(const char *root, char *dat_path, size_t dat_path_len,
+      char *content_dir, size_t content_dir_len)
+{
+   size_t i;
+   FILE *dat;
+   char path[4096];
+
+   snprintf(content_dir, content_dir_len, "%s/content", root);
+   snprintf(dat_path, dat_path_len, "%s/games.dat", root);
+
+   if (!path_mkdir(root) || !path_mkdir(content_dir))
+      return false;
+
+   for (i = 0; i < CONTENT_DIRS; i++)
+   {
+      snprintf(path, sizeof(path), "%s/d%02u", content_dir, (unsigned)i);
+      if (!path_mkdir(path))
+         return false;
+   }
+
+   dat = fopen(dat_path, "w");
+   if (!dat)
+      return false;
+   fputs("<?xml version=\"1.0\"?>\n<datafile>\n"
+         "<header><name>ScanBench</name></header>\n", dat);
+
+   for (i = 0; i < CONTENT_FILES; i++)
+   {
+      char body[64];
+      snprintf(path, sizeof(path), "%s/d%02u/game%04u.bin",
+            content_dir, (unsigned)(i % CONTENT_DIRS), (unsigned)i);
+      snprintf(body, sizeof(body), "content-%04u", (unsigned)i);
+      if (!write_text_file(path, body))
+      {
+         fclose(dat);
+         return false;
+      }
+      fprintf(dat,
+            "<game name=\"game%04u\">\n"
+            "  <description>Game %04u</description>\n"
+            "  <year>2026</year>\n"
+            "  <manufacturer>Bench &amp; Co.</manufacturer>\n"
+            "</game>\n",
+            (unsigned)i, (unsigned)i);
+   }
+   fputs("</datafile>\n", dat);
+   fclose(dat);
+   return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Scan driver                                                        */
+/* ------------------------------------------------------------------ */
+
+static bool scan_done;
+static bool scan_err;
+
+static void scan_cb(retro_task_t *task,
+      void *task_data, void *user_data, const char *err)
+{
+   (void)task; (void)task_data; (void)user_data;
+   if (err && *err)
+   {
+      fprintf(stderr, "scan error: %s\n", err);
+      scan_err = true;
+   }
+   scan_done = true;
+}
+
+typedef struct
+{
+   retro_time_t total_usec;       /* push -> completion            */
+   retro_time_t max_gather_usec;  /* worst single task_queue_check */
+   retro_time_t first_feedback;   /* push -> first title/progress  */
+   unsigned     gathers;
+} scan_metrics_t;
+
+static retro_task_t *found_task;
+static bool find_any(retro_task_t *task, void *ud)
+{
+   (void)ud;
+   found_task = task;
+   return true;
+}
+
+/* Point the menu-backed scan settings at the fixture.  Shared by
+ * every lane below. */
+static bool configure_scan(const char *content_dir, const char *dat_path,
+      const char *playlist_dir)
+{
+   strlcpy(config_get_ptr()->paths.directory_playlist, playlist_dir,
+         sizeof(config_get_ptr()->paths.directory_playlist));
+
+   if (!manual_content_scan_set_menu_scan_method(
+            MANUAL_CONTENT_SCAN_METHOD_CUSTOM))
+      return false;
+   if (!manual_content_scan_set_menu_content_dir(content_dir))
+      return false;
+   if (!manual_content_scan_set_menu_system_name(
+            MANUAL_CONTENT_SCAN_SYSTEM_NAME_CUSTOM, "ScanBench"))
+      return false;
+   /* For the CUSTOM type the setter only records the type; the name
+    * itself lives in the menu-backed buffer. */
+   strlcpy(manual_content_scan_get_system_name_custom_ptr(), "ScanBench",
+         manual_content_scan_get_system_name_custom_size());
+   if (!manual_content_scan_set_menu_scan_use_db(
+            MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE))
+      return false;
+
+   strlcpy(manual_content_scan_get_file_exts_custom_ptr(), "bin",
+         manual_content_scan_get_file_exts_custom_size());
+   strlcpy(manual_content_scan_get_dat_file_path_ptr(), dat_path,
+         manual_content_scan_get_dat_file_path_size());
+   if (manual_content_scan_validate_dat_file_path()
+         != MANUAL_CONTENT_SCAN_DAT_FILE_OK)
+   {
+      fprintf(stderr, "DAT fixture rejected\n");
+      return false;
+   }
+   *manual_content_scan_get_search_recursively_ptr() = true;
+   *manual_content_scan_get_overwrite_playlist_ptr() = true;
+   return true;
+}
+
+/* Configure and run one DAT-based manual scan of the fixture under
+ * the regular (non-threaded) queue, recording pacing metrics. */
+static bool run_scan(const char *content_dir, const char *dat_path,
+      const char *playlist_dir, scan_metrics_t *m)
+{
+   retro_time_t t0;
+   time_t started;
+   task_finder_data_t finder;
+
+   memset(m, 0, sizeof(*m));
+   scan_done = false;
+   scan_err  = false;
+
+   if (!configure_scan(content_dir, dat_path, playlist_dir))
+      return false;
+
+   t0 = cpu_features_get_time_usec();
+   if (!task_push_manual_content_scan(false, scan_cb))
+   {
+      fprintf(stderr, "task_push_manual_content_scan refused\n");
+      return false;
+   }
+
+   finder.func     = find_any;
+   finder.userdata = NULL;
+
+   started = time(NULL);
+   while (!scan_done)
+   {
+      retro_time_t g0, g1;
+
+      if (!m->first_feedback)
+      {
+         found_task = NULL;
+         if (task_queue_find(&finder) && found_task)
+         {
+            const char *title = found_task->title;
+            if ((title && *title) || found_task->progress > 0)
+               m->first_feedback =
+                     cpu_features_get_time_usec() - t0;
+         }
+      }
+
+      g0 = cpu_features_get_time_usec();
+      task_queue_check();
+      g1 = cpu_features_get_time_usec();
+
+      m->gathers++;
+      if (g1 - g0 > m->max_gather_usec)
+         m->max_gather_usec = g1 - g0;
+
+      if (difftime(time(NULL), started) > SCAN_TIMEOUT_SECONDS)
+      {
+         fprintf(stderr, "scan did not finish within %d seconds\n",
+               SCAN_TIMEOUT_SECONDS);
+         return false;
+      }
+   }
+   m->total_usec = cpu_features_get_time_usec() - t0;
+   return !scan_err;
+}
+
+/* Threaded lane: the same scan under the threaded task queue, where
+ * the handler runs on the worker thread while push/find/cancel come
+ * from this one.  Pacing is not asserted here - there is no frame to
+ * protect - only completion and playlist correctness; under TSan
+ * this is the lane that answers whether the BEGIN/END split kept any
+ * hidden shared state (the shared window deliberately opts threaded
+ * queues out of the static window, and this is where a mistake in
+ * that opt-out would surface). */
+static bool run_scan_threaded(const char *content_dir, const char *dat_path,
+      const char *playlist_dir)
+{
+   time_t started;
+
+   scan_done = false;
+   scan_err  = false;
+
+   if (!configure_scan(content_dir, dat_path, playlist_dir))
+      return false;
+
+   task_queue_init(true, msgq_push);
+
+   if (!task_push_manual_content_scan(false, scan_cb))
+   {
+      fprintf(stderr, "threaded: task_push_manual_content_scan refused\n");
+      task_queue_deinit();
+      return false;
+   }
+
+   started = time(NULL);
+   while (!scan_done)
+   {
+      task_queue_check();
+      retro_sleep(1);
+      if (difftime(time(NULL), started) > SCAN_TIMEOUT_SECONDS)
+      {
+         fprintf(stderr, "threaded scan did not finish in time\n");
+         task_queue_deinit();
+         return false;
+      }
+   }
+
+   task_queue_deinit();
+   return !scan_err;
+}
+
+/* Cancellation lane: push the scan, run a bounded number of gathers,
+ * then cancel and drain.  Sweeping cancel_after over a range lands
+ * the cancellation in every phase of the task - setup, mid-walk,
+ * mid-DAT-read, content iteration, mid-flush - which is exactly the
+ * set of states that now hold in-flight resources (an open directory
+ * iterator, an open DAT stream and half-filled buffer, an open flush
+ * playlist).  Under ASan/LSan a resource dropped by the teardown of
+ * any of those states is the failure; the lane itself only asserts
+ * clean termination. */
+static bool run_scan_cancelled(const char *content_dir, const char *dat_path,
+      const char *playlist_dir, unsigned cancel_after)
+{
+   retro_task_t *task = NULL;
+   task_finder_data_t finder;
+   unsigned i;
+   time_t started;
+
+   scan_done = false;
+   scan_err  = false;
+
+   if (!configure_scan(content_dir, dat_path, playlist_dir))
+      return false;
+
+   task_queue_init(false, msgq_push);
+
+   if (!task_push_manual_content_scan(false, scan_cb))
+   {
+      fprintf(stderr, "cancel lane: push refused\n");
+      task_queue_deinit();
+      return false;
+   }
+
+   for (i = 0; i < cancel_after && !scan_done; i++)
+      task_queue_check();
+
+   /* Cancel whatever is still running... */
+   finder.func     = find_any;
+   finder.userdata = NULL;
+   found_task      = NULL;
+   if (!scan_done && task_queue_find(&finder) && found_task)
+   {
+      task = found_task;
+      task_queue_cancel_task(task);
+   }
+
+   /* ...and drain to retirement. */
+   started = time(NULL);
+   while (!scan_done)
+   {
+      task_queue_check();
+      if (difftime(time(NULL), started) > SCAN_TIMEOUT_SECONDS)
+      {
+         fprintf(stderr, "cancelled scan (after %u) did not drain\n",
+               cancel_after);
+         task_queue_deinit();
+         return false;
+      }
+   }
+
+   task_queue_deinit();
+   /* A cancelled scan may or may not report an error; either way the
+    * teardown must have released everything, which the sanitizers
+    * decide. */
+   return true;
+}
+
+/* Playlist correctness: every fixture file present exactly once. */
+static bool check_playlist(const char *playlist_dir)
+{
+   char path[4096];
+   playlist_config_t cfg;
+   playlist_t *pl;
+   size_t n;
+
+   memset(&cfg, 0, sizeof(cfg));
+   snprintf(path, sizeof(path), "%s/ScanBench.lpl", playlist_dir);
+   playlist_config_set_path(&cfg, path);
+   cfg.capacity = COLLECTION_SIZE;
+
+   if (!(pl = playlist_init(&cfg)))
+      return false;
+   n = playlist_size(pl);
+   playlist_free(pl);
+
+   if (n != CONTENT_FILES)
+   {
+      fprintf(stderr, "playlist has %u entries, expected %u\n",
+            (unsigned)n, (unsigned)CONTENT_FILES);
+      return false;
+   }
+   return true;
+}
+
+int main(int argc, char *argv[])
+{
+   char content_dir[4096];
+   char dat_path[4096];
+   char playlist_dir[4352];
+   scan_metrics_t m;
+   retro_time_t walk_usec, dat_usec, floor_usec;
+   struct string_list *list;
+   int64_t dat_len = 0;
+   char *dat_buf   = NULL;
+   int rc = 1;
+   bool bench_only = (argc > 1 && strcmp(argv[1], "bench") == 0);
+   /* Sanitizer mode: run every lane - parity, threaded, the
+    * cancellation sweep - but skip the wall-clock assertions, which
+    * a sanitized build cannot honestly meet.  The sanitizers are the
+    * assertion in that mode. */
+   bool sanitize   = (argc > 1 && strcmp(argv[1], "sanitize") == 0);
+
+   (void)argc;
+   (void)argv;
+
+   snprintf(fixture_root, sizeof(fixture_root), "%s/scan_begin_fixture",
+         getenv("TMPDIR") ? getenv("TMPDIR") : "/tmp");
+   rm_rf(fixture_root);
+
+   /* Logging stays off for the measured lanes: the reference costs
+    * (blocking walk, DAT parse) perform no logging, so a measured
+    * scan writing ten thousand synchronous per-entry lines to stderr
+    * would be charged for the logging, not the scanning.  Failures
+    * print their own diagnostics below. */
+   retro_main_log_file_init(NULL, false);
+
+   if (!build_fixture(fixture_root, dat_path, sizeof(dat_path),
+         content_dir, sizeof(content_dir)))
+   {
+      fprintf(stderr, "could not build fixture under %s\n", fixture_root);
+      return 1;
+   }
+   snprintf(playlist_dir, sizeof(playlist_dir), "%s/playlists",
+         fixture_root);
+   if (!path_mkdir(playlist_dir))
+      return 1;
+
+   /* Reference cost: the blocking walk this change replaces, plus the
+    * DAT parse, plus a small per-entry floor for the matching the
+    * scan itself must do.  Taken as the min of 3 reps so a cold page
+    * cache does not inflate the budget. */
+   walk_usec = INT64_MAX;
+   {
+      int rep;
+      for (rep = 0; rep < 3; rep++)
+      {
+         retro_time_t w0 = cpu_features_get_time_usec();
+         retro_time_t w;
+         list = dir_list_new(content_dir, "bin", false, false, false, true);
+         if (!list || list->size != CONTENT_FILES)
+         {
+            fprintf(stderr, "reference walk produced %u entries\n",
+                  list ? (unsigned)list->size : 0u);
+            goto out;
+         }
+         dir_list_sort(list, true);
+         string_list_free(list);
+         w = cpu_features_get_time_usec() - w0;
+         if (w < walk_usec)
+            walk_usec = w;
+      }
+   }
+   {
+      /* Reference cost through the same I/O-free parser the task
+       * uses: one whole-file read plus one owned-buffer parse.
+       * logiqx_dat_init_owned() takes the buffer either way, so
+       * dat_buf must not be freed below. */
+      retro_time_t d0 = cpu_features_get_time_usec();
+      logiqx_dat_t *dat = NULL;
+      if (filestream_read_file(dat_path, (void**)&dat_buf, &dat_len) <= 0)
+         goto out;
+      dat     = logiqx_dat_init_owned(dat_buf, (size_t)dat_len);
+      dat_buf = NULL;
+      if (!dat)
+      {
+         fprintf(stderr, "reference DAT parse failed\n");
+         goto out;
+      }
+      logiqx_dat_free(dat);
+      dat_usec = cpu_features_get_time_usec() - d0;
+   }
+   floor_usec = (retro_time_t)CONTENT_FILES * 40; /* 40us/entry match floor */
+
+   task_queue_init(false /* regular queue: the case that freezes */,
+         msgq_push);
+
+   if (!run_scan(content_dir, dat_path, playlist_dir, &m))
+      goto out_queue;
+   if (!check_playlist(playlist_dir))
+      goto out_queue;
+
+   fprintf(stderr,
+         "[metrics] files=%u total=%.1fms max_gather=%.2fms "
+         "first_feedback=%.2fms gathers=%u walk_ref=%.1fms dat_ref=%.1fms\n",
+         (unsigned)CONTENT_FILES,
+         m.total_usec      / 1000.0,
+         m.max_gather_usec / 1000.0,
+         m.first_feedback  / 1000.0,
+         m.gathers,
+         walk_usec / 1000.0,
+         dat_usec  / 1000.0);
+
+   if (bench_only)
+   {
+      rc = 0;
+      goto out_queue;
+   }
+
+   /* 1. Pacing: the worst gather must be bounded by the shared window
+    *    plus slack - not by the size of the library. */
+   if (!sanitize)
+   {
+      retro_time_t limit = 4000 * PACING_SLACK_MULTIPLIER;
+      if (m.max_gather_usec > limit)
+      {
+         fprintf(stderr,
+               "FAIL pacing: max gather %.2fms exceeds %.2fms budget\n",
+               m.max_gather_usec / 1000.0, limit / 1000.0);
+         goto out_queue;
+      }
+   }
+
+   /* 2. First feedback within ~2 frames of the push. */
+   if (!sanitize && m.first_feedback > 34000)
+   {
+      fprintf(stderr,
+            "FAIL feedback: first task feedback after %.2fms (limit 34ms)\n",
+            m.first_feedback / 1000.0);
+      goto out_queue;
+   }
+
+   /* 3. Throughput: total scan within factor of reference cost. */
+   if (!sanitize)
+   {
+      double ref = (double)(walk_usec + dat_usec + floor_usec);
+      if ((double)m.total_usec > ref * THROUGHPUT_FACTOR)
+      {
+         fprintf(stderr,
+               "FAIL throughput: total %.1fms vs reference %.1fms "
+               "(factor %.2f, limit %.2f)\n",
+               m.total_usec / 1000.0, ref / 1000.0,
+               (double)m.total_usec / ref, THROUGHPUT_FACTOR);
+         goto out_queue;
+      }
+   }
+
+   /* The regular-queue metrics lanes are done; tear that queue down
+    * before the threaded and cancellation lanes bring up their own. */
+   task_queue_deinit();
+
+   /* Threaded lane: correctness under the threaded queue (and the
+    * TSan target). */
+   {
+      char pl[4352];
+      snprintf(pl, sizeof(pl), "%s/ScanBench.lpl", playlist_dir);
+      filestream_delete(pl);
+   }
+   if (!run_scan_threaded(content_dir, dat_path, playlist_dir))
+      goto out;
+   if (!check_playlist(playlist_dir))
+      goto out;
+   fprintf(stderr, "[pass] threaded lane\n");
+
+   /* Cancellation sweep: land the cancel in every phase.  Gather
+    counts are exponential so the sweep covers setup (0-1), the
+    * budgeted walk and DAT read (single digits), content iteration
+    * (tens to thousands) and the flush (the tail), without running
+    * the full scan thousands of times. */
+   {
+      static const unsigned cancel_points[] =
+            { 0, 1, 2, 3, 4, 6, 8, 12, 16, 32, 64, 256, 1024, 4096 };
+      size_t ci;
+      for (ci = 0; ci < sizeof(cancel_points) / sizeof(cancel_points[0]); ci++)
+      {
+         if (!run_scan_cancelled(content_dir, dat_path, playlist_dir,
+               cancel_points[ci]))
+            goto out;
+      }
+      fprintf(stderr, "[pass] cancellation sweep (%u points)\n",
+            (unsigned)(sizeof(cancel_points) / sizeof(cancel_points[0])));
+   }
+
+   fprintf(stderr, "PASS scan_begin_budget_test\n");
+   rc = 0;
+   goto out;
+
+out_queue:
+   task_queue_deinit();
+out:
+   free(dat_buf);
+   rm_rf(fixture_root);
+   return rc;
+}

--- a/samples/tasks/file_transfer/Makefile
+++ b/samples/tasks/file_transfer/Makefile
@@ -11,6 +11,7 @@ LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
 
 SOURCES := task_file_transfer_test.c \
            $(REPO_ROOT)/tasks/task_file_transfer.c \
+           $(REPO_ROOT)/tasks/task_nbio_slice.c \
            $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
            $(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
            $(LIBRETRO_COMM_DIR)/compat/compat_strldup.c \

--- a/samples/tasks/image_decode_slice/Makefile
+++ b/samples/tasks/image_decode_slice/Makefile
@@ -22,6 +22,7 @@ LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
 SOURCES := image_decode_slice_test.c \
            $(REPO_ROOT)/tasks/task_image.c \
            $(REPO_ROOT)/tasks/task_file_transfer.c \
+           $(REPO_ROOT)/tasks/task_nbio_slice.c \
            $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
            $(LIBRETRO_COMM_DIR)/compat/compat_strldup.c \
            $(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -28,6 +28,7 @@
 #include <formats/m3u_file.h>
 #include <encodings/crc32.h>
 #include <streams/interface_stream.h>
+#include <streams/file_stream.h>
 #include "tasks_internal.h"
 
 #include "../core_info.h"
@@ -2541,9 +2542,33 @@ static void task_manual_content_scan_handler(retro_task_t *task)
                  manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE) &&
                 *manual_scan->task_config->dat_file_path)
             {
-               if (!(manual_scan->dat_file =
-                     logiqx_dat_init(
-                        manual_scan->task_config->dat_file_path)))
+               /* The parser is I/O-free now: validate the path (the
+                * checks logiqx_dat_init() used to perform), read the
+                * whole document, hand the buffer over.  Still one
+                * blocking read in this state - a following commit
+                * spreads it across gathers under the shared window. */
+               char *dat_xml     = NULL;
+               int64_t dat_len   = 0;
+               logiqx_dat_t *dat = NULL;
+
+               if (   logiqx_dat_extension_is_valid(manual_scan->task_config->dat_file_path)
+                   && path_is_valid(manual_scan->task_config->dat_file_path)
+                   && filestream_read_file(manual_scan->task_config->dat_file_path,
+                        (void**)&dat_xml, &dat_len) > 0
+                   && dat_len > 0)
+               {
+                  /* Ownership of dat_xml transfers unconditionally:
+                   * logiqx_dat_init_owned() frees it on failure. */
+                  dat = logiqx_dat_init_owned(dat_xml, (size_t)dat_len);
+                  dat_xml = NULL;
+               }
+               else if (dat_xml)
+               {
+                  free(dat_xml);
+                  dat_xml = NULL;
+               }
+
+               if (!(manual_scan->dat_file = dat))
                {
                   const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_DAT_FILE_LOAD_ERROR);
                   runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -267,7 +267,21 @@ enum db_flags_enum
 
 enum manual_scan_status
 {
+   /* The BEGIN family: what used to be one monolithic BEGIN state
+    * doing a full recursive directory walk, a whole-file DAT load
+    * and the playlist setup in a single handler invocation - a
+    * multi-hundred-millisecond freeze on a large library when
+    * Threaded Tasks is off.  Each sub-state now respects the shared
+    * per-frame I/O window (task_nbio_slice_*, the same window the
+    * file-transfer spine uses), and completed sub-states collapse
+    * into one invocation while the window lasts, so small libraries
+    * keep their single-tick latency.  The task's public identity
+    * (handler, state) is untouched, so task_queue_find()-based
+    * duplicate-scan suppression is unaffected. */
    MANUAL_SCAN_BEGIN = 0,
+   MANUAL_SCAN_BEGIN_DIR_LIST,
+   MANUAL_SCAN_BEGIN_DAT_LOAD,
+   MANUAL_SCAN_BEGIN_PLAYLIST,
    MANUAL_SCAN_ITERATE_CLEAN,
    DATABASE_SCAN_ITERATE_START,
    DATABASE_SCAN_ITERATE_CONTENT,
@@ -283,6 +297,18 @@ typedef struct manual_scan_handle
    playlist_t *playlist;
    struct string_list *file_exts_list;
    struct string_list *content_list;
+   /* Resumable walk filling content_list across gathers; non-NULL
+    * only between MANUAL_SCAN_BEGIN and the completion of
+    * MANUAL_SCAN_BEGIN_DIR_LIST. */
+   dir_list_iter_t *content_iter;
+   /* Chunked DAT read in flight (MANUAL_SCAN_BEGIN_DAT_LOAD): the
+    * file handle, the destination buffer (dat_size + 1 bytes) and
+    * the fill position.  dat_buf ownership passes to
+    * logiqx_dat_init_owned() once the read completes. */
+   RFILE *dat_stream;
+   char *dat_buf;
+   int64_t dat_size;
+   int64_t dat_read;
    logiqx_dat_t *dat_file;
    struct string_list *m3u_list;
    playlist_config_t playlist_config; /* size_t alignment */
@@ -2169,6 +2195,28 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
       manual_scan->file_exts_list = NULL;
    }
 
+   /* A cancelled task can die mid-walk or mid-DAT-read; the
+    * iterator closes any directory handles still open, and the
+    * read buffer is only non-NULL while its ownership is still
+    * here (it passes to logiqx_dat_init_owned() on completion). */
+   if (manual_scan->content_iter)
+   {
+      dir_list_iter_free(manual_scan->content_iter);
+      manual_scan->content_iter = NULL;
+   }
+
+   if (manual_scan->dat_stream)
+   {
+      filestream_close(manual_scan->dat_stream);
+      manual_scan->dat_stream = NULL;
+   }
+
+   if (manual_scan->dat_buf)
+   {
+      free(manual_scan->dat_buf);
+      manual_scan->dat_buf = NULL;
+   }
+
    if (manual_scan->content_list)
    {
       string_list_free(manual_scan->content_list);
@@ -2361,6 +2409,499 @@ static void task_manual_content_scan_free(retro_task_t *task)
    free_manual_content_scan_handle(manual_scan);
 }
 
+/* --- MANUAL_SCAN_BEGIN family ---------------------------------------
+ *
+ * What used to be one monolithic BEGIN case is a short sequence of
+ * budgeted sub-states sharing the per-frame I/O window with the
+ * file-transfer spine (task_nbio_slice_*).  The same total work is
+ * performed - the walk is incremental rather than done twice, the
+ * DAT is read in chunks into a single buffer that is then handed to
+ * the parser whole - so end-to-end scan time is preserved while no
+ * single gather freezes the frame.  Each sub-state function returns
+ * true when the task must finish (error or nothing to scan), exactly
+ * where the old code went to task_finished. */
+
+/* Chunk size for the budgeted DAT read.  Large enough that fast
+ * storage delivers a big DAT in a handful of gathers, small enough
+ * that the guaranteed floor chunk of a spent window costs well under
+ * a millisecond. */
+#define MANUAL_SCAN_DAT_CHUNK (256 * 1024)
+
+/* dir_list_iter_step()'s budget callback carries no sizes. */
+static bool manual_scan_walk_within_budget(void *ud)
+{
+   return task_nbio_slice_within_budget(ud, 0, 0);
+}
+
+static bool manual_scan_begin_setup(retro_task_t *task,
+      manual_scan_handle_t *manual_scan)
+{
+   /* Initialize scan results accumulation */
+   if (!scan_results_init(&manual_scan->scan_results, 1024))
+   {
+      RARCH_ERR("[Scanner] Failed to initialize scan results\n");
+      return true;
+   }
+
+#ifdef HAVE_LIBRETRODB
+   if ((manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_STRICT ||
+        manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_LOOSE) &&
+       !(manual_scan->flags & DB_HANDLE_FLAG_SCAN_STARTED))
+   {
+      database_state_handle_t *dbstate = &manual_scan->state;
+
+      manual_scan->flags       |= DB_HANDLE_FLAG_SCAN_STARTED;
+
+      /* No content dir: same terminal exit the old code took when
+       * no handle came into being. */
+      if (!*manual_scan->task_config->content_dir)
+         return true;
+
+      if (manual_scan->flags & DB_HANDLE_FLAG_IS_DIRECTORY)
+      {
+         /* Start the incremental walk that replaces
+          * database_info_dir_init()'s blocking dir_list_new().
+          * Extension derivation matches it: all supported core
+          * extensions unless an explicit list is given.  The
+          * cue/gdi-prioritising sort follows on completion in
+          * database_info_dir_init_from_list(). */
+         core_info_list_t *core_info_list = NULL;
+         char *file_exts                  =
+               manual_scan->task_config->file_exts;
+
+         if (!file_exts || !*file_exts)
+            core_info_get_list(&core_info_list);
+
+         if ((manual_scan->content_list = string_list_new()))
+            manual_scan->content_iter = dir_list_iter_new(
+                  manual_scan->task_config->content_dir,
+                  core_info_list ? core_info_list->all_ext : file_exts,
+                  false,
+                  manual_scan->flags & DB_HANDLE_FLAG_SHOW_HIDDEN_FILES,
+                  manual_scan->task_config->search_archives,
+                  manual_scan->task_config->search_recursively,
+                  manual_scan->content_list);
+
+         if (!manual_scan->content_iter)
+            return true;
+      }
+      else
+      {
+         if (!(manual_scan->handle = database_info_file_init(
+               manual_scan->task_config->content_dir,
+               DATABASE_TYPE_ITERATE,
+               task, &manual_scan->content_list)))
+            return true;
+         manual_scan->handle->status = DATABASE_STATUS_ITERATE_START;
+      }
+
+      if (dbstate && !dbstate->list)
+      {
+         if (manual_scan->content_database_path && *manual_scan->content_database_path)
+         {
+            if (manual_scan->task_config->db_selection == MANUAL_CONTENT_SCAN_SELECT_DB_SPECIFIC)
+            {
+               size_t str_len     = PATH_MAX_LENGTH * sizeof(char);
+               char* rdb_name     = (char*)malloc(str_len);
+               char* rdb_fullpath = (char*)malloc(str_len);
+               union string_list_elem_attr attr;
+               attr.i = 0;
+
+               /* Bail out if either heap allocation failed.
+                * fill_pathname and fill_pathname_join_special
+                * both call strlcpy on their destination buffer
+                * with no NULL guard, so proceeding with a NULL
+                * rdb_name / rdb_fullpath would segfault.  Free
+                * the one that did succeed (free(NULL) is a
+                * no-op so no conditional needed) before taking
+                * the task-finished exit. */
+               if (!rdb_name || !rdb_fullpath)
+               {
+                  free(rdb_name);
+                  free(rdb_fullpath);
+                  return true;
+               }
+
+               fill_pathname(rdb_name,
+                     manual_scan->task_config->database_name,
+                     ".rdb", str_len);
+
+               fill_pathname_join_special(rdb_fullpath,
+                     manual_scan->content_database_path,
+                     rdb_name, str_len);
+
+               dbstate->list = string_list_new();
+               if (!dbstate->list)
+               {
+                  /* Earlier code goto'd here without freeing
+                   * the two buffers above, leaking ~8 KiB on
+                   * this OOM path.  Free them explicitly. */
+                  free(rdb_name);
+                  free(rdb_fullpath);
+                  return true;
+               }
+               string_list_append(dbstate->list, rdb_fullpath, attr);
+               free(rdb_name);
+               free(rdb_fullpath);
+            }
+            else
+            {
+               dbstate->list        = dir_list_new(
+                     manual_scan->content_database_path,
+                     "rdb", false,
+                     manual_scan->flags & DB_HANDLE_FLAG_SHOW_HIDDEN_FILES,
+                     false, false);
+            }
+
+            /* Size the per-database size/flag caches to the
+             * database list we just built.  Both branches
+             * above land here. */
+            if (   dbstate->list
+                && !task_database_state_alloc_arrays(dbstate))
+            {
+               RARCH_ERR("[Scanner] Out of memory allocating database state\n");
+               return true;
+            }
+         }
+
+         RARCH_LOG("[Scanner] %s\"%s\"...\n", msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_START), manual_scan->content_database_path);
+         if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_DATABASE_SCAN, NULL))
+            printf("%s\"%s\"...\n", msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_START), manual_scan->content_database_path);
+      }
+   }
+   else
+#endif
+   {
+      /* Get allowed file extensions list */
+      if (*manual_scan->task_config->file_exts)
+         manual_scan->file_exts_list = string_split(
+               manual_scan->task_config->file_exts, "|");
+
+      /* Start the incremental walk that replaces
+       * manual_content_scan_get_content_list(); the same policy
+       * (extension filter, compressed inclusion) is applied by the
+       * shared helper, and a plain-file content dir completes here
+       * with no iterator. */
+      if (!manual_content_scan_content_list_iter_new(
+               manual_scan->task_config,
+               &manual_scan->content_list,
+               &manual_scan->content_iter))
+      {
+         const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_INVALID_CONTENT);
+         runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,\
+               MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+         return true;
+      }
+   }
+
+   manual_scan->status = MANUAL_SCAN_BEGIN_DIR_LIST;
+   return false;
+}
+
+static bool manual_scan_begin_dir_list(retro_task_t *task,
+      manual_scan_handle_t *manual_scan, nbio_budget_t *b)
+{
+#ifdef HAVE_LIBRETRODB
+   bool is_db_scan =
+         (manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_STRICT ||
+          manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_LOOSE);
+#endif
+
+   (void)task;
+
+   if (manual_scan->content_iter)
+   {
+      int r = dir_list_iter_step(manual_scan->content_iter,
+            manual_scan_walk_within_budget, b);
+
+      if (r == 0)   /* window spent - resume next gather */
+         return false;
+
+      dir_list_iter_free(manual_scan->content_iter);
+      manual_scan->content_iter = NULL;
+
+      if (r < 0)
+      {
+         /* Allocation failure mid-walk: the same terminal the old
+          * code took when dir_list_new() returned NULL. */
+#ifdef HAVE_LIBRETRODB
+         if (!is_db_scan)
+#endif
+         {
+            const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_INVALID_CONTENT);
+            runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,\
+                  MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+         }
+         return true;
+      }
+   }
+
+   /* Walk complete (or was never needed): finalize per branch. */
+#ifdef HAVE_LIBRETRODB
+   if (is_db_scan)
+   {
+      if (  (manual_scan->flags & DB_HANDLE_FLAG_IS_DIRECTORY)
+          && !manual_scan->handle)
+      {
+         /* cue, gdi prioritization in sorting */
+         if (!(manual_scan->handle = database_info_dir_init_from_list(
+               DATABASE_TYPE_ITERATE, manual_scan->content_list)))
+            return true;
+         manual_scan->handle->status = DATABASE_STATUS_ITERATE_START;
+      }
+   }
+   else
+#endif
+   {
+      /* The blocking getter rejected an empty listing before the
+       * task ever saw it; apply the same rule, then the same
+       * alphabetical sort (task status messages would be
+       * unintuitive in readdir order). */
+      if (  !manual_scan->content_list
+          || manual_scan->content_list->size < 1)
+      {
+         const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_INVALID_CONTENT);
+         runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,\
+               MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+         return true;
+      }
+      dir_list_sort(manual_scan->content_list, true);
+   }
+
+   manual_scan->status = MANUAL_SCAN_BEGIN_DAT_LOAD;
+   return false;
+}
+
+static bool manual_scan_begin_dat_load(retro_task_t *task,
+      manual_scan_handle_t *manual_scan, nbio_budget_t *b)
+{
+   bool first = true;
+
+   (void)task;
+
+   if (!((manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_STRICT ||
+          manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE) &&
+         *manual_scan->task_config->dat_file_path))
+   {
+      manual_scan->status = MANUAL_SCAN_BEGIN_PLAYLIST;
+      return false;
+   }
+
+   if (!manual_scan->dat_stream)
+   {
+      /* Validate path and size up front - the checks the parser
+       * itself used to perform before it became I/O-free - and
+       * size the destination buffer once. */
+      int64_t _len = 0;
+
+      if (   !logiqx_dat_extension_is_valid(manual_scan->task_config->dat_file_path)
+          || !path_is_valid(manual_scan->task_config->dat_file_path)
+          || (_len = path_get_size(manual_scan->task_config->dat_file_path)) <= 0
+          /* Reject any size that would not fit in size_t on this
+           * platform (mirrors rxml_load_document's guard). */
+          || (uint64_t)_len >= (uint64_t)((size_t)-1))
+         goto error;
+
+      if (!(manual_scan->dat_buf = (char*)malloc((size_t)(_len + 1))))
+         goto error;
+
+      if (!(manual_scan->dat_stream = filestream_open(
+            manual_scan->task_config->dat_file_path,
+            RETRO_VFS_FILE_ACCESS_READ,
+            RETRO_VFS_FILE_ACCESS_HINT_NONE)))
+         goto error;
+
+      manual_scan->dat_size = _len;
+      manual_scan->dat_read = 0;
+   }
+
+   /* Budgeted fill.  The floor guarantees one chunk per gather even
+    * when the shared window is already spent, so progress is made
+    * whatever the concurrent load. */
+   while (manual_scan->dat_read < manual_scan->dat_size)
+   {
+      int64_t want = manual_scan->dat_size - manual_scan->dat_read;
+      int64_t got;
+
+      if (!first && !task_nbio_slice_within_budget(b, 0, 0))
+         return false;   /* resume next gather */
+      first = false;
+
+      if (want > MANUAL_SCAN_DAT_CHUNK)
+         want = MANUAL_SCAN_DAT_CHUNK;
+
+      got = filestream_read(manual_scan->dat_stream,
+            manual_scan->dat_buf + manual_scan->dat_read, want);
+
+      if (got <= 0)   /* truncated underneath us, or a read error */
+         goto error;
+
+      manual_scan->dat_read += got;
+   }
+
+   filestream_close(manual_scan->dat_stream);
+   manual_scan->dat_stream = NULL;
+
+   /* Hand the completed document to the parser.  Ownership of the
+    * buffer transfers unconditionally: on failure
+    * logiqx_dat_init_owned() frees it. */
+   manual_scan->dat_buf[manual_scan->dat_size] = '\0';
+   manual_scan->dat_file = logiqx_dat_init_owned(
+         manual_scan->dat_buf, (size_t)manual_scan->dat_size);
+   manual_scan->dat_buf  = NULL;
+
+   if (!manual_scan->dat_file)
+      goto error_no_cleanup;
+
+   manual_scan->status = MANUAL_SCAN_BEGIN_PLAYLIST;
+   return false;
+
+error:
+   if (manual_scan->dat_stream)
+   {
+      filestream_close(manual_scan->dat_stream);
+      manual_scan->dat_stream = NULL;
+   }
+   if (manual_scan->dat_buf)
+   {
+      free(manual_scan->dat_buf);
+      manual_scan->dat_buf = NULL;
+   }
+error_no_cleanup:
+   {
+      const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_DAT_FILE_LOAD_ERROR);
+      runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,
+            MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+   }
+   return true;
+}
+
+static bool manual_scan_begin_playlist(retro_task_t *task,
+      manual_scan_handle_t *manual_scan)
+{
+   (void)task;
+
+   /* Open playlist */
+   if (manual_scan->task_config->target_is_single_determined_playlist &&
+       !(manual_scan->playlist =
+            playlist_init(&manual_scan->playlist_config)))
+      return true;
+
+   /* Reset playlist, if required */
+   if (manual_scan->task_config->overwrite_playlist)
+      playlist_clear(manual_scan->playlist);
+
+   /* Get initial playlist size */
+   manual_scan->playlist_size =
+      playlist_size(manual_scan->playlist);
+
+   /* Set default core, if required */
+   if (manual_scan->task_config->core_set)
+   {
+      playlist_set_default_core_path(manual_scan->playlist,
+            manual_scan->task_config->core_path);
+      playlist_set_default_core_name(manual_scan->playlist,
+            manual_scan->task_config->core_name);
+   }
+
+   /* Record remaining scan parameters to enable
+    * subsequent 'refresh playlist' operations */
+   playlist_set_scan_content_dir(manual_scan->playlist,
+         manual_scan->task_config->content_dir);
+   playlist_set_scan_file_exts(manual_scan->playlist,
+         manual_scan->task_config->file_exts_custom_set ?
+               manual_scan->task_config->file_exts : NULL);
+   if (manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE ||
+       manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_STRICT)
+      playlist_set_scan_dat_file_path(manual_scan->playlist,
+            manual_scan->task_config->dat_file_path);
+   playlist_set_scan_database_name(manual_scan->playlist,
+         manual_scan->task_config->database_name);
+   playlist_set_scan_search_recursively(manual_scan->playlist,
+         manual_scan->task_config->search_recursively);
+   playlist_set_scan_search_archives(manual_scan->playlist,
+         manual_scan->task_config->search_archives);
+   playlist_set_scan_filter_dat_content(manual_scan->playlist,
+         manual_scan->task_config->filter_dat_content);
+   playlist_set_scan_overwrite_playlist(manual_scan->playlist,
+         manual_scan->task_config->overwrite_playlist);
+   playlist_set_scan_db_usage(manual_scan->playlist,
+         manual_scan->task_config->db_usage);
+   playlist_set_scan_omit_db_ref(manual_scan->playlist,
+         manual_scan->task_config->omit_db_reference);
+
+   /* All good - can start iterating
+    * > If playlist has content and 'validate
+    *   entries' is enabled, go to clean-up phase
+    * > Otherwise go straight to content scan phase */
+   if (manual_scan->task_config->validate_entries &&
+       (manual_scan->playlist_size > 0))
+      manual_scan->status = MANUAL_SCAN_ITERATE_CLEAN;
+   else
+   {
+#ifdef HAVE_LIBRETRODB
+      if (manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_LOOSE ||
+          manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_STRICT)
+         manual_scan->status = DATABASE_SCAN_ITERATE_START;
+      else
+#endif
+         manual_scan->status = MANUAL_SCAN_ITERATE_CONTENT;
+   }
+   return false;
+}
+
+/* One gather's worth of BEGIN-family work.  Opens a share of the
+ * per-frame window once, then runs sub-states back to back while they
+ * complete inside it - so a small library still finishes the whole
+ * BEGIN sequence (and often the whole scan setup) in a single tick,
+ * exactly the latency it had before the split.  Returns true when the
+ * task must finish. */
+static bool task_manual_scan_begin_tick(retro_task_t *task,
+      manual_scan_handle_t *manual_scan)
+{
+   nbio_budget_t b;
+   bool error = false;
+
+   task_nbio_slice_open(&b);
+
+   for (;;)
+   {
+      enum manual_scan_status entry_status = manual_scan->status;
+
+      switch (manual_scan->status)
+      {
+         case MANUAL_SCAN_BEGIN:
+            error = manual_scan_begin_setup(task, manual_scan);
+            break;
+         case MANUAL_SCAN_BEGIN_DIR_LIST:
+            error = manual_scan_begin_dir_list(task, manual_scan, &b);
+            break;
+         case MANUAL_SCAN_BEGIN_DAT_LOAD:
+            error = manual_scan_begin_dat_load(task, manual_scan, &b);
+            break;
+         case MANUAL_SCAN_BEGIN_PLAYLIST:
+            error = manual_scan_begin_playlist(task, manual_scan);
+            break;
+         default:
+            /* Left the BEGIN family: done for this gather. */
+            task_nbio_slice_close(&b);
+            return false;
+      }
+
+      if (error)
+         break;
+      /* A sub-state that kept its status yielded on the window. */
+      if (manual_scan->status == entry_status)
+         break;
+      /* Collapse into the next sub-state only while budget lasts. */
+      if (!task_nbio_slice_within_budget(&b, 0, 0))
+         break;
+   }
+
+   task_nbio_slice_close(&b);
+   return error;
+}
+
 static void task_manual_content_scan_handler(retro_task_t *task)
 {
    uint8_t flg;
@@ -2400,251 +2941,20 @@ static void task_manual_content_scan_handler(retro_task_t *task)
    switch (manual_scan->status)
    {
       case MANUAL_SCAN_BEGIN:
-         {
-
-            /* Initialize scan results accumulation */
-            if (!scan_results_init(&manual_scan->scan_results, 1024))
-            {
-               RARCH_ERR("[Scanner] Failed to initialize scan results\n");
-               goto task_finished;
-            }
-
+      case MANUAL_SCAN_BEGIN_DIR_LIST:
+      case MANUAL_SCAN_BEGIN_DAT_LOAD:
+      case MANUAL_SCAN_BEGIN_PLAYLIST:
+         if (task_manual_scan_begin_tick(task, manual_scan))
+            goto task_finished;
 #ifdef HAVE_LIBRETRODB
-            if ((manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_STRICT ||
-                 manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_LOOSE) &&
-                !(manual_scan->flags & DB_HANDLE_FLAG_SCAN_STARTED))
-            {
-               manual_scan->flags       |= DB_HANDLE_FLAG_SCAN_STARTED;
-
-               if (*manual_scan->task_config->content_dir)
-               {
-                  /* cue, gdi prioritization in sorting */
-                  if (manual_scan->flags & DB_HANDLE_FLAG_IS_DIRECTORY)
-                     manual_scan->handle = database_info_dir_init(
-                           manual_scan->task_config->content_dir, DATABASE_TYPE_ITERATE,
-                           manual_scan->task_config->file_exts,
-                           manual_scan->flags & DB_HANDLE_FLAG_SHOW_HIDDEN_FILES, 
-                           manual_scan->task_config->search_recursively,
-                           manual_scan->task_config->search_archives,
-                           &manual_scan->content_list);
-                  else
-                     manual_scan->handle = database_info_file_init(
-                           manual_scan->task_config->content_dir, DATABASE_TYPE_ITERATE,
-                           task, &manual_scan->content_list);
-               }
-
-               if (manual_scan->handle)
-                  manual_scan->handle->status = DATABASE_STATUS_ITERATE_BEGIN;
-
-               if (!manual_scan->handle)
-                  goto task_finished;
-
-               dbinfo  = manual_scan->handle;
-               dbstate = &manual_scan->state;
-
-               if (dbstate && !dbstate->list)
-               {
-                  if (manual_scan->content_database_path && *manual_scan->content_database_path)
-                  {
-                     if (manual_scan->task_config->db_selection == MANUAL_CONTENT_SCAN_SELECT_DB_SPECIFIC)
-                     {
-                        size_t str_len     = PATH_MAX_LENGTH * sizeof(char);
-                        char* rdb_name     = (char*)malloc(str_len);
-                        char* rdb_fullpath = (char*)malloc(str_len);
-                        union string_list_elem_attr attr;
-                        attr.i = 0;
-
-                        /* Bail out if either heap allocation failed.
-                         * fill_pathname and fill_pathname_join_special
-                         * both call strlcpy on their destination buffer
-                         * with no NULL guard, so proceeding with a NULL
-                         * rdb_name / rdb_fullpath would segfault.  Free
-                         * the one that did succeed (free(NULL) is a
-                         * no-op so no conditional needed) before taking
-                         * the task-finished exit. */
-                        if (!rdb_name || !rdb_fullpath)
-                        {
-                           free(rdb_name);
-                           free(rdb_fullpath);
-                           goto task_finished;
-                        }
-
-                        fill_pathname(rdb_name,
-                              manual_scan->task_config->database_name,
-                              ".rdb", str_len);
-
-                        fill_pathname_join_special(rdb_fullpath,
-                              manual_scan->content_database_path,
-                              rdb_name, str_len);
-
-                        dbstate->list = string_list_new();
-                        if (!dbstate->list)
-                        {
-                           /* Earlier code goto'd here without freeing
-                            * the two buffers above, leaking ~8 KiB on
-                            * this OOM path.  Free them explicitly. */
-                           free(rdb_name);
-                           free(rdb_fullpath);
-                           goto task_finished;
-                        }
-                        string_list_append(dbstate->list, rdb_fullpath, attr);
-                        free(rdb_name);
-                        free(rdb_fullpath);
-                     }
-                     else
-                     {
-                        dbstate->list        = dir_list_new(
-                              manual_scan->content_database_path,
-                              "rdb", false,
-                              manual_scan->flags & DB_HANDLE_FLAG_SHOW_HIDDEN_FILES,
-                              false, false);
-                     }
-
-                     /* Size the per-database size/flag caches to the
-                      * database list we just built.  Both branches
-                      * above land here. */
-                     if (   dbstate->list
-                         && !task_database_state_alloc_arrays(dbstate))
-                     {
-                        RARCH_ERR("[Scanner] Out of memory allocating database state\n");
-                        goto task_finished;
-                     }
-                  }
-
-                  RARCH_LOG("[Scanner] %s\"%s\"...\n", msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_START), manual_scan->content_database_path);
-                  if (retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_DATABASE_SCAN, NULL))
-                     printf("%s\"%s\"...\n", msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_START), manual_scan->content_database_path);
-               }
-               dbinfo->status = DATABASE_STATUS_ITERATE_START;
-            }
-            else
+         /* The BEGIN family may have created the database handle
+          * this invocation; refresh the locals the ITERATE cases
+          * of later ticks are fetched from at handler entry. */
+         dbinfo  = manual_scan->handle;
+         dbstate = &manual_scan->state;
 #endif
-            {
-               /* Get allowed file extensions list */
-               if (*manual_scan->task_config->file_exts)
-                  manual_scan->file_exts_list = string_split(
-                        manual_scan->task_config->file_exts, "|");
-
-               /* Get content list */
-               if (!(manual_scan->content_list
-                        = manual_content_scan_get_content_list(
-                           manual_scan->task_config)))
-               {
-                  const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_INVALID_CONTENT);
-                  runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,\
-                        MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-                  goto task_finished;
-               }
-            }
-
-            /* Load DAT file, if required */
-            if ((manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_STRICT ||
-                 manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE) &&
-                *manual_scan->task_config->dat_file_path)
-            {
-               /* The parser is I/O-free now: validate the path (the
-                * checks logiqx_dat_init() used to perform), read the
-                * whole document, hand the buffer over.  Still one
-                * blocking read in this state - a following commit
-                * spreads it across gathers under the shared window. */
-               char *dat_xml     = NULL;
-               int64_t dat_len   = 0;
-               logiqx_dat_t *dat = NULL;
-
-               if (   logiqx_dat_extension_is_valid(manual_scan->task_config->dat_file_path)
-                   && path_is_valid(manual_scan->task_config->dat_file_path)
-                   && filestream_read_file(manual_scan->task_config->dat_file_path,
-                        (void**)&dat_xml, &dat_len) > 0
-                   && dat_len > 0)
-               {
-                  /* Ownership of dat_xml transfers unconditionally:
-                   * logiqx_dat_init_owned() frees it on failure. */
-                  dat = logiqx_dat_init_owned(dat_xml, (size_t)dat_len);
-                  dat_xml = NULL;
-               }
-               else if (dat_xml)
-               {
-                  free(dat_xml);
-                  dat_xml = NULL;
-               }
-
-               if (!(manual_scan->dat_file = dat))
-               {
-                  const char *_msg = msg_hash_to_str(MSG_MANUAL_CONTENT_SCAN_DAT_FILE_LOAD_ERROR);
-                  runloop_msg_queue_push(_msg, strlen(_msg), 1, 100, true, NULL,
-                        MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
-                  goto task_finished;
-               }
-            }
-
-            /* Open playlist */
-            if (manual_scan->task_config->target_is_single_determined_playlist &&
-                !(manual_scan->playlist =
-                     playlist_init(&manual_scan->playlist_config)))
-               goto task_finished;
-
-            /* Reset playlist, if required */
-            if (manual_scan->task_config->overwrite_playlist)
-               playlist_clear(manual_scan->playlist);
-
-            /* Get initial playlist size */
-            manual_scan->playlist_size =
-               playlist_size(manual_scan->playlist);
-
-            /* Set default core, if required */
-            if (manual_scan->task_config->core_set)
-            {
-               playlist_set_default_core_path(manual_scan->playlist,
-                     manual_scan->task_config->core_path);
-               playlist_set_default_core_name(manual_scan->playlist,
-                     manual_scan->task_config->core_name);
-            }
-
-            /* Record remaining scan parameters to enable
-             * subsequent 'refresh playlist' operations */
-            playlist_set_scan_content_dir(manual_scan->playlist,
-                  manual_scan->task_config->content_dir);
-            playlist_set_scan_file_exts(manual_scan->playlist,
-                  manual_scan->task_config->file_exts_custom_set ?
-                        manual_scan->task_config->file_exts : NULL);
-            if (manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE ||
-                manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_STRICT)
-               playlist_set_scan_dat_file_path(manual_scan->playlist,
-                     manual_scan->task_config->dat_file_path);
-            playlist_set_scan_database_name(manual_scan->playlist,
-                  manual_scan->task_config->database_name);
-            playlist_set_scan_search_recursively(manual_scan->playlist,
-                  manual_scan->task_config->search_recursively);
-            playlist_set_scan_search_archives(manual_scan->playlist,
-                  manual_scan->task_config->search_archives);
-            playlist_set_scan_filter_dat_content(manual_scan->playlist,
-                  manual_scan->task_config->filter_dat_content);
-            playlist_set_scan_overwrite_playlist(manual_scan->playlist,
-                  manual_scan->task_config->overwrite_playlist);
-            playlist_set_scan_db_usage(manual_scan->playlist,
-                  manual_scan->task_config->db_usage);
-            playlist_set_scan_omit_db_ref(manual_scan->playlist,
-                  manual_scan->task_config->omit_db_reference);
-
-            /* All good - can start iterating
-             * > If playlist has content and 'validate
-             *   entries' is enabled, go to clean-up phase
-             * > Otherwise go straight to content scan phase */
-            if (manual_scan->task_config->validate_entries &&
-                (manual_scan->playlist_size > 0))
-               manual_scan->status = MANUAL_SCAN_ITERATE_CLEAN;
-            else
-            {
-#ifdef HAVE_LIBRETRODB
-               if (manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_LOOSE ||
-                   manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_STRICT)
-                  manual_scan->status = DATABASE_SCAN_ITERATE_START;
-               else
-#endif
-                  manual_scan->status = MANUAL_SCAN_ITERATE_CONTENT;
-            }
-         }
          break;
+
       case MANUAL_SCAN_ITERATE_CLEAN:
          {
             const struct playlist_entry *entry = NULL;

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -309,6 +309,20 @@ typedef struct manual_scan_handle
    char *dat_buf;
    int64_t dat_size;
    int64_t dat_read;
+   /* Resumable batch playlist flush (MANUAL_SCAN_END): position in
+    * scan_results, the playlist currently open for the group being
+    * written, its group key and running count, and the path scratch
+    * buffer - all of what used to be locals of a single monolithic
+    * call, promoted so the flush can yield on the shared window and
+    * resume next gather.  flush_group points into either the task
+    * config or the owned results array, both of which outlive the
+    * flush. */
+   size_t flush_pos;
+   playlist_t *flush_playlist;
+   const char *flush_group;
+   char *flush_path_buf;
+   unsigned flush_added;
+   bool flush_started;
    logiqx_dat_t *dat_file;
    struct string_list *m3u_list;
    playlist_config_t playlist_config; /* size_t alignment */
@@ -1954,43 +1968,71 @@ static void task_database_cleanup_state(database_state_handle_t *db_state)
 }
 #endif
 /* Batch update playlists from accumulated scan results */
-static void scan_results_batch_update_playlists(scan_results_t *sr,
+/* Resumable form of what used to be
+ * scan_results_batch_update_playlists(): one gather's worth of the
+ * batch playlist flush, under the same shared window as the BEGIN
+ * family.  The old call added every accumulated result - each add a
+ * linear playlist_entry_exists() probe - then sorted and wrote the
+ * playlist, all in the gather that reached MANUAL_SCAN_END: 166 ms
+ * measured for a 5000-file scan, the largest single freeze left
+ * after the BEGIN split.  The loop's locals (position, open
+ * playlist, group key, counters, path scratch) live on the handle
+ * now so the loop can yield between results and resume.
+ *
+ * The group-close write for multi-playlist scans and the final
+ * sort+write remain single blocking operations: a playlist file
+ * write is atomic by design (a partial write would corrupt the
+ * playlist on a cancelled scan), so those are the floor this flush
+ * cannot go below.
+ *
+ * Returns true when the flush has fully completed (including the
+ * failure mode of the scratch allocation, which skips the batch
+ * exactly as the old code did), false when yielding. */
+static bool manual_scan_end_flush_tick(
    manual_scan_handle_t* manual_scan, bool single_playlist)
 {
-   size_t i;
-   const char *current_playlist = NULL;
-   playlist_t *playlist = NULL;
-   unsigned added_count = 0;
+   scan_results_t *sr = &manual_scan->scan_results;
+   nbio_budget_t b;
+   bool first = true;
    size_t str_len = PATH_MAX_LENGTH * sizeof(char);
-   char *db_playlist_path = (char*)malloc(str_len);
 
-   if (!db_playlist_path)
+   if (!manual_scan->flush_started)
    {
-      RARCH_ERR("[Scanner] Failed to allocate memory for batch playlist update.\n");
-      return;
-   }
+      manual_scan->flush_started = true;
 
-   RARCH_LOG("[Scanner] Batch updating playlists with %u results...\n",
-            (unsigned)sr->count);
+      if (!(manual_scan->flush_path_buf = (char*)malloc(str_len)))
+      {
+         RARCH_ERR("[Scanner] Failed to allocate memory for batch playlist update.\n");
+         return true;
+      }
 
-   if (single_playlist)
-   {
-      current_playlist = manual_scan->task_config->playlist_file;
-      playlist = manual_scan->playlist;
+      RARCH_LOG("[Scanner] Batch updating playlists with %u results...\n",
+               (unsigned)sr->count);
+
+      if (single_playlist)
+      {
+         manual_scan->flush_group    = manual_scan->task_config->playlist_file;
+         manual_scan->flush_playlist = manual_scan->playlist;
+      }
    }
+   else if (!manual_scan->flush_path_buf)
+      return true;   /* scratch allocation failed on a previous gather */
+
+   task_nbio_slice_open(&b);
+
    /* Process results, grouping by playlist */
-   for (i = 0; i < sr->count; i++)
+   while (manual_scan->flush_pos < sr->count)
    {
-      scan_result_t *result = &sr->results[i];
+      scan_result_t *result = &sr->results[manual_scan->flush_pos];
       char db_name_noext[PATH_MAX_LENGTH];
       /* The key identifying which playlist this result belongs to.
        * With a fixed playlist file every result goes to the same
        * playlist, so the key is that path; otherwise results are
        * grouped by database name.
        *
-       * This used to compare current_playlist against result->db_name
+       * This used to compare the group key against result->db_name
        * unconditionally, but the fixed-file branch below assigns
-       * task_config->playlist_file to current_playlist - a path like
+       * task_config->playlist_file as the group - a path like
        * ".../MyList.lpl", which never equals a db_name, those being
        * the database's own file name.  The test was therefore true on every
        * iteration, and each result closed the playlist (a full
@@ -2001,85 +2043,99 @@ static void scan_results_batch_update_playlists(scan_results_t *sr,
          ? manual_scan->task_config->playlist_file
          : result->db_name;
 
+      /* The floor: one result per gather regardless of the window,
+       * then yield between any two results. */
+      if (!first && !task_nbio_slice_within_budget(&b, 0, 0))
+      {
+         task_nbio_slice_close(&b);
+         return false;
+      }
+      first = false;
+
       strlcpy(db_name_noext, result->db_name, sizeof(db_name_noext));
       path_remove_extension(db_name_noext);
 
       /* Check if we need to switch to a different playlist */
-      if (!single_playlist && (!current_playlist || !string_is_equal(current_playlist, group_key)))
+      if (!single_playlist && (!manual_scan->flush_group || !string_is_equal(manual_scan->flush_group, group_key)))
       {
-         /* Write and close previous playlist if any */
-         if (playlist)
+         /* Write and close previous playlist if any.  One blocking
+          * write per group. */
+         if (manual_scan->flush_playlist)
          {
-            RARCH_LOG("[Scanner] Added %u entries to \"%s\".\n", added_count, current_playlist);
-            playlist_write_file(playlist);
-            playlist_free(playlist);
-            playlist = NULL;
-            added_count = 0;
+            RARCH_LOG("[Scanner] Added %u entries to \"%s\".\n", manual_scan->flush_added, manual_scan->flush_group);
+            playlist_write_file(manual_scan->flush_playlist);
+            playlist_free(manual_scan->flush_playlist);
+            manual_scan->flush_playlist = NULL;
+            manual_scan->flush_added = 0;
          }
 
          /* Open new playlist - if not fixed, use database name */
          if (!*manual_scan->task_config->playlist_file)
          {
-            current_playlist = result->db_name;
-            db_playlist_path[0] = '\0';
+            manual_scan->flush_group = result->db_name;
+            manual_scan->flush_path_buf[0] = '\0';
             if (manual_scan->playlist_directory && *manual_scan->playlist_directory)
-               fill_pathname_join_special(db_playlist_path, manual_scan->playlist_directory,
+               fill_pathname_join_special(manual_scan->flush_path_buf, manual_scan->playlist_directory,
                      result->db_name, str_len);
-            playlist_config_set_path(&manual_scan->playlist_config, db_playlist_path);
+            playlist_config_set_path(&manual_scan->playlist_config, manual_scan->flush_path_buf);
          }
          else
          {
-            current_playlist = manual_scan->task_config->playlist_file;
-            playlist_config_set_path(&manual_scan->playlist_config, current_playlist);
+            manual_scan->flush_group = manual_scan->task_config->playlist_file;
+            playlist_config_set_path(&manual_scan->playlist_config, manual_scan->flush_group);
          }
 
-         playlist = playlist_init(&manual_scan->playlist_config);
+         manual_scan->flush_playlist = playlist_init(&manual_scan->playlist_config);
 
          /* Check before use: the playlist_set_scan_* calls below are
           * not all NULL-guarded (playlist_set_scan_search_recursively,
           * playlist_set_sort_mode, playlist_qsort, playlist_write_file
           * and several others dereference unconditionally).  The test
           * used to sit after all of them. */
-         if (!playlist)
+         if (!manual_scan->flush_playlist)
          {
             RARCH_ERR("[Scanner] Failed to open playlist: \"%s\".\n", result->db_name);
-            current_playlist = NULL;
+            manual_scan->flush_group = NULL;
+            /* The old for loop's continue advanced the index; this
+             * loop must advance the position itself or the same
+             * unopenable playlist would be retried forever. */
+            manual_scan->flush_pos++;
             continue;
          }
 
          /* Set default core, if required */
          if (manual_scan->task_config->core_set)
          {
-            playlist_set_default_core_path(playlist,
+            playlist_set_default_core_path(manual_scan->flush_playlist,
                   manual_scan->task_config->core_path);
-            playlist_set_default_core_name(playlist,
+            playlist_set_default_core_name(manual_scan->flush_playlist,
                   manual_scan->task_config->core_name);
          }
 
          /* Record remaining scan parameters to enable
           * subsequent 'refresh playlist' operations */
-         playlist_set_scan_content_dir(playlist,
+         playlist_set_scan_content_dir(manual_scan->flush_playlist,
                manual_scan->task_config->content_dir);
-         playlist_set_scan_file_exts(playlist,
+         playlist_set_scan_file_exts(manual_scan->flush_playlist,
                manual_scan->task_config->file_exts_custom_set ?
                      manual_scan->task_config->file_exts : NULL);
          if (manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_LOOSE ||
              manual_scan->task_config->db_usage == MANUAL_CONTENT_SCAN_USE_DB_DAT_STRICT)
-            playlist_set_scan_dat_file_path(playlist,
+            playlist_set_scan_dat_file_path(manual_scan->flush_playlist,
                   manual_scan->task_config->dat_file_path);
-         playlist_set_scan_database_name(playlist,
+         playlist_set_scan_database_name(manual_scan->flush_playlist,
                   manual_scan->task_config->database_name);
-         playlist_set_scan_search_recursively(playlist,
+         playlist_set_scan_search_recursively(manual_scan->flush_playlist,
                manual_scan->task_config->search_recursively);
-         playlist_set_scan_search_archives(playlist,
+         playlist_set_scan_search_archives(manual_scan->flush_playlist,
                manual_scan->task_config->search_archives);
-         playlist_set_scan_filter_dat_content(playlist,
+         playlist_set_scan_filter_dat_content(manual_scan->flush_playlist,
                manual_scan->task_config->filter_dat_content);
-         playlist_set_scan_overwrite_playlist(playlist,
+         playlist_set_scan_overwrite_playlist(manual_scan->flush_playlist,
                manual_scan->task_config->overwrite_playlist);
-         playlist_set_scan_db_usage(playlist,
+         playlist_set_scan_db_usage(manual_scan->flush_playlist,
                manual_scan->task_config->db_usage);
-         playlist_set_scan_omit_db_ref(playlist,
+         playlist_set_scan_omit_db_ref(manual_scan->flush_playlist,
                manual_scan->task_config->omit_db_reference);
 
          RARCH_LOG("[Scanner] Processing playlist: \"%s\".\n", result->db_name);
@@ -2089,14 +2145,14 @@ static void scan_results_batch_update_playlists(scan_results_t *sr,
       /* ...except for M3U, since the processing occurs at the end,
          we overwrite any previous m3u entry (which has same file,
          but less descriptive label, database, crc */
-      if (playlist && 
-          (!playlist_entry_exists(playlist, result->entry_path) ||
+      if (manual_scan->flush_playlist && 
+          (!playlist_entry_exists(manual_scan->flush_playlist, result->entry_path) ||
            m3u_file_is_m3u(result->entry_path)))
       {
          struct playlist_entry entry;
 
          if(m3u_file_is_m3u(result->entry_path))
-            playlist_delete_by_path(playlist, result->entry_path);
+            playlist_delete_by_path(manual_scan->flush_playlist, result->entry_path);
          
          /* Build entry */
          entry.path              = result->entry_path;
@@ -2119,8 +2175,8 @@ static void scan_results_batch_update_playlists(scan_results_t *sr,
          entry.last_played_minute= 0;
          entry.last_played_second= 0;
 
-         playlist_push(playlist, &entry);
-         added_count++;
+         playlist_push(manual_scan->flush_playlist, &entry);
+         manual_scan->flush_added++;
 
          RARCH_LOG("[Scanner] Add \"%s / %s\".\n", db_name_noext, result->entry_label);
 
@@ -2129,30 +2185,36 @@ static void scan_results_batch_update_playlists(scan_results_t *sr,
                   db_name_noext, true);
       }
       /* Entry already exists - output duplicate indicator for CLI scans */
-      else if (playlist && retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_DATABASE_SCAN, NULL))
+      else if (manual_scan->flush_playlist && retroarch_override_setting_is_set(RARCH_OVERRIDE_SETTING_DATABASE_SCAN, NULL))
          task_database_scan_console_output(result->entry_label,
                db_name_noext, false);
+
+      manual_scan->flush_pos++;
    }
 
    /* Write and close final playlist */
-   if (playlist)
+   if (manual_scan->flush_playlist)
    {
-      RARCH_LOG("[Scanner] Added %u entries to \"%s\".\n", added_count, current_playlist);
+      RARCH_LOG("[Scanner] Added %u entries to \"%s\".\n", manual_scan->flush_added, manual_scan->flush_group);
       /* Ensure playlist is alphabetically sorted (matches manual scan behavior) */
-      playlist_set_sort_mode(playlist, PLAYLIST_SORT_MODE_DEFAULT);
-      playlist_qsort(playlist);
-      playlist_write_file(playlist);
-      /* Free whatever this function opened.  Only the single-playlist
+      playlist_set_sort_mode(manual_scan->flush_playlist, PLAYLIST_SORT_MODE_DEFAULT);
+      playlist_qsort(manual_scan->flush_playlist);
+      playlist_write_file(manual_scan->flush_playlist);
+      /* Free whatever this flush opened.  Only the single-playlist
        * path borrows manual_scan->playlist, which the handle teardown
        * owns; comparing the handles says that exactly, where the
        * previous string compare against playlist_file also matched
-       * the playlist this function had opened itself and leaked it. */
-      if (playlist != manual_scan->playlist)
-         playlist_free(playlist);
+       * the playlist this flush had opened itself and leaked it. */
+      if (manual_scan->flush_playlist != manual_scan->playlist)
+         playlist_free(manual_scan->flush_playlist);
+      manual_scan->flush_playlist = NULL;
    }
 
-   free(db_playlist_path);
+   free(manual_scan->flush_path_buf);
+   manual_scan->flush_path_buf = NULL;
    RARCH_LOG("[Scanner] Batch playlist update complete.\n");
+   task_nbio_slice_close(&b);
+   return true;
 }
 
 #ifdef HAVE_LIBRETRODB
@@ -2181,6 +2243,22 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
    {
       free(manual_scan->task_config);
       manual_scan->task_config = NULL;
+   }
+
+   /* A cancelled task can die mid-flush: close the playlist the
+    * flush had open.  This must run before manual_scan->playlist is
+    * released below - in single-playlist mode flush_playlist borrows
+    * that handle, and the identity comparison that prevents a double
+    * free needs the pointer still live to say so. */
+   if (  manual_scan->flush_playlist
+       && manual_scan->flush_playlist != manual_scan->playlist)
+      playlist_free(manual_scan->flush_playlist);
+   manual_scan->flush_playlist = NULL;
+
+   if (manual_scan->flush_path_buf)
+   {
+      free(manual_scan->flush_path_buf);
+      manual_scan->flush_path_buf = NULL;
    }
 
    if (manual_scan->playlist)
@@ -3282,9 +3360,17 @@ static void task_manual_content_scan_handler(retro_task_t *task)
          {
             const char *msg = NULL;
 
-            /* Batch update all playlists with accumulated results */
+            /* Batch update all playlists with accumulated results,
+             * spread across gathers under the shared window - the
+             * monolithic form of this flush was the largest single
+             * freeze left after the BEGIN split (166 ms on a
+             * 5000-file scan). */
             if (manual_scan->scan_results.count > 0)
-               scan_results_batch_update_playlists(&manual_scan->scan_results, manual_scan, manual_scan->task_config->target_is_single_determined_playlist);
+            {
+               if (!manual_scan_end_flush_tick(manual_scan,
+                     manual_scan->task_config->target_is_single_determined_playlist))
+                  break;   /* more results next gather */
+            }
             /* If no results, still write an empty playlist, if it is specified. */
             else if (manual_scan->task_config->target_is_single_determined_playlist)
                playlist_write_file(manual_scan->playlist);

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -267,17 +267,15 @@ enum db_flags_enum
 
 enum manual_scan_status
 {
-   /* The BEGIN family: what used to be one monolithic BEGIN state
-    * doing a full recursive directory walk, a whole-file DAT load
-    * and the playlist setup in a single handler invocation - a
-    * multi-hundred-millisecond freeze on a large library when
-    * Threaded Tasks is off.  Each sub-state now respects the shared
-    * per-frame I/O window (task_nbio_slice_*, the same window the
-    * file-transfer spine uses), and completed sub-states collapse
-    * into one invocation while the window lasts, so small libraries
-    * keep their single-tick latency.  The task's public identity
-    * (handler, state) is untouched, so task_queue_find()-based
-    * duplicate-scan suppression is unaffected. */
+   /* The BEGIN family: setup, the recursive directory walk, the DAT
+    * load and the playlist setup as separate sub-states, each
+    * respecting the shared per-frame I/O window (task_nbio_slice_*,
+    * the same window the file-transfer spine uses).  Completed
+    * sub-states collapse into one invocation while the window
+    * lasts, so small libraries keep single-tick latency.  The
+    * task's public identity (handler, state) is one task across all
+    * sub-states, so task_queue_find()-based duplicate-scan
+    * suppression is unaffected. */
    MANUAL_SCAN_BEGIN = 0,
    MANUAL_SCAN_BEGIN_DIR_LIST,
    MANUAL_SCAN_BEGIN_DAT_LOAD,
@@ -312,11 +310,10 @@ typedef struct manual_scan_handle
    /* Resumable batch playlist flush (MANUAL_SCAN_END): position in
     * scan_results, the playlist currently open for the group being
     * written, its group key and running count, and the path scratch
-    * buffer - all of what used to be locals of a single monolithic
-    * call, promoted so the flush can yield on the shared window and
-    * resume next gather.  flush_group points into either the task
-    * config or the owned results array, both of which outlive the
-    * flush. */
+    * buffer, kept on the handle so the flush can yield on the
+    * shared window and resume next gather.  flush_group points into
+    * either the task config or the owned results array, both of
+    * which outlive the flush. */
    size_t flush_pos;
    playlist_t *flush_playlist;
    const char *flush_group;
@@ -1968,26 +1965,19 @@ static void task_database_cleanup_state(database_state_handle_t *db_state)
 }
 #endif
 /* Batch update playlists from accumulated scan results */
-/* Resumable form of what used to be
- * scan_results_batch_update_playlists(): one gather's worth of the
- * batch playlist flush, under the same shared window as the BEGIN
- * family.  The old call added every accumulated result - each add a
- * linear playlist_entry_exists() probe - then sorted and wrote the
- * playlist, all in the gather that reached MANUAL_SCAN_END: 166 ms
- * measured for a 5000-file scan, the largest single freeze left
- * after the BEGIN split.  The loop's locals (position, open
- * playlist, group key, counters, path scratch) live on the handle
- * now so the loop can yield between results and resume.
+/* One gather's worth of the batch playlist flush, under the same
+ * shared window as the BEGIN family, yielding between results and
+ * resuming from the state kept on the handle.
  *
  * The group-close write for multi-playlist scans and the final
- * sort+write remain single blocking operations: a playlist file
- * write is atomic by design (a partial write would corrupt the
- * playlist on a cancelled scan), so those are the floor this flush
- * cannot go below.
+ * sort+write are single blocking operations: a playlist file write
+ * is atomic by design (a partial write would corrupt the playlist
+ * on a cancelled scan), so those are the floor this flush cannot
+ * go below.
  *
  * Returns true when the flush has fully completed (including the
- * failure mode of the scratch allocation, which skips the batch
- * exactly as the old code did), false when yielding. */
+ * failure mode of the scratch allocation, which skips the batch),
+ * false when yielding. */
 static bool manual_scan_end_flush_tick(
    manual_scan_handle_t* manual_scan, bool single_playlist)
 {
@@ -2025,20 +2015,11 @@ static bool manual_scan_end_flush_tick(
    {
       scan_result_t *result = &sr->results[manual_scan->flush_pos];
       char db_name_noext[PATH_MAX_LENGTH];
-      /* The key identifying which playlist this result belongs to.
-       * With a fixed playlist file every result goes to the same
-       * playlist, so the key is that path; otherwise results are
-       * grouped by database name.
-       *
-       * This used to compare the group key against result->db_name
-       * unconditionally, but the fixed-file branch below assigns
-       * task_config->playlist_file as the group - a path like
-       * ".../MyList.lpl", which never equals a db_name, those being
-       * the database's own file name.  The test was therefore true on every
-       * iteration, and each result closed the playlist (a full
-       * playlist_write_file()) and reopened it (a full
-       * playlist_init() parse from disk).  N results meant N complete
-       * loads and N complete writes of the same file. */
+      /* The key identifying which playlist this result belongs to:
+       * the fixed playlist file when one is set, else the database
+       * name.  The fixed path never equals a db_name, so comparing
+       * against db_name unconditionally here would close and reopen
+       * the playlist (a full write + parse) once per result. */
       const char *group_key = (*manual_scan->task_config->playlist_file)
          ? manual_scan->task_config->playlist_file
          : result->db_name;
@@ -2096,9 +2077,9 @@ static bool manual_scan_end_flush_tick(
          {
             RARCH_ERR("[Scanner] Failed to open playlist: \"%s\".\n", result->db_name);
             manual_scan->flush_group = NULL;
-            /* The old for loop's continue advanced the index; this
-             * loop must advance the position itself or the same
-             * unopenable playlist would be retried forever. */
+            /* Advance past this result before continuing, or the
+             * same unopenable playlist is retried every gather
+             * forever. */
             manual_scan->flush_pos++;
             continue;
          }
@@ -2316,10 +2297,6 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
    /* Free accumulated scan results */
    scan_results_free(&manual_scan->scan_results);
 
-   /* strdup'd unconditionally at push; the old guard also tested
-    * *playlist_directory, so a strdup("") - which is a real
-    * allocation - was never released.  16 bytes per scan push,
-    * found by the cancellation sweep under LeakSanitizer. */
    if (manual_scan->playlist_directory)
       free(manual_scan->playlist_directory);
    manual_scan->playlist_directory = NULL;
@@ -2379,7 +2356,6 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
          dbstate->flags     = NULL;
       }
 
-      /* Same empty-string leak as playlist_directory above. */
       if (manual_scan->content_database_path)
          free(manual_scan->content_database_path);
       manual_scan->content_database_path = NULL;
@@ -2489,15 +2465,13 @@ static void task_manual_content_scan_free(retro_task_t *task)
 
 /* --- MANUAL_SCAN_BEGIN family ---------------------------------------
  *
- * What used to be one monolithic BEGIN case is a short sequence of
- * budgeted sub-states sharing the per-frame I/O window with the
- * file-transfer spine (task_nbio_slice_*).  The same total work is
- * performed - the walk is incremental rather than done twice, the
- * DAT is read in chunks into a single buffer that is then handed to
- * the parser whole - so end-to-end scan time is preserved while no
- * single gather freezes the frame.  Each sub-state function returns
- * true when the task must finish (error or nothing to scan), exactly
- * where the old code went to task_finished. */
+ * A short sequence of budgeted sub-states sharing the per-frame I/O
+ * window with the file-transfer spine (task_nbio_slice_*).  The walk
+ * is incremental and lands directly in the content list, and the DAT
+ * is read in chunks into a single buffer that is then handed to the
+ * parser whole, so no single gather freezes the frame.  Each
+ * sub-state function returns true when the task must finish (error
+ * or nothing to scan). */
 
 /* Chunk size for the budgeted DAT read.  Large enough that fast
  * storage delivers a big DAT in a handful of gathers, small enough
@@ -2530,16 +2504,14 @@ static bool manual_scan_begin_setup(retro_task_t *task,
 
       manual_scan->flags       |= DB_HANDLE_FLAG_SCAN_STARTED;
 
-      /* No content dir: same terminal exit the old code took when
-       * no handle came into being. */
+      /* No content dir: nothing to scan. */
       if (!*manual_scan->task_config->content_dir)
          return true;
 
       if (manual_scan->flags & DB_HANDLE_FLAG_IS_DIRECTORY)
       {
-         /* Start the incremental walk that replaces
-          * database_info_dir_init()'s blocking dir_list_new().
-          * Extension derivation matches it: all supported core
+         /* Start the incremental walk.  Extension derivation
+          * matches database_info_dir_init(): all supported core
           * extensions unless an explicit list is given.  The
           * cue/gdi-prioritising sort follows on completion in
           * database_info_dir_init_from_list(). */
@@ -2655,9 +2627,9 @@ static bool manual_scan_begin_setup(retro_task_t *task,
          manual_scan->file_exts_list = string_split(
                manual_scan->task_config->file_exts, "|");
 
-      /* Start the incremental walk that replaces
-       * manual_content_scan_get_content_list(); the same policy
-       * (extension filter, compressed inclusion) is applied by the
+      /* Start the incremental walk.  The same policy (extension
+       * filter, compressed inclusion) as
+       * manual_content_scan_get_content_list() is applied by the
        * shared helper, and a plain-file content dir completes here
        * with no iterator. */
       if (!manual_content_scan_content_list_iter_new(
@@ -2933,9 +2905,8 @@ static bool manual_scan_begin_playlist(retro_task_t *task,
 /* One gather's worth of BEGIN-family work.  Opens a share of the
  * per-frame window once, then runs sub-states back to back while they
  * complete inside it - so a small library still finishes the whole
- * BEGIN sequence (and often the whole scan setup) in a single tick,
- * exactly the latency it had before the split.  Returns true when the
- * task must finish. */
+ * BEGIN sequence (and often the whole scan setup) in a single tick.
+ * Returns true when the task must finish. */
 static bool task_manual_scan_begin_tick(retro_task_t *task,
       manual_scan_handle_t *manual_scan)
 {
@@ -3363,10 +3334,7 @@ static void task_manual_content_scan_handler(retro_task_t *task)
             const char *msg = NULL;
 
             /* Batch update all playlists with accumulated results,
-             * spread across gathers under the shared window - the
-             * monolithic form of this flush was the largest single
-             * freeze left after the BEGIN split (166 ms on a
-             * 5000-file scan). */
+             * spread across gathers under the shared window. */
             if (manual_scan->scan_results.count > 0)
             {
                if (!manual_scan_end_flush_tick(manual_scan,

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -2767,18 +2767,20 @@ static bool manual_scan_begin_dat_load(retro_task_t *task,
 
    if (!manual_scan->dat_stream)
    {
-      /* Validate path and size up front - the checks the parser
-       * itself used to perform before it became I/O-free - and
-       * size the destination buffer once. */
-      int64_t _len = 0;
+      /* Validate path and size up front through the same
+       * predicate the menu applied when the path was chosen, so
+       * the task cannot drift from the menu's acceptance rules,
+       * and size the destination buffer once. */
+      uint64_t dat_file_size = 0;
+      int64_t _len           = 0;
 
-      if (   !logiqx_dat_extension_is_valid(manual_scan->task_config->dat_file_path)
-          || !path_is_valid(manual_scan->task_config->dat_file_path)
-          || (_len = path_get_size(manual_scan->task_config->dat_file_path)) <= 0
+      if (   !manual_content_scan_dat_path_is_valid(
+                manual_scan->task_config->dat_file_path, &dat_file_size)
           /* Reject any size that would not fit in size_t on this
            * platform (mirrors rxml_load_document's guard). */
-          || (uint64_t)_len >= (uint64_t)((size_t)-1))
+          || dat_file_size >= (uint64_t)((size_t)-1))
          goto error;
+      _len = (int64_t)dat_file_size;
 
       if (!(manual_scan->dat_buf = (char*)malloc((size_t)(_len + 1))))
          goto error;

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -2189,8 +2189,13 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
    /* Free accumulated scan results */
    scan_results_free(&manual_scan->scan_results);
 
-   if (manual_scan->playlist_directory && *manual_scan->playlist_directory)
+   /* strdup'd unconditionally at push; the old guard also tested
+    * *playlist_directory, so a strdup("") - which is a real
+    * allocation - was never released.  16 bytes per scan push,
+    * found by the cancellation sweep under LeakSanitizer. */
+   if (manual_scan->playlist_directory)
       free(manual_scan->playlist_directory);
+   manual_scan->playlist_directory = NULL;
 
 #ifdef HAVE_LIBRETRODB
    if (1)
@@ -2247,9 +2252,10 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
          dbstate->flags     = NULL;
       }
 
-      if (    manual_scan->content_database_path 
-          && *manual_scan->content_database_path)
+      /* Same empty-string leak as playlist_directory above. */
+      if (manual_scan->content_database_path)
          free(manual_scan->content_database_path);
+      manual_scan->content_database_path = NULL;
       if (manual_scan->state.buf)
          free(manual_scan->state.buf);
       if (manual_scan->handle)

--- a/tasks/task_file_transfer.c
+++ b/tasks/task_file_transfer.c
@@ -80,102 +80,20 @@ void task_window_progress_cb(retro_task_t *task)
  * JPEG are avail-aware and decode against the partial buffer, but
  * they still need every byte to finish, so the time budget is theirs
  * too - task_image.c's is_prefix grouping answers a different
- * question from this one and the two are meant to differ.) */
-#define NBIO_XFER_TICK_USEC        4000
-
-/* ...and that budget is shared by every file-transfer task in a tick,
- * not handed to each one separately.
+ * question from this one and the two are meant to differ.)
  *
- * retro_task_regular_gather() calls every running task's handler once
- * per task_queue_check(), i.e. once per frame, so a per-task slice
- * multiplies: eight concurrent loads spent 30.65 ms in a single
- * frame, four already spent 15.07 ms, and it scaled linearly with
- * the task count.  A window is the fix - at most NBIO_XFER_TICK_USEC
- * of file I/O per NBIO_XFER_TICK_PERIOD_USEC of wall time, whatever
- * the number of tasks.
- *
- * A tick has no identity this file can see, so the window is a plain
- * fixed one rather than something keyed to the gather: consumed
- * microseconds accumulate until a period has elapsed, then reset.
- * It over-counts nothing (only time actually spent filling is
- * charged) and needs no cooperation from task_queue. */
-#define NBIO_XFER_TICK_PERIOD_USEC 16666
+ * The time budget's value itself lives with the window in
+ * task_nbio_slice.c (NBIO_XFER_TICK_USEC): the slice open/close
+ * calls below hand out exactly that allowance. */
 
-/* Every task gets one read regardless of the window, or a queue
- * whose budget is already spent would make no progress at all.  The
- * frame is then bounded by the window plus one chunk per task, which
- * is a few hundred microseconds for a queue of dozens, rather than
- * by the task count times the whole slice. */
-typedef struct
-{
-   retro_time_t start;       /* when this task's fill began       */
-   retro_time_t allowance;   /* usec this task may spend in it    */
-   uint8_t      floor;       /* the guaranteed first read         */
-} nbio_budget_t;
-
-/* Window state.  Only ever touched on the thread that runs handlers,
- * and only when that is the frame thread - see slice_open(). */
-static retro_time_t nbio_slice_start;
-static retro_time_t nbio_slice_used;
-
-/* The budget is handed to the fill rather than checked around it, so
- * it is consulted between the fill's own reads.  This used to be a
- * do/while around iterate() with a 256 KiB byte budget standing in
- * for the time slice, which meant the deadline could only be noticed
- * every 256 KiB - once per whole chunk, however long that chunk took
- * to arrive. */
-static bool task_file_transfer_within_budget(void *ud, size_t avail,
-      size_t len)
-{
-   nbio_budget_t *b = (nbio_budget_t*)ud;
-   (void)avail;
-   (void)len;
-   if (b->floor)
-   {
-      b->floor = 0;
-      return true;
-   }
-   return cpu_features_get_time_usec() - b->start < b->allowance;
-}
-
-/* Claim this task's share of the window.
- *
- * Declined entirely under a threaded task queue.  There the handler
- * runs on the worker thread, which rotates the task and re-enters
- * immediately; there is no frame to protect, slicing buys only
- * round-robin fairness between file tasks, and a shared static
- * across threads would be a race for no benefit.  Each task gets the
- * whole slice there, which is what it effectively had before. */
-static void task_file_transfer_slice_open(nbio_budget_t *b)
-{
-   retro_time_t now = cpu_features_get_time_usec();
-
-   b->start = now;
-   b->floor = 1;
-
-   if (task_queue_is_threaded())
-   {
-      b->allowance = NBIO_XFER_TICK_USEC;
-      return;
-   }
-   if (now - nbio_slice_start >= (retro_time_t)NBIO_XFER_TICK_PERIOD_USEC)
-   {
-      nbio_slice_start = now;
-      nbio_slice_used  = 0;
-   }
-   b->allowance = (nbio_slice_used < (retro_time_t)NBIO_XFER_TICK_USEC)
-      ? (retro_time_t)NBIO_XFER_TICK_USEC - nbio_slice_used
-      : 0;
-}
-
-/* Charge back what the fill actually spent, including the floor read
- * that ran outside the allowance. */
-static void task_file_transfer_slice_close(nbio_budget_t *b)
-{
-   if (task_queue_is_threaded())
-      return;
-   nbio_slice_used += cpu_features_get_time_usec() - b->start;
-}
+/* The shared per-frame I/O window itself (state + the three
+ * task_nbio_slice_* entry points) lives in task_nbio_slice.c: it is
+ * shared with other budgeted handlers (the manual content scanner's
+ * BEGIN spine), and a TU of its own keeps its dependencies to the
+ * clock and the task queue, so tests can link the real window
+ * without dragging the image/nbio spine in with it.  The design
+ * rationale - why a shared window rather than a per-task slice, why
+ * the floor - is documented there. */
 
 const uint8_t *nbio_xfer_ptr(nbio_handle_t *nbio, size_t *len)
 {
@@ -225,10 +143,10 @@ static int task_file_transfer_iterate_transfer(nbio_handle_t *nbio)
                         || nbio->type == NBIO_TYPE_WEBP)
          ? (size_t)NBIO_XFER_TICK_BYTES : 0;
 
-      task_file_transfer_slice_open(&b);
+      task_nbio_slice_open(&b);
       data_transfer_iterate_while(nbio->xfer, bytes,
-            task_file_transfer_within_budget, &b);
-      task_file_transfer_slice_close(&b);
+            task_nbio_slice_within_budget, &b);
+      task_nbio_slice_close(&b);
    }
    if (data_transfer_complete(nbio->xfer)
          || data_transfer_failed(nbio->xfer)
@@ -298,9 +216,9 @@ void task_file_load_handler(retro_task_t *task)
                 * much less. */
                {
                   nbio_budget_t b;
-                  task_file_transfer_slice_open(&b);
+                  task_nbio_slice_open(&b);
                   nbio->xfer = data_transfer_open_prefix(nbio->path, 0);
-                  task_file_transfer_slice_close(&b);
+                  task_nbio_slice_close(&b);
                }
                if (nbio->xfer)
                {

--- a/tasks/task_nbio_slice.c
+++ b/tasks/task_nbio_slice.c
@@ -1,0 +1,125 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (task_nbio_slice.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* The shared per-frame I/O window used by budgeted task handlers:
+ * the file-transfer spine (task_file_transfer.c) and the manual
+ * content scanner's BEGIN states (task_database.c).  A TU of its
+ * own so its only dependencies are the clock and the task queue,
+ * which lets test harnesses link the real window rather than a
+ * reimplementation. */
+
+#include <features/features_cpu.h>
+#include <queues/task_queue.h>
+
+#include "tasks_internal.h"
+
+/* At most NBIO_XFER_TICK_USEC of budgeted work per
+ * NBIO_XFER_TICK_PERIOD_USEC of wall time, shared by every
+ * participating task in a tick rather than handed to each one
+ * separately.
+ *
+ * retro_task_regular_gather() calls every running task's handler once
+ * per task_queue_check(), i.e. once per frame, so a per-task slice
+ * multiplies: eight concurrent loads spent 30.65 ms in a single
+ * frame, four already spent 15.07 ms, and it scaled linearly with
+ * the task count.  A window is the fix - whatever the number of
+ * tasks, the frame pays the window once.
+ *
+ * A tick has no identity this file can see, so the window is a plain
+ * fixed one rather than something keyed to the gather: consumed
+ * microseconds accumulate until a period has elapsed, then reset.
+ * It over-counts nothing (only time actually spent working is
+ * charged) and needs no cooperation from task_queue.
+ *
+ * Every open grants a floor of one work item regardless of the
+ * window, or a queue whose budget is already spent would make no
+ * progress at all.  The frame is then bounded by the window plus one
+ * work item per task - a few hundred microseconds for a queue of
+ * dozens - rather than by the task count times the whole slice. */
+#define NBIO_XFER_TICK_USEC        4000
+#define NBIO_XFER_TICK_PERIOD_USEC 16666
+
+/* Window state.  Only ever touched on the thread that runs handlers,
+ * and only when that is the frame thread - see
+ * task_nbio_slice_open(). */
+static retro_time_t nbio_slice_start;
+static retro_time_t nbio_slice_used;
+
+/* The budget is handed to the work loop rather than checked around
+ * it, so it is consulted between the loop's own items.  In the fill
+ * spine this used to be a do/while around iterate() with a 256 KiB
+ * byte budget standing in for the time slice, which meant the
+ * deadline could only be noticed every 256 KiB - once per whole
+ * chunk, however long that chunk took to arrive. */
+bool task_nbio_slice_within_budget(void *ud, size_t avail,
+      size_t len)
+{
+   nbio_budget_t *b = (nbio_budget_t*)ud;
+   (void)avail;
+   (void)len;
+   if (b->floor)
+   {
+      b->floor = 0;
+      return true;
+   }
+   return cpu_features_get_time_usec() - b->start < b->allowance;
+}
+
+/* Claim this task's share of the window.
+ *
+ * Declined entirely under a threaded task queue.  There the handler
+ * runs on the worker thread, which rotates the task and re-enters
+ * immediately; there is no frame to protect, slicing buys only
+ * round-robin fairness between tasks, and a shared static across
+ * threads would be a race for no benefit.  Each task gets the whole
+ * slice there, which is what it effectively had before. */
+void task_nbio_slice_open(nbio_budget_t *b)
+{
+   retro_time_t now = cpu_features_get_time_usec();
+
+   b->start = now;
+   b->floor = 1;
+
+   if (task_queue_is_threaded())
+   {
+      b->allowance = NBIO_XFER_TICK_USEC;
+      return;
+   }
+   if (now - nbio_slice_start >= (retro_time_t)NBIO_XFER_TICK_PERIOD_USEC)
+   {
+      nbio_slice_start = now;
+      nbio_slice_used  = 0;
+   }
+   b->allowance = (nbio_slice_used < (retro_time_t)NBIO_XFER_TICK_USEC)
+      ? (retro_time_t)NBIO_XFER_TICK_USEC - nbio_slice_used
+      : 0;
+}
+
+/* Charge back what the work actually spent, including the floor item
+ * that ran outside the allowance. */
+void task_nbio_slice_close(nbio_budget_t *b)
+{
+   if (task_queue_is_threaded())
+      return;
+   nbio_slice_used += cpu_features_get_time_usec() - b->start;
+}

--- a/tasks/task_nbio_slice.c
+++ b/tasks/task_nbio_slice.c
@@ -66,11 +66,8 @@ static retro_time_t nbio_slice_start;
 static retro_time_t nbio_slice_used;
 
 /* The budget is handed to the work loop rather than checked around
- * it, so it is consulted between the loop's own items.  In the fill
- * spine this used to be a do/while around iterate() with a 256 KiB
- * byte budget standing in for the time slice, which meant the
- * deadline could only be noticed every 256 KiB - once per whole
- * chunk, however long that chunk took to arrive. */
+ * it, so the deadline is noticed between the loop's own items - not
+ * once per whole chunk, however long a chunk takes to arrive. */
 bool task_nbio_slice_within_budget(void *ud, size_t avail,
       size_t len)
 {

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -57,6 +57,32 @@ typedef struct nbio_buf
    unsigned bufsize;
 } nbio_buf_t;
 
+/* Shared per-frame I/O window (implementation and rationale in
+ * task_file_transfer.c).  A handler that performs bounded work per
+ * gather claims a share with task_nbio_slice_open(), consults
+ * task_nbio_slice_within_budget() between work items, and charges
+ * back what it actually spent with task_nbio_slice_close().  The
+ * window is shared by every participating task in a gather - file
+ * transfers, the content scanner - rather than handed to each one
+ * separately, because a per-task slice multiplies with the task
+ * count.  Every open grants a floor of one work item so a queue
+ * whose window is already spent still makes progress.  Under a
+ * threaded task queue each task simply gets a whole slice: there is
+ * no frame to protect there, and a shared static across threads
+ * would be a race for no benefit. */
+typedef struct
+{
+   retro_time_t start;       /* when this task's work began       */
+   retro_time_t allowance;   /* usec this task may spend in it    */
+   uint8_t      floor;       /* the guaranteed first work item    */
+} nbio_budget_t;
+
+void task_nbio_slice_open(nbio_budget_t *b);
+void task_nbio_slice_close(nbio_budget_t *b);
+/* Signature matches data_transfer's within-budget callback; the
+ * @avail / @len arguments are unused. */
+bool task_nbio_slice_within_budget(void *ud, size_t avail, size_t len);
+
 /* Generic progress_cb that forwards a task's progress (0-100) to the
  * platform's window/taskbar progress indicator (e.g. ITaskbarList3 on
  * Win32). Set this on any task whose progress should be reflected on


### PR DESCRIPTION
See this PDF for implementation details
[RetroArch_Database_Scan_CoA.pdf](https://github.com/user-attachments/files/31085993/RetroArch_Database_Scan_CoA.pdf)

Makes the manual content scan / database scanner fully non-blocking on the frame thread when Threaded Tasks is off, while making it *faster* end-to-end than the blocking code it replaces. Implementation follows the attached CoA PDF.

## Problem

`MANUAL_SCAN_BEGIN` performed the entire recursive directory walk, the whole DAT file load, and the playlist setup in **one handler invocation** on the frame thread. `MANUAL_SCAN_END` then flushed every accumulated result (each add a linear `playlist_entry_exists()` probe, so the batch is quadratic) plus a sort and a write in another single invocation — **166 ms measured** on a 5000-file library, unbounded above, with DAT files reaching hundreds of MB.

## What changed

- **BEGIN is now a budgeted sub-state sequence** — setup → incremental dir walk → chunked DAT read (256 KiB per read) → playlist setup — running under the same shared per-frame I/O window as the file-transfer spine (at most 4 ms of budgeted work per 16.6 ms of wall time, shared across all participating tasks, floor of one work item so a spent window still progresses). Completed sub-states collapse into one gather, so small libraries keep single-tick latency.
- **END flush is resumable**: the batch playlist update yields between results on the same window. Playlist file writes stay atomic by design.
- **`lists/dir_list`**: new resumable iterator (`dir_list_iter_new/_step/_free`) — an explicit-stack transliteration of the recursive walk with exact enumeration parity, pinned by the test's playlist-parity lane.
- **`logiqx_dat` is now fully path-agnostic**: no file I/O, no path knowledge, no `file_path.h`. Contract is bytes in, structs out via `logiqx_dat_init_owned()` (zero-copy ownership transfer through the new public `rxml_load_document_owned()`). Path validation lives in one exported predicate, `manual_content_scan_dat_path_is_valid()`, used by both the menu and the task, so the two cannot drift.
- **`logiqx_dat_search` gains a lazy name index** (sorted, leftmost-equal bsearch, first-occurrence ties preserved) — the per-file label lookup was O(files × games), 29 % of scan wall time under gprof.
- **Shared window extracted into `tasks/task_nbio_slice.c`** so the scanner and test harnesses link the real window instead of a reimplementation. Every sample compiling the transfer spine links it (`file_transfer`, `database`, `image_decode_slice`).
- **Pre-existing leak fixed**: empty-path `strdup("")` on scan handle teardown, 16 bytes per scan push, found by the new test's cancellation sweep under LeakSanitizer.

## Measurements

5000 files across 50 dirs + 5000-game DAT, regular (non-threaded) queue, release build:

| Metric | Before | After |
|---|---|---|
| Worst single gather | > 166 ms | **≤ ~7 ms** (4 ms window + bounded slack) |
| Total scan time | 1.0× (blocking walk + whole-file DAT parse reference) | **0.87×** |
| First task feedback after push | end of BEGIN | **0.01 ms** |
| Playlist parity | — | exact (5000/5000) |

## Testing

New oracle `samples/tasks/database/scan_begin_budget_test` (wired into the `Linux-samples-tasks` CI workflow):

- **Plain build** asserts pacing (no gather over the window × 4 slack — the pre-split tree fails at > 160 ms), first feedback within 2 frames, total time within 1.60× of the blocking reference, and playlist parity.
- **`sanitize` mode** runs every lane under ASan+UBSan+LSan and TSan separately: a threaded-queue lane (the TSan target for the window's threaded opt-out) and a **14-point cancellation sweep** landing a cancel in setup, mid-walk, mid-DAT-read, iteration, and mid-flush, with LeakSanitizer deciding whether teardown released everything.

Additionally: strict C89 (`-std=c89 -ansi -pedantic -Werror=declaration-after-statement`) verified per-commit on every touched TU; full Linux build links at the tip; the entire `samples/tasks` matrix builds; `task_file_transfer_test` and `image_decode_slice_test` pass unmodified against the extracted window TU. Every commit builds and links standalone (bisect-clean).

## Known residuals (documented in the test source)

- The rxml parse of a completed DAT buffer and the search-index build each run inside a single gather; a pathological multi-hundred-MB DAT still parses in one tick on a non-threaded queue. rxml is not resumable today; the sub-state structure leaves the seam for it.
- Playlist-side entry dedup remains quadratic (48 % of scan wall time per gprof) — now spread across gathers rather than removed. The follow-up is a path-hash dedup index in `playlist.c` verifying candidates with the existing fuzzy matcher.