### PR TITLE
SDL3: Allow restoring audio devices

### DIFF
--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -64,8 +64,8 @@ typedef struct sdl3_audio
 /**
  * Event callback for SDL_EVENT_AUDIO_DEVICE_REMOVED and _ADDED.
  *
- * Removal matches on the stream's logical device id, so it only fires
- * for streams bound to an explicitly selected device: SDL never sends
+ * Matches on the stream's logical device id, so it only fires for
+ * streams bound to an explicitly selected device: SDL never sends
  * REMOVED for a logical device opened as the system default - it
  * parks that on a zombie device and migrates it to new hardware
  * itself.  The reopen path therefore cannot fight SDL's migration.

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -69,9 +69,6 @@ typedef struct sdl3_audio
  * REMOVED for a logical device opened as the system default - it
  * parks that on a zombie device and migrates it to new hardware
  * itself.  The reopen path therefore cannot fight SDL's migration.
- *
- * A playback device being added lifts defunct, so a reopen that
- * failed with no devices present is retried on the next write.
  */
 static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *event)
 {

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -58,17 +58,20 @@ typedef struct sdl3_audio
    SDL_AtomicInt device_removed; /**< Becomes true when the stream's device is unplugged. Set under lock so a blocked wait wakes. */
    bool nonblock; /**< When true, drop samples instead of waiting for the device to clear. */
    bool data_moved; /**< Wake token set by the stream callback, consumed by waiters. Guarded by lock; makes the queue-full test race-free. */
-   bool defunct; /**< True when the device has completely failed. Saves from retrying each frame. */
+   SDL_AtomicInt defunct; /**< True when the device has completely failed. Saves from retrying each frame; cleared by the watch when a device is added. */
 } sdl3_audio_t;
 
 /**
- * Event callback for SDL_EVENT_AUDIO_DEVICE_REMOVED.
+ * Event callback for SDL_EVENT_AUDIO_DEVICE_REMOVED and _ADDED.
  *
- * Matches on the stream's logical device id, so it only fires for
- * streams bound to an explicitly selected device: SDL never sends
+ * Removal matches on the stream's logical device id, so it only fires
+ * for streams bound to an explicitly selected device: SDL never sends
  * REMOVED for a logical device opened as the system default - it
  * parks that on a zombie device and migrates it to new hardware
  * itself.  The reopen path therefore cannot fight SDL's migration.
+ *
+ * A playback device being added lifts defunct, so a reopen that
+ * failed with no devices present is retried on the next write.
  */
 static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *event)
 {
@@ -83,6 +86,13 @@ static bool SDLCALL sdl3_audio_device_removed_watch(void *userdata, SDL_Event *e
       SDL_SetAtomicInt(&sdl->device_removed, 1);
       SDL_SignalCondition(sdl->cond);
       SDL_UnlockMutex(sdl->lock);
+   }
+   else if (event->type == SDL_EVENT_AUDIO_DEVICE_ADDED
+       && !event->adevice.recording
+       && SDL_GetAtomicInt(&sdl->defunct))
+   {
+      RARCH_LOG("[SDL3 audio] A playback device appeared, retrying audio output.\n");
+      SDL_SetAtomicInt(&sdl->defunct, 0);
    }
    return true;
 }
@@ -439,8 +449,8 @@ static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
 
    if (!stream)
    {
-      RARCH_ERR("[SDL3 audio] Failed to reopen on the default device, giving up on audio output.\n");
-      sdl->defunct = true;
+      RARCH_ERR("[SDL3 audio] Failed to reopen on the default device, waiting for one to be added.\n");
+      SDL_SetAtomicInt(&sdl->defunct, 1);
       return false;
    }
 
@@ -467,7 +477,7 @@ static bool sdl3_audio_reopen_default(sdl3_audio_t *sdl)
  */
 static bool sdl3_audio_stream_ok(sdl3_audio_t *sdl)
 {
-   if (sdl->defunct)
+   if (SDL_GetAtomicInt(&sdl->defunct))
       return false;
    if (SDL_GetAtomicInt(&sdl->device_removed))
       return sdl3_audio_reopen_default(sdl);

--- a/audio/drivers/sdl3_audio.c
+++ b/audio/drivers/sdl3_audio.c
@@ -58,7 +58,7 @@ typedef struct sdl3_audio
    SDL_AtomicInt device_removed; /**< Becomes true when the stream's device is unplugged. Set under lock so a blocked wait wakes. */
    bool nonblock; /**< When true, drop samples instead of waiting for the device to clear. */
    bool data_moved; /**< Wake token set by the stream callback, consumed by waiters. Guarded by lock; makes the queue-full test race-free. */
-   SDL_AtomicInt defunct; /**< True when the device has completely failed. Saves from retrying each frame; cleared by the watch when a device is added. */
+   SDL_AtomicInt defunct; /**< True when the device has completely failed. Saves from retrying each frame. */
 } sdl3_audio_t;
 
 /**


### PR DESCRIPTION
When a playback device is lost, it's flagged as `defunct` so it doesn't try to write to the device again. This change acts on the `SDL_EVENT_AUDIO_DEVICE_ADDED` event to try to restore the audio device.

Makes it so that when an audio device is lost, it can be restored gracefully.