### PR TITLE
Fix null pointer dereferences during joypad/video driver teardown

### DIFF
--- a/gfx/drivers/gl2.c
+++ b/gfx/drivers/gl2.c
@@ -4634,8 +4634,14 @@ static bool gl2_alive(void *data)
    bool quit            = false;
    bool resize          = false;
    gl2_t         *gl    = (gl2_t*)data;
-   unsigned temp_width  = gl->video_width;
-   unsigned temp_height = gl->video_height;
+   unsigned temp_width;
+   unsigned temp_height;
+
+   if (!gl)
+      return false;
+
+   temp_width           = gl->video_width;
+   temp_height          = gl->video_height;
 
    gl->ctx_driver->check_window(gl->ctx_data,
          &quit, &resize, &temp_width, &temp_height);

--- a/input/input_driver.c
+++ b/input/input_driver.c
@@ -2008,6 +2008,7 @@ static int16_t input_state_internal(
          /* Handle Analog to Digital */
          if (     (device == RETRO_DEVICE_JOYPAD)
                && (input_analog_dpad_mode != ANALOG_DPAD_NONE)
+               && joypad
                && (bitmask_enabled || (id >= RETRO_DEVICE_ID_JOYPAD_UP && id <= RETRO_DEVICE_ID_JOYPAD_RIGHT)))
          {
             int16_t ret_axis;
@@ -6803,7 +6804,7 @@ void input_driver_collect_system_input(input_driver_state_t *input_st,
       binds_auto                             = &input_autoconf_binds[joypad_info.joy_idx][RARCH_ENABLE_HOTKEY];
 
 #ifdef HAVE_MENU
-      if (menu_is_alive)
+      if (menu_is_alive && joypad)
       {
          uint8_t s;
          uint8_t a;


### PR DESCRIPTION
## Summary

Three separate `EXC_BAD_ACCESS` crashes reproduced on macOS (arm64, RetroArch 1.22.2, official Xcode/Metal build) where a driver context pointer becomes null while the main loop keeps polling it once per frame, and the polling code never checks for that:

- **`input/input_driver.c`** — `input_state_internal()`'s "Handle Analog to Digital" block calls `input_joypad_analog_axis()` with the primary joypad driver pointer (`joypad`) unguarded. `input_joypad_analog_axis()` itself doesn't null-check its `drv` parameter either (`drv->button` is dereferenced after only checking that the function pointer field itself is non-null), so a null `joypad` crashes reading the `button` field's offset in `struct rarch_joypad_driver`. Sibling call sites a few dozen lines above in the same file already guard this with `if (joypad && ...)`; this one didn't.
- **`input/input_driver.c`** — `input_driver_collect_system_input()`'s menu-analog-navigation block (under `HAVE_MENU`) has the same unguarded call to `input_joypad_analog_axis()`, reached whenever the menu is open and the primary joypad becomes null mid-poll.
- **`gfx/drivers/gl2.c`** — `gl2_alive()`, the GL2 video driver's per-frame "is the context still alive" callback invoked from `runloop_check_state()`, dereferences its `gl` context pointer with no null check at all.

Note: `vulkan_alive()` in `gfx/drivers/vulkan.c` has the identical unguarded pattern (`vk_t *vk = (vk_t*)data; unsigned temp_width = vk->video_width;` with no check on `vk`). I left it unmodified since it wasn't the driver observed crashing in my repro, but it likely has the same latent issue and may be worth a follow-up.

## How this was found

Reproduced repeatedly on a real setup: RetroArch launched as a child process by a frontend (Pegasus), where the child process's joypad/video driver state could be torn down mid-frame relative to the frontend's own process lifecycle. Root-caused via crash reports showing `EXC_BAD_ACCESS` at a faulting address matching "null pointer + small struct-field offset" (e.g. `far: 0x18`, which is exactly the byte offset of the `button` function pointer in `struct rarch_joypad_driver` on arm64), cross-referenced against the actual source at the matching release tag. Confirmed the exact source lines via a debug-symbol build (built via the same `pkg/apple/RetroArch.xcworkspace` / `GitHubCI.xcconfig` used by CI, which happens to retain source line info in the crash backtrace).

## Test plan

- [x] Built via `xcodebuild -workspace pkg/apple/RetroArch.xcworkspace -scheme RetroArch -config Release -xcconfig pkg/apple/GitHubCI.xcconfig` (same as `.github/workflows/MacOS.yml`) — builds clean, 0 errors.
- [x] Deployed and ran on macOS 26.6.2 (arm64) as a drop-in replacement for the installed RetroArch, launched via the same frontend/workflow that originally reproduced all three crashes.
- [x] Each of the three crashes was reproduced once, fixed, and confirmed not to recur in the same session (fixed incrementally, one crash report → one fix → rebuild → next crash report pointed at a different, previously-unaudited call site or driver, until no more crashes were observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)