### PR TITLE
Manual scan follow-ups: O(1) playlist dedup, incremental DAT parse

### DIFF
--- a/.github/workflows/Linux-samples-tasks.yml
+++ b/.github/workflows/Linux-samples-tasks.yml
@@ -492,6 +492,15 @@ jobs:
           # playlist and asserts zero duplicates, driving the index's
           # budgeted seeding at scale.  The throughput factor is
           # tightened to reject the pre-index quadratic flush.
+          #
+          # The big-DAT lane scans 50 files against a 300k-game DAT
+          # and asserts the same pacing budget: no gather may grow
+          # with DAT size now that the rxml parse and the search-
+          # index build step under the shared window.  Its label
+          # check samples the end of the list, so an index that
+          # silently covered only a prefix fails correctness, and
+          # three extra cancel points land inside the budgeted read
+          # and parse of the large document.
           make clean all
           test -x scan_begin_budget_test
           timeout 600 ./scan_begin_budget_test

--- a/.github/workflows/Linux-samples-tasks.yml
+++ b/.github/workflows/Linux-samples-tasks.yml
@@ -481,6 +481,17 @@ jobs:
           # the shared window deliberately opts threaded queues out of
           # its static state, and this is where a mistake in that
           # opt-out would surface.
+          #
+          # Two dedup lanes guard the playlist path-hash index that
+          # replaced the flush's quadratic existence probes: a
+          # differential lane asserts the index answers exactly like
+          # the linear playlist_entry_exists scan over plain, bare-
+          # archive, inside-archive and case-variant paths with fuzzy
+          # archive matching both off and on, and a no-overwrite
+          # rescan lane re-scans the fixture into the populated
+          # playlist and asserts zero duplicates, driving the index's
+          # budgeted seeding at scale.  The throughput factor is
+          # tightened to reject the pre-index quadratic flush.
           make clean all
           test -x scan_begin_budget_test
           timeout 600 ./scan_begin_budget_test

--- a/libretro-common/formats/logiqx_dat/logiqx_dat.c
+++ b/libretro-common/formats/logiqx_dat/logiqx_dat.c
@@ -20,20 +20,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <stdint.h>
+
 #include <string/stdstring.h>
 #include <formats/rxml.h>
 
 #include <formats/logiqx_dat.h>
 
-/* One entry of the lazy search index: a game node keyed by its
- * 'name' attribute, with its position in the document so ties
- * between duplicate names resolve to the first occurrence - the
- * same answer the linear scan gives. */
+/* One slot of the search index: a game node keyed by its 'name'
+ * attribute.  A NULL name is an empty slot.  Duplicate names keep
+ * the first occurrence - the same answer the linear scan gives. */
 typedef struct
 {
    const char *name;   /* points into the document's own storage */
    rxml_node_t *node;
-   size_t seq;
 } logiqx_dat_index_entry_t;
 
 /* Holds all internal DAT file data */
@@ -41,14 +41,20 @@ struct logiqx_dat
 {
    rxml_document_t *data;
    rxml_node_t *current_node;
-   /* Lazy search index, built on the first logiqx_dat_search() and
-    * sorted by name for binary search: without it every search
-    * walks every child of the root, which is O(files x games) for
-    * the scanner's per-file label lookups and quadratic into
-    * MAME-sized lists.  On any allocation failure index_failed is
-    * set and the linear walk remains the answer. */
+   /* Search index, built on the first logiqx_dat_search() (or
+    * incrementally by logiqx_dat_parse_step()): without it every
+    * search walks every child of the root, which is
+    * O(files x games) for the scanner's per-file label lookups and
+    * quadratic into MAME-sized lists.  Open-addressing hash keyed
+    * on the name, power-of-two capacity, load factor at most 1/2,
+    * first occurrence wins on insert.  Exact lookup is all
+    * logiqx_dat_search() needs, and unlike the sorted array this
+    * replaces, the build is a chunkable O(n) fill with no qsort
+    * spike.  On any allocation failure index_failed is set and the
+    * linear walk remains the answer. */
    logiqx_dat_index_entry_t *index;
-   size_t index_size;
+   size_t index_cap;
+   bool index_built;
    bool index_failed;
 };
 
@@ -153,6 +159,209 @@ void logiqx_dat_free(logiqx_dat_t *dat_file)
 
    free(dat_file);
    dat_file = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Incremental initialisation                                          */
+/* ------------------------------------------------------------------ */
+
+static bool logiqx_dat_is_game_node(rxml_node_t *node);
+static size_t logiqx_dat_index_count_chunk(rxml_node_t **cursor,
+      size_t max_nodes);
+static bool logiqx_dat_index_alloc(logiqx_dat_t *dat_file, size_t count);
+static void logiqx_dat_index_fill_chunk(logiqx_dat_t *dat_file,
+      rxml_node_t **cursor, size_t max_nodes);
+
+enum
+{
+   LOGIQX_PARSE_PHASE_XML = 0,   /* stepping the rxml parse */
+   LOGIQX_PARSE_PHASE_COUNT,     /* counting named game nodes */
+   LOGIQX_PARSE_PHASE_FILL,      /* filling the hash index */
+   LOGIQX_PARSE_PHASE_DONE,
+   LOGIQX_PARSE_PHASE_FAILED
+};
+
+struct logiqx_dat_parse
+{
+   rxml_parse_t *xml;        /* live during the XML phase */
+   logiqx_dat_t *dat_file;   /* built at the XML verdict */
+   rxml_node_t *cursor;      /* count/fill resume position */
+   size_t count;
+   unsigned phase;
+};
+
+/* An index visit (name-attribute walk plus one table probe) costs
+ * far less than parsing a byte of XML; mapping the caller's byte
+ * budget to nodes at this ratio keeps index steps comparable in
+ * cost to parse steps.  The floor guarantees forward progress. */
+#define LOGIQX_INDEX_NODES_PER_BYTE_SHIFT 4
+#define LOGIQX_INDEX_NODES_FLOOR          256
+
+logiqx_dat_parse_t *logiqx_dat_parse_begin_owned(char *xml_data,
+      size_t len)
+{
+   logiqx_dat_parse_t *parse;
+
+   if (!xml_data)
+      return NULL;
+
+   if (!(parse = (logiqx_dat_parse_t*)calloc(1, sizeof(*parse))))
+   {
+      free(xml_data);
+      return NULL;
+   }
+
+   /* rxml_parse_begin_owned() takes the buffer under the same
+    * contract as the one-shot path: it is freed on failure. */
+   if (!(parse->xml = rxml_parse_begin_owned(xml_data, len, 0)))
+   {
+      free(parse);
+      return NULL;
+   }
+
+   parse->phase = LOGIQX_PARSE_PHASE_XML;
+   return parse;
+}
+
+/* Validation logiqx_dat_init_owned() performs at the parse verdict:
+ * root element name and a non-empty child list.  On success the
+ * logiqx_dat_t takes ownership of @doc; on failure @doc is freed. */
+static logiqx_dat_t *logiqx_dat_wrap_document(rxml_document_t *doc)
+{
+   logiqx_dat_t *dat_file = NULL;
+   rxml_node_t *root_node = NULL;
+
+   if (!(dat_file = (logiqx_dat_t*)calloc(1, sizeof(*dat_file))))
+   {
+      rxml_free_document(doc);
+      return NULL;
+   }
+   dat_file->data = doc;
+
+   if (!(root_node = rxml_root_node(doc)))
+      goto error;
+   if (!root_node->name || !*root_node->name)
+      goto error;
+   if (   !string_is_equal(root_node->name, "datafile")
+       && !string_is_equal(root_node->name, "mame")
+       && !string_is_equal(root_node->name, "softwarelist"))
+      goto error;
+   if (!(dat_file->current_node = root_node->children))
+      goto error;
+
+   return dat_file;
+
+error:
+   logiqx_dat_free(dat_file);
+   return NULL;
+}
+
+int logiqx_dat_parse_step(logiqx_dat_parse_t *parse, size_t max_work)
+{
+   size_t max_nodes;
+
+   if (!parse)
+      return -1;
+
+   max_nodes = max_work >> LOGIQX_INDEX_NODES_PER_BYTE_SHIFT;
+   if (!max_work)
+      max_nodes = 0;                        /* unbudgeted */
+   else if (max_nodes < LOGIQX_INDEX_NODES_FLOOR)
+      max_nodes = LOGIQX_INDEX_NODES_FLOOR;
+
+   switch (parse->phase)
+   {
+      case LOGIQX_PARSE_PHASE_XML:
+      {
+         int r = rxml_parse_step(parse->xml, max_work);
+         if (r == 0)
+            return 0;
+         if (r < 0)
+         {
+            rxml_parse_end(parse->xml);     /* discards; NULL back */
+            parse->xml   = NULL;
+            parse->phase = LOGIQX_PARSE_PHASE_FAILED;
+            return -1;
+         }
+         {
+            rxml_document_t *doc = rxml_parse_end(parse->xml);
+            parse->xml = NULL;
+            if (!doc || !(parse->dat_file = logiqx_dat_wrap_document(doc)))
+            {
+               parse->phase = LOGIQX_PARSE_PHASE_FAILED;
+               return -1;
+            }
+         }
+         parse->cursor = rxml_root_node(parse->dat_file->data)->children;
+         parse->count  = 0;
+         parse->phase  = LOGIQX_PARSE_PHASE_COUNT;
+         return 0;
+      }
+
+      case LOGIQX_PARSE_PHASE_COUNT:
+         parse->count += logiqx_dat_index_count_chunk(&parse->cursor,
+               max_nodes);
+         if (parse->cursor)
+            return 0;
+         /* The incremental path is the index's one build attempt:
+          * mirror the lazy build's accounting so a later search
+          * neither rebuilds nor bypasses it. */
+         parse->dat_file->index_built  = true;
+         parse->dat_file->index_failed = false;
+         if (!logiqx_dat_index_alloc(parse->dat_file, parse->count))
+         {
+            /* Fallback preserved: searches take the linear walk. */
+            parse->dat_file->index_failed = true;
+            parse->phase = LOGIQX_PARSE_PHASE_DONE;
+            return 1;
+         }
+         parse->cursor = rxml_root_node(parse->dat_file->data)->children;
+         parse->phase  = LOGIQX_PARSE_PHASE_FILL;
+         return 0;
+
+      case LOGIQX_PARSE_PHASE_FILL:
+         logiqx_dat_index_fill_chunk(parse->dat_file, &parse->cursor,
+               max_nodes);
+         if (parse->cursor)
+            return 0;
+         parse->phase = LOGIQX_PARSE_PHASE_DONE;
+         return 1;
+
+      case LOGIQX_PARSE_PHASE_DONE:
+         return 1;
+
+      default:
+         return -1;
+   }
+}
+
+logiqx_dat_t *logiqx_dat_parse_end(logiqx_dat_parse_t *parse)
+{
+   logiqx_dat_t *dat_file = NULL;
+
+   if (!parse)
+      return NULL;
+
+   if (parse->phase == LOGIQX_PARSE_PHASE_DONE)
+      dat_file = parse->dat_file;
+   else
+   {
+      if (parse->xml)
+         rxml_parse_abort(parse->xml);
+      logiqx_dat_free(parse->dat_file);   /* NULL-safe */
+   }
+   free(parse);
+   return dat_file;
+}
+
+void logiqx_dat_parse_abort(logiqx_dat_parse_t *parse)
+{
+   if (!parse)
+      return;
+   if (parse->xml)
+      rxml_parse_abort(parse->xml);
+   logiqx_dat_free(parse->dat_file);
+   free(parse);
 }
 
 /* Game information access */
@@ -406,81 +615,141 @@ bool logiqx_dat_get_next(
 /* Fetches information for the specified game.
  * Returns false if game does not exist, or arguments
  * are invalid. */
-/* qsort comparator for the search index: by name, then by document
- * position, so equal names keep document order and the leftmost
- * match is the first occurrence. */
-static int logiqx_dat_index_compare(const void *a_, const void *b_)
+static uint32_t logiqx_dat_name_hash(const char *s)
 {
-   const logiqx_dat_index_entry_t *a = (const logiqx_dat_index_entry_t*)a_;
-   const logiqx_dat_index_entry_t *b = (const logiqx_dat_index_entry_t*)b_;
-   int cmp = strcmp(a->name, b->name);
-   if (cmp)
-      return cmp;
-   if (a->seq < b->seq)
-      return -1;
-   if (a->seq > b->seq)
-      return 1;
-   return 0;
+   uint32_t h = 5381;
+   while (*s)
+      h = ((h << 5) + h) ^ (uint32_t)(unsigned char)*s++;
+   return h;
 }
 
-/* Build the sorted name index over every game node that carries a
- * non-empty 'name' attribute.  Nodes without one are exactly the
- * nodes the linear scan could never match (the matcher rejects
- * them), so leaving them out changes no answer. */
+/* Walk up to @max_nodes children from *@cursor, counting game nodes
+ * that carry a non-empty 'name' attribute - the only nodes the
+ * linear scan could ever match.  @max_nodes of 0 walks to the end.
+ * Advances *@cursor; returns the count for this chunk. */
+static size_t logiqx_dat_index_count_chunk(rxml_node_t **cursor,
+      size_t max_nodes)
+{
+   size_t count   = 0;
+   size_t visited = 0;
+   rxml_node_t *n = *cursor;
+
+   for (; n && (!max_nodes || visited < max_nodes); n = n->next, visited++)
+   {
+      if (logiqx_dat_is_game_node(n))
+      {
+         const char *name = rxml_node_attrib(n, "name");
+         if (name && *name)
+            count++;
+      }
+   }
+   *cursor = n;
+   return count;
+}
+
+/* Size the table for @count names at a load factor of at most 1/2.
+ * A count of zero leaves the capacity zero: an empty index is a
+ * valid one - every search misses, which is what the linear scan
+ * would conclude too.  Returns false on allocation failure. */
+static bool logiqx_dat_index_alloc(logiqx_dat_t *dat_file, size_t count)
+{
+   size_t cap;
+
+   if (!count)
+      return true;
+
+   for (cap = 64; cap < count * 2; cap <<= 1)
+      ;
+
+   if (!(dat_file->index = (logiqx_dat_index_entry_t*)
+         calloc(cap, sizeof(*dat_file->index))))
+      return false;
+
+   dat_file->index_cap = cap;
+   return true;
+}
+
+/* Insert up to @max_nodes children from *@cursor into the table.
+ * First occurrence wins: an equal name already present is left
+ * alone, preserving the leftmost-match answer of the linear scan.
+ * @max_nodes of 0 walks to the end.  Advances *@cursor. */
+static void logiqx_dat_index_fill_chunk(logiqx_dat_t *dat_file,
+      rxml_node_t **cursor, size_t max_nodes)
+{
+   size_t visited = 0;
+   rxml_node_t *n = *cursor;
+
+   for (; n && (!max_nodes || visited < max_nodes); n = n->next, visited++)
+   {
+      const char *name;
+      size_t idx;
+
+      if (!logiqx_dat_is_game_node(n))
+         continue;
+      if (!(name = rxml_node_attrib(n, "name")) || !*name)
+         continue;
+
+      idx = (size_t)logiqx_dat_name_hash(name)
+            & (dat_file->index_cap - 1);
+      for (;;)
+      {
+         if (!dat_file->index[idx].name)
+         {
+            dat_file->index[idx].name = name;
+            dat_file->index[idx].node = n;
+            break;
+         }
+         if (string_is_equal(dat_file->index[idx].name, name))
+            break;   /* duplicate: first occurrence stays */
+         idx = (idx + 1) & (dat_file->index_cap - 1);
+      }
+   }
+   *cursor = n;
+}
+
+static rxml_node_t *logiqx_dat_index_lookup(logiqx_dat_t *dat_file,
+      const char *game_name)
+{
+   size_t idx;
+
+   if (!dat_file->index_cap)
+      return NULL;
+
+   idx = (size_t)logiqx_dat_name_hash(game_name)
+         & (dat_file->index_cap - 1);
+   while (dat_file->index[idx].name)
+   {
+      if (string_is_equal(dat_file->index[idx].name, game_name))
+         return dat_file->index[idx].node;
+      idx = (idx + 1) & (dat_file->index_cap - 1);
+   }
+   return NULL;
+}
+
+/* Build the whole index in one call: the lazy path taken by the
+ * first logiqx_dat_search() when the incremental parse did not
+ * already build it. */
 static void logiqx_dat_index_build(logiqx_dat_t *dat_file)
 {
    rxml_node_t *root_node = NULL;
-   rxml_node_t *game_node = NULL;
+   rxml_node_t *cursor    = NULL;
    size_t count           = 0;
 
    dat_file->index_failed = true;   /* cleared on success */
+   dat_file->index_built  = true;   /* one attempt only, either way */
 
    if (!(root_node = rxml_root_node(dat_file->data)))
       return;
 
-   for (game_node = root_node->children; game_node; game_node = game_node->next)
-   {
-      if (logiqx_dat_is_game_node(game_node))
-      {
-         const char *name = rxml_node_attrib(game_node, "name");
-         if (name && *name)
-            count++;
-      }
-   }
+   cursor = root_node->children;
+   count  = logiqx_dat_index_count_chunk(&cursor, 0);
 
-   if (!count)
-   {
-      /* An empty index is a valid one: every search misses, which
-       * is what the linear scan would conclude too. */
-      dat_file->index_size   = 0;
-      dat_file->index_failed = false;
-      return;
-   }
-
-   if (!(dat_file->index = (logiqx_dat_index_entry_t*)
-         malloc(count * sizeof(*dat_file->index))))
+   if (!logiqx_dat_index_alloc(dat_file, count))
       return;
 
-   count = 0;
-   for (game_node = root_node->children; game_node; game_node = game_node->next)
-   {
-      if (logiqx_dat_is_game_node(game_node))
-      {
-         const char *name = rxml_node_attrib(game_node, "name");
-         if (name && *name)
-         {
-            dat_file->index[count].name = name;
-            dat_file->index[count].node = game_node;
-            dat_file->index[count].seq  = count;
-            count++;
-         }
-      }
-   }
+   cursor = root_node->children;
+   logiqx_dat_index_fill_chunk(dat_file, &cursor, 0);
 
-   qsort(dat_file->index, count, sizeof(*dat_file->index),
-         logiqx_dat_index_compare);
-
-   dat_file->index_size   = count;
    dat_file->index_failed = false;
 }
 
@@ -499,29 +768,14 @@ bool logiqx_dat_search(
 
    /* Build the name index on first use; on failure fall through to
     * the linear walk below, which remains authoritative. */
-   if (!dat_file->index && !dat_file->index_size && !dat_file->index_failed)
+   if (!dat_file->index_built)
       logiqx_dat_index_build(dat_file);
 
    if (!dat_file->index_failed)
    {
-      /* Binary search for the leftmost entry with this name: lower
-       * bound over (name, seq)-sorted entries. */
-      size_t lo = 0;
-      size_t hi = dat_file->index_size;
-
-      while (lo < hi)
-      {
-         size_t mid = lo + ((hi - lo) >> 1);
-         if (strcmp(dat_file->index[mid].name, game_name) < 0)
-            lo = mid + 1;
-         else
-            hi = mid;
-      }
-
-      if (   lo < dat_file->index_size
-          && string_is_equal(dat_file->index[lo].name, game_name))
-         return logiqx_dat_parse_game_node(dat_file->index[lo].node,
-               game_info);
+      rxml_node_t *game = logiqx_dat_index_lookup(dat_file, game_name);
+      if (game)
+         return logiqx_dat_parse_game_node(game, game_info);
       return false;
    }
 

--- a/libretro-common/formats/xml/rxml.c
+++ b/libretro-common/formats/xml/rxml.c
@@ -197,6 +197,14 @@ struct rxml_parser
    struct rxml_attrib_node *attr;
    rxml_document_t *doc;
    unsigned opts;
+   /* Incremental mode: parsing pauses when the cursor passes this
+    * (set past the end of input by the one-shot path, where the
+    * check can then never fire - the cursor never moves beyond the
+    * terminating NUL).  'suspended' records that the last return
+    * was a pause at the between-constructs point, so the next call
+    * re-enters there. */
+   const unsigned char *stop;
+   unsigned suspended;
 };
 
 /* Accumulator ------------------------------------------------------- */
@@ -1256,6 +1264,17 @@ static int rxml_parse_document(struct rxml_parser *ps)
 {
    int r;
 
+   /* A suspended parse re-enters at the between-constructs point it
+    * paused at.  The jump lands inside the element loop, past
+    * declarations whose values are indeterminate there; the content
+    * path reads none of them - every live parse datum sits in *ps,
+    * which is what makes this the one legal suspension point. */
+   if (ps->suspended)
+   {
+      ps->suspended = 0;
+      goto content_loop;
+   }
+
    /* Optional UTF-8 byte order mark, only at the very first byte. */
    if (*ps->p == 0xEF)
    {
@@ -1353,6 +1372,16 @@ static int rxml_parse_document(struct rxml_parser *ps)
 
       /* Content of the just-opened element. */
 content_loop:
+      /* Between constructs: an element just opened or a child just
+       * closed, and nothing is held in locals.  In incremental mode
+       * this is where the byte budget is honoured; the bound on one
+       * step is therefore max_bytes plus the length of one
+       * construct. */
+      if (ps->p >= ps->stop)
+      {
+         ps->suspended = 1;
+         return 2;
+      }
       for (;;)
       {
          const unsigned char *q = ps->p;
@@ -1607,6 +1636,7 @@ static rxml_document_t *rxml_parse_owned(char *buf, size_t len,
    memset(&ps, 0, sizeof(ps));
    ps.opts       = opts;
    ps.p          = (const unsigned char*)buf;
+   ps.stop       = (const unsigned char*)buf + len + 1;
    ps.acc_cap    = 4096;
    ps.acc        = (char*)malloc(ps.acc_cap);
    ps.frames_cap = 32;
@@ -1660,6 +1690,127 @@ static rxml_document_t *rxml_parse_owned(char *buf, size_t len,
       return NULL;
    }
    return ps.doc;
+}
+
+/* Incremental parse handle: the parser state rxml_parse_owned()
+ * keeps on its stack, lifted to the heap so it survives between
+ * steps, plus the terminal verdict. */
+struct rxml_parse
+{
+   struct rxml_parser ps;
+   char *buf;
+   size_t len;
+   int state;   /* 0 parsing, 1 done (doc valid), -1 failed (doc gone) */
+};
+
+rxml_parse_t *rxml_parse_begin_owned(char *buf, size_t len, unsigned opts)
+{
+   rxml_parse_t *parse;
+
+   if (!buf)
+      return NULL;
+
+   if (!(parse = (rxml_parse_t*)calloc(1, sizeof(*parse))))
+   {
+      free(buf);
+      return NULL;
+   }
+
+   parse->buf           = buf;
+   parse->len           = len;
+   parse->ps.opts       = opts;
+   parse->ps.p          = (const unsigned char*)buf;
+   parse->ps.acc_cap    = 4096;
+   parse->ps.acc        = (char*)malloc(parse->ps.acc_cap);
+   parse->ps.frames_cap = 32;
+   parse->ps.frames     = (struct rxml_frame*)malloc(
+         parse->ps.frames_cap * sizeof(*parse->ps.frames));
+   parse->ps.doc        = (rxml_document_t*)malloc(sizeof(*parse->ps.doc));
+
+   if (!parse->ps.acc || !parse->ps.frames || !parse->ps.doc)
+   {
+      free(parse->ps.acc);
+      free(parse->ps.frames);
+      free(parse->ps.doc);
+      free(buf);
+      free(parse);
+      return NULL;
+   }
+
+   parse->ps.doc->root_node = NULL;
+   parse->ps.doc->blocks    = NULL;
+   /* Same first-block sizing rationale as rxml_parse_owned() */
+   parse->ps.doc->blocksz   = (len > (RXML_ARENA_MIN / 4))
+                            ? (len << 2) : RXML_ARENA_MIN;
+   parse->ps.doc->buf       = buf;
+   return parse;
+}
+
+int rxml_parse_step(rxml_parse_t *parse, size_t max_bytes)
+{
+   int r;
+   const unsigned char *end;
+
+   if (!parse)
+      return -1;
+   if (parse->state != 0)
+      return (parse->state == 1) ? 1 : -1;
+
+   end = (const unsigned char*)parse->buf + parse->len;
+   if (max_bytes == 0 || max_bytes >= (size_t)(end - parse->ps.p))
+      parse->ps.stop = end + 1;         /* run to the verdict */
+   else
+      parse->ps.stop = parse->ps.p + max_bytes;
+
+   r = rxml_parse_document(&parse->ps);
+   if (r == 2)
+      return 0;
+
+   /* Terminal: same verdict rules as rxml_parse_owned(). */
+   if (r < 0 && (parse->ps.opts & RXML_OPT_STRICT_EOF))
+      r = 0;
+   if (r != 0 && (parse->ps.opts & RXML_OPT_LINES)
+         && parse->ps.doc->root_node
+         && !rxml_annotate_lines(parse->ps.doc))
+      r = 0;
+   if (r == 0)
+   {
+      rxml_free_document(parse->ps.doc);   /* releases buf too */
+      parse->ps.doc = NULL;
+      parse->state  = -1;
+      return -1;
+   }
+   parse->state = 1;
+   return 1;
+}
+
+rxml_document_t *rxml_parse_end(rxml_parse_t *parse)
+{
+   rxml_document_t *doc = NULL;
+
+   if (!parse)
+      return NULL;
+
+   if (parse->state == 1)
+      doc = parse->ps.doc;
+   else if (parse->ps.doc)
+      rxml_free_document(parse->ps.doc);   /* unfinished or failed */
+
+   free(parse->ps.acc);
+   free(parse->ps.frames);
+   free(parse);
+   return doc;
+}
+
+void rxml_parse_abort(rxml_parse_t *parse)
+{
+   if (!parse)
+      return;
+   if (parse->ps.doc)
+      rxml_free_document(parse->ps.doc);
+   free(parse->ps.acc);
+   free(parse->ps.frames);
+   free(parse);
 }
 
 rxml_document_t *rxml_load_document_string_opts(const char *str,

--- a/libretro-common/include/formats/logiqx_dat.h
+++ b/libretro-common/include/formats/logiqx_dat.h
@@ -78,6 +78,28 @@ typedef struct
  * Logiqx/MAME XML. */
 logiqx_dat_t *logiqx_dat_init_owned(char *xml_data, size_t len);
 
+/* Incremental variant of logiqx_dat_init_owned(): the same
+ * ownership contract for @xml_data, with the XML parse and the
+ * search-index build spread over as many logiqx_dat_parse_step()
+ * calls as the caller's budget requires.
+ *
+ * logiqx_dat_parse_begin_owned() returns NULL only on allocation
+ * failure (having freed @xml_data).  Each step performs roughly
+ * @max_work bytes' worth of parsing or indexing (0 removes the
+ * budget) and returns 0 to continue, 1 when the DAT is ready, or
+ * -1 when the document is not valid Logiqx/MAME XML.
+ * logiqx_dat_parse_end() releases the parse state and returns the
+ * DAT after success, NULL otherwise (discarding partial work).
+ * logiqx_dat_parse_abort() releases everything unconditionally.
+ * The result must be freed with logiqx_dat_free(). */
+typedef struct logiqx_dat_parse logiqx_dat_parse_t;
+
+logiqx_dat_parse_t *logiqx_dat_parse_begin_owned(char *xml_data,
+      size_t len);
+int logiqx_dat_parse_step(logiqx_dat_parse_t *parse, size_t max_work);
+logiqx_dat_t *logiqx_dat_parse_end(logiqx_dat_parse_t *parse);
+void logiqx_dat_parse_abort(logiqx_dat_parse_t *parse);
+
 /* Frees specified DAT file */
 void logiqx_dat_free(logiqx_dat_t *dat_file);
 

--- a/libretro-common/include/formats/rxml.h
+++ b/libretro-common/include/formats/rxml.h
@@ -94,6 +94,30 @@ rxml_document_t *rxml_load_document_string(const char *str);
  * bytes (e.g. a task that read the file itself) should care about. */
 rxml_document_t *rxml_load_document_owned(char *buf, size_t len);
 
+/* Incremental variant of rxml_load_document_owned(): the same
+ * ownership contract (@buf is heap, NUL-terminated at @len, and is
+ * either given to the resulting document or freed on failure /
+ * abort), with the parse spread over as many rxml_parse_step()
+ * calls as the caller's budget requires.
+ *
+ * rxml_parse_begin_owned() returns NULL only on allocation failure
+ * (having freed @buf).  Each rxml_parse_step() consumes roughly
+ * @max_bytes of input - the bound is @max_bytes plus one construct,
+ * since parsing pauses only between constructs - and returns 0 to
+ * continue, 1 when the document reached its verdict successfully,
+ * or -1 when it failed (@max_bytes of 0 runs to the verdict in one
+ * call).  rxml_parse_end() releases the parse state and returns the
+ * document after a successful verdict, NULL otherwise (discarding
+ * any partial parse).  rxml_parse_abort() releases everything
+ * unconditionally. */
+typedef struct rxml_parse rxml_parse_t;
+
+rxml_parse_t *rxml_parse_begin_owned(char *buf, size_t len,
+      unsigned opts);
+int rxml_parse_step(rxml_parse_t *parse, size_t max_bytes);
+rxml_document_t *rxml_parse_end(rxml_parse_t *parse);
+void rxml_parse_abort(rxml_parse_t *parse);
+
 /* As rxml_load_document_string, with parse options; on failure, *err
  * (when non-NULL) receives the position the parser stopped at. */
 rxml_document_t *rxml_load_document_string_opts(const char *str,

--- a/playlist.c
+++ b/playlist.c
@@ -447,35 +447,29 @@ static bool playlist_path_equal(const char *real_path,
  * contained in specified 'entry'. Will update path_id
  * cache inside specified 'entry', if not already present.
  **/
-static bool playlist_path_matches_entry(playlist_path_id_t *path_id,
-      struct playlist_entry *entry, const playlist_config_t *config)
+/* Compares two content path IDs under the playlist's matching rules:
+ * exact real-path equality first (case-insensitive on
+ * case-insensitive operating systems), then - when fuzzy archive
+ * matching is enabled - the bare-archive vs inside-archive
+ * equivalence on the parent archive path.  Symmetric in its
+ * arguments. */
+static bool playlist_path_ids_match(const playlist_path_id_t *a,
+      const playlist_path_id_t *b, const playlist_config_t *config)
 {
-   /* Sanity check */
-   if (!path_id || !entry || !config)
-      return false;
-
-   /* Check whether entry contains a path ID cache */
-   if (!entry->path_id)
-   {
-      if (!(entry->path_id = playlist_path_id_init(entry->path)))
-         return false;
-   }
-
    /* Ensure we have valid real_path strings */
-   if (   (!path_id->real_path || !*path_id->real_path)
-       || (!entry->path_id->real_path || !*entry->path_id->real_path))
+   if (   (!a->real_path || !*a->real_path)
+       || (!b->real_path || !*b->real_path))
       return false;
 
    /* First pass comparison */
-   if (path_id->real_path_hash == entry->path_id->real_path_hash)
+   if (a->real_path_hash == b->real_path_hash)
    {
 #ifdef _WIN32
       /* Handle case-insensitive operating systems*/
-      if (string_is_equal_noncase(path_id->real_path,
-            entry->path_id->real_path))
+      if (string_is_equal_noncase(a->real_path, b->real_path))
          return true;
 #else
-      if (string_is_equal(path_id->real_path, entry->path_id->real_path))
+      if (string_is_equal(a->real_path, b->real_path))
          return true;
 #endif
    }
@@ -500,31 +494,46 @@ static bool playlist_path_matches_entry(playlist_path_id_t *path_id,
     * loads an archive file via the command line or some
     * external launcher (where the [delimiter][rom_file]
     * part is almost always omitted) */
-   if (   ((path_id->is_archive        && !path_id->is_in_archive)        && entry->path_id->is_in_archive)
-       || ((entry->path_id->is_archive && !entry->path_id->is_in_archive) && path_id->is_in_archive))
+   if (   ((a->is_archive && !a->is_in_archive) && b->is_in_archive)
+       || ((b->is_archive && !b->is_in_archive) && a->is_in_archive))
    {
       /* Ensure we have valid parent archive path
        * strings */
-      if (   (!path_id->archive_path || !*path_id->archive_path)
-          || (!entry->path_id->archive_path || !*entry->path_id->archive_path))
+      if (   (!a->archive_path || !*a->archive_path)
+          || (!b->archive_path || !*b->archive_path))
          return false;
 
-      if (path_id->archive_path_hash == entry->path_id->archive_path_hash)
+      if (a->archive_path_hash == b->archive_path_hash)
       {
 #ifdef _WIN32
          /* Handle case-insensitive operating systems*/
-         if (string_is_equal_noncase(path_id->archive_path,
-               entry->path_id->archive_path))
+         if (string_is_equal_noncase(a->archive_path, b->archive_path))
             return true;
 #else
-         if (string_is_equal(path_id->archive_path,
-               entry->path_id->archive_path))
+         if (string_is_equal(a->archive_path, b->archive_path))
             return true;
 #endif
       }
    }
 
    return false;
+}
+
+static bool playlist_path_matches_entry(playlist_path_id_t *path_id,
+      struct playlist_entry *entry, const playlist_config_t *config)
+{
+   /* Sanity check */
+   if (!path_id || !entry || !config)
+      return false;
+
+   /* Check whether entry contains a path ID cache */
+   if (!entry->path_id)
+   {
+      if (!(entry->path_id = playlist_path_id_init(entry->path)))
+         return false;
+   }
+
+   return playlist_path_ids_match(path_id, entry->path_id, config);
 }
 
 /**

--- a/playlist.c
+++ b/playlist.c
@@ -814,6 +814,278 @@ bool playlist_entry_exists(playlist_t *playlist,
    return false;
 }
 
+/* ============================================================
+ * Content path dedup index
+ *
+ * Open-addressing hash table over content path IDs, answering
+ * playlist_entry_exists() queries in O(1) expected time.  Any two
+ * path IDs that playlist_path_ids_match() accepts share at least
+ * one hash value between their {real, archive} pairs: an exact
+ * match implies equal real-path hashes, and the fuzzy bare-archive
+ * vs inside-archive match implies equal parent-archive hashes,
+ * where a bare archive's archive hash equals its real hash.
+ * Indexing every ID under both of its hashes and probing under
+ * both of the query's hashes therefore yields a candidate superset,
+ * and each candidate is verified with playlist_path_ids_match()
+ * itself - the index can never change an answer, only the cost.
+ *
+ * The index owns every path ID it stores (entries are re-derived
+ * from the entry path strings during seeding, never borrowed from
+ * the entries' lazy caches), so entry deletion and playlist
+ * teardown cannot dangle it.  Any allocation failure degrades the
+ * index permanently: queries fall back to the linear
+ * playlist_entry_exists() scan and stay correct.
+ * ============================================================ */
+
+typedef struct
+{
+   uint32_t hash;
+   playlist_path_id_t *pid;   /* non-owning; NULL = empty slot */
+} playlist_dedup_slot_t;
+
+struct playlist_dedup
+{
+   playlist_dedup_slot_t *table;   /* power-of-two slot count */
+   size_t table_cap;
+   size_t table_used;
+   playlist_path_id_t **owned;     /* every stored ID, exactly once */
+   size_t owned_cnt;
+   size_t owned_cap;
+   size_t seed_pos;                /* next entry index to seed */
+   bool seeded;
+   bool degraded;
+};
+
+static void playlist_dedup_degrade(playlist_dedup_t *dedup)
+{
+   if (dedup->table)
+      free(dedup->table);
+   dedup->table      = NULL;
+   dedup->table_cap  = 0;
+   dedup->table_used = 0;
+   dedup->degraded   = true;
+}
+
+/* Places @pid into the table under @hash; assumes capacity headroom
+ * was already ensured. */
+static void playlist_dedup_place(playlist_dedup_slot_t *table,
+      size_t cap, uint32_t hash, playlist_path_id_t *pid)
+{
+   size_t idx = (size_t)hash & (cap - 1);
+   while (table[idx].pid)
+      idx = (idx + 1) & (cap - 1);
+   table[idx].hash = hash;
+   table[idx].pid  = pid;
+}
+
+/* True when @pid indexes under two distinct hash values (a path
+ * inside an archive: parent hash differs from the full hash). */
+static bool playlist_dedup_two_hashes(const playlist_path_id_t *pid)
+{
+   return pid->is_in_archive
+       && (pid->archive_path_hash != pid->real_path_hash);
+}
+
+/* Ensures room for up to two more slots, growing (or degrading)
+ * as required.  Returns false when the index became degraded. */
+static bool playlist_dedup_reserve(playlist_dedup_t *dedup)
+{
+   playlist_dedup_slot_t *grown = NULL;
+   size_t new_cap;
+   size_t i;
+
+   if (dedup->degraded)
+      return false;
+
+   /* Keep load at or below 3/4 after inserting two slots */
+   if ((dedup->table_used + 2) * 4 <= dedup->table_cap * 3)
+      return true;
+
+   new_cap = (dedup->table_cap == 0) ? 64 : (dedup->table_cap << 1);
+   if (!(grown = (playlist_dedup_slot_t*)calloc(new_cap, sizeof(*grown))))
+   {
+      playlist_dedup_degrade(dedup);
+      return false;
+   }
+
+   for (i = 0; i < dedup->owned_cnt; i++)
+   {
+      playlist_path_id_t *pid = dedup->owned[i];
+      playlist_dedup_place(grown, new_cap, pid->real_path_hash, pid);
+      if (playlist_dedup_two_hashes(pid))
+         playlist_dedup_place(grown, new_cap, pid->archive_path_hash, pid);
+   }
+
+   if (dedup->table)
+      free(dedup->table);
+   dedup->table     = grown;
+   dedup->table_cap = new_cap;
+   return true;
+}
+
+/* Takes ownership of @pid and indexes it under its hash(es).
+ * On failure the index is degraded and @pid is freed. */
+static void playlist_dedup_insert(playlist_dedup_t *dedup,
+      playlist_path_id_t *pid)
+{
+   /* IDs with no real path can never satisfy the matcher;
+    * do not store them */
+   if (!pid->real_path || !*pid->real_path)
+   {
+      playlist_path_id_free(pid);
+      return;
+   }
+
+   if (!playlist_dedup_reserve(dedup))
+   {
+      playlist_path_id_free(pid);
+      return;
+   }
+
+   if (dedup->owned_cnt == dedup->owned_cap)
+   {
+      size_t new_cap = (dedup->owned_cap == 0) ? 64 : (dedup->owned_cap << 1);
+      playlist_path_id_t **grown = (playlist_path_id_t**)realloc(
+            dedup->owned, new_cap * sizeof(*grown));
+      if (!grown)
+      {
+         playlist_dedup_degrade(dedup);
+         playlist_path_id_free(pid);
+         return;
+      }
+      dedup->owned     = grown;
+      dedup->owned_cap = new_cap;
+   }
+   dedup->owned[dedup->owned_cnt++] = pid;
+
+   playlist_dedup_place(dedup->table, dedup->table_cap,
+         pid->real_path_hash, pid);
+   dedup->table_used++;
+   if (playlist_dedup_two_hashes(pid))
+   {
+      playlist_dedup_place(dedup->table, dedup->table_cap,
+            pid->archive_path_hash, pid);
+      dedup->table_used++;
+   }
+}
+
+/* Probes the chain of @hash for a stored ID matching @probe. */
+static bool playlist_dedup_probe_hash(playlist_dedup_t *dedup,
+      const playlist_path_id_t *probe, uint32_t hash,
+      const playlist_config_t *config)
+{
+   size_t idx = (size_t)hash & (dedup->table_cap - 1);
+   while (dedup->table[idx].pid)
+   {
+      if (   dedup->table[idx].hash == hash
+          && playlist_path_ids_match(probe, dedup->table[idx].pid, config))
+         return true;
+      idx = (idx + 1) & (dedup->table_cap - 1);
+   }
+   return false;
+}
+
+static bool playlist_dedup_lookup(playlist_dedup_t *dedup,
+      const playlist_path_id_t *probe, const playlist_config_t *config)
+{
+   if (!dedup->table_cap)
+      return false;
+   if (playlist_dedup_probe_hash(dedup, probe,
+         probe->real_path_hash, config))
+      return true;
+   if (playlist_dedup_two_hashes(probe))
+      return playlist_dedup_probe_hash(dedup, probe,
+            probe->archive_path_hash, config);
+   return false;
+}
+
+playlist_dedup_t *playlist_dedup_init(void)
+{
+   return (playlist_dedup_t*)calloc(1, sizeof(playlist_dedup_t));
+}
+
+bool playlist_dedup_seed_step(playlist_dedup_t *dedup,
+      playlist_t *playlist,
+      bool (*budget_cb)(void *userdata), void *userdata)
+{
+   size_t _len;
+   bool progressed = false;
+
+   if (!dedup || dedup->seeded || dedup->degraded)
+      return true;
+   if (!playlist)
+   {
+      dedup->seeded = true;
+      return true;
+   }
+
+   _len = RBUF_LEN(playlist->entries);
+   while (dedup->seed_pos < _len)
+   {
+      playlist_path_id_t *pid;
+
+      /* Guarantee forward progress: seed at least one entry per
+       * call before consulting the budget */
+      if (progressed && budget_cb && !budget_cb(userdata))
+         return false;
+
+      if (!(pid = playlist_path_id_init(
+            playlist->entries[dedup->seed_pos].path)))
+      {
+         playlist_dedup_degrade(dedup);
+         return true;
+      }
+      playlist_dedup_insert(dedup, pid);
+      if (dedup->degraded)
+         return true;
+
+      dedup->seed_pos++;
+      progressed = true;
+   }
+
+   dedup->seeded = true;
+   return true;
+}
+
+bool playlist_dedup_check_add(playlist_dedup_t *dedup,
+      playlist_t *playlist, const char *path, bool will_add)
+{
+   playlist_path_id_t *path_id = NULL;
+   bool found                  = false;
+
+   if (!playlist || (!path || !*path))
+      return false;
+
+   if (!dedup || dedup->degraded)
+      return playlist_entry_exists(playlist, path);
+
+   if (!(path_id = playlist_path_id_init(path)))
+      return false;
+
+   found = playlist_dedup_lookup(dedup, path_id, &playlist->config);
+
+   if (!found && will_add)
+      playlist_dedup_insert(dedup, path_id);   /* consumes path_id */
+   else
+      playlist_path_id_free(path_id);
+
+   return found;
+}
+
+void playlist_dedup_free(playlist_dedup_t *dedup)
+{
+   size_t i;
+   if (!dedup)
+      return;
+   for (i = 0; i < dedup->owned_cnt; i++)
+      playlist_path_id_free(dedup->owned[i]);
+   if (dedup->owned)
+      free(dedup->owned);
+   if (dedup->table)
+      free(dedup->table);
+   free(dedup);
+}
+
 void playlist_update(playlist_t *playlist, size_t idx,
       const struct playlist_entry *update_entry)
 {

--- a/playlist.c
+++ b/playlist.c
@@ -1327,35 +1327,42 @@ bool playlist_content_path_is_valid(const char *path)
  *
  * Push entry to top of playlist.
  **/
-bool playlist_push(playlist_t *playlist,
-      const struct playlist_entry *entry)
+/* Shared validation preamble of playlist_push() and
+ * playlist_push_unchecked(): checks the core path, builds the path
+ * ID (returned to the caller, who owns it), resolves the real core
+ * path into @real_core_path and derives the core name into
+ * @core_name (which may point at @core_name_buf or at the entry's
+ * own string).  Returns false, having freed nothing but its own
+ * partial work, when the entry cannot legally be pushed. */
+static bool playlist_push_prepare(playlist_t *playlist,
+      const struct playlist_entry *entry,
+      playlist_path_id_t **path_id,
+      char *real_core_path, size_t real_core_path_size,
+      char *core_name_buf, size_t core_name_buf_size,
+      const char **core_name)
 {
-   size_t i, _len;
-   char real_core_path[PATH_MAX_LENGTH];
-   char base_path[NAME_MAX_LENGTH];
-   playlist_path_id_t *path_id = NULL;
-   const char *core_name       = entry->core_name;
-   bool entry_updated          = false;
+   *path_id   = NULL;
+   *core_name = entry ? entry->core_name : NULL;
 
    if (!playlist || !entry)
-      goto error;
+      return false;
 
    if (!entry->core_path || !*entry->core_path)
    {
       RARCH_ERR("[Playlist] Cannot push NULL or empty core path into the playlist.\n");
-      goto error;
+      return false;
    }
 
    /* Get path ID */
-   if (!(path_id = playlist_path_id_init(entry->path)))
-      goto error;
+   if (!(*path_id = playlist_path_id_init(entry->path)))
+      return false;
 
    /* Get 'real' core path */
-   strlcpy(real_core_path, entry->core_path, sizeof(real_core_path));
+   strlcpy(real_core_path, entry->core_path, real_core_path_size);
    if (   !string_is_equal(real_core_path, FILE_PATH_DETECT)
        && !string_is_equal(real_core_path, FILE_PATH_BUILTIN))
       playlist_resolve_path(PLAYLIST_SAVE, true, real_core_path,
-             sizeof(real_core_path));
+             real_core_path_size);
 
    if (!*real_core_path)
    {
@@ -1363,20 +1370,160 @@ bool playlist_push(playlist_t *playlist,
       goto error;
    }
 
-   if (!core_name || !*core_name)
+   if (!*core_name || !**core_name)
    {
-      base_path[0] = '\0';
-      fill_pathname(base_path, path_basename(real_core_path), "",
-            sizeof(base_path));
+      core_name_buf[0] = '\0';
+      fill_pathname(core_name_buf, path_basename(real_core_path), "",
+            core_name_buf_size);
 
-      core_name = base_path;
+      *core_name = core_name_buf;
 
-      if (!core_name || !*core_name)
+      if (!*core_name || !**core_name)
       {
          RARCH_ERR("[Playlist] Cannot push NULL or empty core name into the playlist.\n");
          goto error;
       }
    }
+
+   return true;
+
+error:
+   playlist_path_id_free(*path_id);
+   *path_id = NULL;
+   return false;
+}
+
+/* Appends @entry at the front of @playlist without searching for an
+ * existing match.  @path_id ownership transfers to the new entry on
+ * success and stays with the caller on failure.  Applies the
+ * capacity policy (evicting the oldest entry when full) and marks
+ * the playlist modified. */
+static bool playlist_push_new_entry(playlist_t *playlist,
+      const struct playlist_entry *entry,
+      playlist_path_id_t *path_id,
+      const char *real_core_path, const char *core_name)
+{
+   size_t i;
+   size_t _len = RBUF_LEN(playlist->entries);
+
+   if (playlist->config.capacity == 0)
+      return false;
+
+   if (_len == playlist->config.capacity)
+   {
+      struct playlist_entry *last_entry = &playlist->entries[_len - 1];
+      playlist_free_entry(last_entry);
+      _len--;
+   }
+   else
+   {
+      /* Allocate memory to fit one more item and resize the buffer */
+      if (!RBUF_TRYFIT(playlist->entries, _len + 1))
+         return false; /* out of memory */
+      RBUF_RESIZE(playlist->entries, _len + 1);
+   }
+
+   if (playlist->entries)
+   {
+      memmove(playlist->entries + 1, playlist->entries,
+            _len * sizeof(struct playlist_entry));
+
+      playlist->entries[0].path               = NULL;
+      playlist->entries[0].label              = NULL;
+      playlist->entries[0].core_path          = NULL;
+      playlist->entries[0].core_name          = NULL;
+      playlist->entries[0].db_name            = NULL;
+      playlist->entries[0].crc32              = NULL;
+      playlist->entries[0].subsystem_ident    = NULL;
+      playlist->entries[0].subsystem_name     = NULL;
+      playlist->entries[0].runtime_str        = NULL;
+      playlist->entries[0].last_played_str    = NULL;
+      playlist->entries[0].subsystem_roms     = NULL;
+      playlist->entries[0].path_id            = NULL;
+      playlist->entries[0].runtime_status     = PLAYLIST_RUNTIME_UNKNOWN;
+      playlist->entries[0].runtime_hours      = 0;
+      playlist->entries[0].runtime_minutes    = 0;
+      playlist->entries[0].runtime_seconds    = 0;
+      playlist->entries[0].last_played_year   = 0;
+      playlist->entries[0].last_played_month  = 0;
+      playlist->entries[0].last_played_day    = 0;
+      playlist->entries[0].last_played_hour   = 0;
+      playlist->entries[0].last_played_minute = 0;
+      playlist->entries[0].last_played_second = 0;
+
+      if (path_id->real_path && *path_id->real_path)
+         playlist->entries[0].path            = strdup(path_id->real_path);
+      playlist->entries[0].path_id            = path_id;
+
+      playlist->entries[0].entry_slot         = entry->entry_slot;
+
+      if (entry->label && *entry->label)
+         playlist->entries[0].label           = strdup(entry->label);
+      if (*real_core_path)
+         playlist->entries[0].core_path       = strdup(real_core_path);
+      if (core_name && *core_name)
+         playlist->entries[0].core_name       = strdup(core_name);
+      if (entry->db_name && *entry->db_name)
+         playlist->entries[0].db_name         = strdup(entry->db_name);
+      if (entry->crc32 && *entry->crc32)
+         playlist->entries[0].crc32           = strdup(entry->crc32);
+      if (entry->subsystem_ident && *entry->subsystem_ident)
+         playlist->entries[0].subsystem_ident = strdup(entry->subsystem_ident);
+      if (entry->subsystem_name && *entry->subsystem_name)
+         playlist->entries[0].subsystem_name  = strdup(entry->subsystem_name);
+
+      if (entry->subsystem_roms)
+      {
+         union string_list_elem_attr attributes = {0};
+
+         playlist->entries[0].subsystem_roms    = string_list_new();
+
+         for (i = 0; i < entry->subsystem_roms->size; i++)
+            string_list_append(playlist->entries[0].subsystem_roms, entry->subsystem_roms->elems[i].data, attributes);
+      }
+   }
+
+   playlist->flags   |= CNT_PLAYLIST_FLG_MOD;
+   return true;
+}
+
+bool playlist_push_unchecked(playlist_t *playlist,
+      const struct playlist_entry *entry)
+{
+   char real_core_path[PATH_MAX_LENGTH];
+   char base_path[NAME_MAX_LENGTH];
+   playlist_path_id_t *path_id = NULL;
+   const char *core_name       = NULL;
+
+   if (!playlist_push_prepare(playlist, entry, &path_id,
+         real_core_path, sizeof(real_core_path),
+         base_path, sizeof(base_path), &core_name))
+      return false;
+
+   if (!playlist_push_new_entry(playlist, entry, path_id,
+         real_core_path, core_name))
+   {
+      playlist_path_id_free(path_id);
+      return false;
+   }
+
+   return true;
+}
+
+bool playlist_push(playlist_t *playlist,
+      const struct playlist_entry *entry)
+{
+   size_t i, _len;
+   char real_core_path[PATH_MAX_LENGTH];
+   char base_path[NAME_MAX_LENGTH];
+   playlist_path_id_t *path_id = NULL;
+   const char *core_name       = NULL;
+   bool entry_updated          = false;
+
+   if (!playlist_push_prepare(playlist, entry, &path_id,
+         real_core_path, sizeof(real_core_path),
+         base_path, sizeof(base_path), &core_name))
+      goto error;
 
    _len = RBUF_LEN(playlist->entries);
    for (i = 0; i < _len; i++)
@@ -1505,83 +1652,10 @@ bool playlist_push(playlist_t *playlist,
       goto success;
    }
 
-   if (playlist->config.capacity == 0)
+   if (!playlist_push_new_entry(playlist, entry, path_id,
+         real_core_path, core_name))
       goto error;
-
-   if (_len == playlist->config.capacity)
-   {
-      struct playlist_entry *last_entry = &playlist->entries[_len - 1];
-      playlist_free_entry(last_entry);
-      _len--;
-   }
-   else
-   {
-      /* Allocate memory to fit one more item and resize the buffer */
-      if (!RBUF_TRYFIT(playlist->entries, _len + 1))
-         goto error; /* out of memory */
-      RBUF_RESIZE(playlist->entries, _len + 1);
-   }
-
-   if (playlist->entries)
-   {
-      memmove(playlist->entries + 1, playlist->entries,
-            _len * sizeof(struct playlist_entry));
-
-      playlist->entries[0].path               = NULL;
-      playlist->entries[0].label              = NULL;
-      playlist->entries[0].core_path          = NULL;
-      playlist->entries[0].core_name          = NULL;
-      playlist->entries[0].db_name            = NULL;
-      playlist->entries[0].crc32              = NULL;
-      playlist->entries[0].subsystem_ident    = NULL;
-      playlist->entries[0].subsystem_name     = NULL;
-      playlist->entries[0].runtime_str        = NULL;
-      playlist->entries[0].last_played_str    = NULL;
-      playlist->entries[0].subsystem_roms     = NULL;
-      playlist->entries[0].path_id            = NULL;
-      playlist->entries[0].runtime_status     = PLAYLIST_RUNTIME_UNKNOWN;
-      playlist->entries[0].runtime_hours      = 0;
-      playlist->entries[0].runtime_minutes    = 0;
-      playlist->entries[0].runtime_seconds    = 0;
-      playlist->entries[0].last_played_year   = 0;
-      playlist->entries[0].last_played_month  = 0;
-      playlist->entries[0].last_played_day    = 0;
-      playlist->entries[0].last_played_hour   = 0;
-      playlist->entries[0].last_played_minute = 0;
-      playlist->entries[0].last_played_second = 0;
-
-      if (path_id->real_path && *path_id->real_path)
-         playlist->entries[0].path            = strdup(path_id->real_path);
-      playlist->entries[0].path_id            = path_id;
-      path_id                                 = NULL;
-
-      playlist->entries[0].entry_slot         = entry->entry_slot;
-
-      if (entry->label && *entry->label)
-         playlist->entries[0].label           = strdup(entry->label);
-      if (*real_core_path)
-         playlist->entries[0].core_path       = strdup(real_core_path);
-      if (core_name && *core_name)
-         playlist->entries[0].core_name       = strdup(core_name);
-      if (entry->db_name && *entry->db_name)
-         playlist->entries[0].db_name         = strdup(entry->db_name);
-      if (entry->crc32 && *entry->crc32)
-         playlist->entries[0].crc32           = strdup(entry->crc32);
-      if (entry->subsystem_ident && *entry->subsystem_ident)
-         playlist->entries[0].subsystem_ident = strdup(entry->subsystem_ident);
-      if (entry->subsystem_name && *entry->subsystem_name)
-         playlist->entries[0].subsystem_name  = strdup(entry->subsystem_name);
-
-      if (entry->subsystem_roms)
-      {
-         union string_list_elem_attr attributes = {0};
-
-         playlist->entries[0].subsystem_roms    = string_list_new();
-
-         for (i = 0; i < entry->subsystem_roms->size; i++)
-            string_list_append(playlist->entries[0].subsystem_roms, entry->subsystem_roms->elems[i].data, attributes);
-      }
-   }
+   path_id = NULL;   /* ownership transferred to the new entry */
 
 success:
    if (path_id)

--- a/playlist.h
+++ b/playlist.h
@@ -291,6 +291,19 @@ bool playlist_content_path_is_valid(const char *path);
 bool playlist_push(playlist_t *playlist,
       const struct playlist_entry *entry);
 
+/**
+ * playlist_push_unchecked:
+ *
+ * Appends @entry at the front of @playlist WITHOUT searching for an
+ * existing matching entry.  The caller must have already proven the
+ * entry's content path absent (via playlist_entry_exists() or a
+ * playlist_dedup_t index); pushing a path that is present creates a
+ * duplicate.  Applies the same validation, capacity and eviction
+ * rules as playlist_push().
+ **/
+bool playlist_push_unchecked(playlist_t *playlist,
+      const struct playlist_entry *entry);
+
 bool playlist_push_runtime(playlist_t *playlist,
       const struct playlist_entry *entry);
 

--- a/playlist.h
+++ b/playlist.h
@@ -331,6 +331,43 @@ void playlist_get_index_by_path(playlist_t *playlist,
 bool playlist_entry_exists(playlist_t *playlist,
       const char *path);
 
+/* Content path dedup index: answers playlist_entry_exists() queries
+ * in O(1) expected time for repeated probes against the same
+ * playlist.  Verified candidates go through the same matching rules
+ * as the linear scan (including fuzzy archive matching), so answers
+ * are identical; internal allocation failure degrades the index to
+ * the linear scan transparently.  The index owns all of its state
+ * and may be freed before or after the playlist. */
+typedef struct playlist_dedup playlist_dedup_t;
+
+playlist_dedup_t *playlist_dedup_init(void);
+
+/**
+ * playlist_dedup_seed_step:
+ *
+ * Indexes @playlist's current entries, resuming from where the
+ * previous call stopped.  When @budget_cb is non-NULL it is
+ * consulted between entries and seeding yields (returning false)
+ * once it reports the budget exhausted; at least one entry is
+ * seeded per call.  Returns true when seeding has completed.
+ **/
+bool playlist_dedup_seed_step(playlist_dedup_t *dedup,
+      playlist_t *playlist,
+      bool (*budget_cb)(void *userdata), void *userdata);
+
+/**
+ * playlist_dedup_check_add:
+ *
+ * Returns what playlist_entry_exists(@playlist, @path) would
+ * return.  When @will_add is true and the path was absent, the
+ * path is recorded in the index so that subsequent queries see it;
+ * the caller is expected to push the corresponding entry.
+ **/
+bool playlist_dedup_check_add(playlist_dedup_t *dedup,
+      playlist_t *playlist, const char *path, bool will_add);
+
+void playlist_dedup_free(playlist_dedup_t *dedup);
+
 char *playlist_get_conf_path(playlist_t *playlist);
 
 uint32_t playlist_get_size(playlist_t *playlist);

--- a/samples/tasks/database/scan_begin_budget_test.c
+++ b/samples/tasks/database/scan_begin_budget_test.c
@@ -86,9 +86,10 @@ static retro_time_t thread_cpu_usec(void)
 
 /* Throughput guard: incremental scan total time must stay within
  * this factor of (blocking walk + DAT parse + per-entry floor).
- * Measured locally the ratio is ~1.0; the margin absorbs shared-
- * runner noise without admitting a 2x regression. */
-#define THROUGHPUT_FACTOR 1.60
+ * With the playlist dedup index the measured ratio is ~0.35-0.41;
+ * the margin absorbs shared-runner noise while still rejecting the
+ * pre-index quadratic flush, which lands at ~1.1. */
+#define THROUGHPUT_FACTOR 0.80
 
 /* ------------------------------------------------------------------ */
 /* Stubs (same set as database_scan_test.c - see rationale there)     */
@@ -243,6 +244,9 @@ static bool build_fixture(const char *root, char *dat_path, size_t dat_path_len,
 /* Scan driver                                                        */
 /* ------------------------------------------------------------------ */
 
+/* The rescan lane flips this to drive the no-overwrite path. */
+static bool scan_overwrite = true;
+
 static bool scan_done;
 static bool scan_err;
 
@@ -309,7 +313,7 @@ static bool configure_scan(const char *content_dir, const char *dat_path,
       return false;
    }
    *manual_content_scan_get_search_recursively_ptr() = true;
-   *manual_content_scan_get_overwrite_playlist_ptr() = true;
+   *manual_content_scan_get_overwrite_playlist_ptr() = scan_overwrite;
    return true;
 }
 
@@ -513,6 +517,164 @@ static bool check_playlist(const char *playlist_dir)
    return true;
 }
 
+/* Differential check: the dedup index must answer exactly like the
+ * linear playlist_entry_exists() scan, with fuzzy archive matching
+ * both off and on.  Path IDs are syntactic (archive detection is a
+ * string operation), so none of these paths needs to exist.  Also
+ * pins the will_add contract: a recorded path becomes visible to
+ * the index at once, and playlist_push_unchecked() then brings the
+ * playlist into agreement. */
+static bool check_dedup_differential(const char *root)
+{
+   char plpath[4352];
+   char p_plain[4352], p_zip[4352], p_inzip[4352], p_case[4352];
+   char q_absent[4352], q_bare[4352], q_inother[4352], q_casevar[4352];
+   int fz;
+
+   snprintf(plpath,   sizeof(plpath),   "%s/DedupDiff.lpl", root);
+   snprintf(p_plain,  sizeof(p_plain),  "%s/dd/plain.bin", root);
+   snprintf(p_zip,    sizeof(p_zip),    "%s/dd/archive.zip", root);
+   snprintf(p_inzip,  sizeof(p_inzip),  "%s/dd/inner.zip#rom.bin", root);
+   snprintf(p_case,   sizeof(p_case),   "%s/dd/CaseFile.BIN", root);
+   snprintf(q_absent, sizeof(q_absent), "%s/dd/absent.bin", root);
+   snprintf(q_bare,   sizeof(q_bare),   "%s/dd/inner.zip", root);
+   snprintf(q_inother,sizeof(q_inother),"%s/dd/archive.zip#other.rom", root);
+   snprintf(q_casevar,sizeof(q_casevar),"%s/dd/casefile.bin", root);
+
+   for (fz = 0; fz < 2; fz++)
+   {
+      playlist_config_t cfg;
+      playlist_t *pl        = NULL;
+      playlist_dedup_t *dd  = NULL;
+      const char *entries[4];
+      const char *probes[10];
+      size_t i;
+      bool ok = false;
+
+      entries[0] = p_plain;
+      entries[1] = p_zip;      /* bare archive entry */
+      entries[2] = p_inzip;    /* inside-archive entry (distinct archive) */
+      entries[3] = p_case;
+
+      probes[0] = p_plain;     /* exact hits */
+      probes[1] = p_zip;
+      probes[2] = p_inzip;
+      probes[3] = p_case;
+      probes[4] = q_absent;    /* miss */
+      probes[5] = q_bare;      /* bare probe vs inside-archive entry  */
+      probes[6] = q_inother;   /* inside probe vs bare-archive entry  */
+      probes[7] = q_casevar;   /* case variant: OS-dependent - exactly
+                                  why this lane is differential */
+      probes[8] = plpath;      /* unrelated existing file: miss */
+      probes[9] = "";          /* empty probe: guard parity */
+
+      filestream_delete(plpath);
+      memset(&cfg, 0, sizeof(cfg));
+      playlist_config_set_path(&cfg, plpath);
+      cfg.capacity            = 100;
+      cfg.fuzzy_archive_match = (fz == 1);
+
+      if (!(pl = playlist_init(&cfg)))
+         return false;
+
+      for (i = 0; i < 4; i++)
+      {
+         struct playlist_entry e;
+         memset(&e, 0, sizeof(e));
+         e.path      = (char*)entries[i];
+         e.core_path = (char*)"DETECT";
+         e.core_name = (char*)"DETECT";
+         if (!playlist_push(pl, &e))
+         {
+            fprintf(stderr, "dedup diff: seed push failed\n");
+            goto lane_out;
+         }
+      }
+
+      if (!(dd = playlist_dedup_init()))
+         goto lane_out;
+      /* NULL budget callback: seed everything in one call */
+      if (!playlist_dedup_seed_step(dd, pl, NULL, NULL))
+      {
+         fprintf(stderr, "dedup diff: unbudgeted seeding did not finish\n");
+         goto lane_out;
+      }
+
+      for (i = 0; i < sizeof(probes) / sizeof(probes[0]); i++)
+      {
+         bool lin = playlist_entry_exists(pl, probes[i]);
+         bool idx = playlist_dedup_check_add(dd, pl, probes[i], false);
+         if (lin != idx)
+         {
+            fprintf(stderr,
+                  "dedup diff: fuzzy=%d probe %u \"%s\": linear=%d index=%d\n",
+                  fz, (unsigned)i, probes[i], (int)lin, (int)idx);
+            goto lane_out;
+         }
+      }
+
+      /* Anchor the fuzzy semantics themselves so the differential
+       * cannot rot into vacuity.  In RetroArch proper
+       * (RARCH_INTERNAL) the config gates fuzzy matching; this
+       * sample builds without RARCH_INTERNAL, where the gate is
+       * compiled out and both archive equivalences always hold. */
+      {
+#ifdef RARCH_INTERNAL
+         bool expect_fuzzy = (fz == 1);
+#else
+         bool expect_fuzzy = true;
+#endif
+         if (playlist_entry_exists(pl, q_bare)    != expect_fuzzy
+          || playlist_entry_exists(pl, q_inother) != expect_fuzzy)
+         {
+            fprintf(stderr, "dedup diff: fuzzy anchor changed (fuzzy=%d)\n", fz);
+            goto lane_out;
+         }
+      }
+
+      /* will_add: recording makes the path visible to the index
+       * immediately; the unchecked push then makes the playlist
+       * agree with it. */
+      if (playlist_dedup_check_add(dd, pl, q_absent, true))
+      {
+         fprintf(stderr, "dedup diff: absent path reported present\n");
+         goto lane_out;
+      }
+      if (!playlist_dedup_check_add(dd, pl, q_absent, false))
+      {
+         fprintf(stderr, "dedup diff: recorded path not visible\n");
+         goto lane_out;
+      }
+      {
+         struct playlist_entry e;
+         memset(&e, 0, sizeof(e));
+         e.path      = (char*)q_absent;
+         e.core_path = (char*)"DETECT";
+         e.core_name = (char*)"DETECT";
+         if (!playlist_push_unchecked(pl, &e))
+         {
+            fprintf(stderr, "dedup diff: unchecked push failed\n");
+            goto lane_out;
+         }
+      }
+      if (!playlist_entry_exists(pl, q_absent))
+      {
+         fprintf(stderr, "dedup diff: playlist disagrees after push\n");
+         goto lane_out;
+      }
+
+      ok = true;
+lane_out:
+      playlist_dedup_free(dd);
+      playlist_free(pl);
+      if (!ok)
+         return false;
+   }
+   filestream_delete(plpath);
+   fprintf(stderr, "[pass] dedup differential lane (fuzzy off/on)\n");
+   return true;
+}
+
 int main(int argc, char *argv[])
 {
    char content_dir[4096];
@@ -605,6 +767,9 @@ int main(int argc, char *argv[])
    task_queue_init(false /* regular queue: the case that freezes */,
          msgq_push);
 
+   if (!check_dedup_differential(fixture_root))
+      goto out_queue;
+
    if (!run_scan(content_dir, dat_path, playlist_dir, &m))
       goto out_queue;
    if (!check_playlist(playlist_dir))
@@ -664,6 +829,21 @@ int main(int argc, char *argv[])
          goto out_queue;
       }
    }
+
+   /* Rescan without overwrite: every result must hit the dedup
+    * index against the 5000 entries the first pass wrote, nothing
+    * may be added twice, and the pre-existing entries drive the
+    * budgeted seeding path at scale. */
+   scan_overwrite = false;
+   {
+      scan_metrics_t m2;
+      bool rescan_ok = run_scan(content_dir, dat_path, playlist_dir, &m2)
+            && check_playlist(playlist_dir);
+      scan_overwrite = true;
+      if (!rescan_ok)
+         goto out_queue;
+   }
+   fprintf(stderr, "[pass] no-overwrite rescan lane (0 duplicates)\n");
 
    /* The regular-queue metrics lanes are done; tear that queue down
     * before the threaded and cancellation lanes bring up their own. */

--- a/samples/tasks/database/scan_begin_budget_test.c
+++ b/samples/tasks/database/scan_begin_budget_test.c
@@ -240,6 +240,60 @@ static bool build_fixture(const char *root, char *dat_path, size_t dat_path_len,
    return true;
 }
 
+/* Big-DAT lane fixture: a DAT large enough that an unbudgeted parse
+ * or index build would blow the pacing budget many times over, and
+ * a small content set whose names sample the start, middle and end
+ * of the list.  Scanning it asserts that no gather grows with DAT
+ * size - the last input-proportional single-gather work in the
+ * scan.  ~300k games come to ~40MB of XML; the fixture's own cost
+ * is one streamed write. */
+#define BIG_DAT_GAMES         300000
+#define BIG_DAT_CONTENT_FILES 50
+
+static bool build_big_fixture(const char *root, char *dat_path,
+      size_t dat_path_len, char *content_dir, size_t content_dir_len,
+      char *playlist_dir, size_t playlist_dir_len)
+{
+   size_t i;
+   FILE *dat;
+   char path[4096];
+
+   snprintf(content_dir, content_dir_len, "%s/bigcontent", root);
+   snprintf(dat_path, dat_path_len, "%s/biggames.dat", root);
+   snprintf(playlist_dir, playlist_dir_len, "%s/bigplaylists", root);
+
+   if (   !path_mkdir(content_dir)
+       || !path_mkdir(playlist_dir))
+      return false;
+
+   /* Every 6000th game exists as a file: hits across the whole
+    * list, so a search index that silently covered only a prefix
+    * would mislabel the tail. */
+   for (i = 0; i < BIG_DAT_CONTENT_FILES; i++)
+   {
+      char body[64];
+      unsigned id = (unsigned)(i * (BIG_DAT_GAMES / BIG_DAT_CONTENT_FILES));
+      snprintf(path, sizeof(path), "%s/big%06u.bin", content_dir, id);
+      snprintf(body, sizeof(body), "big-%06u", id);
+      if (!write_text_file(path, body))
+         return false;
+   }
+
+   if (!(dat = fopen(dat_path, "w")))
+      return false;
+   fputs("<?xml version=\"1.0\"?>\n<datafile>\n"
+         "<header><name>ScanBench</name></header>\n", dat);
+   for (i = 0; i < BIG_DAT_GAMES; i++)
+      fprintf(dat,
+            "<game name=\"big%06u\">"
+            "<description>Big Game %06u</description>"
+            "<year>2026</year></game>\n",
+            (unsigned)i, (unsigned)i);
+   fputs("</datafile>\n", dat);
+   fclose(dat);
+   return true;
+}
+
 /* ------------------------------------------------------------------ */
 /* Scan driver                                                        */
 /* ------------------------------------------------------------------ */
@@ -844,6 +898,96 @@ int main(int argc, char *argv[])
          goto out_queue;
    }
    fprintf(stderr, "[pass] no-overwrite rescan lane (0 duplicates)\n");
+
+   /* Big-DAT lane: the pacing contract must not scale with DAT
+    * size.  Before the incremental DAT parse, this lane's whole
+    * ~40MB parse (and the index build after it) sat in single
+    * gathers; the assertion below fails on any return to that. */
+   {
+      char big_dat[4096];
+      char big_content[4096];
+      char big_playlists[4352];
+      scan_metrics_t mb;
+
+      if (!build_big_fixture(fixture_root,
+            big_dat, sizeof(big_dat),
+            big_content, sizeof(big_content),
+            big_playlists, sizeof(big_playlists)))
+      {
+         fprintf(stderr, "big fixture build failed\n");
+         goto out_queue;
+      }
+      if (!run_scan(big_content, big_dat, big_playlists, &mb))
+         goto out_queue;
+
+      /* Correctness: all files present, labelled from the DAT -
+       * including the last sample, whose label only an index
+       * covering the full list can supply. */
+      {
+         char plpath[4608];
+         playlist_config_t cfg;
+         playlist_t *pl;
+         const struct playlist_entry *e = NULL;
+         size_t n, k;
+         bool tail_seen = false;
+
+         memset(&cfg, 0, sizeof(cfg));
+         snprintf(plpath, sizeof(plpath), "%s/ScanBench.lpl",
+               big_playlists);
+         playlist_config_set_path(&cfg, plpath);
+         cfg.capacity = COLLECTION_SIZE;
+         if (!(pl = playlist_init(&cfg)))
+            goto out_queue;
+         n = playlist_size(pl);
+         for (k = 0; k < n; k++)
+         {
+            playlist_get_index(pl, k, &e);
+            if (e && e->label
+                  && !strcmp(e->label, "Big Game 294000"))
+               tail_seen = true;
+         }
+         playlist_free(pl);
+         if (n != BIG_DAT_CONTENT_FILES || !tail_seen)
+         {
+            fprintf(stderr,
+                  "big-DAT lane: %u entries (want %u), tail label %s\n",
+                  (unsigned)n, (unsigned)BIG_DAT_CONTENT_FILES,
+                  tail_seen ? "ok" : "missing");
+            goto out_queue;
+         }
+      }
+
+      if (!sanitize && !bench_only)
+      {
+         retro_time_t limit = 4000 * PACING_SLACK_MULTIPLIER;
+         if (mb.max_gather_usec > limit)
+         {
+            fprintf(stderr,
+                  "FAIL big-DAT pacing: max gather %.2fms CPU exceeds "
+                  "%.2fms budget\n",
+                  mb.max_gather_usec / 1000.0, limit / 1000.0);
+            goto out_queue;
+         }
+      }
+
+      /* Land cancels inside the budgeted DAT read and parse, which
+       * the small fixture's sweep passes in a couple of gathers. */
+      {
+         static const unsigned big_cancel_points[] = { 32, 128, 512 };
+         size_t ci;
+         for (ci = 0;
+              ci < sizeof(big_cancel_points) / sizeof(big_cancel_points[0]);
+              ci++)
+         {
+            if (!run_scan_cancelled(big_content, big_dat, big_playlists,
+                  big_cancel_points[ci]))
+               goto out_queue;
+         }
+      }
+      fprintf(stderr, "[pass] big-DAT lane (%u games, pacing%s)\n",
+            (unsigned)BIG_DAT_GAMES,
+            sanitize ? " skipped under sanitizer" : " held");
+   }
 
    /* The regular-queue metrics lanes are done; tear that queue down
     * before the threaded and cancellation lanes bring up their own. */

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -320,6 +320,7 @@ typedef struct manual_scan_handle
    char *flush_path_buf;
    unsigned flush_added;
    bool flush_started;
+   playlist_dedup_t *flush_dedup;
    logiqx_dat_t *dat_file;
    struct string_list *m3u_list;
    playlist_config_t playlist_config; /* size_t alignment */
@@ -1978,6 +1979,8 @@ static void task_database_cleanup_state(database_state_handle_t *db_state)
  * Returns true when the flush has fully completed (including the
  * failure mode of the scratch allocation, which skips the batch),
  * false when yielding. */
+static bool manual_scan_walk_within_budget(void *ud);
+
 static bool manual_scan_end_flush_tick(
    manual_scan_handle_t* manual_scan, bool single_playlist)
 {
@@ -2003,6 +2006,9 @@ static bool manual_scan_end_flush_tick(
       {
          manual_scan->flush_group    = manual_scan->task_config->playlist_file;
          manual_scan->flush_playlist = manual_scan->playlist;
+         /* NULL on failure: existence checks then take the linear
+          * fallback below */
+         manual_scan->flush_dedup    = playlist_dedup_init();
       }
    }
    else if (!manual_scan->flush_path_buf)
@@ -2023,6 +2029,8 @@ static bool manual_scan_end_flush_tick(
       const char *group_key = (*manual_scan->task_config->playlist_file)
          ? manual_scan->task_config->playlist_file
          : result->db_name;
+      bool entry_present;
+      bool is_m3u;
 
       /* The floor: one result per gather regardless of the window,
        * then yield between any two results. */
@@ -2049,6 +2057,8 @@ static bool manual_scan_end_flush_tick(
             manual_scan->flush_playlist = NULL;
             manual_scan->flush_added = 0;
          }
+         playlist_dedup_free(manual_scan->flush_dedup);
+         manual_scan->flush_dedup = NULL;
 
          /* Open new playlist - if not fixed, use database name */
          if (!*manual_scan->task_config->playlist_file)
@@ -2083,6 +2093,10 @@ static bool manual_scan_end_flush_tick(
             manual_scan->flush_pos++;
             continue;
          }
+
+         /* NULL on failure: existence checks then take the linear
+          * fallback below */
+         manual_scan->flush_dedup = playlist_dedup_init();
 
          /* Set default core, if required */
          if (manual_scan->task_config->core_set)
@@ -2122,17 +2136,40 @@ static bool manual_scan_end_flush_tick(
          RARCH_LOG("[Scanner] Processing playlist: \"%s\".\n", result->db_name);
       }
 
+      /* Index the playlist's pre-existing entries before consulting
+       * the dedup index, resuming across gathers on the shared
+       * window.  flush_pos has not advanced, so a resumed gather
+       * re-enters here with the same group. */
+      if (   manual_scan->flush_dedup
+          && manual_scan->flush_playlist
+          && !playlist_dedup_seed_step(manual_scan->flush_dedup,
+                manual_scan->flush_playlist,
+                manual_scan_walk_within_budget, &b))
+      {
+         task_nbio_slice_close(&b);
+         return false;
+      }
+
       /* Add entry to playlist if it doesn't already exist */
       /* ...except for M3U, since the processing occurs at the end,
          we overwrite any previous m3u entry (which has same file,
          but less descriptive label, database, crc */
-      if (manual_scan->flush_playlist && 
-          (!playlist_entry_exists(manual_scan->flush_playlist, result->entry_path) ||
-           m3u_file_is_m3u(result->entry_path)))
+      is_m3u        = m3u_file_is_m3u(result->entry_path);
+      /* will_add records the path as present exactly when this
+       * result is pushed below: when absent (the push is
+       * unconditional), and in the m3u-present case the path
+       * remains present across the delete + re-push. */
+      entry_present = manual_scan->flush_dedup
+         ? playlist_dedup_check_add(manual_scan->flush_dedup,
+               manual_scan->flush_playlist, result->entry_path, true)
+         : playlist_entry_exists(manual_scan->flush_playlist,
+               result->entry_path);
+
+      if (manual_scan->flush_playlist && (!entry_present || is_m3u))
       {
          struct playlist_entry entry;
 
-         if(m3u_file_is_m3u(result->entry_path))
+         if(is_m3u)
             playlist_delete_by_path(manual_scan->flush_playlist, result->entry_path);
          
          /* Build entry */
@@ -2156,7 +2193,11 @@ static bool manual_scan_end_flush_tick(
          entry.last_played_minute= 0;
          entry.last_played_second= 0;
 
-         playlist_push(manual_scan->flush_playlist, &entry);
+         /* Absence is proven: the existence check above said so, or
+          * this is an m3u whose previous entries were just deleted.
+          * The checked playlist_push() would re-scan the entire
+          * playlist for the same answer. */
+         playlist_push_unchecked(manual_scan->flush_playlist, &entry);
          manual_scan->flush_added++;
 
          RARCH_LOG("[Scanner] Add \"%s / %s\".\n", db_name_noext, result->entry_label);
@@ -2190,6 +2231,9 @@ static bool manual_scan_end_flush_tick(
          playlist_free(manual_scan->flush_playlist);
       manual_scan->flush_playlist = NULL;
    }
+
+   playlist_dedup_free(manual_scan->flush_dedup);
+   manual_scan->flush_dedup = NULL;
 
    free(manual_scan->flush_path_buf);
    manual_scan->flush_path_buf = NULL;
@@ -2235,6 +2279,11 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
        && manual_scan->flush_playlist != manual_scan->playlist)
       playlist_free(manual_scan->flush_playlist);
    manual_scan->flush_playlist = NULL;
+
+   /* The dedup index owns all of its state; order relative to the
+    * playlist frees is immaterial. */
+   playlist_dedup_free(manual_scan->flush_dedup);
+   manual_scan->flush_dedup = NULL;
 
    if (manual_scan->flush_path_buf)
    {

--- a/tasks/task_database.c
+++ b/tasks/task_database.c
@@ -302,9 +302,12 @@ typedef struct manual_scan_handle
    /* Chunked DAT read in flight (MANUAL_SCAN_BEGIN_DAT_LOAD): the
     * file handle, the destination buffer (dat_size + 1 bytes) and
     * the fill position.  dat_buf ownership passes to
-    * logiqx_dat_init_owned() once the read completes. */
+    * logiqx_dat_parse_begin_owned() once the read completes, and
+    * dat_parse holds the budgeted parse + index build until its
+    * verdict. */
    RFILE *dat_stream;
    char *dat_buf;
+   logiqx_dat_parse_t *dat_parse;
    int64_t dat_size;
    int64_t dat_read;
    /* Resumable batch playlist flush (MANUAL_SCAN_END): position in
@@ -2325,6 +2328,13 @@ static void free_manual_content_scan_handle(manual_scan_handle_t *manual_scan)
       manual_scan->dat_buf = NULL;
    }
 
+   /* A cancelled task can also die mid-parse. */
+   if (manual_scan->dat_parse)
+   {
+      logiqx_dat_parse_abort(manual_scan->dat_parse);
+      manual_scan->dat_parse = NULL;
+   }
+
    if (manual_scan->content_list)
    {
       string_list_free(manual_scan->content_list);
@@ -2527,6 +2537,13 @@ static void task_manual_content_scan_free(retro_task_t *task)
  * that the guaranteed floor chunk of a spent window costs well under
  * a millisecond. */
 #define MANUAL_SCAN_DAT_CHUNK (256 * 1024)
+
+/* Bytes of XML handed to logiqx_dat_parse_step() per step: small
+ * enough that several steps fit one shared window in a plain build
+ * and one step stays frame-sized even under sanitizer inflation,
+ * large enough that a MAME-sized list completes in a few hundred
+ * steps. */
+#define MANUAL_SCAN_DAT_PARSE_STEP (256 * 1024)
 
 /* dir_list_iter_step()'s budget callback carries no sizes. */
 static bool manual_scan_walk_within_budget(void *ud)
@@ -2786,6 +2803,9 @@ static bool manual_scan_begin_dat_load(retro_task_t *task,
       return false;
    }
 
+   if (manual_scan->dat_parse)
+      goto parse_phase;
+
    if (!manual_scan->dat_stream)
    {
       /* Validate path and size up front through the same
@@ -2843,13 +2863,40 @@ static bool manual_scan_begin_dat_load(retro_task_t *task,
    filestream_close(manual_scan->dat_stream);
    manual_scan->dat_stream = NULL;
 
-   /* Hand the completed document to the parser.  Ownership of the
-    * buffer transfers unconditionally: on failure
-    * logiqx_dat_init_owned() frees it. */
+   /* Hand the completed document to the incremental parser.
+    * Ownership of the buffer transfers unconditionally: on failure
+    * logiqx_dat_parse_begin_owned() frees it. */
    manual_scan->dat_buf[manual_scan->dat_size] = '\0';
-   manual_scan->dat_file = logiqx_dat_init_owned(
+   manual_scan->dat_parse = logiqx_dat_parse_begin_owned(
          manual_scan->dat_buf, (size_t)manual_scan->dat_size);
-   manual_scan->dat_buf  = NULL;
+   manual_scan->dat_buf   = NULL;
+
+   if (!manual_scan->dat_parse)
+      goto error_no_cleanup;
+
+parse_phase:
+   /* Budgeted parse and index build: one step per gather whatever
+    * the window says (the floor), then further steps while it
+    * lasts.  A resumed gather jumps straight back here. */
+   for (;;)
+   {
+      int r = logiqx_dat_parse_step(manual_scan->dat_parse,
+            MANUAL_SCAN_DAT_PARSE_STEP);
+
+      if (r < 0)
+      {
+         logiqx_dat_parse_end(manual_scan->dat_parse);   /* discards */
+         manual_scan->dat_parse = NULL;
+         goto error_no_cleanup;
+      }
+      if (r > 0)
+         break;
+      if (!task_nbio_slice_within_budget(b, 0, 0))
+         return false;   /* resume next gather */
+   }
+
+   manual_scan->dat_file  = logiqx_dat_parse_end(manual_scan->dat_parse);
+   manual_scan->dat_parse = NULL;
 
    if (!manual_scan->dat_file)
       goto error_no_cleanup;


### PR DESCRIPTION
Follow-up to #19407, resolving both residuals documented there: the quadratic playlist flush and the single-gather DAT parse. With this series, no single gather anywhere in the manual scan grows with collection or DAT size.

## Playlist dedup (commits 1–5)

The END flush paid **two** linear matcher scans per added result: the `playlist_entry_exists()` probe, then `playlist_push()`'s own duplicate scan reaching the same conclusion — 48% of scan wall time under gprof, quadratic in collection size.

- `playlist_path_ids_match()` extracted from the entry matcher (pure refactor, symmetric, const).
- `playlist_push()` split into a shared validation preamble and an append tail; new `playlist_push_unchecked()` for callers that have already proven absence. Fixes a latent pre-NULL-check dereference of `entry->core_name` in passing.
- `playlist_dedup_t`: open-addressing hash over content path IDs. Correctness rests on a superset property of the matching rules — any two IDs the matcher accepts share at least one hash between their {real, archive} pairs — so every candidate is verified with `playlist_path_ids_match()` itself; the index can change only the cost of a query, never its answer. It owns all stored IDs (immune to the m3u `delete_by_path` mid-flush), seeds resumably under the shared window, and degrades to the linear scan on any allocation failure.
- Flush wiring: budgeted seeding across gathers, `check_add(will_add)` probe, unchecked push.

**Result:** 5000-file fixture drops from ~230 ms to 73–84 ms (~3× faster than pre-index, ~0.3× of the blocking scanner this all replaced).

## Incremental DAT parse (commits 6–9)

`MANUAL_SCAN_BEGIN_DAT_LOAD` read the DAT in budgeted chunks, then parsed the completed buffer in **one** `logiqx_dat_init_owned()` call, with the search index (two walks + qsort) following in whichever gather issued the first search.

- **rxml:** the parser was already fully iterative with all state in `struct rxml_parser`; it now suspends at its one no-live-locals point between constructs. New `rxml_parse_begin_owned()` / `_step()` / `_end()` / `_abort()`, same ownership contract and verdict rules (`STRICT_EOF`, `LINES`, tolerated-EOF partial tree) as the one-shot path, whose cost is one always-false comparison per construct.
- **logiqx:** sorted-array-plus-qsort index replaced by a first-occurrence-wins hash (exact lookup is all `logiqx_dat_search()` ever needed; leftmost-match answers preserved, linear-walk fallback preserved). New `logiqx_dat_parse_begin_owned()` / `_step()` / `_end()` / `_abort()` phasing XML → count → fill.
- **task:** the completed buffer steps 256 KiB at a time under the shared window, one step per gather as the floor; cancelled tasks abort the in-flight parse in teardown.

**Result:** max gather CPU 6.9–8.4 ms on the fixture (DAT spike gone), and the new big-DAT lane holds the same 16 ms budget scanning against a generated **300k-game (~40 MB)** DAT.

## Oracle additions

- **Dedup differential lane:** index answers must equal the linear scan over plain / bare-archive / inside-archive / case-variant probes, fuzzy matching both off and on, plus the `will_add` contract.
- **No-overwrite rescan lane:** full rescan into the populated playlist, zero duplicates, seeding driven at scale.
- **Big-DAT lane:** 300k games, pacing asserted, tail-of-list label verified (an index silently covering only a prefix fails), three cancel points landed inside the budgeted read and parse.
- `THROUGHPUT_FACTOR` tightened 1.60 → 0.80 (measured ratio ~0.35–0.41; the pre-index flush lands at ~1.1 and is rejected).

## Verification

Every commit: strict C89 syntax gate (`-ansi -pedantic -Werror=declaration-after-statement`, MSVC-safe declarations). Full series: the CI step's literal command sequence — plain, ASan+UBSan+LSan, and TSan (sanitize mode) — passes with **zero reports**, including the 14-point cancellation sweep and both new abort paths. rxml and logiqx additionally verified by standalone differential harnesses (stepped-vs-one-shot tree/answer parity at step sizes down to 1 byte, verdict parity on invalid/truncated documents, abort sweeps under ASan).

Known and deliberate: instrumented builds still exceed the 16 ms pacing budget without the sanitize-mode skip; a probe attributes 16.8 ms CPU of that gather to the retained one-blocking-write-per-group final sort+write (~5 ms plain), the parity carve-out documented in #19407. The budget remains a production-build contract.