### PR TITLE
wayland/webOS: keep the native surface across a content load

### DIFF
--- a/gfx/drivers_context/wayland_ctx.c
+++ b/gfx/drivers_context/wayland_ctx.c
@@ -504,6 +504,8 @@ static void wl_surface_frame_done(void *data, struct wl_callback *cb, uint32_t t
    gfx_ctx_wayland_data_t *wl = (gfx_ctx_wayland_data_t*)data;
 
    wl->swap_complete = true;
+   if (wl->frame_cb == cb)
+      wl->frame_cb   = NULL;
 
    /* Destroy this callback */
    wl_callback_destroy(cb);
@@ -540,6 +542,7 @@ static void gfx_ctx_wl_swap_buffers(void *data)
       /* Set Wayland frame callback. */
       cb = wl_surface_frame(wl->surface);
       wl_callback_add_listener(cb, &wl_surface_frame_listener, wl);
+      wl->frame_cb = cb;
    }
 
    if (wl->present_clock)
@@ -579,6 +582,7 @@ static void gfx_ctx_wl_swap_buffers(void *data)
          {
             /* Deadline met. */
             wl_callback_destroy(cb);
+            wl->frame_cb = NULL;
             return;
          }
          uint64_t remaining_time = deadline - current_time;
@@ -595,6 +599,7 @@ static void gfx_ctx_wl_swap_buffers(void *data)
                /* Timeout met, or polling error. */
                wl_display_cancel_read(wl->input.dpy);
                wl_callback_destroy(cb);
+               wl->frame_cb = NULL;
                return;
             }
             wl_display_read_events(wl->input.dpy);

--- a/input/common/wayland_common.h
+++ b/input/common/wayland_common.h
@@ -299,6 +299,10 @@ typedef struct gfx_ctx_wayland_data
    bool activated;
    bool reported_display_size;
    bool swap_complete;
+   /* The in-flight frame callback. A webOS surface outlives its
+    * context, so teardown has to cancel this one or the compositor
+    * delivers done into freed memory. */
+   struct wl_callback *frame_cb;
 } gfx_ctx_wayland_data_t;
 
 typedef struct wl_present_feedback

--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -29,6 +29,7 @@
 #include "../../frontend/frontend_driver.h"
 #include "../../gfx/common/wayland_common.h"
 #include "../../gfx/video_driver.h"
+#include "../../runloop.h"
 #include "../../verbosity.h"
 #include "../input_keymaps.h"
 
@@ -375,8 +376,220 @@ void gfx_ctx_wl_get_video_size_webos(void *data,
    }
 }
 
+/* webOS hands the screen back to the Home dashboard the moment a native
+ * app destroys its only wl_surface, and RetroArch tears the Wayland
+ * context down and builds a new one on every content load. Keep the
+ * display connection and the shell surfaces across that reinit, so the
+ * compositor never sees a zero-surface app; the shutdown pass destroys
+ * them for real. Only one context exists at a time, so one cache is
+ * enough. */
+static struct
+{
+   struct wl_display *dpy;
+   struct wl_registry *registry;
+   struct wl_compositor *compositor;
+   struct wl_shm *shm;
+   struct wl_shell *shell;
+   struct wl_shell_surface *shell_surface;
+   struct wl_webos_shell *webos_shell;
+   struct wl_webos_shell_surface *webos_shell_surface;
+   struct wl_surface *surface;
+   struct wl_surface *cursor_surface;
+   struct wl_seat *seat;
+   struct wl_data_device_manager *data_device_manager;
+   struct wl_list all_outputs;
+   struct wl_list current_outputs;
+   struct wl_list all_seats;
+   int fd;
+   bool valid;
+} s_webos_keep;
+
+/* Move the live objects out of wl into the cache (reinit) or destroy
+ * them (shutdown). Returns true when the objects were stashed and the
+ * caller must skip its own teardown of them. */
+static bool gfx_ctx_wl_webos_keep_or_destroy(gfx_ctx_wayland_data_t *wl,
+      bool reinit)
+{
+   if (!wl)
+      return false;
+
+   if (reinit)
+   {
+      /* Stash. The seat/output lists are moved wholesale; their nodes
+       * stay allocated and are re-adopted by the next context. */
+      s_webos_keep.dpy                 = wl->input.dpy;
+      s_webos_keep.registry            = wl->registry;
+      s_webos_keep.compositor          = wl->compositor;
+      s_webos_keep.shm                 = wl->shm;
+      s_webos_keep.shell               = wl->shell;
+      s_webos_keep.shell_surface       = wl->shell_surface;
+      s_webos_keep.webos_shell         = wl->webos_shell;
+      s_webos_keep.webos_shell_surface = wl->webos_shell_surface;
+      s_webos_keep.surface             = wl->surface;
+      s_webos_keep.cursor_surface      = wl->cursor.surface;
+      s_webos_keep.seat                = wl->seat;
+      s_webos_keep.data_device_manager = wl->data_device_manager;
+      s_webos_keep.fd                  = wl->input.fd;
+
+      wl_list_init(&s_webos_keep.all_outputs);
+      wl_list_init(&s_webos_keep.current_outputs);
+      wl_list_init(&s_webos_keep.all_seats);
+      /* wl_list_insert_list moves every node out of the source list,
+       * leaving it empty, so the per-context teardown below (skipped
+       * when kept) will not double-free them. */
+      wl_list_insert_list(&s_webos_keep.all_outputs, &wl->all_outputs);
+      wl_list_insert_list(&s_webos_keep.current_outputs, &wl->current_outputs);
+      wl_list_insert_list(&s_webos_keep.all_seats, &wl->all_seats);
+
+      s_webos_keep.valid = true;
+      RARCH_LOG("[Wayland/webOS] Keeping surface across video reinit.\n");
+      return true;
+   }
+
+   /* Shutdown: destroy any previously stashed objects for real. */
+   if (s_webos_keep.valid)
+   {
+      if (s_webos_keep.shell_surface)
+         wl_shell_surface_destroy(s_webos_keep.shell_surface);
+      if (s_webos_keep.webos_shell_surface)
+         wl_webos_shell_surface_destroy(s_webos_keep.webos_shell_surface);
+      if (s_webos_keep.surface)
+         wl_surface_destroy(s_webos_keep.surface);
+      if (s_webos_keep.cursor_surface)
+         wl_surface_destroy(s_webos_keep.cursor_surface);
+      if (s_webos_keep.seat)
+         wl_seat_destroy(s_webos_keep.seat);
+      if (s_webos_keep.webos_shell)
+         wl_webos_shell_destroy(s_webos_keep.webos_shell);
+      if (s_webos_keep.data_device_manager)
+         wl_data_device_manager_destroy(s_webos_keep.data_device_manager);
+      if (s_webos_keep.shm)
+         wl_shm_destroy(s_webos_keep.shm);
+      if (s_webos_keep.compositor)
+         wl_compositor_destroy(s_webos_keep.compositor);
+      if (s_webos_keep.registry)
+         wl_registry_destroy(s_webos_keep.registry);
+      if (s_webos_keep.dpy)
+      {
+         wl_display_flush(s_webos_keep.dpy);
+         wl_display_disconnect(s_webos_keep.dpy);
+      }
+      memset(&s_webos_keep, 0, sizeof(s_webos_keep));
+   }
+   return false;
+}
+
+/* Build a fresh context around a previously stashed set of objects.
+ * Returns true when a cache was present and adopted, leaving the
+ * context as ready to use as a cold init would. */
+static bool gfx_ctx_wl_webos_adopt(gfx_ctx_wayland_data_t *wl)
+{
+   int i;
+   seat_info_t *si;
+
+   if (!wl || !s_webos_keep.valid)
+      return false;
+
+   wl->input.dpy          = s_webos_keep.dpy;
+   wl->registry           = s_webos_keep.registry;
+   wl->compositor         = s_webos_keep.compositor;
+   wl->shm                = s_webos_keep.shm;
+   wl->shell              = s_webos_keep.shell;
+   wl->shell_surface      = s_webos_keep.shell_surface;
+   wl->webos_shell        = s_webos_keep.webos_shell;
+   wl->webos_shell_surface= s_webos_keep.webos_shell_surface;
+   wl->surface            = s_webos_keep.surface;
+   wl->cursor.surface     = s_webos_keep.cursor_surface;
+   wl->seat               = s_webos_keep.seat;
+   wl->data_device_manager= s_webos_keep.data_device_manager;
+   wl->input.fd           = s_webos_keep.fd;
+
+   wl_list_insert_list(&wl->all_outputs, &s_webos_keep.all_outputs);
+   wl_list_insert_list(&wl->current_outputs, &s_webos_keep.current_outputs);
+   wl_list_insert_list(&wl->all_seats, &s_webos_keep.all_seats);
+
+   /* Every kept proxy still hands the freed context to its listener:
+    * libwayland stores that pointer inside the proxy at add_listener
+    * time. Key presses would land in the dead context's key_state, so
+    * the live input driver never sees a hotkey, and the write is a
+    * use-after-free. Re-point the proxies rather than re-add the
+    * listeners, which Wayland forbids. */
+   if (wl->registry)
+      wl_registry_set_user_data(wl->registry, wl);
+   if (wl->webos_shell_surface)
+      wl_webos_shell_surface_set_user_data(wl->webos_shell_surface, wl);
+
+   wl_list_for_each(si, &wl->all_seats, link)
+   {
+      /* The seat keeps its node, but that node caches the context it
+       * hands to keyboards/pointers it creates later, on a capability
+       * change. */
+      si->wl = wl;
+      if (si->wl_keyboard)
+         wl_keyboard_set_user_data(si->wl_keyboard, wl);
+      if (si->wl_pointer)
+         wl_pointer_set_user_data(si->wl_pointer, wl);
+      if (si->wl_touch)
+         wl_touch_set_user_data(si->wl_touch, wl);
+   }
+
+   /* What the cold path sets up once its surface exists. */
+   wl->buffer_scale          = 1;
+   wl->floating_width        = DEFAULT_WINDOW_WIDTH;
+   wl->floating_height       = DEFAULT_WINDOW_HEIGHT;
+   wl->configured            = true;
+   wl->input.keyboard_focus  = true;
+   wl->input.mouse.focus     = true;
+   /* No second pointer enter arrives for a surface that never went
+    * away, and the button listener drops clicks whose focus surface is
+    * not wl->surface. */
+   wl->input.mouse.surface   = wl->surface;
+   /* The theme went with the old context; its surface was kept. */
+   wl->cursor.theme          = wl_cursor_theme_load(NULL, 16, wl->shm);
+   if (wl->cursor.theme)
+      wl->cursor.default_cursor = wl_cursor_theme_get_cursor(
+            wl->cursor.theme, "left_ptr");
+
+   wl->num_active_touches = 0;
+   for (i = 0; i < MAX_TOUCHES; i++)
+   {
+      wl->active_touch_positions[i].active = false;
+      wl->active_touch_positions[i].id     = -1;
+      wl->active_touch_positions[i].x      = 0;
+      wl->active_touch_positions[i].y      = 0;
+   }
+
+   memset(&s_webos_keep, 0, sizeof(s_webos_keep));
+   flush_wayland_fd(&wl->input);
+   RARCH_LOG("[Wayland/webOS] Adopted cached surface after reinit.\n");
+   return true;
+}
+
 void gfx_ctx_wl_destroy_resources_webos(gfx_ctx_wayland_data_t *wl)
 {
+   /* A content load reinits video without shutting the runloop down,
+    * and that is the pass whose surface has to survive. */
+   bool reinit = !(runloop_get_flags() & RUNLOOP_FLAG_SHUTDOWN_INITIATED);
+   bool kept   = gfx_ctx_wl_webos_keep_or_destroy(wl, reinit);
+
+   /* A frame callback outstanding on a kept surface would fire into
+    * this context after it is freed. */
+   if (wl->frame_cb)
+   {
+      wl_callback_destroy(wl->frame_cb);
+      wl->frame_cb = NULL;
+   }
+
+   if (wl->cursor.theme)
+      wl_cursor_theme_destroy(wl->cursor.theme);
+
+   /* The cache owns the rest now. The keymap in particular arrives
+    * once per wl_keyboard, so a kept keyboard never resends it:
+    * freeing the xkb state would leave modifier handling dead for the
+    * rest of the session. */
+   if (kept)
+      goto clear;
+
 #ifdef HAVE_XKBCOMMON
    free_xkb();
 #endif
@@ -388,11 +601,11 @@ void gfx_ctx_wl_destroy_resources_webos(gfx_ctx_wayland_data_t *wl)
    if (wl->wl_touch)
       wl_touch_destroy(wl->wl_touch);
 
-   if (wl->cursor.theme)
-      wl_cursor_theme_destroy(wl->cursor.theme);
    if (wl->cursor.surface)
       wl_surface_destroy(wl->cursor.surface);
 
+   if (wl->shell_surface)
+      wl_shell_surface_destroy(wl->shell_surface);
    if (wl->webos_shell_surface)
       wl_webos_shell_surface_destroy(wl->webos_shell_surface);
    if (wl->surface)
@@ -457,10 +670,13 @@ void gfx_ctx_wl_destroy_resources_webos(gfx_ctx_wayland_data_t *wl)
       wl_display_disconnect(wl->input.dpy);
    }
 
+clear:
    wl->input.dpy                = NULL;
    wl->registry                 = NULL;
    wl->compositor               = NULL;
    wl->shm                      = NULL;
+   wl->shell                    = NULL;
+   wl->shell_surface            = NULL;
    wl->webos_shell              = NULL;
    wl->seat                     = NULL;
    wl->surface                  = NULL;
@@ -513,6 +729,11 @@ bool gfx_ctx_wl_init_webos(
    wl_list_init(&wl->all_seats);
 
    frontend_driver_destroy_signal_handler_state();
+
+   /* Only connect and create objects on a cold start; a reinit reuses
+    * what the previous context left behind. */
+   if (gfx_ctx_wl_webos_adopt(wl))
+      return true;
 
    wl->input.dpy       = wl_display_connect(NULL);
    wl->buffer_scale    = 1;

--- a/runloop.c
+++ b/runloop.c
@@ -5951,6 +5951,73 @@ void runloop_msg_queue_push(
    RUNLOOP_MSG_QUEUE_UNLOCK(runloop_st);
 }
 
+#ifdef WEBOS
+void runloop_present_blocking_msg(const char *msg, size_t len)
+{
+   settings_t *settings           = config_get_ptr();
+   video_driver_state_t *video_st = video_state_get_ptr();
+   runloop_state_t *runloop_st    = &runloop_state;
+   unsigned output_width          = 0;
+   unsigned output_height         = 0;
+   retro_time_t deadline;
+#if defined(HAVE_GFX_WIDGETS)
+   gfx_display_t *p_disp          = disp_get_ptr();
+   bool widgets_active            = dispwidget_get_ptr()->active;
+   bool video_is_fullscreen       = settings->bools.video_fullscreen
+      || (video_st->flags & VIDEO_FLAG_FORCE_FULLSCREEN);
+#endif
+
+   if (!msg || !*msg)
+      return;
+
+   /* Kept short: nothing expires it while the caller blocks, so this
+    * is how long it lingers once frames start being drawn again. */
+   runloop_msg_queue_push(msg, len, 1, 60, true, NULL,
+         MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_INFO);
+
+   /* A pending delay would hide the notification for exactly the frames
+    * drawn below, which are the only ones that will be drawn. */
+   runloop_st->msg_queue_delay = 0;
+
+   video_driver_get_output_size(&output_width, &output_height);
+
+   /* Notifications animate in from off-screen, so a single frame shows
+    * nothing. Redraw for slightly longer than that animation, then let
+    * the caller block: the message stays up on the retained surface. */
+   deadline = cpu_features_get_time_usec()
+      + ((MSG_QUEUE_ANIMATION_DURATION + 80) * 1000);
+
+   while (cpu_features_get_time_usec() < deadline)
+   {
+      gfx_animation_update(cpu_features_get_time_usec(),
+            settings->bools.menu_timedate_enable,
+            settings->floats.menu_ticker_speed,
+            output_width,
+            output_height);
+
+#if defined(HAVE_GFX_WIDGETS)
+      if (widgets_active)
+      {
+         RUNLOOP_MSG_QUEUE_LOCK(runloop_st);
+         gfx_widgets_iterate(
+               p_disp,
+               settings,
+               output_width,
+               output_height,
+               video_is_fullscreen,
+               settings->paths.directory_assets,
+               settings->paths.path_font,
+               VIDEO_DRIVER_IS_THREADED_INTERNAL(video_st));
+         RUNLOOP_MSG_QUEUE_UNLOCK(runloop_st);
+      }
+#endif
+
+      video_driver_cached_frame();
+      retro_sleep(8);
+   }
+}
+#endif
+
 #ifdef HAVE_MENU
 /* Display the libretro core's framebuffer onscreen. */
 static bool display_menu_libretro(

--- a/runloop.h
+++ b/runloop.h
@@ -451,6 +451,13 @@ void runloop_msg_queue_push(const char *msg, size_t len,
       enum message_queue_icon icon,
       enum message_queue_category category);
 
+#ifdef WEBOS
+/* Push a notification and redraw until it has animated into view, for
+ * callers about to block the runloop. The webOS surface survives the
+ * video reinit a content load performs, so these frames stay up. */
+void runloop_present_blocking_msg(const char *msg, size_t len);
+#endif
+
 void runloop_set_current_core_type(
       enum rarch_core_type type, bool explicitly_set);
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1946,6 +1946,20 @@ static bool content_load(content_ctx_info_t *info,
       rarch_argc_ptr = (int*)&rarch_argc;
    }
 
+#ifdef WEBOS
+   /* Everything below is synchronous and draws no frames, while the
+    * kept webOS surface still shows the last one. Put the loading
+    * notification up there first, so the frame left on screen says
+    * so. The dummy core comes through here too, on startup and on
+    * close content; task_push_start_dummy_core() clears the content
+    * path first, which is what tells the two apart. */
+   if (!string_is_empty(path_get(RARCH_PATH_CONTENT)))
+   {
+      const char *msg = msg_hash_to_str(MSG_LOADING);
+      runloop_present_blocking_msg(msg, strlen(msg));
+   }
+#endif
+
    retroarch_ctl(RARCH_CTL_MAIN_DEINIT, NULL);
 
    wrap_args->argc = *rarch_argc_ptr;


### PR DESCRIPTION
## wayland/webOS: keep the native surface across a content load

Loading anything on a webOS TV drops the screen to the Home dashboard for as long as the load takes. RetroArch comes back once the core is up. On a large ROM that means several seconds sitting on the TV's launcher, which reads as a crash.

The teardown that causes it is doing nothing wrong. `content_load()` runs `RARCH_CTL_MAIN_DEINIT`, the video driver is reinitialised, and `gfx_ctx_wl_destroy_resources_webos()` destroys `wl->surface` and disconnects the display, which is what a context teardown should do. The webOS compositor is what makes it visible. An app holding no `wl_surface` has no claim on the screen, so the screen goes back to Home. A desktop compositor lets a window vanish and come back; this one hands the display to something else in the gap.

So on this platform the surface has to outlive the context that created it.

### What is kept, and how the two passes are told apart

`gfx_ctx_wl_destroy_resources_webos()` now stashes the display connection, the `wl_shell` and `wl_webos_shell` surfaces, the seat, and the output and seat lists into a file-local cache rather than destroying them. `gfx_ctx_wl_init_webos()` then builds the next context around that cache instead of calling `wl_display_connect()` again, setting up the same derived state a cold start would.

`RUNLOOP_FLAG_SHUTDOWN_INITIATED` tells a reinit from a real exit. On the shutdown pass the cache is destroyed for real, so a clean exit still frees everything, just from one place instead of two.

List nodes move with `wl_list_insert_list()`, which leaves the source list empty. That is what stops the per-context teardown from freeing nodes the cache now owns.

### The listener user_data is the part worth reviewing

This is the half that is easy to miss, and it is why the first working version of this still had a dead in-game menu.

`libwayland` stores the `user_data` pointer inside the proxy when the listener is added, and a kept proxy goes on handing that pointer to its callbacks. After a reinit every one of them was still passing the context that had just been freed. Key presses landed in the dead context's `key_state`, the live input driver never saw a hotkey, and the write itself was a use-after-free that stayed quiet because the memory had not been reused yet.

Re-adding the listeners is not available; Wayland forbids a second `add_listener` on the same proxy. The adopt path re-points the proxies instead, through `wl_registry_set_user_data()` and its siblings, and refreshes the cached context pointer on each `seat_info_t`, since that node is what hands the context to any keyboard or pointer the seat creates later on a capability change.

The pointer needed one thing more. No second `enter` arrives for a surface that never went away, so `input.mouse.surface` came back NULL and the button listener rejected every click whose focus surface did not match `wl->surface`. Motion and highlighting worked while clicks did nothing, which is a confusing way for this to present. Adopt restores it explicitly.

### The keymap only arrives once per wl_keyboard

`free_xkb()` is skipped when the objects are kept. A kept `wl_keyboard` never resends its keymap, so freeing the xkb state on a reinit would kill modifier handling for the rest of the session instead of for one load.

### The frame callback outlives the surface

A frame callback in flight over a kept surface would fire into a context that is about to be freed, so the context tracks the callback it set and cancels it on teardown.

That is the entire footprint outside webOS-only code: one `struct wl_callback *frame_cb` field and five lines in `wayland_ctx.c`. Two of those five clear the pointer at the existing deadline and poll-timeout bail-outs, which already destroyed the callback. Without them the tracking pointer becomes the thing that dangles.

### Second commit: something on screen during the load

With the surface retained the load no longer drops to Home. It holds the last menu frame instead, motionless, for the whole load, which still reads as a hang.

Everything past that point in `content_load()` is synchronous and draws no frames. `runloop_present_blocking_msg()` puts RetroArch's own translated `MSG_LOADING` up first and pumps `gfx_animation_update()`, `gfx_widgets_iterate()` and `video_driver_cached_frame()` until the notification has actually animated into view. Pushing it and returning does nothing visible: notifications animate in from off-screen over `MSG_QUEUE_ANIMATION_DURATION`, and once the load owns the thread there is nothing left to advance that animation.

It is gated on `RARCH_PATH_CONTENT` being non-empty. Starting the dummy core reaches the same function, on startup and every time content is closed, and `task_push_start_dummy_core()` clears the content path first, which is what separates the two cases. Without the gate the toast fires when the app opens and again when a game is closed. That is how I found it.

Both the helper and its declaration sit behind `#ifdef WEBOS`.

### How to verify

```
make -f Makefile.webos ADD_SDL2_LIB=1 HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 \
     HAVE_WAYLAND=1 HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1
ares-package webos/dist && ares-install com.retroarch.webos_*_arm.ipk
```

Load content and watch the screen. It should stay on RetroArch throughout, with the loading notification visible, and never show the Home dashboard. Still in game, open the menu with the hotkey, move the pointer across the entry list, click an entry. Then close content and reopen the app, checking that no stray loading toast appears on either.

The log should carry one `Keeping surface across video reinit` and one `Adopted cached surface after reinit` per load, and neither line on exit.

### What this does not do, and what was not checked

Testing was one device: an LG OLED65G5 on webOS 10.3.1, running RetroArch 1.22.2 built from this branch. I have no second webOS TV, so the version spread is untested, and since the behaviour being worked around belongs to the compositor, older releases are the plausible risk.

It covers the `wl_shell` path only. The webOS context uses `wl_shell` plus `wl_webos_shell` and the cache mirrors that, so it has nothing to say about `xdg_shell` in the common Wayland driver. The desktop driver is otherwise untouched apart from the frame-callback tracking, which is inert anywhere a surface dies with its context. That field does live in the shared struct, though, and it is the one place a non-webOS regression could come from.

Three more things worth stating plainly:

- There is a `wl_shell_surface_destroy()` in the shutdown path that was not there before. Upstream leaks it today, and once the cache started destroying the kept one, the direct path not doing so looked wrong. Two lines, separable, drop them if you would rather this PR did the one thing.
- The load is not faster. This changes what the screen shows while it happens and nothing else.
- No leak check under a memory tool. Keep and adopt were paired by reading the code and by repeated load cycles on the device, not by valgrind or ASan, neither of which is wired up in this webOS toolchain.
