### PR TITLE
Fix unbalanced braces from commit 20a9c21 (HAVE_LAKKA_SWITCH)

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -73,7 +73,6 @@ void android_app_set_window_settings(bool notch_write_over,
 
 #ifdef HAVE_LAKKA_SWITCH
 #include "lakka-switch.h"
-   }
 #endif
 
 #if defined(HAVE_LIBNX)
@@ -7076,6 +7075,7 @@ static bool config_load_file(global_t *global,
       FILE* f = fopen(BLUETOOTH_ERTM_TOGGLE_PATH, "w");
       fprintf(f, "0\n");
       fclose(f);
+   }
    }
 #endif
 


### PR DESCRIPTION
## Problem

Commit 20a9c21 ("configuration: scope the Switch clock and toggle
blocks for C90") introduced two unbalanced braces inside
`#ifdef HAVE_LAKKA_SWITCH` blocks in `configuration.c`:

1. A stray `}` right after the `lakka-switch.h` include near the top
   of the file, with no matching `{` anywhere (confirmed
   `lakka-switch.h` itself only contains `#define` macros, no braces).
2. A missing closing `}` for the `{` opened before
   `FILE* f = fopen(SWITCH_OC_TOGGLE_PATH, "w")` inside
   `config_load_file()`, whose block was never closed before its
   `#endif`.

Together these leave `configuration.c` with an unbalanced brace count,
which breaks any `HAVE_LAKKA_SWITCH=1` build (Lakka on Nintendo
Switch, `PROJECT=L4T DEVICE=Switch`) with cascading
"invalid storage class" errors on every `static` function declared
after that point in the file.

## Change

Removes the stray top-of-file `}` and adds the missing closing `}`
before the `#endif` around the `switch_oc`/`switch_cec`/
`bluetooth_ertm` block. No functional change beyond restoring correct
brace balance; confirmed with a brace-count check (453 `{` / 453 `}`)
and a full rebuild.

## Testing

Built and confirmed passing with `HAVE_LAKKA_SWITCH=1` under
Lakka-LibreELEC (`PROJECT=L4T DEVICE=Switch`).

## Note

Investigation and patch drafting assisted by Claude (Anthropic).

Thanks
ASAI, Shigeaki