### PR TITLE
Add playlist entry index option to all menu drivers

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -756,6 +756,9 @@ typedef struct materialui_handle
          last_landscape_layout_optimization;
    enum materialui_list_view_type list_view_type;
 
+   char entry_index_str[32];
+   char entry_index_offset;
+
    char msgbox[1024];
    char menu_title[NAME_MAX_LENGTH];
    char fullscreen_thumbnail_label[NAME_MAX_LENGTH];
@@ -7336,6 +7339,24 @@ MUI_NOINLINE static void materialui_render_header(
             TEXT_ALIGN_LEFT, 1.0f, false, 0.0f, false);
    }
 
+   /* > Draw playlist index, if required */
+   if (*mui->entry_index_str)
+   {
+      int str_width = font_driver_get_message_width(
+            mui->font_data.hint.font,
+            mui->entry_index_str,
+            strlen(mui->entry_index_str),
+            1.0f);
+      int str_x     = (int)(video_width - str_width) >> 1;
+
+      gfx_display_draw_text(mui->font_data.hint.font,
+            mui->entry_index_str,
+            str_x,
+            sys_bar_text_y,
+            video_width, video_height, mui->colors.sys_bar_text,
+            TEXT_ALIGN_LEFT, 1.0f, false, 0.0f, false);
+   }
+
    /* Title bar items */
 
    /* > Draw 'back' icon, if required */
@@ -10070,6 +10091,34 @@ static void materialui_navigation_set(void *data, bool scroll)
    if (show_sublabels && current_sel_only)
       materialui_compute_entries_box(mui, mui->last_width, mui->last_height, p_disp->header_height);
 
+   /* Update entry index text */
+   mui->entry_index_str[0] = '\0';
+   if (     config_get_ptr()->bools.playlist_show_entry_idx
+         && ((mui->flags & MUI_FLAG_IS_PLAYLIST) || (mui->flags & MUI_FLAG_IS_EXPLORE_LIST)))
+   {
+      menu_list_t *menu_list     = menu_st->entries.list;
+      size_t entry_idx_selection = selection + 1;
+      size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+      unsigned entry_idx_offset  = mui->entry_index_offset;
+      bool show_entry_idx        = true;
+
+      if (mui->flags & MUI_FLAG_IS_EXPLORE_LIST)
+      {
+         if (entry_idx_selection > entry_idx_offset && entry_idx_offset)
+            entry_idx_selection -= entry_idx_offset;
+         else
+            show_entry_idx = false;
+
+         if (list_size >= entry_idx_offset)
+            list_size           -= entry_idx_offset;
+      }
+
+      if (show_entry_idx)
+         snprintf(mui->entry_index_str, sizeof(mui->entry_index_str),
+               "%lu/%lu", (unsigned long)entry_idx_selection,
+                          (unsigned long)list_size);
+   }
+
    materialui_animate_scroll(
          mui,
          materialui_get_scroll(mui, p_disp),
@@ -10502,6 +10551,51 @@ static void materialui_populate_entries(void *data, const char *path,
    }
    else
       mui->flags &= ~MUI_FLAG_IS_SAVESTATE_LIST;
+
+   /* Determine whether to show entry index */
+   mui->entry_index_str[0] = '\0';
+   if (     settings->bools.playlist_show_entry_idx
+         && ((mui->flags & MUI_FLAG_IS_PLAYLIST) || (mui->flags & MUI_FLAG_IS_EXPLORE_LIST)))
+   {
+      menu_list_t *menu_list     = menu_st->entries.list;
+      size_t entry_idx_selection = menu_st->selection_ptr + 1;
+      size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+      unsigned entry_idx_offset  = 0;
+      bool show_entry_idx        = true;
+
+      if (mui->flags & MUI_FLAG_IS_EXPLORE_LIST)
+      {
+         if (string_is_equal(path, MENU_ENUM_LABEL_GOTO_EXPLORE_STR))
+            show_entry_idx = false;
+         else
+         {
+            /* Skip header items (Search Name + Add Additional Filter + Save as View + Delete this View) */
+            menu_entry_t entry;
+            MENU_ENTRY_INITIALIZE(entry);
+            menu_entry_get(&entry, 0, 0, NULL, true);
+
+            if (entry.type == MENU_SETTINGS_LAST + 1 || entry.type == FILE_TYPE_PLAIN)
+               entry_idx_offset = 1;
+            else if (entry.type == FILE_TYPE_RDB)
+               entry_idx_offset = 2;
+         }
+
+         if (entry_idx_selection > entry_idx_offset && entry_idx_offset)
+            entry_idx_selection -= entry_idx_offset;
+         else
+            show_entry_idx = false;
+
+         if (list_size >= entry_idx_offset)
+            list_size           -= entry_idx_offset;
+      }
+
+      mui->entry_index_offset = entry_idx_offset;
+
+      if (show_entry_idx)
+         snprintf(mui->entry_index_str, sizeof(mui->entry_index_str),
+            "%lu/%lu", (unsigned long)entry_idx_selection,
+                       (unsigned long)list_size);
+   }
 
    /* Update navigation bar tabs
     * > Note: We do this regardless of whether

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -132,6 +132,13 @@
 #define RGUI_SYMBOL_WIDTH_STRIDE  (RGUI_SYMBOL_WIDTH + 1)
 #define RGUI_SYMBOL_HEIGHT_STRIDE (RGUI_SYMBOL_HEIGHT + 1)
 
+enum rgui_playlist_mainmenu_selection
+{
+   RGUI_MAINMENU_HISTORY = 0,
+   RGUI_MAINMENU_FAVORITES,
+   RGUI_MAINMENU_LAST
+};
+
 /* Defines all possible entry value types
  * > Note: These are not necessarily 'values',
  *   but they correspond to the object drawn in
@@ -350,11 +357,15 @@ typedef struct
    uint8_t settings_selection_ptr;
    size_t playlist_selection_ptr;
    size_t playlist_selection[NAME_MAX_LENGTH];
+   size_t playlist_mainmenu_selection[RGUI_MAINMENU_LAST]; /* History + Favorites */
    int16_t scroll_y;
    rgui_colors_t colors;   /* int16_t alignment */
 
    struct scaler_ctx image_scaler;
    menu_input_pointer_t pointer;
+
+   char entry_index_str[32];
+   char entry_index_offset;
 
    char menu_title[NAME_MAX_LENGTH];              /* Must be a fixed length array... */
    char msgbox[1024];
@@ -6014,6 +6025,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
       unsigned term_mid_point        = 0;
       size_t powerstate_len          = 0;
       size_t timedate_len            = 0;
+      size_t sublabel_len            = 0;
 
       /* Cache mini thumbnail related parameters, if required */
       if (show_mini_thumbnails)
@@ -6455,6 +6467,23 @@ static void rgui_render(void *data, unsigned width, unsigned height,
                   rgui_swap_thumbnails, thumbnail_background, false);
       }
 
+      /* Draw entry index of current selection */
+      if (*rgui->entry_index_str)
+      {
+         size_t len = strlen(rgui->entry_index_str);
+
+         /* Subtract from sublabel width */
+         sublabel_len += len + 1;
+
+         rgui_blit_line(rgui,
+               fb_width,
+               term_end_x - (len * rgui->font_width_stride),
+               sublabel_y,
+               rgui->entry_index_str,
+               rgui->colors.hover_color,
+               rgui->colors.shadow_color);
+      }
+
       /* Print menu sublabel/core name (if required) */
       if (menu_show_sublabels && *rgui->menu_sublabel)
       {
@@ -6464,7 +6493,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          if (use_smooth_ticker)
          {
             ticker_smooth.selected    = true;
-            ticker_smooth.field_width = rgui->term_layout.width * rgui->font_width_stride;
+            ticker_smooth.field_width = (rgui->term_layout.width - sublabel_len) * rgui->font_width_stride;
             ticker_smooth.src_str     = rgui->menu_sublabel;
             ticker_smooth.dst_str     = sublabel_buf;
             ticker_smooth.dst_str_len = sizeof(sublabel_buf);
@@ -6476,7 +6505,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          {
             ticker.s                  = sublabel_buf;
             ticker.s_len              = sizeof(sublabel_buf);
-            ticker.len                = rgui->term_layout.width;
+            ticker.len                = rgui->term_layout.width - sublabel_len;
             ticker.str                = rgui->menu_sublabel;
             ticker.selected           = true;
 
@@ -6502,7 +6531,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          if (use_smooth_ticker)
          {
             ticker_smooth.selected    = true;
-            ticker_smooth.field_width = rgui->term_layout.width * rgui->font_width_stride;
+            ticker_smooth.field_width = (rgui->term_layout.width - sublabel_len) * rgui->font_width_stride;
             ticker_smooth.src_str     = core_title;
             ticker_smooth.dst_str     = core_title_buf;
             ticker_smooth.dst_str_len = sizeof(core_title_buf);
@@ -6514,7 +6543,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
          {
             ticker.s                  = core_title_buf;
             ticker.s_len              = sizeof(core_title_buf);
-            ticker.len                = rgui->term_layout.width;
+            ticker.len                = rgui->term_layout.width - sublabel_len;
             ticker.str                = core_title;
             ticker.selected           = true;
 
@@ -8017,7 +8046,6 @@ static void rgui_update_menu_sublabel(rgui_t *rgui, size_t selection)
 static void rgui_navigation_set(void *data, bool scroll)
 {
    size_t start                   = 0;
-   bool menu_show_sublabels       = false;
    struct menu_state *menu_st     = menu_state_get_ptr();
    menu_list_t *menu_list         = menu_st->entries.list;
    size_t end                     = menu_list ? MENU_LIST_GET_SELECTION(menu_list, 0)->size : 0;
@@ -8027,10 +8055,15 @@ static void rgui_navigation_set(void *data, bool scroll)
    if (!rgui)
       return;
 
-   menu_show_sublabels            = config_get_ptr()->bools.menu_show_sublabels;
-
    if (rgui->flags & RGUI_FLAG_IS_PLAYLIST)
-      rgui->playlist_selection[rgui->playlist_selection_ptr] = selection;
+   {
+      if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_HISTORY_TAB)))
+         rgui->playlist_mainmenu_selection[RGUI_MAINMENU_HISTORY] = selection;
+      else if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB)))
+         rgui->playlist_mainmenu_selection[RGUI_MAINMENU_FAVORITES] = selection;
+      else
+         rgui->playlist_selection[rgui->playlist_selection_ptr] = selection;
+   }
    else if (rgui->flags & RGUI_FLAG_IS_PLAYLISTS_TAB)
       rgui->playlist_selection_ptr = selection;
    else if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_SETTINGS)))
@@ -8039,8 +8072,35 @@ static void rgui_navigation_set(void *data, bool scroll)
    rgui_scan_selected_entry_thumbnail(rgui, false);
 
    rgui->menu_sublabel[0]         = '\0';
-   if (menu_show_sublabels && selection < end)
+   if (config_get_ptr()->bools.menu_show_sublabels && selection < end)
       rgui_update_menu_sublabel(rgui, selection);
+
+   /* Update entry index text */
+   rgui->entry_index_str[0]       = '\0';
+   if (     config_get_ptr()->bools.playlist_show_entry_idx
+         && ((rgui->flags & RGUI_FLAG_IS_PLAYLIST) || (rgui->flags & RGUI_FLAG_IS_EXPLORE_LIST)))
+   {
+      size_t entry_idx_selection = selection + 1;
+      size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+      unsigned entry_idx_offset  = rgui->entry_index_offset;
+      bool show_entry_idx        = true;
+
+      if (rgui->flags & RGUI_FLAG_IS_EXPLORE_LIST)
+      {
+         if (entry_idx_selection > entry_idx_offset && entry_idx_offset)
+            entry_idx_selection -= entry_idx_offset;
+         else
+            show_entry_idx = false;
+
+         if (list_size >= entry_idx_offset)
+            list_size           -= entry_idx_offset;
+      }
+
+      if (show_entry_idx)
+         snprintf(rgui->entry_index_str, sizeof(rgui->entry_index_str),
+               "%lu/%lu", (unsigned long)entry_idx_selection,
+                          (unsigned long)list_size);
+   }
 
    if (!scroll)
       return;
@@ -8185,12 +8245,18 @@ static void rgui_populate_entries(
    /* Cancel any pending thumbnail load operations */
    rgui->flags &= ~RGUI_FLAG_THUMBNAIL_LOAD_PENDING;
 
-   if (     rgui->flags & RGUI_FLAG_IS_PLAYLIST
-         && !string_is_equal(label, MENU_ENUM_LABEL_LOAD_CONTENT_HISTORY_STR))
+   if (rgui->flags & RGUI_FLAG_IS_PLAYLIST)
    {
       if (     remember_selection == MENU_REMEMBER_SELECTION_ALWAYS
             || remember_selection == MENU_REMEMBER_SELECTION_PLAYLISTS)
-         menu_st->selection_ptr = rgui->playlist_selection[rgui->playlist_selection_ptr];
+      {
+         if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_HISTORY_TAB)))
+            menu_st->selection_ptr = rgui->playlist_mainmenu_selection[RGUI_MAINMENU_HISTORY];
+         else if (string_is_equal(rgui->menu_title, msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES_TAB)))
+            menu_st->selection_ptr = rgui->playlist_mainmenu_selection[RGUI_MAINMENU_FAVORITES];
+         else
+            menu_st->selection_ptr = rgui->playlist_selection[rgui->playlist_selection_ptr];
+      }
    }
    else if (rgui->flags & RGUI_FLAG_IS_PLAYLISTS_TAB)
    {
@@ -8206,6 +8272,51 @@ static void rgui_populate_entries(
    }
 
    rgui_navigation_set(data, true);
+
+   /* Determine whether to show entry index */
+   rgui->entry_index_str[0] = '\0';
+   if (     settings->bools.playlist_show_entry_idx
+         && ((rgui->flags & RGUI_FLAG_IS_PLAYLIST) || (rgui->flags & RGUI_FLAG_IS_EXPLORE_LIST)))
+   {
+      menu_list_t *menu_list     = menu_st->entries.list;
+      size_t entry_idx_selection = menu_st->selection_ptr + 1;
+      size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+      unsigned entry_idx_offset  = 0;
+      bool show_entry_idx        = true;
+
+      if (rgui->flags & RGUI_FLAG_IS_EXPLORE_LIST)
+      {
+         if (string_is_equal(path, MENU_ENUM_LABEL_GOTO_EXPLORE_STR))
+            show_entry_idx = false;
+         else
+         {
+            /* Skip header items (Search Name + Add Additional Filter + Save as View + Delete this View) */
+            menu_entry_t entry;
+            MENU_ENTRY_INITIALIZE(entry);
+            menu_entry_get(&entry, 0, 0, NULL, true);
+
+            if (entry.type == MENU_SETTINGS_LAST + 1 || entry.type == FILE_TYPE_PLAIN)
+               entry_idx_offset = 1;
+            else if (entry.type == FILE_TYPE_RDB)
+               entry_idx_offset = 2;
+         }
+
+         if (entry_idx_selection > entry_idx_offset && entry_idx_offset)
+            entry_idx_selection -= entry_idx_offset;
+         else
+            show_entry_idx = false;
+
+         if (list_size >= entry_idx_offset)
+            list_size           -= entry_idx_offset;
+      }
+
+      rgui->entry_index_offset = entry_idx_offset;
+
+      if (show_entry_idx)
+         snprintf(rgui->entry_index_str, sizeof(rgui->entry_index_str),
+            "%lu/%lu", (unsigned long)entry_idx_selection,
+                       (unsigned long)list_size);
+   }
 
    /* If aspect ratio lock is enabled, must restore
     * content video settings when accessing the video
@@ -8657,6 +8768,10 @@ static void rgui_toggle(void *userdata, bool menu_on)
 
    /* Reset */
    rgui->flags &= ~RGUI_FLAG_DRAW_ENTRY_SKIP;
+
+   /* Forget history playlist selection in order to
+    * focus back on the same launched entry. */
+   rgui->playlist_mainmenu_selection[0] = 0;
 
    /* Have to reset this, otherwise savestate
     * thumbnail won't update after selecting

--- a/menu/drivers/xmb.c
+++ b/menu/drivers/xmb.c
@@ -429,8 +429,6 @@ typedef struct xmb_handle
    size_t selection_ptr_old;
    size_t fullscreen_thumbnail_selection;
 
-   /* size of the current list */
-   size_t list_size;
    size_t tab_selection[XMB_TAB_MAX_LENGTH];
 
    int depth;
@@ -509,7 +507,6 @@ typedef struct xmb_handle
    char title_name[NAME_MAX_LENGTH];
    char title_name_alt[NAME_MAX_LENGTH];
 
-   /* Cached texts showing current entry index / current list size */
    char entry_index_str[32];
    char entry_index_offset;
 
@@ -567,9 +564,6 @@ typedef struct xmb_handle
     * the very first frame at alpha=0 (a black screen) before the
     * fade-in animation starts. */
    bool is_first_frame;
-
-   /* Whether to show entry index for current list */
-   bool entry_idx_enabled;
 
    /* Per-instance layout scale modifiers (was file-scope static) */
    float scale_mod[8];
@@ -2468,24 +2462,27 @@ static void xmb_selection_pointer_changed(
       unsigned depth          = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
 
       /* Update entry index text */
-      if (xmb->entry_idx_enabled)
+      xmb->entry_index_str[0] = '\0';
+      if (     config_get_ptr()->bools.playlist_show_entry_idx
+            && (xmb->is_playlist || xmb->is_explore_list))
       {
          size_t entry_idx_selection = selection + 1;
          size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
          unsigned entry_idx_offset  = xmb->entry_index_offset;
-         bool show_entry_idx        = (xmb->is_playlist || xmb->is_explore_list) ? true : false;
+         bool show_entry_idx        = true;
 
          if (xmb->is_explore_list)
          {
-            if (entry_idx_selection > entry_idx_offset)
+            if (entry_idx_selection > entry_idx_offset && entry_idx_offset)
                entry_idx_selection -= entry_idx_offset;
             else
                show_entry_idx = false;
+
+            if (list_size >= entry_idx_offset)
+               list_size           -= entry_idx_offset;
          }
 
-         if (!show_entry_idx)
-            xmb->entry_index_str[0] = '\0';
-         else
+         if (show_entry_idx)
             snprintf(xmb->entry_index_str, sizeof(xmb->entry_index_str),
                   "%lu/%lu", (unsigned long)entry_idx_selection,
                              (unsigned long)list_size);
@@ -3933,7 +3930,6 @@ static void xmb_populate_entries(void *data,
    settings_t *settings               = config_get_ptr();
    struct menu_state *menu_st         = menu_state_get_ptr();
    menu_list_t *menu_list             = menu_st->entries.list;
-   bool playlist_show_entry_idx       = settings->bools.playlist_show_entry_idx;
    bool was_db_manager_list           = false;
    int depth                          = (unsigned)xmb_list_get_size(xmb, MENU_LIST_PLAIN);
 
@@ -4109,39 +4105,44 @@ static void xmb_populate_entries(void *data,
 
    /* Determine whether to show entry index */
    xmb->entry_index_str[0] = '\0';
-   xmb->entry_idx_enabled  = playlist_show_entry_idx;
-
-   if (     !xmb->is_quick_menu
+   if (     settings->bools.playlist_show_entry_idx
          && (xmb->is_playlist || xmb->is_explore_list))
    {
       size_t entry_idx_selection = menu_st->selection_ptr + 1;
       size_t list_size           = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
       unsigned entry_idx_offset  = 0;
-      playlist_show_entry_idx    = (xmb->is_playlist || xmb->is_explore_list)
-         ? playlist_show_entry_idx : false;
+      bool show_entry_idx        = true;
 
       if (xmb->is_explore_list)
       {
-         entry_idx_offset = 2;
-         if (     string_is_equal(label, MENU_ENUM_LABEL_DEFERRED_EXPLORE_LIST_STR)
-               || xmb_horizontal_type == MENU_EXPLORE_TAB)
-            entry_idx_offset = 1;
+         if (     string_is_equal(path, MENU_ENUM_LABEL_GOTO_EXPLORE_STR)
+               || (xmb->depth == 1 && !string_is_equal(label, MENU_ENUM_LABEL_HORIZONTAL_MENU_STR)))
+            show_entry_idx = false;
+         else
+         {
+            /* Skip header items (Search Name + Add Additional Filter + Save as View + Delete this View) */
+            menu_entry_t entry;
+            MENU_ENTRY_INITIALIZE(entry);
+            menu_entry_get(&entry, 0, 0, NULL, true);
 
-         if (entry_idx_selection > entry_idx_offset)
+            if (entry.type == MENU_SETTINGS_LAST + 1 || entry.type == FILE_TYPE_PLAIN)
+               entry_idx_offset = 1;
+            else if (entry.type == FILE_TYPE_RDB)
+               entry_idx_offset = 2;
+         }
+
+         if (entry_idx_selection > entry_idx_offset && entry_idx_offset)
             entry_idx_selection -= entry_idx_offset;
          else
-            playlist_show_entry_idx = false;
+            show_entry_idx = false;
 
          if (list_size >= entry_idx_offset)
             list_size           -= entry_idx_offset;
       }
 
-      xmb->list_size          = list_size;
       xmb->entry_index_offset = entry_idx_offset;
 
-      if (!playlist_show_entry_idx)
-         xmb->entry_index_str[0] = '\0';
-      else
+      if (show_entry_idx)
          snprintf(xmb->entry_index_str, sizeof(xmb->entry_index_str),
             "%lu/%lu", (unsigned long)entry_idx_selection,
                        (unsigned long)list_size);
@@ -6174,7 +6175,6 @@ XMB_NOINLINE static int xmb_draw_item(
 
    /* Draw entry index of current selection */
    if (     i == current
-         && xmb->entry_idx_enabled
          && *xmb->entry_index_str)
    {
       float entry_idx_margin = 12 * xmb->last_scale_factor;

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -16047,14 +16047,13 @@ static void settings_build_playlist(
        * sub group. */
                      ADD_DESC(pl_desc_1);
 
-      /* Playlist entry index display and content specific history icon
-       * are currently supported only by Ozone & XMB */
+#if defined(HAVE_OZONE) || defined(HAVE_XMB)
       if (   string_is_equal(settings->arrays.menu_driver, "xmb")
           || string_is_equal(settings->arrays.menu_driver, "ozone"))
       {
                         ADD_DESC(pl_desc_2);
       }
-
+#endif
                      ADD_DESC(pl_desc_3);
 
 #if defined(HAVE_OZONE) || defined(HAVE_XMB)

--- a/settings/settings_def_playlist_display.h
+++ b/settings/settings_def_playlist_display.h
@@ -31,6 +31,11 @@ S_UINT_EX(playlist_show_inline_core_name, PLAYLIST_SHOW_INLINE_CORE_NAME,
       "Show Associated Cores in Playlists",
       "Specify when to tag playlist entries with the currently associated core (if any). This setting is ignored when playlist sublabels are enabled.")
 #endif
+S_BOOL(playlist_show_entry_idx, PLAYLIST_SHOW_ENTRY_IDX,
+      "playlist_show_entry_idx",
+      DEFAULT_PLAYLIST_SHOW_ENTRY_IDX, SD_FLAG_NONE, 0, 0,
+      "Show Playlist Entry Index",
+      "Show entry numbers when viewing playlists. Display format is dependent upon the currently selected menu driver.")
 S_BOOL(playlist_fuzzy_archive_match, PLAYLIST_FUZZY_ARCHIVE_MATCH,
       "playlist_fuzzy_archive_match",
       DEFAULT_PLAYLIST_FUZZY_ARCHIVE_MATCH, SD_FLAG_NONE, 0, 0,

--- a/settings/settings_def_playlist_history.h
+++ b/settings/settings_def_playlist_history.h
@@ -13,8 +13,3 @@ S_UINT_EX(playlist_show_history_icons, PLAYLIST_SHOW_HISTORY_ICONS,
       "Show Content Specific Icons in History and Favorites",
       "Show specific icons for each history and favorites playlist entry. Has a variable performance impact.")
 #endif
-S_BOOL(playlist_show_entry_idx, PLAYLIST_SHOW_ENTRY_IDX,
-      "playlist_show_entry_idx",
-      DEFAULT_PLAYLIST_SHOW_ENTRY_IDX, SD_FLAG_NONE, 0, 0,
-      "Show Playlist Entry Index",
-      "Show entry numbers when viewing playlists. Display format is dependent upon the currently selected menu driver.")

--- a/tools/settings_table.reference
+++ b/tools/settings_table.reference
@@ -188,6 +188,7 @@ bool	content_show_explore	1	1
 bool	xmb_entry_icons	1	1
 bool	xmb_switch_icons	1	1
 bool	xmb_shadows_enable	1	1
+bool	playlist_show_entry_idx	1	1
 bool	playlist_fuzzy_archive_match	1	0
 bool	scan_without_core_match	1	0
 bool	scan_serial_and_crc	1	0
@@ -212,7 +213,6 @@ bool	ozone_show_sidebar	1	1
 bool	ozone_collapse_sidebar	1	0
 bool	video_hdr_scanlines	1	1
 bool	rewind_enable	1	0
-bool	playlist_show_entry_idx	1	1
 bool	menu_linear_filter	1	0
 bool	xmb_vertical_thumbnails	1	0
 bool	pause_on_disconnect	1	0
@@ -837,6 +837,7 @@ bool	content_show_explore	1	1
 bool	xmb_entry_icons	1	1
 bool	xmb_switch_icons	1	1
 bool	xmb_shadows_enable	1	1
+bool	playlist_show_entry_idx	1	1
 bool	playlist_fuzzy_archive_match	1	0
 bool	scan_without_core_match	1	0
 bool	scan_serial_and_crc	1	0
@@ -861,7 +862,6 @@ bool	ozone_show_sidebar	1	1
 bool	ozone_collapse_sidebar	1	0
 bool	video_hdr_scanlines	1	1
 bool	rewind_enable	1	0
-bool	playlist_show_entry_idx	1	1
 bool	menu_linear_filter	1	0
 bool	xmb_vertical_thumbnails	1	0
 bool	pause_on_disconnect	1	0
@@ -1485,6 +1485,7 @@ bool	content_show_explore	1	1
 bool	xmb_entry_icons	1	1
 bool	xmb_switch_icons	1	1
 bool	xmb_shadows_enable	1	1
+bool	playlist_show_entry_idx	1	1
 bool	playlist_fuzzy_archive_match	1	0
 bool	scan_without_core_match	1	0
 bool	scan_serial_and_crc	1	0
@@ -1509,7 +1510,6 @@ bool	ozone_show_sidebar	1	1
 bool	ozone_collapse_sidebar	1	0
 bool	video_hdr_scanlines	1	1
 bool	rewind_enable	1	0
-bool	playlist_show_entry_idx	1	1
 bool	menu_linear_filter	1	0
 bool	xmb_vertical_thumbnails	1	0
 bool	pause_on_disconnect	1	0


### PR DESCRIPTION
## Description

Currently only Ozone and XMB are showing current playlist selection index, so let's add it also to RGUI and GLUI. RGUI shows it in the bottom right corner like XMB, and GLUI shows it in the top center sysbar, since there is no other place to put it.

Also fixed RGUI main menu playlists (history+favorites) selection remembering.

