### PR TITLE
android: remove input poll log when in debug mode

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1514,10 +1514,6 @@ static INLINE void android_input_poll_event_type_key(
       return;
    buf           = android_key_state[port];
 
-   RARCH_DBG("android_input_poll_event_type_key: keycode:%d port:%d source:0x%x action:%d device_id:%d is_kbd_id:%d\n",
-      keycode, port, source, action, device_id,
-      android_is_keyboard_id(device_id));
-
    /* Handle 'duplicate' inputs that correspond
     * to the same RETROK_* key */
    switch (keycode)


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Remove debug logging that was added for Android TV back button.

## Related Issues

## Related Pull Requests

## Reviewers