### PR TITLE
apple: add rustynes core to App Store builds

### DIFF
--- a/pkg/apple/update-cores.sh
+++ b/pkg/apple/update-cores.sh
@@ -265,6 +265,7 @@ appstore_cores=(
     quicknes
     race
     reminiscence
+    rustynes
     sameboy
     sameduck
     scummvm


### PR DESCRIPTION
The RustyNES core builds cleanly for every Apple target on the buildbot but is absent from `appstore_cores`, so it is never bundled into the App Store builds and is unavailable to users on **iOS, iPadOS and tvOS**.

One line, inserted in alphabetical order between `reminiscence` and `sameboy`:

```diff
     quicknes
     race
     reminiscence
+    rustynes
     sameboy
     sameduck
```

## This is not a build problem

I verified the artifact before submitting rather than assuming the buildbot output was usable. `nightly/apple/ios-arm64/latest/rustynes_libretro.dylib.zip`:

- **Mach-O 64-bit arm64 dynamically linked shared library**, 1.3 MiB unpacked
- exports all **51** `retro_*` symbols, including the full disk-control interface (`retro_get_num_images`, `retro_set_image_index`, `retro_add_image_index`) that the FDS multi-side support needs

Present and building on `ios-arm64`, `tvos-arm64` and `osx/arm64`, so this single entry covers iOS, tvOS and the macOS App Store build.

## About the core

`rustynes` is a cycle-accurate NES/Famicom core written in Rust (`libretro/RustyNES` on the buildbot; info file in `libretro-super/dist/info/`). Relevant to bundling:

- **No JIT and no dynamic code generation** — a straightforward interpreter, so nothing here conflicts with App Store restrictions.
- **Software rendering** (`hw_render = "false"`), no external runtime dependencies.
- **Deterministic**, with `savestate_features = "deterministic"` — so run-ahead and RetroArch's rollback netplay both work.
- Native `SET_MEMORY_MAPS` for achievements, disk control for FDS, and native Game Genie cheats.

## Licensing

RustyNES is **GPL-3.0-or-later**. Flagging it explicitly since App Store distribution is the context: this matches `mesen` and `bsnes_hd_beta`, which are GPLv3 and already in this list, and RetroArch itself. The copyright holder is aware of and has approved App Store distribution under these terms.

Two companion PRs correct the core's advertised license, which predates a relicense: [libretro-super#2069](https://github.com/libretro/libretro-super/pull/2069) and [docs#1180](https://github.com/libretro/docs/pull/1180).

Happy to adjust anything that doesn't fit house convention.
