### PR TITLE
SDL3: Switch audio system to use callbacks

### DIFF
--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -33,11 +33,7 @@
 
 /* SDL3 Audio Driver */
 
-/* Upper bound in milliseconds on how long a blocking write or read
- * waits for the device to move data before giving up and reporting a
- * short count. Never reached in normal operation - the stream callback
- * signals every device period - so it only decides how long a stalled
- * device takes to be noticed. */
+/* Timeout in milliseconds for blocking read/write to detect a stalled audio device. */
 #define SDL3_AUDIO_STALL_TIMEOUT_MS 256
 
 /* Context for an audio device. Covered by three different states:
@@ -47,19 +43,19 @@
 typedef struct sdl3_audio
 {
    SDL_AudioStream *stream; /**< The device stream. */
-   SDL_Mutex *lock; /**< Guards cond; the stream callbacks signal under it. */
-   SDL_Condition *cond; /**< Signalled each time the device moves data, waking a blocked write or read. */
+   SDL_Mutex *lock; /**< Guards condition, the stream callbacks are called through it. */
+   SDL_Condition *cond; /**< Signalled each time the device moves data. */
    SDL_AudioSpec spec; /**< The format for the given audio sample. */
-   SDL_AudioDeviceID devid; /**< Logical device the stream is bound to, matched against removal events. */
+   SDL_AudioDeviceID devid; /**< The device the stream is bound to. */
    size_t buffer_size; /**< Cap in bytes on queued audio: writes block past it, capture backlog is dropped past it. */
    size_t in_cap; /**< buffer_size converted into input-format bytes; equal to buffer_size outside the write_raw fast path. */
    int raw_rate; /**< Core rate the write_raw fast path set as the stream's input side (int16 stereo); 0 while the input side matches the device spec. */
-   unsigned latency; /**< Requested latency in ms, kept for reopening on device removal. */
+   unsigned latency; /**< The amount of requested latency in milliseconds. */
    float ratio; /**< Frequency ratio currently set on the stream, to skip redundant sets. */
    float gain; /**< Gain currently set on the stream, to skip redundant sets. */
    bool nonblock; /**< When true, drop samples instead of waiting for the device to clear. */
-   bool device_removed; /**< Set by the event watch when the stream's device is unplugged. */
-   bool defunct; /**< Reopening on the default device failed; fail fast instead of retrying every write. */
+   bool device_removed; /**< Becomes true when the stream's device is unplugged. */
+   bool defunct; /**< True when the device has completely failed. Saves from retrying each frame. */
 } sdl3_audio_t;
 
 /**
@@ -421,13 +417,7 @@ static size_t sdl3_audio_write_avail(void *data)
 }
 
 /**
- * Reopens the output stream on the default playback device after the
- * device it was bound to was removed.
- *
- * SDL migrates streams that were opened on the default device by
- * itself. This covers streams opened on an explicitly chosen device,
- * which SDL instead parks on a "zombie" device that silently discards
- * everything queued to it, forever.
+ * Attempts to reopen a lost audio device.
  *
  * @return True when writes may proceed on the new stream.
  */
@@ -439,15 +429,8 @@ static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
 
    RARCH_WARN("[SDL3 audio] Reopening output on the default device.\n");
 
-   /* buffer_size is kept as-is rather than re-clamped to the new
-    * device's period: the audio core caches it at init for rate
-    * control, so it must stay stable across the reopen. */
    stream = sdl3_audio_open_stream(NULL, false, (unsigned)sdl->spec.freq,
          sdl->latency, 2, &spec, &device_sample_frames);
-
-   /* Keep the stream's input side on the original device format so
-    * the rest of the pipeline is unaffected; SDL converts to the new
-    * device's format transparently. */
    if (stream && !SDL_SetAudioStreamFormat(stream, &sdl->spec, NULL))
    {
       SDL_DestroyAudioStream(stream);
@@ -468,17 +451,15 @@ static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
 }
 
 /**
- * Recovers the output stream when its device was removed.
+ * Checks whether or not the given audio stream is okay, and attempts
+ * to reopen it if it was removed.
  *
- * @return False when writing is impossible: the device is gone and
- * could not be replaced.
+ * @return False when writing is impossible and the device is gone.
  */
 static bool sdl3_audio_stream_ok(sdl3_audio_t *sdl)
 {
    if (sdl->defunct)
       return false;
-   /* Recover before the caller configures the stream, so any raw
-    * format lands on the replacement stream. */
    if (sdl->device_removed)
       return sdl3_audio_reopen_default(sdl);
    return true;
@@ -487,7 +468,7 @@ static bool sdl3_audio_stream_ok(sdl3_audio_t *sdl)
 /**
  * Queues frame-aligned data up to the given cap.
  *
- * This drops excess if nonblocking, or blocks until drained/timed out.
+ * This will drops excess if nonblocking, or blocks until drained/timed out.
  *
  * @return The number of bytes queued, or -1 when the first write failed.
  */
@@ -521,8 +502,8 @@ static ssize_t sdl3_audio_queue(sdl3_audio_t *sdl, const void *s,
          if (sdl->nonblock)
             break;
 
-         /* Sleep until the get callback signals: the device pulling
-          * data is the moment queue space opens up. */
+         /* Wait until the get callback is hit and there is space
+          * available in the buffer to write. */
          if (!sdl3_audio_wait_for_device(sdl))
             break;
       }
@@ -885,8 +866,7 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
    if (!sdl || !mic || !s)
       return -1;
 
-   /* The microphone was unplugged; without this, SDL parks the
-    * stream on a "zombie" device that records silence forever. */
+   /* Avoid using a recording device that doesn't exist. */
    if (mic->device_removed)
       return -1;
 
@@ -894,8 +874,7 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
    {
       int got;
 
-      /* Keep what was already captured; the next call reports the
-       * failure. */
+      /* Safety check. */
       if (mic->device_removed)
          break;
 
@@ -914,8 +893,8 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
          if (sdl->nonblock)
             break;
 
-         /* Sleep until the put callback signals that the device
-          * captured more samples. */
+         /* Wait until the put callback signals that the device
+          * can capture more samples. */
          if (!sdl3_audio_wait_for_device(mic))
             break;
       }

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -78,6 +78,8 @@ static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *e
    if (   event->type == SDL_EVENT_AUDIO_DEVICE_REMOVED
        && event->adevice.which == sdl->devid)
    {
+      RARCH_WARN("[SDL3 audio] Audio %s device was removed.\n",
+            event->adevice.recording ? "input" : "output");
       SDL_LockMutex(sdl->lock);
       sdl->device_removed = true;
       SDL_SignalCondition(sdl->cond);
@@ -385,8 +387,11 @@ static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
    int device_sample_frames = 0;
    SDL_AudioStream *stream = NULL;
 
-   RARCH_WARN("[SDL3 audio] Output device was removed, reopening on the default device.\n");
+   RARCH_WARN("[SDL3 audio] Reopening output on the default device.\n");
 
+   /* buffer_size is kept as-is rather than re-clamped to the new
+    * device's period: the audio core caches it at init for rate
+    * control, so it must stay stable across the reopen. */
    stream = sdl3_audio_open_stream(NULL, false, (unsigned)sdl->spec.freq,
          sdl->latency, 2, &spec, &device_sample_frames);
 

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -59,13 +59,7 @@ typedef struct sdl3_audio
 } sdl3_audio_t;
 
 /**
- * Event watch for SDL_EVENT_AUDIO_DEVICE_REMOVED.
- *
- * SDL only emits this for streams bound to an explicitly chosen
- * device; streams opened on the default device are migrated by SDL
- * itself and never see it. The event is delivered whenever the
- * frontend pumps SDL events, and a watch fires as it is pushed, so
- * nothing needs to drain the event queue.
+ * Event callback for SDL_EVENT_AUDIO_DEVICE_REMOVED.
  */
 static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *event)
 {
@@ -235,9 +229,8 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
 }
 
 /**
- * Stream callback fired from the device thread each time the device
- * moves data: the moment queue space opens up for playback, or more
- * samples arrive from a microphone. Wakes a blocked write or read.
+ * Device thread callback which wakes blocked reads/writes when
+ * queue space becomes available.
  */
 static void SDLCALL sdl3_audio_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)
@@ -250,16 +243,9 @@ static void SDLCALL sdl3_audio_stream_cb(void *userdata,
 }
 
 /**
- * Blocks a full write / empty read until a stream callback signals
- * that the device moved data.
+ * Blocks until the stream callback signals device data movement.
  *
- * The callbacks signal while SDL holds the stream lock, so the caller
- * must not query the stream under ctx->lock; the cost is that a
- * signal raised between the caller's check and this wait is missed,
- * and the next device period (or the stall timeout) covers it.
- *
- * @return False once the device stops moving data entirely, so the
- * caller reports a short count instead of blocking forever.
+ * @return False if the device stalls/stops moving data (to report short count).
  */
 static bool sdl3_audio_wait_for_device(sdl3_audio_t *ctx)
 {
@@ -282,8 +268,6 @@ static void sdl3_audio_destroy_context(sdl3_audio_t *ctx)
    /* Stop the watch from touching the lock before tearing it down. */
    SDL_RemoveEventWatch(sdl3_audio_device_removed_watch, ctx);
 
-   /* Destroying the stream also closes the device and detaches
-    * the stream callback. */
    if (ctx->stream)
       SDL_DestroyAudioStream(ctx->stream);
    if (ctx->cond)
@@ -305,10 +289,11 @@ static void sdl3_audio_free(void *data)
 }
 
 /**
- * Preps a freshly opened output stream: tracks its device for the
- * removal watch, installs the wake callback, resets the write_raw
- * state to a fresh stream's defaults, prefills the latency cushion
- * with silence, and starts the device (streams open paused).
+ * Prepares a new output stream.
+ *
+ * Registers device event tracking, binds the wake callback,
+ * resets write_raw state, prefills silence for latency
+ * cushioning, and starts playback.
  */
 static void sdl3_audio_prime_stream(sdl3_audio_t *sdl)
 {
@@ -317,8 +302,6 @@ static void sdl3_audio_prime_stream(sdl3_audio_t *sdl)
    sdl->devid = SDL_GetAudioStreamDevice(sdl->stream);
    SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
 
-   /* A fresh stream starts with default ratio/gain, and write_raw
-    * reconfigures its input side on the next call. */
    sdl->raw_rate = 0;
    sdl->in_cap = sdl->buffer_size;
    sdl->ratio = 1.0f;

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -33,12 +33,12 @@
 
 /* SDL3 Audio Driver */
 
-/* The duration of time to continue polling in order to give up
- * on a device. */
-#define SDL3_AUDIO_STALL_TIMEOUT_NS SDL_MS_TO_NS(256)
-
-/* The number of nanoseconds to wait between device polls. */
-#define SDL3_AUDIO_POLL_INTERVAL_NS SDL_NS_PER_MS
+/* Upper bound in milliseconds on how long a blocking write or read
+ * waits for the device to move data before giving up and reporting a
+ * short count. Never reached in normal operation - the stream callback
+ * signals every device period - so it only decides how long a stalled
+ * device takes to be noticed. */
+#define SDL3_AUDIO_STALL_TIMEOUT_MS 256
 
 /* Context for an audio device. Covered by three different states:
  * 1. Output Driver, used for playback
@@ -47,14 +47,44 @@
 typedef struct sdl3_audio
 {
    SDL_AudioStream *stream; /**< The device stream. */
+   SDL_Mutex *lock; /**< Guards cond; the stream callbacks signal under it. */
+   SDL_Condition *cond; /**< Signalled each time the device moves data, waking a blocked write or read. */
    SDL_AudioSpec spec; /**< The format for the given audio sample. */
+   SDL_AudioDeviceID devid; /**< Logical device the stream is bound to, matched against removal events. */
    size_t buffer_size; /**< Cap in bytes on queued audio: writes block past it, capture backlog is dropped past it. */
    size_t in_cap; /**< buffer_size converted into input-format bytes; equal to buffer_size outside the write_raw fast path. */
    int raw_rate; /**< Core rate the write_raw fast path set as the stream's input side (int16 stereo); 0 while the input side matches the device spec. */
+   unsigned latency; /**< Requested latency in ms, kept for reopening on device removal. */
    float ratio; /**< Frequency ratio currently set on the stream, to skip redundant sets. */
    float gain; /**< Gain currently set on the stream, to skip redundant sets. */
    bool nonblock; /**< When true, drop samples instead of waiting for the device to clear. */
+   bool device_removed; /**< Set by the event watch when the stream's device is unplugged. */
+   bool defunct; /**< Reopening on the default device failed; fail fast instead of retrying every write. */
 } sdl3_audio_t;
+
+/**
+ * Event watch for SDL_EVENT_AUDIO_DEVICE_REMOVED.
+ *
+ * SDL only emits this for streams bound to an explicitly chosen
+ * device; streams opened on the default device are migrated by SDL
+ * itself and never see it. The event is delivered whenever the
+ * frontend pumps SDL events, and a watch fires as it is pushed, so
+ * nothing needs to drain the event queue.
+ */
+static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *event)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)userdata;
+
+   if (   event->type == SDL_EVENT_AUDIO_DEVICE_REMOVED
+       && event->adevice.which == sdl->devid)
+   {
+      SDL_LockMutex(sdl->lock);
+      sdl->device_removed = true;
+      SDL_SignalCondition(sdl->cond);
+      SDL_UnlockMutex(sdl->lock);
+   }
+   return true;
+}
 
 /**
  * Looks up an audio device by name, returning the default
@@ -206,15 +236,38 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
    return stream;
 }
 
+/**
+ * Stream callback fired from the device thread each time the device
+ * pulls data: the moment queue space is about to open up. Wakes a
+ * blocked write.
+ */
+static void SDLCALL sdl3_audio_stream_cb(void *userdata,
+      SDL_AudioStream *stream, int additional_amount, int total_amount)
+{
+   sdl3_audio_t *sdl = (sdl3_audio_t*)userdata;
+
+   SDL_LockMutex(sdl->lock);
+   SDL_SignalCondition(sdl->cond);
+   SDL_UnlockMutex(sdl->lock);
+}
+
 static void sdl3_audio_free(void *data)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
    if (sdl)
    {
-      /* Destroying the stream also closes the device. */
+      /* Stop the watch from touching the lock before tearing it down. */
+      SDL_RemoveEventWatch(sdl3_audio_device_removed_watch, sdl);
+
+      /* Destroying the stream also closes the device and detaches
+       * the stream callback. */
       if (sdl->stream)
          SDL_DestroyAudioStream(sdl->stream);
+      if (sdl->cond)
+         SDL_DestroyCondition(sdl->cond);
+      if (sdl->lock)
+         SDL_DestroyMutex(sdl->lock);
 
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
    }
@@ -242,9 +295,19 @@ static void *sdl3_audio_init(const char *device,
       return NULL;
    }
 
+   if (!(sdl->lock = SDL_CreateMutex()))
+      goto error;
+   if (!(sdl->cond = SDL_CreateCondition()))
+      goto error;
+
    if (!(sdl->stream = sdl3_audio_open_stream(device, false, rate, latency,
          2, &sdl->spec, &device_sample_frames)))
       goto error;
+
+   sdl->devid = SDL_GetAudioStreamDevice(sdl->stream);
+   sdl->latency = latency;
+   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
+   SDL_AddEventWatch(sdl3_audio_device_removed_watch, sdl);
 
    /* Buffer the requested latency's worth of audio. */
    frame_size = SDL_AUDIO_FRAMESIZE(sdl->spec);
@@ -305,6 +368,72 @@ static size_t sdl3_audio_write_avail(void *data)
 }
 
 /**
+ * Reopens the output stream on the default playback device after the
+ * device it was bound to was removed.
+ *
+ * SDL migrates streams that were opened on the default device by
+ * itself. This covers streams opened on an explicitly chosen device,
+ * which SDL instead parks on a "zombie" device that silently discards
+ * everything queued to it, forever.
+ *
+ * @return True when writes may proceed on the new stream.
+ */
+static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
+{
+   void *tmp = NULL;
+   SDL_AudioSpec spec = {0};
+   int device_sample_frames = 0;
+   SDL_AudioStream *stream = NULL;
+
+   RARCH_WARN("[SDL3 audio] Output device was removed, reopening on the default device.\n");
+
+   stream = sdl3_audio_open_stream(NULL, false, (unsigned)sdl->spec.freq,
+         sdl->latency, 2, &spec, &device_sample_frames);
+
+   /* Keep the stream's input side on the original device format so
+    * the rest of the pipeline is unaffected; SDL converts to the new
+    * device's format transparently. */
+   if (stream && !SDL_SetAudioStreamFormat(stream, &sdl->spec, NULL))
+   {
+      SDL_DestroyAudioStream(stream);
+      stream = NULL;
+   }
+
+   if (!stream)
+   {
+      RARCH_ERR("[SDL3 audio] Failed to reopen on the default device, giving up on audio output.\n");
+      sdl->defunct = true;
+      return false;
+   }
+
+   SDL_DestroyAudioStream(sdl->stream);
+   sdl->stream = stream;
+   sdl->devid = SDL_GetAudioStreamDevice(stream);
+   /* A fresh stream starts with default ratio/gain, and write_raw
+    * reconfigures its input side on the next call. */
+   sdl->raw_rate = 0;
+   sdl->in_cap = sdl->buffer_size;
+   sdl->ratio = 1.0f;
+   sdl->gain = 1.0f;
+
+   SDL_LockMutex(sdl->lock);
+   sdl->device_removed = false;
+   SDL_UnlockMutex(sdl->lock);
+
+   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
+
+   /* Prefill the new stream with silence to rebuild the latency cushion. */
+   if ((tmp = calloc(1, sdl->buffer_size)))
+   {
+      SDL_PutAudioStreamData(sdl->stream, tmp, (int)sdl->buffer_size);
+      free(tmp);
+   }
+
+   SDL_ResumeAudioStreamDevice(sdl->stream);
+   return true;
+}
+
+/**
  * Queues frame-aligned data up to the given cap.
  *
  * This will drops excess if nonblocking, or blocks until drained/timed out.
@@ -315,12 +444,19 @@ static ssize_t sdl3_audio_queue(sdl3_audio_t *sdl, const void *s,
       size_t len, size_t cap, size_t frame_size)
 {
    size_t size = 0;
-   Uint64 deadline = 0;
 
    while (size < len)
    {
-      int queued   = SDL_GetAudioStreamQueued(sdl->stream);
-      size_t avail = (queued < 0 || (size_t)queued >= cap)
+      int queued;
+      size_t avail;
+
+      /* The device is gone; drop the rest and let the next write
+       * reopen on the default device. */
+      if (sdl->device_removed)
+         break;
+
+      queued = SDL_GetAudioStreamQueued(sdl->stream);
+      avail  = (queued < 0 || (size_t)queued >= cap)
             ? 0 : cap - (size_t)queued;
 
       /* Only queue whole frames. */
@@ -328,19 +464,30 @@ static ssize_t sdl3_audio_queue(sdl3_audio_t *sdl, const void *s,
 
       if (avail == 0)
       {
-         Uint64 now;
+         bool signalled;
 
          /* When the queue is full, and we can't wait on the
           * process for the queue to clear a bit, we're unable
           * to do anything, so skip the rest. */
          if (sdl->nonblock)
             break;
-         now = SDL_GetTicksNS();
-         if (deadline == 0)
-            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_NS;
-         else if (now >= deadline)
+
+         /* Sleep until the get callback signals that the device pulled
+          * data. The callback signals while SDL holds the stream lock,
+          * so the queue must not be re-checked under sdl->lock; the
+          * cost is that a signal raised between the check above and
+          * this wait is missed, and the next device period (or the
+          * stall timeout) covers it. */
+         SDL_LockMutex(sdl->lock);
+         signalled = sdl->device_removed
+               || SDL_WaitConditionTimeout(sdl->cond, sdl->lock,
+                     SDL3_AUDIO_STALL_TIMEOUT_MS);
+         SDL_UnlockMutex(sdl->lock);
+
+         /* The device stopped pulling data entirely; report the
+          * short write instead of blocking forever. */
+         if (!signalled)
             break;
-         SDL_DelayNS(SDL3_AUDIO_POLL_INTERVAL_NS);
       }
       else
       {
@@ -355,7 +502,6 @@ static ssize_t sdl3_audio_queue(sdl3_audio_t *sdl, const void *s,
             break;
          }
          size += write_amt;
-         deadline = 0; /* Reset the stall clock. */
       }
    }
 
@@ -366,7 +512,10 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
-   if (!sdl)
+   if (!sdl || sdl->defunct)
+      return -1;
+
+   if (sdl->device_removed && !sdl3_audio_reopen_default(sdl))
       return -1;
 
    /* Reset stream format and SDL rate/gain to defaults when exiting
@@ -399,7 +548,12 @@ static ssize_t sdl3_audio_write_raw(void *data, const int16_t *samples,
    const size_t frame_size = 2 * sizeof(int16_t);
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
-   if (!sdl || !samples || input_rate == 0)
+   if (!sdl || !samples || input_rate == 0 || sdl->defunct)
+      return -1;
+
+   /* Recover before configuring the stream, so the raw format lands
+    * on the replacement stream. */
+   if (sdl->device_removed && !sdl3_audio_reopen_default(sdl))
       return -1;
 
    /* Set stream input to core-rate int16 stereo and reconfigure
@@ -528,7 +682,8 @@ audio_driver_t audio_sdl3 = {
 
 /**
  * Stream callback for the microphone to drop stale audio to allow
- * space within the buffer.
+ * space within the buffer, and to wake a read blocked on an empty
+ * stream now that the device has captured more samples.
  */
 static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)
@@ -537,6 +692,10 @@ static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
 
    if (SDL_GetAudioStreamAvailable(stream) > (int)mic->buffer_size)
       SDL_ClearAudioStream(stream);
+
+   SDL_LockMutex(mic->lock);
+   SDL_SignalCondition(mic->cond);
+   SDL_UnlockMutex(mic->lock);
 }
 
 static void *sdl3_microphone_init(void)
@@ -576,9 +735,17 @@ static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
    if (!mic)
       return;
 
-   /* Destroying the stream also closes the device. */
+   /* Stop the watch from touching the lock before tearing it down. */
+   SDL_RemoveEventWatch(sdl3_audio_device_removed_watch, mic);
+
+   /* Destroying the stream also closes the device and detaches
+    * the stream callback. */
    if (mic->stream)
       SDL_DestroyAudioStream(mic->stream);
+   if (mic->cond)
+      SDL_DestroyCondition(mic->cond);
+   if (mic->lock)
+      SDL_DestroyMutex(mic->lock);
 
    RARCH_LOG("[SDL3 audio] Freed microphone.\n");
    free(mic);
@@ -614,11 +781,19 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
       }
    }
 
+   if (!(mic->lock = SDL_CreateMutex()))
+      goto error;
+   if (!(mic->cond = SDL_CreateCondition()))
+      goto error;
+
    /* Device streams open in a paused state. The frontend starts
     * them with start_mic. Microphones usually provide mono input. */
    if (!(mic->stream = sdl3_audio_open_stream(device, true, rate, latency,
          1, &mic->spec, &device_sample_frames)))
       goto error;
+
+   mic->devid = SDL_GetAudioStreamDevice(mic->stream);
+   SDL_AddEventWatch(sdl3_audio_device_removed_watch, mic);
 
    /* Buffer up to double the latency budget. */
    frame_size = SDL_AUDIO_FRAMESIZE(mic->spec);
@@ -689,16 +864,27 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
       void *s, size_t len)
 {
    size_t size = 0;
-   Uint64 deadline = 0;
    sdl3_audio_t *sdl = (sdl3_audio_t*)driver_context;
    sdl3_audio_t *mic = (sdl3_audio_t*)mic_context;
 
    if (!sdl || !mic || !s)
       return -1;
 
+   /* The microphone was unplugged; without this, SDL parks the
+    * stream on a "zombie" device that records silence forever. */
+   if (mic->device_removed)
+      return -1;
+
    while (size < len)
    {
-      int got = SDL_GetAudioStreamData(mic->stream, (char*)s + size, (int)(len - size));
+      int got;
+
+      /* Keep what was already captured; the next call reports the
+       * failure. */
+      if (mic->device_removed)
+         break;
+
+      got = SDL_GetAudioStreamData(mic->stream, (char*)s + size, (int)(len - size));
       if (got < 0)
       {
          RARCH_ERR("[SDL3 audio] Failed to read from microphone stream: %s.\n", SDL_GetError());
@@ -707,24 +893,31 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
          break;
       }
       if (got > 0)
-      {
          size += (size_t)got;
-         deadline = 0; /* Reset the stall clock. */
-      }
       else
       {
-         Uint64 now;
+         bool signalled;
+
          if (sdl->nonblock)
             break;
-         /* Poll until the device puts more samples into the stream.
-          * Bounded: if the device stops making progress, give up
-          * after the stall timeout instead of blocking forever. */
-         now = SDL_GetTicksNS();
-         if (deadline == 0)
-            deadline = now + SDL3_AUDIO_STALL_TIMEOUT_NS;
-         else if (now >= deadline)
+
+         /* Sleep until the put callback signals that the device
+          * captured more samples. The callback signals while SDL
+          * holds the stream lock, so the stream must not be
+          * re-checked under mic->lock; the cost is that a signal
+          * raised between the read above and this wait is missed,
+          * and the next device period (or the stall timeout)
+          * covers it. */
+         SDL_LockMutex(mic->lock);
+         signalled = mic->device_removed
+               || SDL_WaitConditionTimeout(mic->cond, mic->lock,
+                     SDL3_AUDIO_STALL_TIMEOUT_MS);
+         SDL_UnlockMutex(mic->lock);
+
+         /* The device stopped capturing entirely; report the short
+          * read instead of blocking forever. */
+         if (!signalled)
             break;
-         SDL_DelayNS(SDL3_AUDIO_POLL_INTERVAL_NS);
       }
    }
 

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -675,7 +675,7 @@ audio_driver_t audio_sdl3 = {
 
 /**
  * Stream callback for the microphone to drop stale audio to allow
- * space within the buffer, on top of the usual read wakeup.
+ * space within the buffer.
  */
 static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -240,8 +240,8 @@ static SDL_AudioStream *sdl3_audio_open_stream(const char *device,
 
 /**
  * Stream callback fired from the device thread each time the device
- * pulls data: the moment queue space is about to open up. Wakes a
- * blocked write.
+ * moves data: the moment queue space opens up for playback, or more
+ * samples arrive from a microphone. Wakes a blocked write or read.
  */
 static void SDLCALL sdl3_audio_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)
@@ -253,27 +253,92 @@ static void SDLCALL sdl3_audio_stream_cb(void *userdata,
    SDL_UnlockMutex(sdl->lock);
 }
 
+/**
+ * Blocks a full write / empty read until a stream callback signals
+ * that the device moved data.
+ *
+ * The callbacks signal while SDL holds the stream lock, so the caller
+ * must not query the stream under ctx->lock; the cost is that a
+ * signal raised between the caller's check and this wait is missed,
+ * and the next device period (or the stall timeout) covers it.
+ *
+ * @return False once the device stops moving data entirely, so the
+ * caller reports a short count instead of blocking forever.
+ */
+static bool sdl3_audio_wait_for_device(sdl3_audio_t *ctx)
+{
+   bool signalled;
+
+   SDL_LockMutex(ctx->lock);
+   signalled = ctx->device_removed
+         || SDL_WaitConditionTimeout(ctx->cond, ctx->lock,
+               SDL3_AUDIO_STALL_TIMEOUT_MS);
+   SDL_UnlockMutex(ctx->lock);
+
+   return signalled;
+}
+
+/**
+ * Releases a context's removal watch, stream, and wake signalling.
+ */
+static void sdl3_audio_destroy_context(sdl3_audio_t *ctx)
+{
+   /* Stop the watch from touching the lock before tearing it down. */
+   SDL_RemoveEventWatch(sdl3_audio_device_removed_watch, ctx);
+
+   /* Destroying the stream also closes the device and detaches
+    * the stream callback. */
+   if (ctx->stream)
+      SDL_DestroyAudioStream(ctx->stream);
+   if (ctx->cond)
+      SDL_DestroyCondition(ctx->cond);
+   if (ctx->lock)
+      SDL_DestroyMutex(ctx->lock);
+}
+
 static void sdl3_audio_free(void *data)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
    if (sdl)
    {
-      /* Stop the watch from touching the lock before tearing it down. */
-      SDL_RemoveEventWatch(sdl3_audio_device_removed_watch, sdl);
-
-      /* Destroying the stream also closes the device and detaches
-       * the stream callback. */
-      if (sdl->stream)
-         SDL_DestroyAudioStream(sdl->stream);
-      if (sdl->cond)
-         SDL_DestroyCondition(sdl->cond);
-      if (sdl->lock)
-         SDL_DestroyMutex(sdl->lock);
-
+      sdl3_audio_destroy_context(sdl);
       SDL_QuitSubSystem(SDL_INIT_AUDIO);
    }
    free(sdl);
+}
+
+/**
+ * Preps a freshly opened output stream: tracks its device for the
+ * removal watch, installs the wake callback, resets the write_raw
+ * state to a fresh stream's defaults, prefills the latency cushion
+ * with silence, and starts the device (streams open paused).
+ */
+static void sdl3_audio_prime_stream(sdl3_audio_t *sdl)
+{
+   void *tmp;
+
+   sdl->devid = SDL_GetAudioStreamDevice(sdl->stream);
+   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
+
+   /* A fresh stream starts with default ratio/gain, and write_raw
+    * reconfigures its input side on the next call. */
+   sdl->raw_rate = 0;
+   sdl->in_cap = sdl->buffer_size;
+   sdl->ratio = 1.0f;
+   sdl->gain = 1.0f;
+
+   SDL_LockMutex(sdl->lock);
+   sdl->device_removed = false;
+   SDL_UnlockMutex(sdl->lock);
+
+   if ((tmp = calloc(1, sdl->buffer_size)))
+   {
+      SDL_PutAudioStreamData(sdl->stream, tmp, (int)sdl->buffer_size);
+      free(tmp);
+   }
+
+   SDL_ResumeAudioStreamDevice(sdl->stream);
 }
 
 static void *sdl3_audio_init(const char *device,
@@ -281,7 +346,6 @@ static void *sdl3_audio_init(const char *device,
       unsigned block_frames, unsigned *new_rate)
 {
    size_t frame_size, min_size;
-   void *tmp = NULL;
    int device_sample_frames = 0;
    sdl3_audio_t *sdl = NULL;
 
@@ -306,10 +370,7 @@ static void *sdl3_audio_init(const char *device,
          2, &sdl->spec, &device_sample_frames)))
       goto error;
 
-   sdl->devid = SDL_GetAudioStreamDevice(sdl->stream);
    sdl->latency = latency;
-   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
-   SDL_AddEventWatch(sdl3_audio_device_removed_watch, sdl);
 
    /* Buffer the requested latency's worth of audio. */
    frame_size = SDL_AUDIO_FRAMESIZE(sdl->spec);
@@ -317,9 +378,6 @@ static void *sdl3_audio_init(const char *device,
    min_size = (size_t)(2 * device_sample_frames) * frame_size;
    if (sdl->buffer_size < min_size)
       sdl->buffer_size = min_size;
-   sdl->in_cap = sdl->buffer_size;
-   sdl->ratio = 1.0f;
-   sdl->gain = 1.0f;
 
    *new_rate = sdl->spec.freq;
 
@@ -328,15 +386,8 @@ static void *sdl3_audio_init(const char *device,
          (int)((sdl->buffer_size / frame_size + device_sample_frames)
             * 1000 / sdl->spec.freq));
 
-   /* Prefill the stream with silence. */
-   if ((tmp = calloc(1, sdl->buffer_size)))
-   {
-      SDL_PutAudioStreamData(sdl->stream, tmp, (int)sdl->buffer_size);
-      free(tmp);
-   }
-
-   /* Device streams open in a paused state. */
-   SDL_ResumeAudioStreamDevice(sdl->stream);
+   sdl3_audio_prime_stream(sdl);
+   SDL_AddEventWatch(sdl3_audio_device_removed_watch, sdl);
 
    return sdl;
 
@@ -382,7 +433,6 @@ static size_t sdl3_audio_write_avail(void *data)
  */
 static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
 {
-   void *tmp = NULL;
    SDL_AudioSpec spec = {0};
    int device_sample_frames = 0;
    SDL_AudioStream *stream = NULL;
@@ -413,35 +463,31 @@ static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
 
    SDL_DestroyAudioStream(sdl->stream);
    sdl->stream = stream;
-   sdl->devid = SDL_GetAudioStreamDevice(stream);
-   /* A fresh stream starts with default ratio/gain, and write_raw
-    * reconfigures its input side on the next call. */
-   sdl->raw_rate = 0;
-   sdl->in_cap = sdl->buffer_size;
-   sdl->ratio = 1.0f;
-   sdl->gain = 1.0f;
+   sdl3_audio_prime_stream(sdl);
+   return true;
+}
 
-   SDL_LockMutex(sdl->lock);
-   sdl->device_removed = false;
-   SDL_UnlockMutex(sdl->lock);
-
-   SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
-
-   /* Prefill the new stream with silence to rebuild the latency cushion. */
-   if ((tmp = calloc(1, sdl->buffer_size)))
-   {
-      SDL_PutAudioStreamData(sdl->stream, tmp, (int)sdl->buffer_size);
-      free(tmp);
-   }
-
-   SDL_ResumeAudioStreamDevice(sdl->stream);
+/**
+ * Recovers the output stream when its device was removed.
+ *
+ * @return False when writing is impossible: the device is gone and
+ * could not be replaced.
+ */
+static bool sdl3_audio_stream_ok(sdl3_audio_t *sdl)
+{
+   if (sdl->defunct)
+      return false;
+   /* Recover before the caller configures the stream, so any raw
+    * format lands on the replacement stream. */
+   if (sdl->device_removed)
+      return sdl3_audio_reopen_default(sdl);
    return true;
 }
 
 /**
  * Queues frame-aligned data up to the given cap.
  *
- * This will drops excess if nonblocking, or blocks until drained/timed out.
+ * This drops excess if nonblocking, or blocks until drained/timed out.
  *
  * @return The number of bytes queued, or -1 when the first write failed.
  */
@@ -469,29 +515,15 @@ static ssize_t sdl3_audio_queue(sdl3_audio_t *sdl, const void *s,
 
       if (avail == 0)
       {
-         bool signalled;
-
          /* When the queue is full, and we can't wait on the
           * process for the queue to clear a bit, we're unable
           * to do anything, so skip the rest. */
          if (sdl->nonblock)
             break;
 
-         /* Sleep until the get callback signals that the device pulled
-          * data. The callback signals while SDL holds the stream lock,
-          * so the queue must not be re-checked under sdl->lock; the
-          * cost is that a signal raised between the check above and
-          * this wait is missed, and the next device period (or the
-          * stall timeout) covers it. */
-         SDL_LockMutex(sdl->lock);
-         signalled = sdl->device_removed
-               || SDL_WaitConditionTimeout(sdl->cond, sdl->lock,
-                     SDL3_AUDIO_STALL_TIMEOUT_MS);
-         SDL_UnlockMutex(sdl->lock);
-
-         /* The device stopped pulling data entirely; report the
-          * short write instead of blocking forever. */
-         if (!signalled)
+         /* Sleep until the get callback signals: the device pulling
+          * data is the moment queue space opens up. */
+         if (!sdl3_audio_wait_for_device(sdl))
             break;
       }
       else
@@ -517,10 +549,7 @@ static ssize_t sdl3_audio_write(void *data, const void *s, size_t len)
 {
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
-   if (!sdl || sdl->defunct)
-      return -1;
-
-   if (sdl->device_removed && !sdl3_audio_reopen_default(sdl))
+   if (!sdl || !sdl3_audio_stream_ok(sdl))
       return -1;
 
    /* Reset stream format and SDL rate/gain to defaults when exiting
@@ -553,12 +582,7 @@ static ssize_t sdl3_audio_write_raw(void *data, const int16_t *samples,
    const size_t frame_size = 2 * sizeof(int16_t);
    sdl3_audio_t *sdl = (sdl3_audio_t*)data;
 
-   if (!sdl || !samples || input_rate == 0 || sdl->defunct)
-      return -1;
-
-   /* Recover before configuring the stream, so the raw format lands
-    * on the replacement stream. */
-   if (sdl->device_removed && !sdl3_audio_reopen_default(sdl))
+   if (!sdl || !samples || input_rate == 0 || !sdl3_audio_stream_ok(sdl))
       return -1;
 
    /* Set stream input to core-rate int16 stereo and reconfigure
@@ -687,8 +711,7 @@ audio_driver_t audio_sdl3 = {
 
 /**
  * Stream callback for the microphone to drop stale audio to allow
- * space within the buffer, and to wake a read blocked on an empty
- * stream now that the device has captured more samples.
+ * space within the buffer, on top of the usual read wakeup.
  */
 static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
       SDL_AudioStream *stream, int additional_amount, int total_amount)
@@ -698,9 +721,7 @@ static void SDLCALL sdl3_microphone_stream_cb(void *userdata,
    if (SDL_GetAudioStreamAvailable(stream) > (int)mic->buffer_size)
       SDL_ClearAudioStream(stream);
 
-   SDL_LockMutex(mic->lock);
-   SDL_SignalCondition(mic->cond);
-   SDL_UnlockMutex(mic->lock);
+   sdl3_audio_stream_cb(userdata, stream, additional_amount, total_amount);
 }
 
 static void *sdl3_microphone_init(void)
@@ -740,18 +761,7 @@ static void sdl3_microphone_close_mic(void *driver_context, void *mic_context)
    if (!mic)
       return;
 
-   /* Stop the watch from touching the lock before tearing it down. */
-   SDL_RemoveEventWatch(sdl3_audio_device_removed_watch, mic);
-
-   /* Destroying the stream also closes the device and detaches
-    * the stream callback. */
-   if (mic->stream)
-      SDL_DestroyAudioStream(mic->stream);
-   if (mic->cond)
-      SDL_DestroyCondition(mic->cond);
-   if (mic->lock)
-      SDL_DestroyMutex(mic->lock);
-
+   sdl3_audio_destroy_context(mic);
    RARCH_LOG("[SDL3 audio] Freed microphone.\n");
    free(mic);
 }
@@ -901,27 +911,12 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
          size += (size_t)got;
       else
       {
-         bool signalled;
-
          if (sdl->nonblock)
             break;
 
          /* Sleep until the put callback signals that the device
-          * captured more samples. The callback signals while SDL
-          * holds the stream lock, so the stream must not be
-          * re-checked under mic->lock; the cost is that a signal
-          * raised between the read above and this wait is missed,
-          * and the next device period (or the stall timeout)
-          * covers it. */
-         SDL_LockMutex(mic->lock);
-         signalled = mic->device_removed
-               || SDL_WaitConditionTimeout(mic->cond, mic->lock,
-                     SDL3_AUDIO_STALL_TIMEOUT_MS);
-         SDL_UnlockMutex(mic->lock);
-
-         /* The device stopped capturing entirely; report the short
-          * read instead of blocking forever. */
-         if (!signalled)
+          * captured more samples. */
+         if (!sdl3_audio_wait_for_device(mic))
             break;
       }
    }

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -46,7 +46,7 @@ typedef struct sdl3_audio
    SDL_Mutex *lock; /**< Guards condition, the stream callbacks are called through it. */
    SDL_Condition *cond; /**< Signalled each time the device moves data. */
    SDL_AudioSpec spec; /**< The format for the given audio sample. */
-   SDL_AudioDeviceID devid; /**< The device the stream is bound to. */
+   SDL_AtomicU32 devid; /**< The device the stream is bound to. */
    size_t buffer_size; /**< Cap in bytes on queued audio: writes block past it, capture backlog is dropped past it. */
    size_t in_cap; /**< buffer_size converted into input-format bytes; equal to buffer_size outside the write_raw fast path. */
    int raw_rate; /**< Core rate the write_raw fast path set as the stream's input side (int16 stereo); 0 while the input side matches the device spec. */
@@ -54,7 +54,7 @@ typedef struct sdl3_audio
    float ratio; /**< Frequency ratio currently set on the stream, to skip redundant sets. */
    float gain; /**< Gain currently set on the stream, to skip redundant sets. */
    bool nonblock; /**< When true, drop samples instead of waiting for the device to clear. */
-   bool device_removed; /**< Becomes true when the stream's device is unplugged. */
+   SDL_AtomicInt device_removed; /**< Becomes true when the stream's device is unplugged. Set under lock so a blocked wait wakes. */
    bool defunct; /**< True when the device has completely failed. Saves from retrying each frame. */
 } sdl3_audio_t;
 
@@ -66,12 +66,12 @@ static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *e
    sdl3_audio_t *sdl = (sdl3_audio_t*)userdata;
 
    if (   event->type == SDL_EVENT_AUDIO_DEVICE_REMOVED
-       && event->adevice.which == sdl->devid)
+       && event->adevice.which == SDL_GetAtomicU32(&sdl->devid))
    {
       RARCH_WARN("[SDL3 audio] Audio %s device was removed.\n",
             event->adevice.recording ? "input" : "output");
       SDL_LockMutex(sdl->lock);
-      sdl->device_removed = true;
+      SDL_SetAtomicInt(&sdl->device_removed, 1);
       SDL_SignalCondition(sdl->cond);
       SDL_UnlockMutex(sdl->lock);
    }
@@ -252,7 +252,7 @@ static bool sdl3_audio_wait_for_device(sdl3_audio_t *ctx)
    bool signalled;
 
    SDL_LockMutex(ctx->lock);
-   signalled = ctx->device_removed
+   signalled = SDL_GetAtomicInt(&ctx->device_removed)
          || SDL_WaitConditionTimeout(ctx->cond, ctx->lock,
                SDL3_AUDIO_STALL_TIMEOUT_MS);
    SDL_UnlockMutex(ctx->lock);
@@ -299,7 +299,7 @@ static void sdl3_audio_prime_stream(sdl3_audio_t *sdl)
 {
    void *tmp;
 
-   sdl->devid = SDL_GetAudioStreamDevice(sdl->stream);
+   SDL_SetAtomicU32(&sdl->devid, SDL_GetAudioStreamDevice(sdl->stream));
    SDL_SetAudioStreamGetCallback(sdl->stream, sdl3_audio_stream_cb, sdl);
 
    sdl->raw_rate = 0;
@@ -308,7 +308,7 @@ static void sdl3_audio_prime_stream(sdl3_audio_t *sdl)
    sdl->gain = 1.0f;
 
    SDL_LockMutex(sdl->lock);
-   sdl->device_removed = false;
+   SDL_SetAtomicInt(&sdl->device_removed, 0);
    SDL_UnlockMutex(sdl->lock);
 
    if ((tmp = calloc(1, sdl->buffer_size)))
@@ -443,7 +443,7 @@ static bool sdl3_audio_stream_ok(sdl3_audio_t *sdl)
 {
    if (sdl->defunct)
       return false;
-   if (sdl->device_removed)
+   if (SDL_GetAtomicInt(&sdl->device_removed))
       return sdl3_audio_reopen_default(sdl);
    return true;
 }
@@ -467,7 +467,7 @@ static ssize_t sdl3_audio_queue(sdl3_audio_t *sdl, const void *s,
 
       /* The device is gone; drop the rest and let the next write
        * reopen on the default device. */
-      if (sdl->device_removed)
+      if (SDL_GetAtomicInt(&sdl->device_removed))
          break;
 
       queued = SDL_GetAudioStreamQueued(sdl->stream);
@@ -771,7 +771,7 @@ static void *sdl3_microphone_open_mic(void *driver_context, const char *device,
          1, &mic->spec, &device_sample_frames)))
       goto error;
 
-   mic->devid = SDL_GetAudioStreamDevice(mic->stream);
+   SDL_SetAtomicU32(&mic->devid, SDL_GetAudioStreamDevice(mic->stream));
    SDL_AddEventWatch(sdl3_audio_device_removed_watch, mic);
 
    /* Buffer up to double the latency budget. */
@@ -850,7 +850,7 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
       return -1;
 
    /* Avoid using a recording device that doesn't exist. */
-   if (mic->device_removed)
+   if (SDL_GetAtomicInt(&mic->device_removed))
       return -1;
 
    while (size < len)
@@ -858,7 +858,7 @@ static int sdl3_microphone_read(void *driver_context, void *mic_context,
       int got;
 
       /* Safety check. */
-      if (mic->device_removed)
+      if (SDL_GetAtomicInt(&mic->device_removed))
          break;
 
       got = SDL_GetAudioStreamData(mic->stream, (char*)s + size, (int)(len - size));


### PR DESCRIPTION
This switches the SDL3 Audio System to use event callbacks rather than constant polling. There are a few benefits out of this over what was there before...

1. **Wait**: Before when the buffer was full, it waited in a loop, sleeping 1 millisecond each iteration. Now instead of a 1ms loop, it registers a wait condition, meaning it'll fill the buffer precisely when it's available. Also makes sure it's on the right thread.
2. **Device Removal**: Before if a device was lost, like a USB mic was removed, it would keep writing the audio device. Now there's a device removed event that will attempt to re-open the device, or eventually give up if it can't re-find it.

### Test

1. Switch your audio device to `sdl3`, for both audio and mic
2. Load a core that plays some sounds, like [audio_microphone](https://github.com/libretro/libretro-samples/pull/34)
3. Expect to be able to record and hear sounds