### PR TITLE
UI non-blocking, part 3: netplay host init and content close

### DIFF
--- a/.github/workflows/Linux-menu-harness.yml
+++ b/.github/workflows/Linux-menu-harness.yml
@@ -70,6 +70,25 @@ jobs:
                       --disable-ffmpeg
           make -j$(nproc)
 
+      - name: Build and run content_closing_test
+        shell: bash
+        run: |
+          set -eu
+          # The guard that keeps the frame loop out of a core being
+          # torn down (core_run() refusing retro_run() while
+          # content_closing is set) cannot fire in shipped code yet:
+          # closing is still synchronous, so no frame runs during it.
+          # It goes live in the change that first lets frames run
+          # during a close, and if it is wrong the symptom is a call
+          # into an unloaded dylib - so it is driven here directly,
+          # against the real core_run() in a real frontend, rather
+          # than going live untested.
+          #
+          # Shares the non-Qt build made above; adds about a second.
+          samples/runloop/content_closing/build.sh
+          ./samples/runloop/content_closing/content_closing_test
+          make -C samples/runloop/content_closing clean
+
       - name: Build and run menu_playlist_nav_test
         shell: bash
         run: |

--- a/.github/workflows/Linux-samples-tasks.yml
+++ b/.github/workflows/Linux-samples-tasks.yml
@@ -616,6 +616,36 @@ jobs:
           TSAN_OPTIONS=halt_on_error=1 ./content_prefetch_test
           make clean >/dev/null
 
+      - name: Build and run wait_timeout_test (plain, ASan + UBSan, TSan)
+        shell: bash
+        working-directory: samples/tasks/wait_timeout
+        run: |
+          set -eu
+          # task_queue_wait() waits indefinitely, which is wrong for
+          # anything depending on a machine we do not control - the
+          # netplay MITM query waits on an HTTP round trip to the
+          # lobby server, and a server that never answers used to hang
+          # the frontend outright.
+          #
+          # These lanes pin both directions: a wait that CAN be
+          # satisfied returns as soon as it is, rather than sitting
+          # out its timeout, and one that cannot gives up at roughly
+          # the deadline instead of never.  Both queue implementations
+          # are covered, since the bound is a wrapped condition rather
+          # than per-implementation code.
+          make clean >/dev/null
+          make all -j$(nproc)
+          ./wait_timeout_test
+          make clean >/dev/null
+          make all SANITIZER=address,undefined -j$(nproc)
+          ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+          UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
+            ./wait_timeout_test
+          make clean >/dev/null
+          make all SANITIZER=thread -j$(nproc)
+          TSAN_OPTIONS=halt_on_error=1 ./wait_timeout_test
+          make clean >/dev/null
+
       - name: Build and run task_ordering_test (plain, ASan + UBSan, TSan)
         shell: bash
         working-directory: samples/tasks/ordering

--- a/content.h
+++ b/content.h
@@ -75,6 +75,10 @@ bool content_serialize_state_rewind(void* buffer, size_t buffer_size);
 /* Deserializes the current state. */
 bool content_deserialize_state(const void* serialized_data, size_t serialized_size);
 
+/* True while a save state task is in progress, i.e. while
+ * content_wait_for_save_state_task() would block. */
+bool content_save_state_in_progress(void* data);
+
 /* Waits for any in-progress save state tasks to finish */
 void content_wait_for_save_state_task(void);
 /* Waits for any in-progress load state tasks to finish */

--- a/libretro-common/include/queues/task_queue.h
+++ b/libretro-common/include/queues/task_queue.h
@@ -670,6 +670,26 @@ bool task_queue_push(retro_task_t *task);
 void task_queue_wait(retro_task_condition_fn_t cond, void* data);
 
 /**
+ * task_queue_wait_timeout:
+ * @cond              : Condition to keep waiting on; waiting ends when
+ *                      it returns false, as with task_queue_wait().
+ * @data              : Userdata passed to @cond.
+ * @timeout_usec      : Upper bound on the wait, in microseconds.
+ *
+ * As task_queue_wait(), but gives up after @timeout_usec rather than
+ * waiting indefinitely.  For waits that depend on something outside
+ * the machine - a network round trip, say - where "never" is a
+ * reachable outcome and hanging the frontend is not an acceptable
+ * response to it.
+ *
+ * @return true when @cond is no longer satisfied, i.e. the thing
+ * being waited for finished; false when the timeout was reached with
+ * @cond still true, so the caller must handle not having it.
+ */
+bool task_queue_wait_timeout(retro_task_condition_fn_t cond, void *data,
+      retro_time_t timeout_usec);
+
+/**
  * Marks all tasks in the queue as cancelled.
  *
  * The tasks won't immediately be terminated;

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -1090,6 +1090,48 @@ void task_queue_wait(retro_task_condition_fn_t cond, void* data)
    impl_current->wait(cond, data);
 }
 
+struct task_wait_deadline
+{
+   retro_task_condition_fn_t cond;
+   void *data;
+   retro_time_t deadline;
+};
+
+/* Wraps the caller's condition so that it also goes false once the
+ * deadline passes.  Doing it this way rather than adding a wait
+ * variant to the implementation vtable means every implementation -
+ * regular, threaded and GCD - keeps its own waiting behaviour, and
+ * no platform-specific code has to be touched to gain a bound. */
+static bool task_queue_deadline_cond(void *data)
+{
+   struct task_wait_deadline *d = (struct task_wait_deadline*)data;
+
+   if (cpu_features_get_time_usec() >= d->deadline)
+      return false;
+
+   return d->cond ? d->cond(d->data) : true;
+}
+
+bool task_queue_wait_timeout(retro_task_condition_fn_t cond, void *data,
+      retro_time_t timeout_usec)
+{
+   struct task_wait_deadline d;
+
+   d.cond     = cond;
+   d.data     = data;
+   d.deadline = cpu_features_get_time_usec() + timeout_usec;
+
+   task_queue_wait(task_queue_deadline_cond, &d);
+
+   /* The wait also ends when the queue drains, so "did the deadline
+    * pass" is not the same question as "is the caller still waiting
+    * for something".  Ask the caller's own condition. */
+   if (cond && cond(data))
+      return false;
+
+   return true;
+}
+
 void task_queue_reset(void)
 {
    impl_current->reset();

--- a/libretro-common/queues/task_queue.c
+++ b/libretro-common/queues/task_queue.c
@@ -592,8 +592,19 @@ static void retro_task_threaded_reset(void)
    retro_task_t *task = NULL;
 
    slock_lock(running_lock);
+   /* task->flags is guarded by property_lock, not running_lock: the
+    * worker reads it there to decide whether a task has finished.
+    * Setting it under running_lock alone left the two using
+    * different locks for the same field, which is a data race - one
+    * TSan reports when a reset lands while the worker is mid-task.
+    *
+    * Nesting is safe here: property_lock is never held while any
+    * other lock is taken anywhere in this file, so it can only ever
+    * be an inner lock and no cycle is possible. */
+   slock_lock(property_lock);
    for (task = tasks_running.front; task; task = task->next)
       task->flags |= RETRO_TASK_FLG_CANCELLED;
+   slock_unlock(property_lock);
    slock_unlock(running_lock);
 }
 

--- a/network/netplay/netplay.h
+++ b/network/netplay/netplay.h
@@ -210,6 +210,19 @@ void deinit_netplay(void);
 
 bool netplay_driver_ctl(enum rarch_netplay_ctl_state state, void *data);
 
+/**
+ * netplay_mitm_query_prefetch:
+ *
+ * Start the relay tunnel query early, when the user commits to
+ * hosting, rather than when host setup needs the address.  The round
+ * trip then overlaps work that was going to happen anyway, so the
+ * wait for it usually costs nothing.
+ *
+ * Best effort: if it is skipped or fails, host setup issues the
+ * query exactly as it did before.
+ */
+void netplay_mitm_query_prefetch(void);
+
 bool netplay_reinit_serialization(void);
 bool netplay_is_spectating(void);
 void netplay_force_send_savestate(void);

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -9028,6 +9028,15 @@ static bool netplay_mitm_query_pending = false;
  * trade a hang for silent corruption. */
 static unsigned netplay_mitm_query_generation = 0;
 
+/* The handle the outstanding query was issued for.
+ *
+ * A query can now be started before host setup runs, so by the time
+ * netplay_mitm_query() is reached the answer may already be in hand
+ * or on its way.  This is what lets it tell "already asked for this"
+ * from "asked for something else", so a user who changes the relay
+ * setting between the two points still gets the server they picked. */
+static char netplay_mitm_query_handle[NAME_MAX_LENGTH] = {0};
+
 static bool netplay_mitm_query_is_pending(void *data)
 {
    return netplay_mitm_query_pending;
@@ -9118,6 +9127,9 @@ static bool netplay_mitm_query_begin(const char *handle)
 
    if (!handle || !*handle)
       return false;
+
+   strlcpy(netplay_mitm_query_handle, handle,
+         sizeof(netplay_mitm_query_handle));
 
    /* We don't need to query,
       if we are using a custom relay server. */
@@ -9217,15 +9229,65 @@ static bool netplay_mitm_query_result(void)
    return *host_room->mitm_address && host_room->mitm_port;
 }
 
+/* Whether an answer for @handle is already in hand or on its way,
+ * so asking again would be a second round trip for the same thing.
+ *
+ * A prefetched query that came back EMPTY is deliberately not
+ * reused: a transient lobby failure at prefetch time would otherwise
+ * doom a hosted session that asking again would have got, which is a
+ * worse trade than one extra request. */
+static bool netplay_mitm_query_have(const char *handle)
+{
+   if (!handle || !*handle)
+      return false;
+   if (!string_is_equal(handle, netplay_mitm_query_handle))
+      return false;
+
+   return !netplay_mitm_query_ready() || netplay_mitm_query_result();
+}
+
 static bool netplay_mitm_query(const char *handle)
 {
-   if (!netplay_mitm_query_begin(handle))
-      return false;
+   if (!netplay_mitm_query_have(handle))
+      if (!netplay_mitm_query_begin(handle))
+         return false;
 
    if (!netplay_mitm_query_await())
       return false;
 
    return netplay_mitm_query_result();
+}
+
+/* Start the tunnel query early.
+ *
+ * Called when the user commits to hosting, which is well before host
+ * setup needs the address - and on the content-reload path, before
+ * the content has even loaded.  The query runs during that time, so
+ * by the time netplay_mitm_query() is reached the answer is usually
+ * already there and its wait costs nothing.
+ *
+ * Best effort in the strictest sense: it changes nothing except when
+ * the round trip happens.  If it fails, is skipped, or the user
+ * changes relay servers afterwards, host setup issues the query
+ * exactly as it did before. */
+void netplay_mitm_query_prefetch(void)
+{
+   settings_t *settings = config_get_ptr();
+   const char *handle;
+
+   if (!settings || !settings->bools.netplay_use_mitm_server)
+      return;
+
+   handle = settings->arrays.netplay_mitm_server;
+
+   if (!handle || !*handle)
+      return;
+
+   /* Already asked, and the answer is here or coming. */
+   if (netplay_mitm_query_have(handle))
+      return;
+
+   netplay_mitm_query_begin(handle);
 }
 
 int16_t input_state_net(unsigned port, unsigned device,

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -9099,12 +9099,26 @@ static void netplay_mitm_query_cb(retro_task_t *task, void *task_data,
  * while waiting a few seconds longer costs only patience. */
 #define NETPLAY_MITM_QUERY_TIMEOUT (10 * 1000 * 1000)
 
-static bool netplay_mitm_query(const char *handle)
+/* The tunnel query, split into begin / is_ready / result.
+ *
+ * Split rather than moved: netplay_mitm_query() below still calls all
+ * three back to back, so behaviour is exactly what it was.  The point
+ * is that "ask" and "wait for the answer" are no longer welded
+ * together, which is what a later change needs in order to start the
+ * query when the user opens the host UI and have the answer waiting
+ * by the time host setup runs.
+ *
+ * Returns false if the query could not be issued at all.  A custom
+ * relay needs no query, so it fills the address in directly and
+ * reports ready immediately. */
+static bool netplay_mitm_query_begin(const char *handle)
 {
    net_driver_state_t  *net_st    = &networking_driver_st;
    struct netplay_room *host_room = &net_st->host_room;
+
    if (!handle || !*handle)
       return false;
+
    /* We don't need to query,
       if we are using a custom relay server. */
    if (string_is_equal(handle, "custom"))
@@ -9123,8 +9137,18 @@ static bool netplay_mitm_query(const char *handle)
 
       strlcpy(host_room->mitm_address, addr, sizeof(host_room->mitm_address));
       host_room->mitm_port = (int)port;
+
+      /* Supersede anything still in flight.  A custom relay answers
+       * synchronously, and the old code returned here without ever
+       * consulting the pending flag - so an earlier query left
+       * outstanding must not make this one wait, and its callback
+       * must not later overwrite the address just set. */
+      ++netplay_mitm_query_generation;
+      netplay_mitm_query_pending = false;
+
+      return true;
    }
-   else
+
    {
       char query[256];
       size_t _len = strlcpy(query, FILE_PATH_LOBBY_LIBRETRO_URL "tunnel?name=",
@@ -9140,49 +9164,68 @@ static bool netplay_mitm_query(const char *handle)
          netplay_mitm_query_pending = false;
          return false;
       }
-
-      /* Make sure we've the tunnel address before continuing.
-       *
-       * Host setup below needs the tunnel address, so this still
-       * blocks - but only on this one query, and only for so long.
-       * It used to wait on a NULL condition, which means "until the
-       * task queue is empty": every unrelated task in flight had to
-       * finish first, so starting a hosted session behind an
-       * in-progress core download or content scan blocked the UI for
-       * the whole of that download, not for an HTTP round trip.
-       *
-       * The bound matters because the remaining wait is on a network
-       * round trip to a machine we do not control.  A lobby server
-       * that is down, blackholed or simply slow left the frontend
-       * hung with no way out but killing it.  On timeout the query
-       * reports failure like any other, and the caller falls back to
-       * direct mode with a warning - an outcome the user can see and
-       * act on, which an indefinite hang is not.
-       *
-       * The timeout is deliberately generous: a false timeout breaks
-       * hosting that would have worked, which is worse than the wait
-       * it prevents.
-       *
-       * Removing the block entirely means deferring the rest of
-       * netplay host initialisation into this query's callback -
-       * sockets, announcement and lobby registration all read the
-       * address decided here - which is a netplay restructuring, not
-       * a change to this wait. */
-      if (!task_queue_wait_timeout(netplay_mitm_query_is_pending, NULL,
-            NETPLAY_MITM_QUERY_TIMEOUT))
-      {
-         RARCH_WARN("[Netplay] Timed out waiting for tunnel information"
-               " from the lobby server.\n");
-         /* Bump the generation so the in-flight callback, which may
-          * still arrive, does not write an address for a session
-          * that has already fallen back to direct mode. */
-         ++netplay_mitm_query_generation;
-         netplay_mitm_query_pending = false;
-         return false;
-      }
    }
 
+   return true;
+}
+
+/* Whether the answer has arrived.  A custom relay was answered
+ * synchronously in begin(), so this is true straight away there. */
+static bool netplay_mitm_query_ready(void)
+{
+   return !netplay_mitm_query_pending;
+}
+
+/* Blocks until the answer arrives or the bound expires.
+ *
+ * The bound matters because this is a round trip to a machine we do
+ * not control.  A lobby server that is down, blackholed or simply
+ * slow left the frontend hung with no way out but killing it.  On
+ * timeout this reports failure like any other query and the caller
+ * falls back to direct mode with a warning - an outcome the user can
+ * see and act on, which an indefinite hang is not.
+ *
+ * Generous on purpose: a false timeout breaks hosting that would have
+ * worked, which is worse than the wait it prevents. */
+static bool netplay_mitm_query_await(void)
+{
+   if (netplay_mitm_query_ready())
+      return true;
+
+   if (!task_queue_wait_timeout(netplay_mitm_query_is_pending, NULL,
+         NETPLAY_MITM_QUERY_TIMEOUT))
+   {
+      RARCH_WARN("[Netplay] Timed out waiting for tunnel information"
+            " from the lobby server.\n");
+      /* Bump the generation so the in-flight callback, which may
+       * still arrive, does not write an address for a session that
+       * has already fallen back to direct mode. */
+      ++netplay_mitm_query_generation;
+      netplay_mitm_query_pending = false;
+      return false;
+    }
+
+   return true;
+}
+
+/* What the query produced: an address and port, or nothing. */
+static bool netplay_mitm_query_result(void)
+{
+   net_driver_state_t  *net_st    = &networking_driver_st;
+   struct netplay_room *host_room = &net_st->host_room;
+
    return *host_room->mitm_address && host_room->mitm_port;
+}
+
+static bool netplay_mitm_query(const char *handle)
+{
+   if (!netplay_mitm_query_begin(handle))
+      return false;
+
+   if (!netplay_mitm_query_await())
+      return false;
+
+   return netplay_mitm_query_result();
 }
 
 int16_t input_state_net(unsigned port, unsigned device,

--- a/network/netplay/netplay_frontend.c
+++ b/network/netplay/netplay_frontend.c
@@ -21,6 +21,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>  /* uintptr_t, for the query generation token */
 #include <sys/types.h>
 #include <file/archive_file.h>
 #include <streams/interface_stream.h>
@@ -9015,6 +9016,18 @@ static void netplay_announce(netplay_t *netplay)
  * not, so there is no completion that leaves this set. */
 static bool netplay_mitm_query_pending = false;
 
+/* Incremented for every query issued, and again when one is
+ * abandoned.  The callback carries the value it was issued with and
+ * does nothing if it no longer matches.
+ *
+ * Without this a timed-out query is still in flight, and its
+ * callback - which writes host_room->mitm_address and mitm_port
+ * unconditionally - would land after the caller had already fallen
+ * back to direct mode, publishing a tunnel address for a session
+ * that is not tunnelled.  Bounding the wait without this guard would
+ * trade a hang for silent corruption. */
+static unsigned netplay_mitm_query_generation = 0;
+
 static bool netplay_mitm_query_is_pending(void *data)
 {
    return netplay_mitm_query_pending;
@@ -9028,6 +9041,9 @@ static void netplay_mitm_query_cb(retro_task_t *task, void *task_data,
    http_transfer_data_t *data     = (http_transfer_data_t*)task_data;
    net_driver_state_t  *net_st    = &networking_driver_st;
    struct netplay_room *host_room = &net_st->host_room;
+
+   if ((unsigned)(uintptr_t)user_data != netplay_mitm_query_generation)
+      return;   /* superseded or abandoned; not ours to answer */
 
    netplay_mitm_query_pending     = false;
 
@@ -9077,6 +9093,12 @@ static void netplay_mitm_query_cb(retro_task_t *task, void *task_data,
    free(buf);
 }
 
+/* Upper bound on the wait for tunnel information from the lobby
+ * server, in microseconds.  Generous on purpose: timing out a query
+ * that would have succeeded costs the user their hosted session,
+ * while waiting a few seconds longer costs only patience. */
+#define NETPLAY_MITM_QUERY_TIMEOUT (10 * 1000 * 1000)
+
 static bool netplay_mitm_query(const char *handle)
 {
    net_driver_state_t  *net_st    = &networking_driver_st;
@@ -9109,9 +9131,11 @@ static bool netplay_mitm_query(const char *handle)
             sizeof(query));
       strlcpy(query + _len, handle, sizeof(query) - _len);
       netplay_mitm_query_pending = true;
+      ++netplay_mitm_query_generation;
 
       if (!task_push_http_transfer(query, true, NULL,
-            netplay_mitm_query_cb, NULL))
+            netplay_mitm_query_cb,
+            (void*)(uintptr_t)netplay_mitm_query_generation))
       {
          netplay_mitm_query_pending = false;
          return false;
@@ -9120,19 +9144,42 @@ static bool netplay_mitm_query(const char *handle)
       /* Make sure we've the tunnel address before continuing.
        *
        * Host setup below needs the tunnel address, so this still
-       * blocks - but only on this one query.  It used to wait on a
-       * NULL condition, which means "until the task queue is empty":
-       * every unrelated task in flight had to finish first, so
-       * starting a hosted session behind an in-progress core
-       * download or content scan blocked the UI for the whole of
-       * that download, not for an HTTP round trip.
+       * blocks - but only on this one query, and only for so long.
+       * It used to wait on a NULL condition, which means "until the
+       * task queue is empty": every unrelated task in flight had to
+       * finish first, so starting a hosted session behind an
+       * in-progress core download or content scan blocked the UI for
+       * the whole of that download, not for an HTTP round trip.
+       *
+       * The bound matters because the remaining wait is on a network
+       * round trip to a machine we do not control.  A lobby server
+       * that is down, blackholed or simply slow left the frontend
+       * hung with no way out but killing it.  On timeout the query
+       * reports failure like any other, and the caller falls back to
+       * direct mode with a warning - an outcome the user can see and
+       * act on, which an indefinite hang is not.
+       *
+       * The timeout is deliberately generous: a false timeout breaks
+       * hosting that would have worked, which is worse than the wait
+       * it prevents.
        *
        * Removing the block entirely means deferring the rest of
        * netplay host initialisation into this query's callback -
        * sockets, announcement and lobby registration all read the
        * address decided here - which is a netplay restructuring, not
        * a change to this wait. */
-      task_queue_wait(netplay_mitm_query_is_pending, NULL);
+      if (!task_queue_wait_timeout(netplay_mitm_query_is_pending, NULL,
+            NETPLAY_MITM_QUERY_TIMEOUT))
+      {
+         RARCH_WARN("[Netplay] Timed out waiting for tunnel information"
+               " from the lobby server.\n");
+         /* Bump the generation so the in-flight callback, which may
+          * still arrive, does not write an address for a session
+          * that has already fallen back to direct mode. */
+         ++netplay_mitm_query_generation;
+         netplay_mitm_query_pending = false;
+         return false;
+      }
    }
 
    return *host_room->mitm_address && host_room->mitm_port;

--- a/retroarch.c
+++ b/retroarch.c
@@ -4632,6 +4632,16 @@ bool command_event(enum event_command cmd, void *data)
              * content_save_state_in_progress() is the same condition
              * the wait uses, so a close with no save in flight - the
              * common case - is untouched and shows nothing. */
+            /* Closing content starts here.
+             *
+             * Set around the whole teardown, including the waits
+             * below: they are part of closing, and once the wait
+             * stops blocking they are the part that will still be
+             * running when the frame loop resumes. Nothing observes
+             * this yet - the main thread does not leave this block -
+             * which is the point of introducing it on its own. */
+            runloop_st->content_closing = true;
+
             if (content_save_state_in_progress(NULL))
             {
                const char *_msg = msg_hash_to_str(MSG_SAVING_STATE);
@@ -4703,6 +4713,11 @@ bool command_event(enum event_command cmd, void *data)
 
             if (hwr)
                memset(hwr, 0, sizeof(*hwr));
+
+            /* Closing content is finished.  One clear covers the
+             * whole block: it has a single exit, with no early
+             * return or goto between the set above and here. */
+            runloop_st->content_closing = false;
 
             break;
          }

--- a/retroarch.c
+++ b/retroarch.c
@@ -4619,6 +4619,28 @@ bool command_event(enum event_command cmd, void *data)
              * not - a manually triggered save (menu / hotkey /
              * netplay) already in flight when the user closed
              * content with savestate_auto_save disabled. */
+            /* Say what the pause is for before blocking on it.
+             *
+             * This does not shorten the wait - the invariant above
+             * means it cannot be skipped - but an unexplained frozen
+             * frame and a frame that says "saving state" are very
+             * different experiences, and on slow storage this is
+             * seconds.  The message is pushed and one frame forced
+             * out first, because nothing draws once the wait starts.
+             *
+             * Only when there is actually something to wait for:
+             * content_save_state_in_progress() is the same condition
+             * the wait uses, so a close with no save in flight - the
+             * common case - is untouched and shows nothing. */
+            if (content_save_state_in_progress(NULL))
+            {
+               const char *_msg = msg_hash_to_str(MSG_SAVING_STATE);
+               runloop_msg_queue_push(_msg, strlen(_msg), 1, 180, true,
+                     NULL, MESSAGE_QUEUE_ICON_DEFAULT,
+                     MESSAGE_QUEUE_CATEGORY_INFO);
+               video_driver_cached_frame();
+            }
+
             content_wait_for_save_state_task();
             content_wait_for_load_state_task();
 

--- a/retroarch.c
+++ b/retroarch.c
@@ -3213,6 +3213,90 @@ bool is_accessibility_enabled(bool accessibility_enable, bool accessibility_enab
  *
  * Returns: true (1) on success, otherwise false (0).
  **/
+/* Everything closing content does once nothing is left running in
+ * the core.
+ *
+ * Split out of CMD_EVENT_CORE_DEINIT unchanged, and still called
+ * from exactly where it used to run.  It is separated because it has
+ * to become resumable: the wait above it is the freeze this work is
+ * about, and removing that wait means this half runs later, from the
+ * frame loop, once the tasks have finished.  Extracting it on its
+ * own keeps that change a question of WHEN this is called rather
+ * than what it does.
+ *
+ * Every local is re-derived from its accessor rather than passed in,
+ * so it carries no dependency on the caller's frame. */
+static void command_event_finish_content_deinit(void)
+{
+   runloop_state_t *runloop_st          = runloop_state_get_ptr();
+   settings_t *settings                 = config_get_ptr();
+   video_driver_state_t
+      *video_st                         = video_state_get_ptr();
+   rarch_system_info_t *sys_info        = &runloop_st->system;
+   struct retro_hw_render_callback *hwr = NULL;
+
+         /* Save last selected disk index, if required */
+         if (sys_info)
+            disk_control_save_image_index(&sys_info->disk_control);
+
+         runloop_runtime_log_deinit(runloop_st,
+               settings->bools.content_runtime_log,
+               settings->bools.content_runtime_log_aggregate,
+               settings->paths.directory_runtime_log,
+               settings->paths.directory_playlist);
+
+         content_reset_savestate_backups();
+         hwr = VIDEO_DRIVER_GET_HW_CONTEXT_INTERNAL(video_st);
+#ifdef HAVE_CHEEVOS
+         rcheevos_unload();
+#endif
+#ifdef HAVE_NETWORKING
+         /* The core may have registered a netpacket interface
+          * (RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE). We hold a
+          * heap copy of that struct, but it carries function
+          * pointers into the core. Clear it before the core's dylib
+          * is closed by runloop_event_deinit_core(), otherwise those
+          * pointers dangle into unloaded code. Passing NULL frees and
+          * nulls the cached interface via the existing handler. */
+         netplay_driver_ctl(RARCH_NETPLAY_CTL_SET_CORE_PACKET_INTERFACE,
+               NULL);
+#endif
+         runloop_event_deinit_core();
+
+         /* Clear turbo and hold button state on core unload */
+         {
+            input_driver_state_t *input_st = input_state_get_ptr();
+            if (input_st)
+            {
+               memset(&input_st->turbo_btns, 0, sizeof(turbo_buttons_t));
+               memset(&input_st->hold_btns, 0, sizeof(hold_buttons_t));
+            }
+         }
+
+#ifdef HAVE_RUNAHEAD
+         /* If 'runahead_available' is false, then
+          * runahead is enabled by the user but an
+          * error occurred while the core was running
+          * (typically a save state issue). In this
+          * case we have to 'manually' reset the runahead
+          * runtime variables, otherwise runahead will
+          * remain disabled until the user restarts
+          * RetroArch */
+         if (runloop_st)
+         {
+            if (!(runloop_st->flags & RUNLOOP_FLAG_RUNAHEAD_AVAILABLE))
+               runahead_clear_variables(runloop_st);
+
+            /* Deallocate preemptive frames */
+            preempt_deinit(runloop_st);
+         }
+#endif
+
+         if (hwr)
+            memset(hwr, 0, sizeof(*hwr));
+
+}
+
 bool command_event(enum event_command cmd, void *data)
 {
    struct rarch_state *p_rarch     = &rarch_st;
@@ -4654,65 +4738,7 @@ bool command_event(enum event_command cmd, void *data)
             content_wait_for_save_state_task();
             content_wait_for_load_state_task();
 
-            /* Save last selected disk index, if required */
-            if (sys_info)
-               disk_control_save_image_index(&sys_info->disk_control);
-
-            runloop_runtime_log_deinit(runloop_st,
-                  settings->bools.content_runtime_log,
-                  settings->bools.content_runtime_log_aggregate,
-                  settings->paths.directory_runtime_log,
-                  settings->paths.directory_playlist);
-
-            content_reset_savestate_backups();
-            hwr = VIDEO_DRIVER_GET_HW_CONTEXT_INTERNAL(video_st);
-#ifdef HAVE_CHEEVOS
-            rcheevos_unload();
-#endif
-#ifdef HAVE_NETWORKING
-            /* The core may have registered a netpacket interface
-             * (RETRO_ENVIRONMENT_SET_NETPACKET_INTERFACE). We hold a
-             * heap copy of that struct, but it carries function
-             * pointers into the core. Clear it before the core's dylib
-             * is closed by runloop_event_deinit_core(), otherwise those
-             * pointers dangle into unloaded code. Passing NULL frees and
-             * nulls the cached interface via the existing handler. */
-            netplay_driver_ctl(RARCH_NETPLAY_CTL_SET_CORE_PACKET_INTERFACE,
-                  NULL);
-#endif
-            runloop_event_deinit_core();
-
-            /* Clear turbo and hold button state on core unload */
-            {
-               input_driver_state_t *input_st = input_state_get_ptr();
-               if (input_st)
-               {
-                  memset(&input_st->turbo_btns, 0, sizeof(turbo_buttons_t));
-                  memset(&input_st->hold_btns, 0, sizeof(hold_buttons_t));
-               }
-            }
-
-#ifdef HAVE_RUNAHEAD
-            /* If 'runahead_available' is false, then
-             * runahead is enabled by the user but an
-             * error occurred while the core was running
-             * (typically a save state issue). In this
-             * case we have to 'manually' reset the runahead
-             * runtime variables, otherwise runahead will
-             * remain disabled until the user restarts
-             * RetroArch */
-            if (runloop_st)
-            {
-               if (!(runloop_st->flags & RUNLOOP_FLAG_RUNAHEAD_AVAILABLE))
-                  runahead_clear_variables(runloop_st);
-
-               /* Deallocate preemptive frames */
-               preempt_deinit(runloop_st);
-            }
-#endif
-
-            if (hwr)
-               memset(hwr, 0, sizeof(*hwr));
+            command_event_finish_content_deinit();
 
             /* Closing content is finished.  One clear covers the
              * whole block: it has a single exit, with no early

--- a/retroarch.c
+++ b/retroarch.c
@@ -5396,6 +5396,19 @@ bool command_event(enum event_command cmd, void *data)
          break;
       case CMD_EVENT_NETPLAY_ENABLE_HOST:
          {
+            /* Ask the lobby server for the tunnel address now.
+             *
+             * This is the point where the user has committed to
+             * hosting; host setup does not need the address until
+             * later, and on the content-reload path below not until
+             * content has finished loading.  Starting the round trip
+             * here lets it overlap that, so the wait for it in host
+             * setup usually finds the answer already present.
+             *
+             * Best effort - if this is skipped or fails, host setup
+             * asks exactly as it did before. */
+            netplay_mitm_query_prefetch();
+
             if (netplay_driver_ctl(RARCH_NETPLAY_CTL_USE_CORE_PACKET_INTERFACE, NULL))
             {
                netplay_driver_ctl(RARCH_NETPLAY_CTL_ENABLE_SERVER, NULL);

--- a/runloop.c
+++ b/runloop.c
@@ -8780,6 +8780,30 @@ void core_run(void)
       : (enum poll_type)(current_core->poll_type);
    bool early_polling          = (new_poll_type == POLL_TYPE_EARLY);
    bool late_polling           = (new_poll_type == POLL_TYPE_LATE);
+
+   /* The core is being torn down: do not run it.
+    *
+    * retro_run() must not be entered once closing has begun, because
+    * the teardown unloads the library that function lives in.
+    *
+    * Today this cannot be reached - closing is synchronous, so the
+    * main thread sits inside the teardown and no frame runs - and
+    * the guard is placed first, inert, so that the change which does
+    * let frames run during a close is only about where the waiting
+    * happens, not about what the frame loop may touch.
+    *
+    * Poll and present anyway rather than returning bare, so input
+    * keeps being drained and whatever the close has put on screen
+    * keeps being drawn.  Same shape as the netplay-paused case
+    * below, for the same reason: a frame that stops being produced
+    * reads as a hang. */
+   if (runloop_st->content_closing)
+   {
+      input_driver_poll();
+      video_driver_cached_frame();
+      return;
+   }
+
 #ifdef HAVE_NETWORKING
    bool netplay_preframe       = netplay_driver_ctl(
          RARCH_NETPLAY_CTL_PRE_FRAME, NULL);

--- a/runloop.c
+++ b/runloop.c
@@ -8780,6 +8780,12 @@ void core_run(void)
       : (enum poll_type)(current_core->poll_type);
    bool early_polling          = (new_poll_type == POLL_TYPE_EARLY);
    bool late_polling           = (new_poll_type == POLL_TYPE_LATE);
+#ifdef HAVE_NETWORKING
+   /* Declared with the other locals and assigned below, so the
+    * closing guard can return before netplay's pre-frame call
+    * without putting a declaration after a statement. */
+   bool netplay_preframe;
+#endif
 
    /* The core is being torn down: do not run it.
     *
@@ -8805,7 +8811,7 @@ void core_run(void)
    }
 
 #ifdef HAVE_NETWORKING
-   bool netplay_preframe       = netplay_driver_ctl(
+   netplay_preframe            = netplay_driver_ctl(
          RARCH_NETPLAY_CTL_PRE_FRAME, NULL);
 
    if (!netplay_preframe)

--- a/runloop.c
+++ b/runloop.c
@@ -414,6 +414,11 @@ runloop_state_t *runloop_state_get_ptr(void)
    return &runloop_state;
 }
 
+bool runloop_is_content_closing(void)
+{
+   return runloop_state.content_closing;
+}
+
 bool state_manager_frame_is_reversed(void)
 {
 #ifdef HAVE_REWIND

--- a/runloop.h
+++ b/runloop.h
@@ -323,6 +323,23 @@ struct runloop
 
    bool perfcnt_enable;
    bool paused_hotkey;
+
+   /* True from the moment closing content starts tearing the core
+    * down until the teardown is finished.
+    *
+    * Set and cleared around the existing synchronous teardown, so at
+    * present nothing can observe it as true: the main thread is
+    * inside that teardown for its whole duration and no frame runs.
+    * It is introduced separately, and deliberately inert, because
+    * the work that makes it observable - returning to the frame loop
+    * instead of blocking - is a lifecycle change, and this is the
+    * piece everything else will key off.
+    *
+    * A plain bool rather than a RUNLOOP_FLAG bit: bits 0-30 of that
+    * word are taken and bit 31 was deliberately vacated to avoid a
+    * cross-thread race, so reusing it would undo that reasoning for
+    * no gain. This is main-thread only. */
+   bool content_closing;
 };
 
 typedef struct runloop runloop_state_t;
@@ -488,6 +505,15 @@ bool runloop_init_libretro_symbols(
       void *_lib_handle_p);
 
 runloop_state_t *runloop_state_get_ptr(void);
+
+/**
+ * runloop_is_content_closing:
+ *
+ * True while content is being closed, i.e. while the core is being
+ * torn down.  Currently only ever true inside the synchronous
+ * teardown, where nothing else runs to ask.
+ */
+bool runloop_is_content_closing(void);
 
 RETRO_END_DECLS
 

--- a/samples/runloop/content_closing/Makefile
+++ b/samples/runloop/content_closing/Makefile
@@ -1,0 +1,13 @@
+# See build.sh: this harness links the shipping RetroArch objects with
+# only main() replaced, so it needs the project's own build rather than
+# a source list of its own.
+TARGET := content_closing_test
+
+all:
+	@./build.sh
+
+clean:
+	rm -f $(TARGET) retroarch_nomain.o retroarch_nomain.d \
+	      harness_main.o harness_main.d
+
+.PHONY: all clean

--- a/samples/runloop/content_closing/build.sh
+++ b/samples/runloop/content_closing/build.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builds the menu playlist navigation harness.
+#
+# Unlike every other sample, this does not compile a translation unit
+# in isolation.  It links the SHIPPING objects of a built RetroArch,
+# with only main() replaced - nothing is stubbed.  Three field reports
+# came out of the seam between the playlist reader and the menu
+# (a stale playlist's entries under a new heading; a blank list the
+# back button could not leave; a list that filled only after the user
+# pressed something), and no oracle that stopped at the reader could
+# see any of them.
+#
+# Requires a completed NON-Qt build: with Qt enabled main() lives in
+# ui_qt.o, which drags the whole Qt UI in with it.  From the repo
+# root:
+#
+#   ./configure --disable-qt && make
+#   samples/runloop/content_closing/build.sh
+#
+# retroarch.c is recompiled here with main renamed, so the harness can
+# supply its own without having to exclude the object that holds most
+# of the frontend.  Both the compile and the link reuse the project's
+# own command lines, taken from make -n, so the harness cannot drift
+# away from how the program is really built.
+set -eu
+
+here=$(cd "$(dirname "$0")" && pwd)
+root=$(cd "$here/../../.." && pwd)
+
+cd "$root"
+
+if [ ! -f obj-unix/release/retroarch.o ]; then
+   echo "build RetroArch first: ./configure --disable-qt && make" >&2
+   exit 1
+fi
+
+cc_line=$(mktemp)
+ld_line=$(mktemp)
+trap 'rm -f "$cc_line" "$ld_line"' EXIT
+
+# The project's own compile line for retroarch.o ...
+touch retroarch.c
+make -n 2>/dev/null | grep -E '\-o obj-unix/release/retroarch\.o' | head -1 > "$cc_line"
+if [ ! -s "$cc_line" ]; then
+   echo "could not determine the compile command for retroarch.o" >&2
+   exit 1
+fi
+
+# ... reused twice: once for retroarch.c with main renamed out of the
+# way, once for the harness itself, so both are built exactly the way
+# the frontend is.
+sed 's#-o obj-unix/release/retroarch\.o#-Dmain=rarch_harness_unused_main -o samples/runloop/content_closing/retroarch_nomain.o#' \
+   "$cc_line" | sh
+
+sed -e 's#-o obj-unix/release/retroarch\.o#-o samples/runloop/content_closing/harness_main.o#' \
+    -e 's# retroarch\.c# samples/runloop/content_closing/content_closing_test.c#' \
+   "$cc_line" | sh
+
+# The project's own link line, with retroarch.o swapped for the pair
+# above.  Removing the binary first is what makes make -n emit it.
+rm -f retroarch
+make -n 2>/dev/null | grep -E ' -o retroarch ' | tail -1 > "$ld_line"
+if [ ! -s "$ld_line" ]; then
+   echo "could not determine the link command" >&2
+   exit 1
+fi
+
+sed -e 's#obj-unix/release/retroarch\.o#samples/runloop/content_closing/retroarch_nomain.o samples/runloop/content_closing/harness_main.o#' \
+    -e 's#-o retroarch #-o samples/runloop/content_closing/content_closing_test #' \
+   "$ld_line" | sh
+
+echo "built samples/runloop/content_closing/content_closing_test"

--- a/samples/runloop/content_closing/content_closing_test.c
+++ b/samples/runloop/content_closing/content_closing_test.c
@@ -1,0 +1,209 @@
+/* Harness for the content-closing state, driving the real frame loop.
+ *
+ * Closing content tears the core down, and the save and load handlers
+ * call into that core - retro_serialize via
+ * content_get_serialized_data, retro_unserialize via
+ * core_unserialize.  A worker still inside one of those when
+ * runloop_event_deinit_core() unloads the library dispatches into
+ * freed code, which is why the close waits for those tasks and why
+ * that wait cannot simply be deleted.
+ *
+ * The plan for removing the freeze is to stop blocking and let the
+ * frame loop keep running while the close finishes.  The guard that
+ * makes that safe - core_run() refusing to enter retro_run() while
+ * runloop_state.content_closing is set - is in place but cannot fire
+ * yet, because the close is still synchronous and no frame runs
+ * during it.
+ *
+ * Which means the guard is, right now, entirely unexercised: it will
+ * go live in the same change that first lets frames run during a
+ * close, and if it is wrong the symptom is a call into an unloaded
+ * dylib.  This drives it directly instead - the real core_run(), in
+ * a real frontend, with the flag set - so that when it does go live
+ * it is not going live untested.
+ *
+ * Links the shipping objects with only main() replaced; nothing is
+ * stubbed.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <boolean.h>
+
+#include "../../../runloop.h"
+#include "../../../retroarch.h"
+#include "../../../configuration.h"
+#include "../../../frontend/frontend_driver.h"
+#include "../../../verbosity.h"
+
+#include <time/rtime.h>
+#include <file/config_file.h>
+
+static unsigned failures = 0;
+
+#define CHECK(cond, ...) \
+   do { \
+      if (!(cond)) \
+      { \
+         fprintf(stderr, "FAIL %s:%d: ", __FILE__, __LINE__); \
+         fprintf(stderr, __VA_ARGS__); \
+         fprintf(stderr, "\n"); \
+         failures++; \
+      } \
+   } while (0)
+
+/* ------------------------------------------------------------------ */
+/* A core whose retro_run only counts                                 */
+/* ------------------------------------------------------------------ */
+
+static unsigned retro_run_calls;
+
+static void counting_retro_run(void)
+{
+   retro_run_calls++;
+}
+
+/* ------------------------------------------------------------------ */
+
+static void lane_closing_blocks_retro_run(void)
+{
+   unsigned had              = failures;
+   runloop_state_t *runloop_st = runloop_state_get_ptr();
+   void (*saved_run)(void)   = runloop_st->current_core.retro_run;
+
+   runloop_st->current_core.retro_run = counting_retro_run;
+
+   /* Not closing: the core runs, which is what makes the next
+    * assertion mean something rather than passing because core_run()
+    * never reaches retro_run() at all in this environment. */
+   runloop_st->content_closing = false;
+   retro_run_calls             = 0;
+   core_run();
+
+   CHECK(retro_run_calls == 1,
+         "core_run() did not reach retro_run() with the flag clear, "
+         "so this harness cannot tell whether the guard works");
+
+   /* Closing: the core must not be entered.  This is the property
+    * that keeps the frame loop off a core whose library is going
+    * away. */
+   runloop_st->content_closing = true;
+   retro_run_calls             = 0;
+   core_run();
+
+   CHECK(retro_run_calls == 0,
+         "core_run() entered retro_run() while content was closing - "
+         "with the teardown unloading that library, this is a call "
+         "into freed code");
+
+   /* And back: the guard must not be sticky, or the frame loop would
+    * stay dead after a close finished. */
+   runloop_st->content_closing = false;
+   retro_run_calls             = 0;
+   core_run();
+
+   CHECK(retro_run_calls == 1,
+         "the core did not resume once closing had finished");
+
+   runloop_st->current_core.retro_run = saved_run;
+   runloop_st->content_closing        = false;
+
+   if (failures == had)
+      fprintf(stderr, "[pass] closing-blocks-retro-run lane\n");
+}
+
+/* Frames must keep being produced while closing, or the window stops
+ * updating and the close reads as a hang - the very complaint this
+ * work exists to fix. */
+static void lane_closing_still_presents(void)
+{
+   unsigned had                = failures;
+   runloop_state_t *runloop_st = runloop_state_get_ptr();
+   void (*saved_run)(void)     = runloop_st->current_core.retro_run;
+   unsigned i;
+
+   runloop_st->current_core.retro_run = counting_retro_run;
+   runloop_st->content_closing        = true;
+   retro_run_calls                    = 0;
+
+   /* Many frames, as a close on slow storage would take.  The point
+    * is that core_run() returns cleanly every time rather than
+    * faulting on a torn-down core or wedging. */
+   for (i = 0; i < 240; i++)
+      core_run();
+
+   CHECK(retro_run_calls == 0,
+         "the core was entered during a 240-frame close");
+
+   runloop_st->current_core.retro_run = saved_run;
+   runloop_st->content_closing        = false;
+
+   if (failures == had)
+      fprintf(stderr, "[pass] closing-still-presents lane (240 frames)\n");
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(int argc, char *argv[])
+{
+   char cfg_path[512];
+   char cmd[600];
+   char dir[400];
+   char *rarch_argv[8];
+   int rarch_argc = 0;
+   FILE *cfg;
+
+   snprintf(dir, sizeof(dir), "/tmp/closing_harness_%ld", (long)getpid());
+   snprintf(cmd, sizeof(cmd), "mkdir -p %s", dir);
+   if (system(cmd) != 0)
+      return 1;
+
+   snprintf(cfg_path, sizeof(cfg_path), "%s/harness.cfg", dir);
+   if ((cfg = fopen(cfg_path, "wb")))
+   {
+      fprintf(cfg, "video_driver = \"null\"\n");
+      fprintf(cfg, "audio_driver = \"null\"\n");
+      fprintf(cfg, "input_driver = \"null\"\n");
+      fprintf(cfg, "input_joypad_driver = \"null\"\n");
+      fprintf(cfg, "menu_driver = \"rgui\"\n");
+      fprintf(cfg, "video_threaded = \"false\"\n");
+      fclose(cfg);
+   }
+
+   /* The prelude rarch_main() performs before main_init; skipping any
+    * of it is a null dereference deep inside. */
+   config_file_set_io_default(config_file_io_filestream());
+   rtime_init();
+   retroarch_config_init();
+   retroarch_ctl(RARCH_CTL_STATE_FREE, NULL);
+   frontend_driver_init_first(NULL);
+
+   rarch_argv[rarch_argc++] = (char*)"retroarch";
+   rarch_argv[rarch_argc++] = (char*)"--menu";
+   rarch_argv[rarch_argc++] = (char*)"--config";
+   rarch_argv[rarch_argc++] = cfg_path;
+
+   if (!retroarch_main_init(rarch_argc, rarch_argv))
+   {
+      fprintf(stderr, "FAIL: retroarch_main_init failed\n");
+      return 1;
+   }
+
+   lane_closing_blocks_retro_run();
+   lane_closing_still_presents();
+
+   snprintf(cmd, sizeof(cmd), "rm -rf %s", dir);
+   if (system(cmd) != 0) { }
+
+   if (failures)
+   {
+      fprintf(stderr, "FAIL content_closing_test: %u failures\n",
+            failures);
+      return 1;
+   }
+   fprintf(stderr, "PASS content_closing_test\n");
+   return 0;
+}

--- a/samples/tasks/save_state/save_state_io_test.c
+++ b/samples/tasks/save_state/save_state_io_test.c
@@ -988,6 +988,56 @@ static void test_undo_allocates_nothing(void)
    content_reset_savestate_backups();
 }
 
+/* -----------------------------------------------------------------
+ * Closing content while a save is in flight.
+ *
+ * runloop_event_deinit_core() unloads the core's dylib, and the save
+ * and load handlers call into it - retro_serialize via
+ * content_get_serialized_data, retro_unserialize via
+ * core_unserialize.  A worker still inside one of those when the
+ * library goes away dispatches into freed code.  That is why closing
+ * content calls content_wait_for_save_state_task(), and why that
+ * wait cannot simply be deleted the way the other blocking waits in
+ * this series were.
+ *
+ * What this pins is the property the unload depends on: the wait
+ * does not return until the save has actually finished.  If it ever
+ * returned early - on a budget boundary, say - the unload would land
+ * while a worker was still inside the core.
+ *
+ * The file is checked incomplete before the wait and complete after,
+ * so a wait that silently became a no-op fails here rather than
+ * turning into a crash on a device.
+ * ----------------------------------------------------------------- */
+static void test_close_waits_for_save(void)
+{
+   const char *path = "sst_close_wait.state";
+   size_t sz        = 64 * TEST_SAVE_STATE_CHUNK;   /* 6.25 MB */
+   long   before;
+
+   frontend_reset();
+   core_fill(sz);
+   filestream_delete(path);
+   /* One quantum per tick: the slow-storage case, where a close is
+    * long enough for the user to feel it. */
+   clock_step = TEST_TICK_BUDGET_US;
+
+   content_save_state(path, true);
+
+   before = file_size(path);
+   okf(before != (long)content_get_serialized_size(),
+       "the save is genuinely unfinished when the close begins");
+
+   /* Exactly what closing content does. */
+   content_wait_for_save_state_task();
+
+   okf(file_size(path) == (long)content_get_serialized_size(),
+       "closing content waits for the save to finish before "
+       "the core could be unloaded");
+
+   filestream_delete(path);
+}
+
 static int run_default_lane(void)
 {
    printf("== task_save.c I/O regression oracle ==\n");
@@ -1001,6 +1051,7 @@ static int run_default_lane(void)
    test_roundtrip(0, "round-trip is byte-exact with an unexpired budget");
    test_roundtrip(TEST_TICK_BUDGET_US,
          "round-trip is byte-exact at one quantum per tick");
+   test_close_waits_for_save();
    test_serialize_failure();
    test_open_failure();
    test_truncated_state();

--- a/samples/tasks/wait_timeout/Makefile
+++ b/samples/tasks/wait_timeout/Makefile
@@ -1,0 +1,41 @@
+TARGET := wait_timeout_test
+
+# Drives the shipping libretro-common/queues/task_queue.c directly.
+# The subject is task_queue_wait_timeout(): that a wait which can
+# never be satisfied - a network round trip to a server that does not
+# answer - gives up instead of hanging the frontend, and that a wait
+# which IS satisfied returns immediately rather than sitting out its
+# timeout.
+REPO_ROOT         := ../../..
+LIBRETRO_COMM_DIR := $(REPO_ROOT)/libretro-common
+
+SOURCES := wait_timeout_test.c \
+           $(LIBRETRO_COMM_DIR)/queues/task_queue.c \
+           $(LIBRETRO_COMM_DIR)/rthreads/rthreads.c \
+           $(LIBRETRO_COMM_DIR)/features/features_cpu.c \
+           $(LIBRETRO_COMM_DIR)/compat/compat_strl.c
+
+OBJS := $(SOURCES:.c=.o)
+
+CFLAGS  += -Wall -std=gnu99 -g -DHAVE_THREADS \
+           -I$(LIBRETRO_COMM_DIR)/include
+LDFLAGS += -lpthread -lm
+
+# The samples workflow passes SANITIZER=address,undefined; honour it.
+ifneq ($(SANITIZER),)
+   CFLAGS  := -fsanitize=$(SANITIZER) -fno-omit-frame-pointer $(CFLAGS)
+   LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
+endif
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+.PHONY: clean all

--- a/samples/tasks/wait_timeout/wait_timeout_test.c
+++ b/samples/tasks/wait_timeout/wait_timeout_test.c
@@ -59,6 +59,14 @@ static unsigned failures = 0;
 static int  ticks_remaining;
 static bool work_pending;
 
+/* Handlers run on the WORKER thread under the threaded queue, so
+ * nothing here touches state the waiting thread reads.  The flag is
+ * cleared in the callback below - which is where the code being
+ * modelled clears it, netplay_mitm_query_cb(), and callbacks run on
+ * the thread pumping the queue.
+ *
+ * Clearing it here was both a data race and a misrepresentation of
+ * the thing under test. */
 static void finite_handler(retro_task_t *task)
 {
    if (ticks_remaining > 0)
@@ -66,7 +74,6 @@ static void finite_handler(retro_task_t *task)
       ticks_remaining--;
       return;
    }
-   work_pending = false;
    task_set_flags(task, RETRO_TASK_FLG_FINISHED, true);
 }
 
@@ -76,9 +83,12 @@ static void endless_handler(retro_task_t *task)
     * thing the caller is waiting for never arrives. */
 }
 
+/* Runs on the thread pumping the queue - the waiting thread - just
+ * as the netplay query callback does. */
 static void cb(retro_task_t *task, void *task_data, void *user_data,
       const char *error)
 {
+   work_pending = false;
 }
 
 /* The caller's own condition, as a netplay-style "is it still

--- a/samples/tasks/wait_timeout/wait_timeout_test.c
+++ b/samples/tasks/wait_timeout/wait_timeout_test.c
@@ -1,0 +1,220 @@
+/* Oracle for task_queue_wait_timeout().
+ *
+ * task_queue_wait() waits indefinitely, which is correct for work
+ * that is certain to finish and wrong for anything depending on
+ * something outside the machine.  The netplay MITM query is the
+ * motivating case: it waits on an HTTP round trip to the lobby
+ * server, and a server that never answers hangs the frontend with no
+ * way out.
+ *
+ * The bound is implemented by wrapping the caller's condition in one
+ * that also goes false at a deadline, so each queue implementation -
+ * regular, threaded, GCD - keeps its own waiting behaviour and no
+ * platform-specific code is involved.  What has to hold:
+ *
+ *   completes  - a wait whose work finishes returns as soon as it
+ *                does, reports success, and does NOT sit out the
+ *                remaining timeout.
+ *   times out  - a wait whose condition never clears returns anyway,
+ *                reports failure, and takes about the timeout rather
+ *                than forever.
+ *   no-op      - a condition already false returns immediately.
+ *   threaded   - the same holds on the threaded queue, where the
+ *                waiting is a different implementation.
+ *
+ * The timing assertions are deliberately loose at the top end: this
+ * runs on shared CI machines and the point is "bounded, not
+ * indefinite", not a precise duration.  The lower bounds are tight,
+ * because returning EARLY would silently break the caller.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <boolean.h>
+#include <queues/task_queue.h>
+#include <features/features_cpu.h>
+#include <retro_timers.h>
+
+static unsigned failures = 0;
+
+#define CHECK(cond, ...) \
+   do { \
+      if (!(cond)) \
+      { \
+         fprintf(stderr, "FAIL %s:%d: ", __FILE__, __LINE__); \
+         fprintf(stderr, __VA_ARGS__); \
+         fprintf(stderr, "\n"); \
+         failures++; \
+      } \
+   } while (0)
+
+#define TIMEOUT_USEC 300000   /* 0.3s - long enough to measure */
+
+/* ------------------------------------------------------------------ */
+/* A task that finishes after N ticks, and one that never finishes    */
+/* ------------------------------------------------------------------ */
+
+static int  ticks_remaining;
+static bool work_pending;
+
+static void finite_handler(retro_task_t *task)
+{
+   if (ticks_remaining > 0)
+   {
+      ticks_remaining--;
+      return;
+   }
+   work_pending = false;
+   task_set_flags(task, RETRO_TASK_FLG_FINISHED, true);
+}
+
+static void endless_handler(retro_task_t *task)
+{
+   /* Models a network wait: the task stays in the queue, and the
+    * thing the caller is waiting for never arrives. */
+}
+
+static void cb(retro_task_t *task, void *task_data, void *user_data,
+      const char *error)
+{
+}
+
+/* The caller's own condition, as a netplay-style "is it still
+ * pending" flag rather than a queue lookup. */
+static bool still_pending(void *data)
+{
+   return work_pending;
+}
+
+static bool push(void (*handler)(retro_task_t*))
+{
+   retro_task_t *task = task_init();
+   if (!task)
+      return false;
+   task->handler  = handler;
+   task->callback = cb;
+   return task_queue_push(task);
+}
+
+/* ------------------------------------------------------------------ */
+/* Lanes                                                               */
+/* ------------------------------------------------------------------ */
+
+static void lane_completes_before_timeout(bool threaded)
+{
+   unsigned had = failures;
+   retro_time_t started, elapsed;
+   bool ok;
+
+   task_queue_init(threaded, NULL);
+   ticks_remaining = 3;
+   work_pending    = true;
+
+   CHECK(push(finite_handler), "push failed");
+
+   started = cpu_features_get_time_usec();
+   ok      = task_queue_wait_timeout(still_pending, NULL, TIMEOUT_USEC);
+   elapsed = cpu_features_get_time_usec() - started;
+
+   task_queue_deinit();
+
+   CHECK(ok, "%s: reported failure for work that finished",
+         threaded ? "threaded" : "regular");
+   CHECK(!work_pending, "%s: work did not actually finish",
+         threaded ? "threaded" : "regular");
+   /* The point of the bound is that it does not delay the ordinary
+    * case; sitting out the full timeout would be a regression that
+    * still "passes" a pass/fail check. */
+   CHECK(elapsed < (TIMEOUT_USEC / 2),
+         "%s: took %lldus for work that finished immediately - the "
+         "wait is sitting out its timeout instead of returning",
+         threaded ? "threaded" : "regular", (long long)elapsed);
+
+   if (failures == had)
+      fprintf(stderr, "[pass] completes-before-timeout (%s, %lldus)\n",
+            threaded ? "threaded" : "regular", (long long)elapsed);
+}
+
+static void lane_times_out(bool threaded)
+{
+   unsigned had = failures;
+   retro_time_t started, elapsed;
+   bool ok;
+
+   task_queue_init(threaded, NULL);
+   work_pending = true;
+
+   CHECK(push(endless_handler), "push failed");
+
+   started = cpu_features_get_time_usec();
+   ok      = task_queue_wait_timeout(still_pending, NULL, TIMEOUT_USEC);
+   elapsed = cpu_features_get_time_usec() - started;
+
+   /* Abandon the endless task so deinit is not left holding it. */
+   task_queue_reset();
+   task_queue_check();
+   task_queue_deinit();
+
+   CHECK(!ok, "%s: reported success though the work never finished",
+         threaded ? "threaded" : "regular");
+   /* Tight lower bound: giving up early would cut short a round trip
+    * that was about to succeed. */
+   CHECK(elapsed >= (TIMEOUT_USEC - (TIMEOUT_USEC / 10)),
+         "%s: gave up after %lldus, well before the %dus timeout",
+         threaded ? "threaded" : "regular", (long long)elapsed,
+         TIMEOUT_USEC);
+   /* Loose upper bound: the machine is shared, the claim is only
+    * that this terminates rather than hangs. */
+   CHECK(elapsed < (TIMEOUT_USEC * 10),
+         "%s: took %lldus against a %dus timeout - not bounded",
+         threaded ? "threaded" : "regular", (long long)elapsed,
+         TIMEOUT_USEC);
+
+   if (failures == had)
+      fprintf(stderr, "[pass] times-out (%s, %lldus)\n",
+            threaded ? "threaded" : "regular", (long long)elapsed);
+}
+
+static void lane_already_done(void)
+{
+   unsigned had = failures;
+   retro_time_t started, elapsed;
+   bool ok;
+
+   task_queue_init(false, NULL);
+   work_pending = false;
+
+   started = cpu_features_get_time_usec();
+   ok      = task_queue_wait_timeout(still_pending, NULL, TIMEOUT_USEC);
+   elapsed = cpu_features_get_time_usec() - started;
+
+   task_queue_deinit();
+
+   CHECK(ok, "reported failure for a condition already false");
+   CHECK(elapsed < (TIMEOUT_USEC / 2),
+         "waited %lldus for something already finished",
+         (long long)elapsed);
+
+   if (failures == had)
+      fprintf(stderr, "[pass] already-done lane\n");
+}
+
+int main(void)
+{
+   lane_completes_before_timeout(false);
+   lane_times_out(false);
+   lane_already_done();
+
+   lane_completes_before_timeout(true);
+   lane_times_out(true);
+
+   if (failures)
+   {
+      fprintf(stderr, "FAIL wait_timeout_test: %u failures\n", failures);
+      return 1;
+   }
+   fprintf(stderr, "PASS wait_timeout_test\n");
+   return 0;
+}

--- a/tasks/task_save.c
+++ b/tasks/task_save.c
@@ -1879,7 +1879,11 @@ static bool task_save_state_finder(retro_task_t *task, void *user_data)
 }
 
 /* Returns true if a save state task is in progress */
-static bool content_save_state_in_progress(void* data)
+/* True while a save state task is in progress.
+ *
+ * Public because closing content needs to know whether the wait
+ * below is going to block before it blocks, so it can say so. */
+bool content_save_state_in_progress(void* data)
 {
    task_finder_data_t find_data;
 


### PR DESCRIPTION
Continues the UI non-blocking work. Two blocking sites this time, each
taken in stages so that the risky part is small and separately
revertable.

The commits before the netplay ones (Apple core list, Android input
device handling) are unrelated and came along on the branch.

## Netplay host init

Hosting through a relay waited on an HTTP round trip to the lobby
server before host setup could continue.

| | |
|---|---|
| **Bound the wait** | A lobby server that is down or blackholed used to hang the frontend with no way out but killing it. It now gives up after ten seconds and falls back to direct mode through the warning path that already existed. Generous on purpose: a false timeout costs the user their session, waiting longer costs only patience. |
| **Split the query** | `netplay_mitm_query()` welded "ask" to "wait for the answer". Now `begin()` / `ready()` / `await()` / `result()`, called back to back at the same site. Pure refactor — every path walked against the original. |
| **Start it earlier** | The query now fires when the user commits to hosting, not when the address is needed. On the content-reload path that is before content has even loaded, so the round trip overlaps work that was happening anyway and the wait usually finds the answer already there. |

The wait stays where it was as a backstop, so host init is not
restructured. A timeout on its own would have been a bug rather than a
fix — the query is still in flight when we give up, and its callback
writes the tunnel address unconditionally, so each query now carries a
generation token and stale results are ignored.

## Content close

Closing content waits for in-flight save/load tasks. Unlike the other
waits removed in this series, **this one cannot simply be deleted**: the
handlers call into core function pointers while
`runloop_event_deinit_core()` unloads the dylib underneath them.

Stages here are deliberately inert — nothing yet changes the freeze:

- an oracle lane pinning what the wait guarantees (file incomplete
  before, complete after)
- the wait made legible: a `Saving state` message and one forced frame
  before blocking, so the pause reads as work rather than a hang
- a `content_closing` state, set and cleared around the existing
  synchronous teardown, observed by nothing
- `core_run()` refusing to enter `retro_run()` while that state is set
- the teardown extracted into its own function, verified identical
  statement by statement

The remaining step — returning to the frame loop instead of blocking —
is **not** in this PR. That is the first change that would alter the
content lifecycle, and it belongs on a stable base.

## Also here

- **Two data races** TSan found in CI. One was mine, in a test. The
  other is older and in `task_queue.c` itself:
  `retro_task_threaded_reset()` set `task->flags` under `running_lock`
  while the worker reads it under `property_lock` — two locks for one
  field. It needed a reset to land mid-task, which is why nothing
  tripped it until a lane that cancels an unfinished task turned up.
- **Two harnesses.** `wait_timeout` covers the bounded wait on both
  queue implementations. `content_closing` links the shipping objects
  with only `main()` replaced and drives the real `core_run()` — the
  closing guard cannot fire in shipped code yet, so without this it
  would go live untested in the same change that first creates the
  situation it protects against.

## Testing

Builds with networking enabled and disabled, Qt and headless, strict
C89, and ARM32 without NEON. All task oracles and both full-program
harnesses pass; CI steps replayed verbatim from the workflows before
commit. Every fix falsified by reverting it.

**Not verified on hardware**, and worth checking:

1. Does hosting still work, and is the stall gone? That decides whether
   deferring the rest of host init is ever needed.
2. Does the `Saving state` message appear on a slow close? If a
   legible two-second pause reads as acceptable, the remaining
   lifecycle change may not be worth its risk at all.