### PR TITLE
android: avoid aliasing gamepad Back as X

### DIFF
--- a/input/drivers/android_input.c
+++ b/input/drivers/android_input.c
@@ -1590,6 +1590,9 @@ static INLINE void android_input_poll_event_type_key(
    int action    = AKeyEvent_getAction(event);
    int keysym    = keycode;
    int device_id = AInputEvent_getDeviceId(event);
+   bool alias_back_as_x =
+         (source & AINPUT_SOURCE_GAMEPAD) != AINPUT_SOURCE_GAMEPAD &&
+         (source & AINPUT_SOURCE_JOYSTICK) != AINPUT_SOURCE_JOYSTICK;
 
    /* android_key_state[] has one row per pad slot plus the
     * dedicated keyboard row at ANDROID_KEYBOARD_PORT. */
@@ -1615,12 +1618,12 @@ static INLINE void android_input_poll_event_type_key(
    {
       case AKEY_EVENT_ACTION_UP:
          BIT_CLEAR(buf, keysym);
-         if (keysym == AKEYCODE_BACK)
+         if (keysym == AKEYCODE_BACK && alias_back_as_x)
             BIT_CLEAR(buf, AKEYCODE_X); /* alias BACK on remote */
          break;
       case AKEY_EVENT_ACTION_DOWN:
          BIT_SET(buf, keysym);
-         if (keysym == AKEYCODE_BACK)
+         if (keysym == AKEYCODE_BACK && alias_back_as_x)
          {
             BIT_SET(buf, AKEYCODE_X);
             BIT_SET(android_key_state[ANDROID_KEYBOARD_PORT], AKEYCODE_X);


### PR DESCRIPTION
## Description

Keep the Android `AKEYCODE_BACK` to `AKEYCODE_X` compatibility alias for remote controls, but do not apply it to input events whose source identifies a gamepad or joystick.

PR #19333 added the alias for Google TV remotes. Since it was unconditional, a physical controller that exposes a distinct Back key reports both Back and X inside RetroArch. Commit `2131e2b9f2` additionally copies the synthetic X state to the keyboard port, making Back appear as X in input binding and potentially triggering an unrelated keyboard bind.

Android input source constants contain shared class bits, so this change compares the complete `AINPUT_SOURCE_GAMEPAD` and `AINPUT_SOURCE_JOYSTICK` masks instead of testing for any overlapping bit.

## Hardware observation

An Odin 3 built-in controller exposes `KEYBOARD | GAMEPAD | JOYSTICK`. Android reports its physical Back key and X button as distinct key codes, but current RetroArch aliases Back to X.

## Verification

- `git diff --check`
- Confirmed the remote alias remains active for sources that are not gamepads or joysticks
- Android APK was not built locally
