### PR TITLE
linux: use same temp folder as android for consistency

### DIFF
--- a/frontend/drivers/platform_unix.c
+++ b/frontend/drivers/platform_unix.c
@@ -2339,7 +2339,7 @@ static void frontend_unix_get_env(int *argc,
    else
    {
       fill_pathname_join(g_defaults.dirs[DEFAULT_DIR_CACHE], base_path,
-         "cache", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
+         "temp", sizeof(g_defaults.dirs[DEFAULT_DIR_CACHE]));
    }
 #endif
 


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Suggestion from @sonninnos to keep temp folder same as Android for consistency (and support)

## Related Issues

## Related Pull Requests


## Reviewers
