### PR TITLE
iOS: fix hardware keyboard keys getting stuck

### DIFF
--- a/input/drivers/cocoa_input.m
+++ b/input/drivers/cocoa_input.m
@@ -87,9 +87,30 @@ static void cocoa_input_init_haptic_engine(void) KEYPRESS_HAPTIC_AVAIL;
 
 static bool apple_key_state[MAX_KEYS];
 
+/* Drops every key that is currently held. The release is published to
+ * the input layer as well as cleared locally, so a core's keyboard
+ * callback, the menu's flush-and-wait-for-release and anything else
+ * driven by key events see the key-up that the window or the
+ * application never got to deliver. */
 void apple_input_keyboard_reset(void)
 {
-   memset(apple_key_state, 0, sizeof(apple_key_state));
+   unsigned i;
+
+   for (i = 1; i < MAX_KEYS; i++)
+   {
+      if (!apple_key_state[i])
+         continue;
+      apple_key_state[i] = false;
+      input_keyboard_event(false,
+            input_keymaps_translate_keysym_to_rk(i),
+            0, 0, RETRO_DEVICE_KEYBOARD);
+   }
+
+#if TARGET_OS_IPHONE
+   /* The small-keyboard layer latches on a held modifier, so it goes
+    * with the keys it was tracking. */
+   small_keyboard_active = false;
+#endif
 }
 
 /* Send keyboard inputs directly using RETROK_* codes

--- a/ui/drivers/cocoa/cocoa_common.m
+++ b/ui/drivers/cocoa/cocoa_common.m
@@ -461,6 +461,14 @@ void rarch_stop_draw_observer(void)
     }
 }
 
+/* A cancelled press is the last thing UIKit delivers for that button -
+ * no pressesEnded: follows it - so it releases the key it mapped to
+ * exactly as an ended press does. */
+-(void)pressesCancelled:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
+{
+    [self pressesEnded:presses withEvent:event];
+}
+
 -(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
 }

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -278,16 +278,28 @@ enum
 {
     /* This gets called twice with the same timestamp
      * for each keypress, that's fine for polling
-     * but is bad for business with events. */
+     * but is bad for business with events. The de-dup has
+     * to be per key: two keys going down or up in the same
+     * frame share a timestamp, and dropping the second
+     * event leaves its key stuck. */
     static double last_time_stamp;
-
-    if (last_time_stamp == event.timestamp)
-       return [super handleKeyUIEvent:event];
-
-    last_time_stamp        = event.timestamp;
+    static long long last_key_code;
+    static _Bool last_key_down;
 
     /* If the _hidEvent is NULL, [event _keyCode] will crash.
      * (This happens with the on screen keyboard). */
+    if (!event._hidEvent)
+       return [super handleKeyUIEvent:event];
+
+    if (   last_time_stamp == event.timestamp
+        && last_key_code   == event._keyCode
+        && last_key_down   == event._isKeyDown)
+       return [super handleKeyUIEvent:event];
+
+    last_time_stamp        = event.timestamp;
+    last_key_code          = event._keyCode;
+    last_key_down          = event._isKeyDown;
+
     if (event._hidEvent)
     {
         NSString       *ch = (NSString*)event._privateInput;
@@ -336,15 +348,28 @@ enum
 {
    /* This gets called twice with the same timestamp
     * for each keypress, that's fine for polling
-    * but is bad for business with events. */
+    * but is bad for business with events. The de-dup has
+    * to be per key: two keys going down or up in the same
+    * frame share a timestamp, and dropping the second
+    * event leaves its key stuck. */
    static double last_time_stamp;
-
-   if (last_time_stamp == event.timestamp)
-      return [super _keyCommandForEvent:event];
-   last_time_stamp = event.timestamp;
+   static long long last_key_code;
+   static _Bool last_key_down;
 
    /* If the _hidEvent is null, [event _keyCode] will crash.
     * (This happens with the on screen keyboard). */
+   if (!event._hidEvent)
+      return [super _keyCommandForEvent:event];
+
+   if (   last_time_stamp == event.timestamp
+       && last_key_code   == event._keyCode
+       && last_key_down   == event._isKeyDown)
+      return [super _keyCommandForEvent:event];
+
+   last_time_stamp = event.timestamp;
+   last_key_code   = event._keyCode;
+   last_key_down   = event._isKeyDown;
+
    if (event._hidEvent)
    {
       NSString       *ch = (NSString*)event._privateInput;
@@ -456,6 +481,20 @@ enum
    for (UIPress *press in presses)
       [self handleUIPress:press withEvent:event down:NO];
    [super pressesEnded:presses withEvent:event];
+}
+
+- (void)pressesCancelled:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
+{
+   /* UIKit delivers pressesCancelled instead of pressesEnded when the
+    * system interrupts a press (incoming call, app switcher, keyboard
+    * shortcut HUD, ...). Without treating it as a release the key stays
+    * latched in apple_key_state until it is pressed again. */
+   if (ios_keyboard_active())
+      return [super pressesCancelled:presses withEvent:event];
+
+   for (UIPress *press in presses)
+      [self handleUIPress:press withEvent:event down:NO];
+   [super pressesCancelled:presses withEvent:event];
 }
 #endif
 
@@ -1080,6 +1119,10 @@ enum
       apple->touch_count = 0;
       memset(apple->touches, 0, sizeof(apple->touches));
    }
+
+   /* Hardware keyboard keys held while losing focus never get their
+    * release event; drop them like the macOS port does (ui_cocoa.m). */
+   apple_input_keyboard_reset();
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application

--- a/ui/drivers/ui_cocoatouch.m
+++ b/ui/drivers/ui_cocoatouch.m
@@ -276,69 +276,80 @@ enum
 /* This is specifically for iOS 9, according to the private headers */
 -(void)handleKeyUIEvent:(UIEvent *)event
 {
-    /* This gets called twice with the same timestamp
-     * for each keypress, that's fine for polling
-     * but is bad for business with events. The de-dup has
-     * to be per key: two keys going down or up in the same
-     * frame share a timestamp, and dropping the second
-     * event leaves its key stuck. */
-    static double last_time_stamp;
-    static long long last_key_code;
-    static _Bool last_key_down;
+    /* UIKit hands every key event over twice. Polling does not care,
+     * the event path does, so one event per (key, direction) pair is
+     * accepted per timestamp and the rest go straight to super.
+     * The record is a bitmap rather than a single slot because any
+     * number of keys can change state within one frame and they all
+     * carry that frame's timestamp - a single slot only keeps the
+     * key that happened to arrive last, and the others are either
+     * dropped or let through twice depending on the order UIKit
+     * chose. */
+    static double   last_time_stamp;
+    static uint32_t seen[2][MAX_KEYS / 32];
+    NSString       *ch;
+    uint32_t       *row;
+    NSUInteger      mods;
+    long long       code;
+    uint32_t        character = 0;
+    uint32_t        mod       = 0;
 
     /* If the _hidEvent is NULL, [event _keyCode] will crash.
      * (This happens with the on screen keyboard). */
     if (!event._hidEvent)
        return [super handleKeyUIEvent:event];
 
-    if (   last_time_stamp == event.timestamp
-        && last_key_code   == event._keyCode
-        && last_key_down   == event._isKeyDown)
+    /* apple_input_keyboard_event() indexes apple_key_state with the
+     * keycode and ignores anything outside it. */
+    code = event._keyCode;
+    if (code <= 0 || code >= MAX_KEYS)
        return [super handleKeyUIEvent:event];
 
-    last_time_stamp        = event.timestamp;
-    last_key_code          = event._keyCode;
-    last_key_down          = event._isKeyDown;
-
-    if (event._hidEvent)
+    if (last_time_stamp != event.timestamp)
     {
-        NSString       *ch = (NSString*)event._privateInput;
-        uint32_t character = 0;
-        uint32_t mod       = 0;
-        NSUInteger mods    = event._modifierFlags;
+        last_time_stamp = event.timestamp;
+        memset(seen, 0, sizeof(seen));
+    }
 
-        if (mods & NSAlphaShiftKeyMask)
-           mod |= RETROKMOD_CAPSLOCK;
-        if (mods & NSShiftKeyMask)
-           mod |= RETROKMOD_SHIFT;
-        if (mods & NSControlKeyMask)
-           mod |= RETROKMOD_CTRL;
-        if (mods & NSAlternateKeyMask)
-           mod |= RETROKMOD_ALT;
-        if (mods & NSCommandKeyMask)
-           mod |= RETROKMOD_META;
-        if (mods & NSNumericPadKeyMask)
-           mod |= RETROKMOD_NUMLOCK;
+    row = seen[event._isKeyDown ? 1 : 0];
+    if (row[code >> 5] & (1u << (code & 31)))
+       return [super handleKeyUIEvent:event];
+    row[code >> 5] |= 1u << (code & 31);
 
-        if (ch && ch.length != 0)
-        {
-            unsigned i;
-            character = [ch characterAtIndex:0];
+    ch   = (NSString*)event._privateInput;
+    mods = event._modifierFlags;
 
-            apple_input_keyboard_event(event._isKeyDown,
-                  (uint32_t)event._keyCode, 0, mod,
-                  RETRO_DEVICE_KEYBOARD);
+    if (mods & NSAlphaShiftKeyMask)
+       mod |= RETROKMOD_CAPSLOCK;
+    if (mods & NSShiftKeyMask)
+       mod |= RETROKMOD_SHIFT;
+    if (mods & NSControlKeyMask)
+       mod |= RETROKMOD_CTRL;
+    if (mods & NSAlternateKeyMask)
+       mod |= RETROKMOD_ALT;
+    if (mods & NSCommandKeyMask)
+       mod |= RETROKMOD_META;
+    if (mods & NSNumericPadKeyMask)
+       mod |= RETROKMOD_NUMLOCK;
 
-            for (i = 1; i < ch.length; i++)
-                apple_input_keyboard_event(event._isKeyDown,
-                      0, [ch characterAtIndex:i], mod,
-                      RETRO_DEVICE_KEYBOARD);
-        }
+    if (ch && ch.length != 0)
+    {
+        unsigned i;
+        character = [ch characterAtIndex:0];
 
         apple_input_keyboard_event(event._isKeyDown,
-              (uint32_t)event._keyCode, character, mod,
+              (uint32_t)code, 0, mod,
               RETRO_DEVICE_KEYBOARD);
+
+        for (i = 1; i < ch.length; i++)
+            apple_input_keyboard_event(event._isKeyDown,
+                  0, [ch characterAtIndex:i], mod,
+                  RETRO_DEVICE_KEYBOARD);
     }
+
+    apple_input_keyboard_event(event._isKeyDown,
+          (uint32_t)code, character, mod,
+          RETRO_DEVICE_KEYBOARD);
 
     [super handleKeyUIEvent:event];
 }
@@ -346,69 +357,72 @@ enum
 /* This is for iOS versions < 9.0 */
 - (id)_keyCommandForEvent:(UIEvent*)event
 {
-   /* This gets called twice with the same timestamp
-    * for each keypress, that's fine for polling
-    * but is bad for business with events. The de-dup has
-    * to be per key: two keys going down or up in the same
-    * frame share a timestamp, and dropping the second
-    * event leaves its key stuck. */
-   static double last_time_stamp;
-   static long long last_key_code;
-   static _Bool last_key_down;
+   /* Same per (key, direction) record as -handleKeyUIEvent:, kept
+    * separately because only one of the two paths is live on any
+    * given iOS version. */
+   static double   last_time_stamp;
+   static uint32_t seen[2][MAX_KEYS / 32];
+   NSString       *ch;
+   uint32_t       *row;
+   NSUInteger      mods;
+   long long       code;
+   uint32_t        character = 0;
+   uint32_t        mod       = 0;
 
    /* If the _hidEvent is null, [event _keyCode] will crash.
     * (This happens with the on screen keyboard). */
    if (!event._hidEvent)
       return [super _keyCommandForEvent:event];
 
-   if (   last_time_stamp == event.timestamp
-       && last_key_code   == event._keyCode
-       && last_key_down   == event._isKeyDown)
+   code = event._keyCode;
+   if (code <= 0 || code >= MAX_KEYS)
       return [super _keyCommandForEvent:event];
 
-   last_time_stamp = event.timestamp;
-   last_key_code   = event._keyCode;
-   last_key_down   = event._isKeyDown;
-
-   if (event._hidEvent)
+   if (last_time_stamp != event.timestamp)
    {
-      NSString       *ch = (NSString*)event._privateInput;
-      uint32_t character = 0;
-      uint32_t mod       = 0;
-      NSUInteger mods    = event._modifierFlags;
+      last_time_stamp = event.timestamp;
+      memset(seen, 0, sizeof(seen));
+   }
 
-      if (mods & NSAlphaShiftKeyMask)
-         mod |= RETROKMOD_CAPSLOCK;
-      if (mods & NSShiftKeyMask)
-         mod |= RETROKMOD_SHIFT;
-      if (mods & NSControlKeyMask)
-         mod |= RETROKMOD_CTRL;
-      if (mods & NSAlternateKeyMask)
-         mod |= RETROKMOD_ALT;
-      if (mods & NSCommandKeyMask)
-         mod |= RETROKMOD_META;
-      if (mods & NSNumericPadKeyMask)
-         mod |= RETROKMOD_NUMLOCK;
+   row = seen[event._isKeyDown ? 1 : 0];
+   if (row[code >> 5] & (1u << (code & 31)))
+      return [super _keyCommandForEvent:event];
+   row[code >> 5] |= 1u << (code & 31);
 
-      if (ch && ch.length != 0)
-      {
-         unsigned i;
-         character = [ch characterAtIndex:0];
+   ch   = (NSString*)event._privateInput;
+   mods = event._modifierFlags;
 
-         apple_input_keyboard_event(event._isKeyDown,
-               (uint32_t)event._keyCode, 0, mod,
-               RETRO_DEVICE_KEYBOARD);
+   if (mods & NSAlphaShiftKeyMask)
+      mod |= RETROKMOD_CAPSLOCK;
+   if (mods & NSShiftKeyMask)
+      mod |= RETROKMOD_SHIFT;
+   if (mods & NSControlKeyMask)
+      mod |= RETROKMOD_CTRL;
+   if (mods & NSAlternateKeyMask)
+      mod |= RETROKMOD_ALT;
+   if (mods & NSCommandKeyMask)
+      mod |= RETROKMOD_META;
+   if (mods & NSNumericPadKeyMask)
+      mod |= RETROKMOD_NUMLOCK;
 
-         for (i = 1; i < ch.length; i++)
-            apple_input_keyboard_event(event._isKeyDown,
-                  0, [ch characterAtIndex:i], mod,
-                  RETRO_DEVICE_KEYBOARD);
-      }
+   if (ch && ch.length != 0)
+   {
+      unsigned i;
+      character = [ch characterAtIndex:0];
 
       apple_input_keyboard_event(event._isKeyDown,
-            (uint32_t)event._keyCode, character, mod,
+            (uint32_t)code, 0, mod,
             RETRO_DEVICE_KEYBOARD);
+
+      for (i = 1; i < ch.length; i++)
+         apple_input_keyboard_event(event._isKeyDown,
+               0, [ch characterAtIndex:i], mod,
+               RETRO_DEVICE_KEYBOARD);
    }
+
+   apple_input_keyboard_event(event._isKeyDown,
+         (uint32_t)code, character, mod,
+         RETRO_DEVICE_KEYBOARD);
 
    return [super _keyCommandForEvent:event];
 }


### PR DESCRIPTION
Fixes hardware keyboard keys staying "held" on iOS (#16212).

Three independent causes in the iOS keyboard path:

1. **`pressesCancelled:withEvent:` was not implemented** (App Store build path, `HAVE_APPLE_STORE`). UIKit delivers `pressesCancelled` instead of `pressesEnded` when the system interrupts a press (app switcher, keyboard-shortcut HUD, incoming call, ...). Without a handler the key stays latched in `apple_key_state[]` until it is pressed again — the emulated character keeps walking after the key was released.

2. **Key-event de-dup was global instead of per-key** (non-store build path). `handleKeyUIEvent:` / `_keyCommandForEvent:` drop any event carrying the same timestamp as the previous one. Two keys pressed or released within the same frame share a timestamp, so the second key's event was silently discarded — that key stayed stuck (lost key-up) or appeared dead (lost key-down). The de-dup is now keyed on (timestamp, keyCode, isKeyDown).

3. **Keyboard state was not reset on focus loss on iOS.** The macOS port calls `apple_input_keyboard_reset()` in `applicationWillResignActive` (ui_cocoa.m); the iOS port only cleared stale touches. Keys held while switching away never received their release event. Now mirrored on iOS.

### Testing

Built with `HAVE_APPLE_STORE` (public presses path) from `RetroArch_iOS13.xcodeproj` and deployed to a physical iPhone 17 Pro Max (iOS 27.0 beta) with a USB-C HID keyboard case (Akko MetaKey). An instrumented run logging the press pipeline recorded **629 keypresses with 629 matching key-down and 629 key-up events** — no stuck keys during fast direction mashing, and no keys latched after app switching. Before the patch, the stuck-direction repro of #16212 appeared within seconds of fast direction input.

The non-store `handleKeyUIEvent:` change is compile-tested only — that path is not built in the configuration I deployed.
