### PR TITLE
Defer auto state load for cores requiring initialization

### DIFF
--- a/command.c
+++ b/command.c
@@ -1818,6 +1818,8 @@ bool command_event_load_auto_state(void)
    runloop_state_t *runloop_st     = runloop_state_get_ptr();
    const char *name_savestate      = runloop_st->name.savestate;
    bool ret                        = false;
+   bool must_initialize            = (core_serialization_quirks()
+         & RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE) != 0;
 
    /* No early save-capability gate here: content_load_state() decides,
     * and an existing .auto state file outranks stale metadata. */
@@ -1838,6 +1840,28 @@ bool command_event_load_auto_state(void)
 
    if (!path_is_valid(savestate_name_auto))
       return false;
+
+   if (must_initialize
+         && runloop_st->auto_state_load_attempted
+         && !runloop_st->auto_state_load_ready)
+      return false;
+
+   if (must_initialize && !runloop_st->auto_state_load_ready)
+   {
+      if (!runloop_st->auto_state_load_pending)
+      {
+         runloop_st->auto_state_load_pending = true;
+         RARCH_LOG("[State] Auto-loading savestate \"%s\" deferred until after the first core run.\n",
+               savestate_name_auto);
+      }
+      return true;
+   }
+
+   if (must_initialize)
+   {
+      runloop_st->auto_state_load_pending  = false;
+      runloop_st->auto_state_load_attempted = true;
+   }
 
    ret = content_load_state(savestate_name_auto, false, true);
 

--- a/runloop.c
+++ b/runloop.c
@@ -3144,6 +3144,11 @@ bool runloop_environment_cb(unsigned cmd, void *data)
       }
 
       case RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS:
+#if RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS != 44
+      /* Older libretro-common headers assigned 44 to this environment
+       * before it was moved to make room for SET_HW_SHARED_CONTEXT. */
+      case 44:
+#endif
       {
          uint64_t *quirks = (uint64_t *) data;
 
@@ -4395,6 +4400,13 @@ static bool core_unload_game(void)
    return true;
 }
 
+static void runloop_reset_auto_state_load(runloop_state_t *runloop_st)
+{
+   runloop_st->auto_state_load_pending   = false;
+   runloop_st->auto_state_load_attempted = false;
+   runloop_st->auto_state_load_ready     = false;
+}
+
 static void runloop_apply_fastmotion_override(runloop_state_t *runloop_st,
       bool frame_time_counter_auto_reset,
       float fastforward_ratio_default,
@@ -4478,6 +4490,8 @@ void runloop_event_deinit_core(void)
       *video_st                = video_state_get_ptr();
    runloop_state_t *runloop_st = &runloop_state;
    settings_t        *settings = config_get_ptr();
+
+   runloop_reset_auto_state_load(runloop_st);
 
 #ifdef HAVE_THREADS
    /* Defensive: ensure the autosave worker thread is joined
@@ -4705,6 +4719,8 @@ static bool event_init_content(
    const enum rarch_core_type current_core_type = runloop_st->current_core_type;
    uint8_t flags                                = content_get_flags();
    bool entry_state_load                        = runloop_st->entry_state_slot > -1;
+
+   runloop_reset_auto_state_load(runloop_st);
 
    if (current_core_type == CORE_TYPE_PLAIN)
       runloop_st->flags |=  RUNLOOP_FLAG_USE_SRAM;
@@ -5301,7 +5317,10 @@ bool runloop_event_init_core(
          show_set_initial_disk_msg, initial_disk_change_enable);
 
    if (!runloop_event_load_core(runloop_st, poll_type_behavior))
+   {
+      runloop_reset_auto_state_load(runloop_st);
       return false;
+   }
 
    runloop_set_frame_limit(&video_st->av_info, fastforward_ratio);
    runloop_st->frame_limit_last_time    = cpu_features_get_time_usec();
@@ -5948,6 +5967,8 @@ void runloop_msg_queue_push(
    RUNLOOP_MSG_QUEUE_UNLOCK(runloop_st);
 }
 
+static void runloop_load_deferred_auto_state(void);
+
 #ifdef HAVE_MENU
 /* Display the libretro core's framebuffer onscreen. */
 static bool display_menu_libretro(
@@ -5970,6 +5991,7 @@ static bool display_menu_libretro(
          input_st->flags |= INP_FLAG_BLOCK_LIBRETRO_INPUT;
 
       core_run();
+      runloop_load_deferred_auto_state();
       runloop_st->core_runtime_usec       +=
          runloop_core_runtime_tick(runloop_st, slowmotion_ratio, current_time);
       input_st->flags                     &= ~INP_FLAG_BLOCK_LIBRETRO_INPUT;
@@ -8224,6 +8246,8 @@ int runloop_iterate(void)
          core_run();
    }
 
+   runloop_load_deferred_auto_state();
+
    /* Increment runtime tick counter after each call to
     * core_run() or run_ahead() */
    runloop_st->core_runtime_usec += runloop_core_runtime_tick(
@@ -8941,6 +8965,39 @@ void core_reset(void)
 
    video_driver_cached_frame_invalidate();
    runloop_st->current_core.retro_reset();
+}
+
+static void runloop_load_deferred_auto_state(void)
+{
+   runloop_state_t *runloop_st = &runloop_state;
+   settings_t *settings        = config_get_ptr();
+
+   if (!runloop_st->auto_state_load_pending)
+      return;
+
+   runloop_st->auto_state_load_pending = false;
+
+   if (!settings->bools.savestate_auto_load)
+   {
+      runloop_st->auto_state_load_attempted = true;
+      RARCH_LOG("[State] Deferred auto-load canceled because Auto Load State is disabled.\n");
+      return;
+   }
+
+   if (     runloop_st->content_closing
+         || !(runloop_st->current_core.flags & RETRO_CORE_FLAG_GAME_LOADED))
+   {
+      runloop_st->auto_state_load_attempted = true;
+      return;
+   }
+
+   /* The command handler defers this core's initial auto-load. Mark this
+    * dispatch as ready so the call below uses the existing state task path
+    * exactly once. */
+   runloop_st->auto_state_load_attempted = true;
+   runloop_st->auto_state_load_ready     = true;
+   command_event_load_auto_state();
+   runloop_st->auto_state_load_ready     = false;
 }
 
 void core_run(void)

--- a/runloop.h
+++ b/runloop.h
@@ -346,6 +346,12 @@ struct runloop
     * cross-thread race, so reusing it would undo that reasoning for
     * no gain. This is main-thread only. */
    bool content_closing;
+
+   /* Main-thread state for cores that cannot deserialize before their
+    * first retro_run(). */
+   bool auto_state_load_pending;
+   bool auto_state_load_attempted;
+   bool auto_state_load_ready;
 };
 
 /* Frame pacing sources.


### PR DESCRIPTION
## Summary

Honor `RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE` when State Auto Load is enabled.

For cores that advertise this quirk, automatic state loading is deferred until the core has had an initial execution opportunity. The existing state-loading path is then used unchanged.

## Problem

Some cores are not ready to unserialize a save state immediately after content loading.

RetroArch can currently attempt State Auto Load before such a core has completed initialization. This can cause automatic loading to fail even though loading the same state manually after startup succeeds.

## Solution

Track whether the active core advertises `RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE`.

When it does, defer the initial automatic state-load request until after the core has completed its first top-level execution cycle, then invoke the existing Auto Load path.

The deferred request is one-shot and is cleared across content/core lifecycle changes.

Cores that do not advertise `RETRO_SERIALIZATION_QUIRK_MUST_INITIALIZE` continue to use the existing Auto Load path without the added delay.

## Testing

Built and tested on Android AArch64 with Mupen64Plus-Next using GLideN64/OpenGL.

With State Auto Save and State Auto Load enabled:

1. Launched a game and progressed to a recognizable game state.
2. Exited normally and confirmed the automatic state was saved.
3. Relaunched the same content.
4. The saved state was restored automatically without invoking Load State manually.

State saving, startup, and gameplay remained stable during testing.

## Related

- #3431
- #17684
- Companion Mupen64Plus-Next PR: https://github.com/libretro/mupen64plus-libretro-nx/pull/645