### PR TITLE
SDL3: Fix relative mouse mode while grabbed

### DIFF
--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -751,11 +751,8 @@ static void sdl3_grab_mouse(void *data, bool state)
    if (win)
    {
       SDL_SetWindowMouseGrab(win, state);
-      /* Cores that capture the mouse (DOSBox, FPS cores) expect
-       * unbounded relative motion; a plain grab confines the cursor
-       * but keeps absolute semantics, so deltas die at the window
-       * edges. Relative mouse mode matches the game-focus behaviour
-       * of the other desktop input drivers (winraw/x11/udev). */
+      /* Relative mouse mode matches the game-focus behaviour of
+       * the other desktop input drivers (winraw/x11/udev). */
       SDL_SetWindowRelativeMouseMode(win, state);
    }
 }

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -749,7 +749,15 @@ static void sdl3_grab_mouse(void *data, bool state)
    SDL_Window *win = sdl3_input_window();
 
    if (win)
+   {
       SDL_SetWindowMouseGrab(win, state);
+      /* Cores that capture the mouse (DOSBox, FPS cores) expect
+       * unbounded relative motion; a plain grab confines the cursor
+       * but keeps absolute semantics, so deltas die at the window
+       * edges. Relative mouse mode matches the game-focus behaviour
+       * of the other desktop input drivers (winraw/x11/udev). */
+      SDL_SetWindowRelativeMouseMode(win, state);
+   }
 }
 
 static uint64_t sdl3_get_capabilities(void *data)


### PR DESCRIPTION
When RetroArch enables mouse grab, we should also set the relative mouse mode so that captured mouse motion is not limited by the window edges:
https://wiki.libsdl.org/SDL3/SDL_SetWindowRelativeMouseMode