### PR TITLE
SDL3: Allow GL cores to enable `debug_context`

### DIFF
--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -183,8 +183,7 @@ static bool sdl3_ctx_set_video_mode(void *data,
 #ifdef GL_DEBUG
       bool debug = true;
 #else
-      struct retro_hw_render_callback *hwr =
-         video_driver_get_hw_context();
+      struct retro_hw_render_callback *hwr = video_driver_get_hw_context();
       bool debug = hwr && hwr->debug_context;
 #endif
 

--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -181,10 +181,11 @@ static bool sdl3_ctx_set_video_mode(void *data,
    if (!sdl->win)
    {
 #ifdef GL_DEBUG
-      bool debug = true;
+      SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 #else
       struct retro_hw_render_callback *hwr = video_driver_get_hw_context();
-      bool debug = hwr && hwr->debug_context;
+      if (hwr && hwr->debug_context)
+         SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 #endif
 
       if (sdl3_gl_api == GFX_CTX_OPENGL_ES_API)
@@ -199,9 +200,6 @@ static bool sdl3_ctx_set_video_mode(void *data,
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, sdl3_gl_major);
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, sdl3_gl_minor);
       }
-
-      if (debug)
-         SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
    }
 
    if (!sdl3_window_set_video_mode(&sdl->win, width, height, fullscreen, SDL_WINDOW_OPENGL))

--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -180,6 +180,14 @@ static bool sdl3_ctx_set_video_mode(void *data,
    /* GL attributes must be set before the window is created. */
    if (!sdl->win)
    {
+#ifdef GL_DEBUG
+      bool debug = true;
+#else
+      struct retro_hw_render_callback *hwr =
+         video_driver_get_hw_context();
+      bool debug = hwr && hwr->debug_context;
+#endif
+
       if (sdl3_gl_api == GFX_CTX_OPENGL_ES_API)
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
       else if (sdl3_gl_core_profile(sdl))
@@ -192,6 +200,11 @@ static bool sdl3_ctx_set_video_mode(void *data,
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, sdl3_gl_major);
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, sdl3_gl_minor);
       }
+
+      /* hw_render.debug_context. The attribute is sticky, so the
+       * shared context from bind_hw_render inherits it too. */
+      if (debug)
+         SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
    }
 
    if (!sdl3_window_set_video_mode(&sdl->win, width, height, fullscreen, SDL_WINDOW_OPENGL))

--- a/gfx/drivers_context/sdl3_gl_ctx.c
+++ b/gfx/drivers_context/sdl3_gl_ctx.c
@@ -201,8 +201,6 @@ static bool sdl3_ctx_set_video_mode(void *data,
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, sdl3_gl_minor);
       }
 
-      /* hw_render.debug_context. The attribute is sticky, so the
-       * shared context from bind_hw_render inherits it too. */
       if (debug)
          SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
    }


### PR DESCRIPTION
When a libretro core registers their `retro_hw_render_callback`, they can pass in `debug_context`. This PR enables the `SDL_GL_CONTEXT_DEBUG_FLAG` attribute when setting up the context when debugging was requested, or the `GL_DEBUG` flag is enabled.