### PR TITLE
streams: latch a failed tell() in the filestream_gets() lookahead

### DIFF
--- a/.github/workflows/Linux-libretro-common-samples.yml
+++ b/.github/workflows/Linux-libretro-common-samples.yml
@@ -80,6 +80,7 @@ jobs:
             vfs_seek_contract_test
             vfs_bulk_read_test
             vfs_hybrid_test
+            filestream_rbuf_fault_test
             cdrom_cuesheet_overflow_test
             cdfs_dir_record_test
             cdfs_pure_api_test

--- a/libretro-common/Makefile.test
+++ b/libretro-common/Makefile.test
@@ -165,6 +165,10 @@ vfs-samples:
 	$(MAKE) -C samples/file/vfs clean
 	$(MAKE) -C samples/file/vfs SANITIZER=address,undefined
 	cd samples/file/vfs && ./vfs_seek_contract_test && ./vfs_large_file_test
+	# filestream_rbuf_fault_test drives filestream_rbuf_fill()'s two
+	# failure arms through its own VFS, which leaves it lane-independent
+	# - running it a second time under MMAP=0 would be the same run.
+	cd samples/file/vfs && ./filestream_rbuf_fault_test
 	$(MAKE) -C samples/file/vfs clean
 	$(MAKE) -C samples/file/vfs MMAP=0 SANITIZER=address,undefined
 	cd samples/file/vfs && ./vfs_seek_contract_test

--- a/libretro-common/samples/file/vfs/Makefile
+++ b/libretro-common/samples/file/vfs/Makefile
@@ -3,6 +3,7 @@ TARGET_TEST := vfs_mapped_ptr_test
 TARGET_TEST2 := vfs_large_file_test
 TARGET_TEST3 := vfs_seek_contract_test
 TARGET_TEST4 := vfs_bulk_read_test
+TARGET_TEST5 := filestream_rbuf_fault_test
 
 LIBRETRO_COMM_DIR := ../../..
 
@@ -19,7 +20,7 @@ COMMON_SOURCES := \
 COMMON_OBJS := $(COMMON_SOURCES:.c=.o)
 OBJS        := vfs_read_overflow_test.o vfs_mapped_ptr_test.o \
 	vfs_large_file_test.o vfs_seek_contract_test.o \
-	vfs_bulk_read_test.o $(COMMON_OBJS)
+	vfs_bulk_read_test.o filestream_rbuf_fault_test.o $(COMMON_OBJS)
 
 # -DHAVE_MMAP is required for vfs_read_overflow_test to exercise the
 # patched code path; without it the implementation falls back to
@@ -57,6 +58,17 @@ ifeq ($(DESCRIPTOR_IO),1)
    CFLAGS += -DVFS_HAVE_DESCRIPTOR_IO=1
 endif
 
+# filestream_rbuf_fault_test drives the two arms on which
+# filestream_rbuf_fill() gives up and hands the caller back to the
+# byte-at-a-time path.  The tell arm needs nothing from the
+# implementation - filestream_vfs_init() is seam enough - but a refused
+# allocation has no other way in, so file_stream.c routes that one
+# allocation through FILESTREAM_RBUF_MALLOC() when this is defined.
+# Nothing else in the tree defines it: in every other build, RetroArch
+# included, the macro is malloc() and the indirection does not exist.
+# It is inert for the other targets here, which install no allocator.
+CFLAGS += -DFILESTREAM_RBUF_TEST_HOOKS
+
 CFLAGS += -Wall -pedantic -std=gnu99 -g -I$(LIBRETRO_COMM_DIR)/include
 
 # The samples workflow passes SANITIZER=address,undefined to every
@@ -67,7 +79,8 @@ ifneq ($(SANITIZER),)
    LDFLAGS := -fsanitize=$(SANITIZER) $(LDFLAGS)
 endif
 
-all: $(TARGET) $(TARGET_TEST) $(TARGET_TEST2) $(TARGET_TEST3) $(TARGET_TEST4)
+all: $(TARGET) $(TARGET_TEST) $(TARGET_TEST2) $(TARGET_TEST3) $(TARGET_TEST4) \
+	$(TARGET_TEST5)
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
@@ -98,10 +111,17 @@ $(TARGET_TEST3): vfs_seek_contract_test.o $(COMMON_OBJS)
 $(TARGET_TEST4): vfs_bulk_read_test.o $(COMMON_OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS) -lpthread
 
+# filestream_rbuf_fault_test installs its own VFS, which takes the
+# memory mapping out of play, so it behaves identically with MMAP=1 and
+# MMAP=0 and there is nothing to gain from running it in both lanes.
+$(TARGET_TEST5): filestream_rbuf_fault_test.o $(COMMON_OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
+
 clean:
 	rm -f $(TARGET) $(TARGET_TEST) $(TARGET_TEST2) $(TARGET_TEST3) \
-		$(TARGET_TEST4) $(OBJS)
+		$(TARGET_TEST4) $(TARGET_TEST5) $(OBJS)
 	rm -f large_3gib.bin large_5gib.bin seek_small.bin seek_4gib.bin
+	rm -f rbuf_fault.txt
 	rm -f bulk_select.bin bulk_select_w.bin bulk_roundtrip.bin \
 		bulk_short.bin bulk_shrank.bin bulk_error.bin \
 		bulk_binary.bin bulk_threads.bin

--- a/libretro-common/samples/file/vfs/filestream_rbuf_fault_test.c
+++ b/libretro-common/samples/file/vfs/filestream_rbuf_fault_test.c
@@ -1,0 +1,463 @@
+/* Copyright  (C) 2010-2026 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (filestream_rbuf_fault_test.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* filestream_rbuf_fill() has two ways to give up, and neither is
+ * reachable from a normal run: the allocation of the lookahead buffer
+ * fails, or the handle cannot report a position.  Both hand the caller
+ * back to the byte-at-a-time path, and until something can drive them
+ * that path is untested code with a comment on it.  Every other sample
+ * in this directory reads ordinary files through an ordinary allocator
+ * and therefore never enters either arm.
+ *
+ * Neither arm is a byte-content property, which is why comparing
+ * output against fgets() cannot express what is being asserted here.
+ * The claims are about how often the implementation asks the VFS and
+ * the allocator for something:
+ *
+ *   - a handle whose tell() fails must be asked exactly ONCE.  The
+ *     failure is a property of the backend (a pipe, a FIFO, a socket,
+ *     a frontend VFS with read but no tell), so nothing between two
+ *     fills can change the answer, and re-asking costs a failed tell()
+ *     per byte on top of the one-byte read - strictly more work than
+ *     the unbuffered code the lookahead replaced.
+ *
+ *   - a handle whose allocation fails must NOT be latched.  That
+ *     failure is usually a moment, not a property, and it is likeliest
+ *     on exactly the memory-constrained targets the lookahead exists
+ *     for.  It must be retried, and it must be retried at a smaller
+ *     size, so a handle that can have 1 KiB is buffered instead of
+ *     degraded.
+ *
+ * Two seams drive them.  The tell arm needs nothing from the
+ * implementation: filestream_vfs_init() already accepts a caller-
+ * supplied VFS, so this installs a pass-through one whose tell() can
+ * be made to fail and whose calls are counted.  Installing it also
+ * takes the memory-mapped fast path out of filestream_gets() - a
+ * caller-supplied VFS has no mapping this side of its callbacks - so
+ * every case below goes through the lookahead deterministically.
+ * The allocation arm has no such seam, so file_stream.c routes that
+ * one allocation through FILESTREAM_RBUF_MALLOC(); with
+ * FILESTREAM_RBUF_TEST_HOOKS undefined that macro is malloc() and
+ * nothing else exists.
+ *
+ * All fixtures are generated ASCII. Nothing here reads, produces or
+ * requires any real data.
+ *
+ * Build:  make filestream_rbuf_fault_test
+ *         (SANITIZER=address,undefined for a checked run)
+ */
+
+/* The VFS interface's callbacks take struct retro_vfs_file_handle*,
+ * the *_impl functions take libretro_vfs_implementation_file*, and the
+ * two are the same type only under VFS_FRONTEND - which is what
+ * file_stream.c itself compiles with.  Defined before any include so
+ * nothing can pull in vfs/vfs.h with the other typedef first. */
+#define VFS_FRONTEND
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <boolean.h>
+#include <libretro.h>
+#include <streams/file_stream.h>
+#include <vfs/vfs_implementation.h>
+
+/* Must match file_stream.c.  Not included from anywhere: the constant
+ * is an implementation detail there, and a test that redefined it
+ * would be asserting against itself rather than against the code. */
+#define RBUF_LEN 16384
+
+#define FIXTURE_PATH "rbuf_fault.txt"
+#define LINE_BUF     64
+
+/* Fills that return bytes, plus the two that return none: the fixture
+ * ends without a newline, so the gets() that consumes the tail keeps
+ * going until something reports end of file, and the gets() after that
+ * asks once more before returning NULL.  Both are ordinary behaviour,
+ * not an artefact of the faults below - the baseline case pins the
+ * same number. */
+#define EXPECT_FILLS(cap) \
+   ((unsigned long)((fixture_len + (cap) - 1) / (cap)) + 2)
+
+/* The unbuffered fallback costs one 1-byte read per byte, and the same
+ * two end-of-file probes. */
+#define EXPECT_BYTE_READS ((unsigned long)fixture_len + 2)
+
+static int test_fails;
+
+#define CHECK(cond, msg) \
+   do { \
+      if (!(cond)) \
+      { \
+         printf("FAIL: %s\n", msg); \
+         test_fails++; \
+      } \
+      else \
+         printf("ok:   %s\n", msg); \
+   } while (0)
+
+/* ---- the allocation seam ------------------------------------------ */
+
+extern void *(*filestream_rbuf_test_malloc)(size_t len);
+
+static unsigned long alloc_calls;
+static unsigned long alloc_refusals;
+static size_t        alloc_last_granted;
+static size_t        alloc_refuse_at_least;  /* 0 = refuse nothing */
+static unsigned long alloc_refuse_first_n;   /* transient failure    */
+
+static void *fault_malloc(size_t len)
+{
+   alloc_calls++;
+
+   if (alloc_refuse_first_n != 0)
+   {
+      alloc_refuse_first_n--;
+      alloc_refusals++;
+      return NULL;
+   }
+
+   if (alloc_refuse_at_least != 0 && len >= alloc_refuse_at_least)
+   {
+      alloc_refusals++;
+      return NULL;
+   }
+
+   alloc_last_granted = len;
+   return malloc(len);
+}
+
+/* ---- the pass-through VFS ----------------------------------------- */
+
+static unsigned long vfs_tell_calls;
+static unsigned long vfs_read_calls;
+static bool          vfs_tell_fails;
+
+static int64_t shim_tell(libretro_vfs_implementation_file *stream)
+{
+   vfs_tell_calls++;
+   if (vfs_tell_fails)
+      return -1;
+   return retro_vfs_file_tell_impl(stream);
+}
+
+static int64_t shim_read(libretro_vfs_implementation_file *stream,
+      void *s, uint64_t len)
+{
+   vfs_read_calls++;
+   return retro_vfs_file_read_impl(stream, s, len);
+}
+
+static struct retro_vfs_interface shim_iface;
+
+static void install_shim_vfs(void)
+{
+   struct retro_vfs_interface_info info;
+
+   memset(&shim_iface, 0, sizeof(shim_iface));
+   shim_iface.get_path = retro_vfs_file_get_path_impl;
+   shim_iface.open     = retro_vfs_file_open_impl;
+   shim_iface.close    = retro_vfs_file_close_impl;
+   shim_iface.size     = retro_vfs_file_size_impl;
+   shim_iface.tell     = shim_tell;
+   shim_iface.seek     = retro_vfs_file_seek_impl;
+   shim_iface.read     = shim_read;
+   shim_iface.write    = retro_vfs_file_write_impl;
+   shim_iface.flush    = retro_vfs_file_flush_impl;
+   shim_iface.remove   = retro_vfs_file_remove_impl;
+   shim_iface.rename   = retro_vfs_file_rename_impl;
+   shim_iface.truncate = retro_vfs_file_truncate_impl;
+
+   info.required_interface_version = FILESTREAM_REQUIRED_VFS_VERSION;
+   info.iface                      = &shim_iface;
+   filestream_vfs_init(&info);
+
+   filestream_rbuf_test_malloc = fault_malloc;
+}
+
+static void reset_counters(void)
+{
+   alloc_calls           = 0;
+   alloc_refusals        = 0;
+   alloc_last_granted    = 0;
+   alloc_refuse_at_least = 0;
+   alloc_refuse_first_n  = 0;
+   vfs_tell_calls        = 0;
+   vfs_read_calls        = 0;
+   vfs_tell_fails        = false;
+}
+
+/* ---- fixture ------------------------------------------------------- */
+
+/* Ragged ASCII, written through stdio rather than through the code
+ * under test, and kept in memory so the scan below has something to be
+ * exact against.  Lines run from 1 to 96 characters so that LINE_BUF
+ * splits some of them and not others, and the file ends without a
+ * final newline. */
+static char  *fixture;
+static size_t fixture_len;
+
+static bool make_fixture(void)
+{
+   FILE  *fp;
+   size_t cap = 40000;
+   size_t n   = 0;
+   unsigned line;
+
+   if (!(fixture = (char*)malloc(cap)))
+      return false;
+
+   for (line = 0; n + 128 < cap; line++)
+   {
+      size_t width = 1 + (line * 37) % 96;
+      size_t i;
+
+      for (i = 0; i < width; i++)
+         fixture[n++] = (char)('a' + ((line + i) % 26));
+      fixture[n++] = '\n';
+   }
+
+   /* Tail with no newline: the last gets() must still return it. */
+   for (line = 0; n < cap; line++)
+      fixture[n++] = (char)('0' + (line % 10));
+
+   fixture_len = n;
+
+   if (!(fp = fopen(FIXTURE_PATH, "wb")))
+      return false;
+   if (fwrite(fixture, 1, fixture_len, fp) != fixture_len)
+   {
+      fclose(fp);
+      return false;
+   }
+   fclose(fp);
+   return true;
+}
+
+/* ---- the scan ------------------------------------------------------ */
+
+/* Walk the whole file with filestream_gets() and compare every byte it
+ * hands back against the fixture at the offset it should have come
+ * from.  Returns the number of bytes consumed, or (size_t)-1 on a
+ * mismatch, so a caller can assert both content and length. */
+static size_t scan_file(bool *err_flag_out)
+{
+   char   line[LINE_BUF];
+   RFILE *fp   = filestream_open(FIXTURE_PATH,
+         RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   size_t off  = 0;
+
+   if (err_flag_out)
+      *err_flag_out = false;
+
+   if (!fp)
+      return (size_t)-1;
+
+   while (filestream_gets(fp, line, sizeof(line)))
+   {
+      size_t n = strlen(line);
+
+      if (n == 0 || n > sizeof(line) - 1)
+      {
+         off = (size_t)-1;
+         break;
+      }
+      if (off + n > fixture_len || memcmp(fixture + off, line, n) != 0)
+      {
+         off = (size_t)-1;
+         break;
+      }
+      off += n;
+   }
+
+   if (err_flag_out && off != (size_t)-1)
+      *err_flag_out = filestream_error(fp) ? true : false;
+
+   filestream_close(fp);
+   return off;
+}
+
+/* ---- cases --------------------------------------------------------- */
+
+/* Baseline.  Nothing is faulted; this is what the shim on its own
+ * costs, and it is what the faulted runs below are read against.  It
+ * is also the control that keeps them honest: if the shim itself
+ * degraded the handle, every "the handle is buffered" assertion below
+ * would pass vacuously. */
+static void case_baseline(void)
+{
+   size_t        got;
+   unsigned long expect_fills = EXPECT_FILLS(RBUF_LEN);
+
+   reset_counters();
+   got = scan_file(NULL);
+
+   CHECK(got == fixture_len, "baseline: whole file read back byte-exact");
+   CHECK(alloc_last_granted == RBUF_LEN,
+         "baseline: lookahead allocated at the nominal 16 KiB");
+   CHECK(alloc_refusals == 0, "baseline: no allocation refused");
+   CHECK(vfs_tell_calls == expect_fills,
+         "baseline: one tell() per fill, not per byte");
+   CHECK(vfs_read_calls == expect_fills,
+         "baseline: one read() per fill, not per byte");
+   printf("info: baseline %lu tell, %lu read, %lu alloc for %lu bytes\n",
+         vfs_tell_calls, vfs_read_calls, alloc_calls,
+         (unsigned long)fixture_len);
+}
+
+/* The latch.  tell() fails on this handle from the first call, which
+ * is what a pipe, a FIFO, or a frontend VFS without a tell callback
+ * looks like.  The scan must still be byte-exact - the fallback path
+ * is the pre-lookahead code and has to keep behaving like it - and the
+ * implementation must ask exactly once. */
+static void case_tell_failure_is_latched(void)
+{
+   size_t got;
+   bool   err = false;
+
+   reset_counters();
+   vfs_tell_fails = true;
+   got            = scan_file(&err);
+
+   CHECK(got == fixture_len,
+         "sticky tell: degraded path returns the file byte-exact");
+   CHECK(vfs_tell_calls == 1,
+         "sticky tell: tell() attempted exactly once for the handle");
+   CHECK(vfs_read_calls == EXPECT_BYTE_READS,
+         "sticky tell: fallback is one 1-byte read per byte, and nothing else");
+   CHECK(alloc_calls == 1,
+         "sticky tell: the lookahead is allocated once and not reattempted");
+   printf("info: sticky tell %lu tell, %lu read for %lu bytes\n",
+         vfs_tell_calls, vfs_read_calls, (unsigned long)fixture_len);
+   /* Not asserted: filestream_raw_tell() sets err_flag on failure, so a
+    * successful scan of a non-seekable handle leaves filestream_error()
+    * true.  The latch reduces that from once per byte to once per
+    * handle but does not remove it.  It is a separate defect from the
+    * one this file covers and is deliberately left alone here. */
+   printf("info: filestream_error() after the scan = %s\n",
+         err ? "true" : "false");
+}
+
+/* The other arm, and the one that must NOT latch.  Every allocation is
+ * refused, so every fill gives up and every byte goes through the
+ * one-byte path.  The implementation is required to keep asking: the
+ * handle must not be written off. */
+static void case_alloc_failure_is_not_latched(void)
+{
+   size_t got;
+
+   reset_counters();
+   alloc_refuse_at_least = 1;      /* refuse every size */
+   got                   = scan_file(NULL);
+
+   CHECK(got == fixture_len,
+         "alloc refused: degraded path returns the file byte-exact");
+   CHECK(vfs_tell_calls == 0,
+         "alloc refused: no tell() is attempted when there is no buffer");
+   CHECK(vfs_read_calls == EXPECT_BYTE_READS,
+         "alloc refused: fallback is one 1-byte read per byte");
+   CHECK(alloc_calls > 1,
+         "alloc refused: the handle is not latched - allocation is retried");
+   printf("info: alloc refused %lu allocation attempts for %lu bytes\n",
+         alloc_calls, (unsigned long)fixture_len);
+}
+
+/* Refuse the nominal size but allow anything smaller.  This is the
+ * shape a fragmented or nearly-full heap actually has, and the handle
+ * is supposed to come out of it buffered rather than degraded. */
+static void case_alloc_falls_back_to_smaller(void)
+{
+   size_t got;
+
+   reset_counters();
+   alloc_refuse_at_least = RBUF_LEN;
+   got                   = scan_file(NULL);
+
+   CHECK(got == fixture_len,
+         "smaller buffer: whole file read back byte-exact");
+   CHECK(alloc_last_granted == RBUF_LEN / 4,
+         "smaller buffer: the next size down is taken, not the byte path");
+   CHECK(alloc_refusals == 1,
+         "smaller buffer: the nominal size is refused once, then left alone");
+   CHECK(vfs_read_calls == EXPECT_FILLS(RBUF_LEN / 4),
+         "smaller buffer: read count is the 4 KiB one, not the per-byte one");
+   printf("info: smaller buffer granted %lu bytes, %lu read calls\n",
+         (unsigned long)alloc_last_granted, vfs_read_calls);
+}
+
+/* A bad moment rather than a bad handle: the first ladder's worth of
+ * requests is refused and everything after it is granted.  The handle
+ * must recover to the nominal buffer on its own - which is the whole
+ * reason this arm is not latched. */
+static void case_transient_alloc_failure_recovers(void)
+{
+   size_t got;
+
+   reset_counters();
+   alloc_refuse_first_n = 3;       /* 16 KiB, 4 KiB, 1 KiB */
+   got                  = scan_file(NULL);
+
+   CHECK(got == fixture_len,
+         "transient: whole file read back byte-exact");
+   CHECK(alloc_refusals == 3,
+         "transient: the first fill exhausted the ladder and gave up");
+   CHECK(alloc_last_granted == RBUF_LEN,
+         "transient: a later fill got the nominal size back");
+   CHECK(vfs_read_calls == EXPECT_FILLS(RBUF_LEN),
+         "transient: the handle went back to the 16 KiB read count");
+   printf("info: transient %lu refusals then %lu bytes, %lu read calls\n",
+         alloc_refusals, (unsigned long)alloc_last_granted, vfs_read_calls);
+}
+
+int main(void)
+{
+   if (!make_fixture())
+   {
+      printf("FAIL: could not build the fixture\n");
+      return 1;
+   }
+
+   install_shim_vfs();
+
+   printf("fixture: %lu bytes, lookahead %d bytes\n",
+         (unsigned long)fixture_len, RBUF_LEN);
+
+   case_baseline();
+   case_tell_failure_is_latched();
+   case_alloc_failure_is_not_latched();
+   case_alloc_falls_back_to_smaller();
+   case_transient_alloc_failure_recovers();
+
+   filestream_rbuf_test_malloc = NULL;
+   remove(FIXTURE_PATH);
+   free(fixture);
+
+   if (test_fails)
+      printf("\n%d check(s) failed\n", test_fails);
+   else
+      printf("\nall checks passed\n");
+
+   return test_fails ? 1 : 0;
+}

--- a/libretro-common/samples/file/vfs/filestream_rbuf_fault_test.c
+++ b/libretro-common/samples/file/vfs/filestream_rbuf_fault_test.c
@@ -429,6 +429,53 @@ static void case_tell_latch_clears_on_seek(void)
    filestream_close(fp);
 }
 
+/* The other half of the clear, and without it the suite cannot tell a
+ * correct implementation from one that clears unconditionally.  Only a
+ * SUCCESSFUL seek is evidence the position may have moved; a seek that
+ * fails leaves the handle exactly where it was, so the latch must
+ * survive it.  A pipe is the case that matters - it can neither tell
+ * nor seek - and if a failed seek cleared the latch, every seek attempt
+ * on such a handle would re-arm a tell() the code already knows will
+ * fail.
+ *
+ * Seeking to a negative offset is used rather than a fault hook: it
+ * fails through the real code path with no injection at all, which is
+ * one less thing the test has to be trusted about. */
+static void case_failed_seek_keeps_the_latch(void)
+{
+   char          line[LINE_BUF];
+   RFILE        *fp;
+   unsigned long tell_after_first;
+
+   reset_counters();
+   vfs_tell_fails = true;
+
+   fp = filestream_open(FIXTURE_PATH,
+         RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   CHECK(fp != NULL, "failed seek: fixture opened");
+   if (!fp)
+      return;
+
+   CHECK(filestream_gets(fp, line, sizeof(line)) != NULL,
+         "failed seek: the degraded first read still returns a line");
+   tell_after_first = vfs_tell_calls;
+   CHECK(tell_after_first == 1,
+         "failed seek: the first fill asks tell() once and latches");
+
+   CHECK(filestream_seek(fp, -1, RETRO_VFS_SEEK_POSITION_START) == -1,
+         "failed seek: seeking to a negative offset does fail");
+
+   CHECK(filestream_gets(fp, line, sizeof(line)) != NULL,
+         "failed seek: the next read still returns a line");
+   CHECK(vfs_tell_calls == tell_after_first,
+         "failed seek: a failed seek does not re-arm tell()");
+
+   printf("info: failed seek %lu tell, latch held\n", vfs_tell_calls);
+
+   filestream_close(fp);
+}
+
 static void case_alloc_failure_is_not_latched(void)
 {
    size_t got;
@@ -512,6 +559,7 @@ int main(void)
    case_baseline();
    case_tell_failure_is_latched();
    case_tell_latch_clears_on_seek();
+   case_failed_seek_keeps_the_latch();
    case_alloc_failure_is_not_latched();
    case_alloc_falls_back_to_smaller();
    case_transient_alloc_failure_recovers();

--- a/libretro-common/samples/file/vfs/filestream_rbuf_fault_test.c
+++ b/libretro-common/samples/file/vfs/filestream_rbuf_fault_test.c
@@ -327,11 +327,16 @@ static void case_baseline(void)
          (unsigned long)fixture_len);
 }
 
-/* The latch.  tell() fails on this handle from the first call, which
- * is what a pipe, a FIFO, or a frontend VFS without a tell callback
- * looks like.  The scan must still be byte-exact - the fallback path
- * is the pre-lookahead code and has to keep behaving like it - and the
- * implementation must ask exactly once. */
+/* The latch.  tell() fails on this handle from the first call.  Two
+ * unrelated things produce that: a backend with no tell callback at
+ * all - a pipe, a FIFO, a socket - and an ordinary seekable file whose
+ * position has passed what ftell() can return on a build without
+ * 64-bit offsets.  This case covers the first only; the second is
+ * covered by case_tell_latch_clears_on_seek below, and the two must
+ * not be conflated, because the latch is permanent for one and must
+ * not be for the other.  The scan must still be byte-exact - the
+ * fallback path is the pre-lookahead code and has to keep behaving
+ * like it - and the implementation must ask exactly once. */
 static void case_tell_failure_is_latched(void)
 {
    size_t got;
@@ -364,6 +369,66 @@ static void case_tell_failure_is_latched(void)
  * refused, so every fill gives up and every byte goes through the
  * one-byte path.  The implementation is required to keep asking: the
  * handle must not be written off. */
+/* The clear, and it is the reason the latch is not permanent.  A
+ * failed tell() is not always a fact about the handle: retro_vfs_fp_tell64()
+ * falls through to ftell() on a build without 64-bit offsets, and that
+ * returns -1 once the position passes LONG_MAX.  Seeking back makes it
+ * work again.  A latch that never cleared would pin an ordinary
+ * seekable file to per-byte reads for the rest of its life because it
+ * once crossed 2 GiB.
+ *
+ * The failure is simulated rather than reproduced - a 2 GiB fixture is
+ * not something a unit test should write - but the code path is the
+ * real one: the same tell() returning the same -1 through the same
+ * VFS callback.
+ *
+ * What is asserted is the cost bound the struct comment claims. After
+ * the seek the latch is gone, so ONE fill() asks tell() again; if it
+ * failed again the latch would re-arm on that single call rather than
+ * re-arming per byte.  Two tell() calls across two scans is that bound
+ * observed; anything higher would mean the clear re-opened the
+ * per-byte cost the latch exists to close. */
+static void case_tell_latch_clears_on_seek(void)
+{
+   char          line[LINE_BUF];
+   RFILE        *fp;
+   unsigned long tell_after_first;
+
+   reset_counters();
+   vfs_tell_fails = true;
+
+   fp = filestream_open(FIXTURE_PATH,
+         RETRO_VFS_FILE_ACCESS_READ,
+         RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   CHECK(fp != NULL, "latch clear: fixture opened");
+   if (!fp)
+      return;
+
+   CHECK(filestream_gets(fp, line, sizeof(line)) != NULL,
+         "latch clear: the degraded first read still returns a line");
+   tell_after_first = vfs_tell_calls;
+   CHECK(tell_after_first == 1,
+         "latch clear: the first fill asks tell() once and latches on the failure");
+
+   /* The position was the problem, not the handle. */
+   vfs_tell_fails = false;
+   /* -1 rather than VFS_ERROR_RETURN_VALUE: that macro is private to
+    * file_stream.c and the public header does not export it. */
+   CHECK(filestream_seek(fp, 0, RETRO_VFS_SEEK_POSITION_START) != -1,
+         "latch clear: the rewind succeeds");
+
+   CHECK(filestream_gets(fp, line, sizeof(line)) != NULL,
+         "latch clear: the rewound read returns a line");
+   CHECK(vfs_tell_calls == tell_after_first + 1,
+         "latch clear: the seek re-armed exactly one tell(), not one per byte");
+   CHECK(strlen(line) != 0 && memcmp(fixture, line, strlen(line)) == 0,
+         "latch clear: the rewound read returns the head of the file");
+
+   printf("info: latch clear %lu tell across two scans\n", vfs_tell_calls);
+
+   filestream_close(fp);
+}
+
 static void case_alloc_failure_is_not_latched(void)
 {
    size_t got;
@@ -446,6 +511,7 @@ int main(void)
 
    case_baseline();
    case_tell_failure_is_latched();
+   case_tell_latch_clears_on_seek();
    case_alloc_failure_is_not_latched();
    case_alloc_falls_back_to_smaller();
    case_transient_alloc_failure_recovers();

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -58,6 +58,22 @@
 #define FILESTREAM_RBUF_LEN 16384
 #endif
 
+/* Allocation seam for that buffer.  A refused allocation is one of the
+ * only two ways filestream_rbuf_fill() can give up, and no test that
+ * cannot make an allocation fail can reach it, so
+ * samples/file/vfs/filestream_rbuf_fault_test builds with this defined
+ * and installs its own allocator.  Every other build - RetroArch's
+ * included - gets plain malloc() and no extra symbol; the indirection
+ * is not compiled at all. */
+#ifdef FILESTREAM_RBUF_TEST_HOOKS
+void *(*filestream_rbuf_test_malloc)(size_t len) = NULL;
+#define FILESTREAM_RBUF_MALLOC(len) \
+   (filestream_rbuf_test_malloc ? filestream_rbuf_test_malloc(len) \
+                                : malloc(len))
+#else
+#define FILESTREAM_RBUF_MALLOC(len) malloc(len)
+#endif
+
 /* Largest single read filestream_read_file() will ask for.  Every
  * backend it can reach expresses a count in something at least this
  * wide - the narrowest is Windows' _read(), an unsigned int returning
@@ -95,6 +111,29 @@ struct RFILE
 {
    struct retro_vfs_file_handle *hfile;
    bool err_flag;
+   /* Set once filestream_rbuf_fill() has seen this handle's tell()
+    * fail, so it stops asking.  A handle that cannot report a
+    * position is one whose backend does not implement the operation -
+    * a pipe, a FIFO, a socket, a frontend VFS that supplies read but
+    * not tell - and nothing between two fills changes that, so the
+    * second attempt is bit-for-bit the first.  Unlatched, the
+    * fallback pays a failed tell() per byte on top of the one-byte
+    * read it already pays, which is strictly more work than the
+    * unbuffered code this lookahead replaced.
+    *
+    * Deliberately NOT set for the other way fill() gives up, a failed
+    * allocation: that is usually transient, and it is likeliest on
+    * exactly the memory-constrained targets the lookahead exists for.
+    * Latching it would pin such a handle to per-byte reads for the
+    * rest of its life over one bad moment.  fill() retries instead,
+    * at a smaller size if that is what fits.
+    *
+    * Never cleared.  A successful seek is not evidence to the
+    * contrary - seek and tell are separate VFS callbacks and a
+    * backend may implement either without the other - and clearing
+    * there would re-arm one failed tell() per byte after every
+    * seek. */
+   bool rbuf_no_tell;
    /* Sequential read lookahead.  Only filestream_rbuf_fill() ever
     * puts bytes here, and only filestream_gets()/filestream_getc()
     * trigger a fill; every other operation on the handle either
@@ -275,21 +314,50 @@ static void filestream_rbuf_discard(RFILE *stream)
  * could be allocated or the handle cannot report a position - in both
  * of those cases the caller falls back to the unbuffered byte path,
  * which behaves exactly as this function did before the lookahead
- * existed. */
+ * existed.
+ *
+ * The two -1 arms are not interchangeable; see rbuf_no_tell in struct
+ * RFILE for why one of them is remembered and the other is not. */
 static int filestream_rbuf_fill(RFILE *stream)
 {
    int64_t off;
    int64_t got;
 
+   /* Asked once, answered for the life of the handle. */
+   if (stream->rbuf_no_tell)
+      return -1;
+
    if (!stream->rbuf)
    {
-      if (!(stream->rbuf = (uint8_t*)malloc(FILESTREAM_RBUF_LEN)))
+      size_t cap;
+
+      /* Step down rather than give up: 16 KiB, then 4, then 1.  A
+       * handle that gets the smallest of those is still a buffered
+       * handle, and still crosses the VFS a thousand times less often
+       * than the byte-at-a-time fallback would.  The nominal size is
+       * unchanged - this runs only once the allocator has refused
+       * it.  The cap != 0 term matters only for an override small
+       * enough that the floor divides to zero; it keeps the loop off
+       * malloc(0). */
+      for (cap = FILESTREAM_RBUF_LEN;
+            cap != 0 && cap >= FILESTREAM_RBUF_LEN / 16; cap >>= 2)
+      {
+         if ((stream->rbuf = (uint8_t*)FILESTREAM_RBUF_MALLOC(cap)))
+         {
+            stream->rbuf_cap = cap;
+            break;
+         }
+      }
+
+      if (!stream->rbuf)
          return -1;
-      stream->rbuf_cap = FILESTREAM_RBUF_LEN;
    }
 
    if ((off = filestream_raw_tell(stream)) < 0)
+   {
+      stream->rbuf_no_tell = true;
       return -1;
+   }
 
    if ((got = filestream_raw_read(stream, stream->rbuf,
                (int64_t)stream->rbuf_cap)) <= 0)
@@ -323,6 +391,7 @@ RFILE* filestream_open(const char *path, unsigned mode, unsigned hints)
    }
 
    output->err_flag      = false;
+   output->rbuf_no_tell  = false;
    output->hfile         = fp;
    output->rbuf          = NULL;
    output->rbuf_cap      = 0;

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -1451,17 +1451,18 @@ int64_t filestream_seek(RFILE *stream, int64_t offset, int seek_position)
        * the logical position observably does not move. */
       if (output != VFS_ERROR_RETURN_VALUE)
       {
-         stream->rbuf_pos     = 0;
-         stream->rbuf_len     = 0;
-         stream->rbuf_no_tell = false;
+         stream->rbuf_pos = 0;
+         stream->rbuf_len = 0;
       }
       return output;
    }
 
-   /* Same clear on the spanless path, and it is the one that matters:
-    * a latched handle has no span, so it arrives HERE and not above.
-    * Clearing only in the branch guarded by rbuf_len != 0 would be
-    * dead code for exactly the handles the latch is set on. */
+   /* The latch clears here and only here.  It cannot be set while a
+    * span exists: rbuf_len is set only by a fill that succeeded, which
+    * means tell() succeeded, and both gets() and getc() zero rbuf_pos
+    * and rbuf_len when the span drains - so a latched handle always
+    * has rbuf_len == 0 and always takes this path.  A clear in the
+    * branch above would be unreachable. */
    plain = filestream_raw_seek(stream, offset, seek_position);
    if (stream && plain != VFS_ERROR_RETURN_VALUE)
       stream->rbuf_no_tell = false;

--- a/libretro-common/streams/file_stream.c
+++ b/libretro-common/streams/file_stream.c
@@ -112,14 +112,10 @@ struct RFILE
    struct retro_vfs_file_handle *hfile;
    bool err_flag;
    /* Set once filestream_rbuf_fill() has seen this handle's tell()
-    * fail, so it stops asking.  A handle that cannot report a
-    * position is one whose backend does not implement the operation -
-    * a pipe, a FIFO, a socket, a frontend VFS that supplies read but
-    * not tell - and nothing between two fills changes that, so the
-    * second attempt is bit-for-bit the first.  Unlatched, the
-    * fallback pays a failed tell() per byte on top of the one-byte
-    * read it already pays, which is strictly more work than the
-    * unbuffered code this lookahead replaced.
+    * fail, so it stops asking.  Unlatched, the fallback pays a failed
+    * tell() per byte on top of the one-byte read it already pays,
+    * which is strictly more work than the unbuffered code this
+    * lookahead replaced.
     *
     * Deliberately NOT set for the other way fill() gives up, a failed
     * allocation: that is usually transient, and it is likeliest on
@@ -128,11 +124,31 @@ struct RFILE
     * rest of its life over one bad moment.  fill() retries instead,
     * at a smaller size if that is what fits.
     *
-    * Never cleared.  A successful seek is not evidence to the
-    * contrary - seek and tell are separate VFS callbacks and a
-    * backend may implement either without the other - and clearing
-    * there would re-arm one failed tell() per byte after every
-    * seek. */
+    * Cleared by a successful seek, and that is not the same
+    * concession.  Two different things make tell() fail and only one
+    * of them is a property of the handle.  A backend that does not
+    * implement the operation at all - a pipe, a FIFO, a socket, a
+    * frontend VFS supplying read but not tell - fails every time, and
+    * a handle like that cannot be seeked either, so its latch is
+    * never cleared and it behaves exactly as if it never were.  But
+    * retro_vfs_fp_tell64() falls through to ftell() where none of
+    * RETRO_VFS_HAVE_FSEEKI64 / RETRO_VFS_HAVE_FPOS64 /
+    * HAVE_64BIT_OFFSETS is set, and that returns -1 past LONG_MAX.
+    * There the failure is a property of WHERE the handle is, not of
+    * what it is, and seeking back under 2 GiB makes tell() work
+    * again.  A latch that never cleared would pin an ordinary
+    * seekable file to per-byte reads for the rest of its life because
+    * it once crossed 2 GiB - the same permanence this comment refuses
+    * two paragraphs up for the allocation case, arrived at by a
+    * different route.
+    *
+    * The clear is cheap because the latch re-arms on the first
+    * failure, not on every byte: after a seek, one fill() calls
+    * tell(), and if it fails again every later fill() short-circuits
+    * on the latch without calling anything.  The cost of being wrong
+    * is therefore one failed tell() per successful seek, paid only by
+    * a backend that implements seek but not tell.  The cost of not
+    * clearing is unbounded. */
    bool rbuf_no_tell;
    /* Sequential read lookahead.  Only filestream_rbuf_fill() ever
     * puts bytes here, and only filestream_gets()/filestream_getc()
@@ -1411,6 +1427,8 @@ static int64_t filestream_raw_seek(RFILE *stream,
 
 int64_t filestream_seek(RFILE *stream, int64_t offset, int seek_position)
 {
+   int64_t plain;
+
    if (stream && stream->rbuf_len != 0)
    {
       int64_t output;
@@ -1433,12 +1451,21 @@ int64_t filestream_seek(RFILE *stream, int64_t offset, int seek_position)
        * the logical position observably does not move. */
       if (output != VFS_ERROR_RETURN_VALUE)
       {
-         stream->rbuf_pos = 0;
-         stream->rbuf_len = 0;
+         stream->rbuf_pos     = 0;
+         stream->rbuf_len     = 0;
+         stream->rbuf_no_tell = false;
       }
       return output;
    }
-   return filestream_raw_seek(stream, offset, seek_position);
+
+   /* Same clear on the spanless path, and it is the one that matters:
+    * a latched handle has no span, so it arrives HERE and not above.
+    * Clearing only in the branch guarded by rbuf_len != 0 would be
+    * dead code for exactly the handles the latch is set on. */
+   plain = filestream_raw_seek(stream, offset, seek_position);
+   if (stream && plain != VFS_ERROR_RETURN_VALUE)
+      stream->rbuf_no_tell = false;
+   return plain;
 }
 
 int filestream_eof(RFILE *stream)


### PR DESCRIPTION
## streams: latch a failed `tell()` in the `filestream_gets()` lookahead

`filestream_rbuf_fill()` gives up two ways, and the degraded path treats them the same.

When it returns -1, `filestream_gets()` falls back to the `getc()` loop, and `filestream_getc()`
calls `fill()` again for every byte. Neither -1 path is self-clearing: a failed `malloc` leaves
`rbuf` NULL so the next call reissues the same request, and if `raw_tell()` is what failed, nothing
between two fills changes that. On a handle whose `tell()` fails, the fallback therefore pays a
failed `tell()` **plus** a one-byte read per byte, where the pre-lookahead code paid just the
one-byte read. The degraded path is slower than the thing it replaced.

**The commits are separable on purpose, and the second is the one to argue with.**

- `7195ab890d` latches the `tell()` failure and not the allocation. This is what you specified.
- `d0d4520833` clears that latch on a successful seek. This is a deviation from what you specified,
  and it is isolated so you can drop it and take the first commit alone. `6e64c79faf` is
  corrections to both.

### The allocation is not latched

A refused allocation is usually a bad moment, and it is likeliest on exactly the memory-constrained
targets the lookahead exists for; latching it would pin such a handle to per-byte reads over one
refusal. `fill()` steps the request down instead — 16K, then 4K, then 1K — and keeps whatever it is
granted. A handle that gets 1K is still a buffered handle. `rbuf_cap` was already the only place the
size is read after allocation, so nothing downstream changes. Nominal size unchanged, no knob added.

### Why the latch clears on a successful seek

Not because a seek proves `tell()` will now work — it does not, and they are separate callbacks.
Because the two failure modes are asymmetric:

| if the code is wrong | cost |
|---|---|
| clears when it should not have | one failed `tell()` per successful seek |
| never clears when it should have | per-byte reads, permanently |

The clear is cheap because the latch re-arms on the first failure rather than per byte: after a
seek one `fill()` asks, and if it fails again every later `fill()` short-circuits. The expensive
error has no bound. Under that asymmetry, clearing is the safe default even where it buys nothing.

Where it buys something: `retro_vfs_fp_tell64()` falls through to `ftell()` when none of
`RETRO_VFS_HAVE_FSEEKI64` / `RETRO_VFS_HAVE_FPOS64` / `HAVE_64BIT_OFFSETS` is set, and `ftell()`
returns -1 past `LONG_MAX`. There the failure is a property of *where* the handle is rather than
what it is, and seeking back makes it work again. A backend with no `tell` at all — pipe, FIFO,
socket — cannot be seeked either, so its latch is never cleared and it behaves exactly as a
permanent one would.

The clear is on the spanless path only. It cannot be reached with a span present: `rbuf_len` is set
only by a fill that succeeded, which means `tell()` succeeded, and both `gets()` and `getc()` zero
the span when it drains — so a latched handle always has `rbuf_len == 0`. A clear in the other
branch would be unreachable, and the first revision of this had one.

`sizeof(RFILE)` is unchanged at 64 on LP64, checked by static assertion rather than counted off the
declaration; the `bool` lands in `err_flag`'s padding.

### How to verify

```
cd libretro-common/samples/file/vfs && make && ./filestream_rbuf_fault_test
# expect: all checks passed, exit 0, and among the info lines
#   info: baseline 5 tell, 5 read, 1 alloc for 40000 bytes
#   info: sticky tell 1 tell, 40002 read for 40000 bytes
#   info: latch clear 2 tell across two scans
#   info: failed seek 1 tell, latch held
#   info: smaller buffer granted 4096 bytes, 12 read calls
#   info: transient 3 refusals then 16384 bytes, 5 read calls
```

The result is the call count: **41,097 `tell()` calls down to 1** on a 40,000-byte scan through a
VFS whose `tell()` always fails.

The sample installs its own allocator and its own VFS so both -1 arms are reachable; neither is
reachable otherwise, which is why `master` has no test for either.

**Every gate here can fail, and that was checked rather than assumed.** Against unmodified `master`
with only the allocation seam grafted on so the suite can run at all, it reports **8 failures**.
Remove only the seek clear and `latch clear` fails alone, reporting 1 `tell` across two scans
instead of 2. Remove only the success guard on that clear and `failed seek` fails alone, reporting
2 instead of 1.

Also run clean: the other five VFS samples in that directory, including `vfs_seek_contract_test`,
which exercises `filestream_seek` directly and covers files past 4 GiB; and `libretro-common`'s
`test_hash`, which links `file_stream.c`.

### What this does not do

- **No wall-clock number, and not for want of one.** What the change removes is one VFS callback
  per byte, and what that callback costs is a property of the backend the frontend supplies.
  Measuring it against the sample measures the sample's own stub, whose `tell()` is a counter
  increment and a `return -1` — the cheapest `tell()` that can exist. The transferable figure is
  the call count. No device was measured and no device claim is made here.
- **One platform, and it is the wrong one for the motivating case.** Everything above is a 64-bit
  build under Apple clang. The `ftell()`/`LONG_MAX` case can only occur where `long` is 32 bits,
  which is exactly the configuration never compiled here — that case is reasoned from the source,
  not reproduced. The asymmetry argument above does not depend on it.
- **It does not fix `filestream_error()`.** `filestream_raw_tell()` sets `err_flag`, so a successful
  `gets()` on such a handle still leaves `filestream_error()` true where the pre-lookahead code left
  it false. The latch takes that from once per byte to once per handle. Removing it is a separate
  change and this is not it.
- **A runtime VFS swap does not clear the latch.** `filestream_vfs_init()` replaces the callbacks
  process-wide and a handle latched under the old set stays latched under the new. Covering it
  needs a generation counter, which is more machinery than the defect warrants unless you disagree.
- **The all-refused allocation case got more expensive**, not merely no better: 41,097 `malloc`
  calls before, 123,291 after, because the ladder tries three sizes where the old code tried one.
  Both from the sample. The pre-existing behaviour was already one refusal per byte.
- **The buffer sweep is dropped** and 16K is unchanged, per your reply.

### The strongest argument against it

The clear-on-seek rule assumes a seek is the only event that can make a failed `tell()` start
succeeding. That is true of the two causes above and it is an assumption, not a proof — a backend
failing for some third, self-clearing reason keeps the latch until something seeks. What makes that
acceptable is the asymmetry, not the assumption being airtight. If you would rather the latch be
unconditional, drop `d0d4520833` and the first commit stands on its own.
