### PR TITLE
menu: the mouse wheel moves the list, not the selection

### DIFF
--- a/menu/drivers/materialui.c
+++ b/menu/drivers/materialui.c
@@ -10046,6 +10046,35 @@ static void materialui_animate_scroll(materialui_handle_t *mui,
    gfx_animation_push(&animation_entry);
 }
 
+static bool materialui_wheel_scroll(void *data, int notches)
+{
+   float scroll_y_max;
+   materialui_handle_t *mui = (materialui_handle_t*)data;
+   gfx_display_t *p_disp    = disp_get_ptr();
+
+   if (!mui)
+      return false;
+
+   /* Fullscreen thumbnails swallow all input, and a scrollbar
+    * drag owns scroll_y until it is released. */
+   if (     (mui->flags & MUI_FLAG_SHOW_FULLSCREEN_THUMBNAILS)
+         || (mui->flags & MUI_FLAG_SCROLLBAR_DRAGGED))
+      return false;
+
+   scroll_y_max = materialui_get_scroll_y_max(mui, mui->last_height,
+         p_disp->header_height);
+
+   /* Three rows a notch, a row being about a third of the base
+    * unit. Clamped here because the animation would otherwise
+    * pull towards a target the render loop keeps clamping back. */
+   materialui_animate_scroll(mui,
+         materialui_clamp_scroll(mui->scroll_y
+               + ((float)notches * mui->dip_base_unit_size),
+               scroll_y_max),
+         MUI_ANIM_DURATION_SCROLL);
+   return true;
+}
+
 /* The navigation pointer has been updated (for example by pressing up or down
    on the keyboard) */
 static void materialui_navigation_set(void *data, bool scroll)
@@ -13013,5 +13042,6 @@ menu_ctx_driver_t menu_ctx_mui = {
    materialui_update_savestate_thumbnail_image,
    materialui_pointer_down,
    materialui_pointer_up,
-   materialui_menu_entry_action
+   materialui_menu_entry_action,
+   materialui_wheel_scroll
 };

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -670,6 +670,10 @@ struct ozone_handle
    float last_framebuffer_opacity;
 
    int16_t pointer_active_delta;
+   /* Wheel notches waiting to be turned into list movement, so
+    * that the clamping already done for drag scrolling applies
+    * to them too. */
+   int16_t wheel_notches;
    int16_t cursor_x_old;
    int16_t cursor_y_old;
 
@@ -707,6 +711,11 @@ struct ozone_handle
    bool show_playlist_tabs;
    bool sidebar_collapsed;
    bool font_unicode;
+   /* Set when a pending NEED_COMPUTE was raised by something that
+    * changed entry geometry without touching the list. The compute
+    * pass then keeps the view where it is, rather than re-deriving
+    * it from the selection. */
+   bool preserve_scroll_on_compute;
 
    struct
    {
@@ -4399,6 +4408,11 @@ static void ozone_go_to_sidebar(ozone_handle_t *ozone,
    else
       ozone->flags               &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR_OLD;
    ozone->flags                  |=  OZONE_FLAG_CURSOR_IN_SIDEBAR;
+   /* Focus moving here hides the thumbnail bar, which rewraps every
+    * entry and raises a compute. The list itself is unchanged, and
+    * a pointer leaves the selection wherever it was resting, so
+    * re-deriving the scroll from it would drag the list about. */
+   ozone->preserve_scroll_on_compute = true;
 
    /* If sublabels are enabled only for the currently selected entry,
     * recalculate geometry values to keep correct spacing and animation. */
@@ -4682,6 +4696,9 @@ static void ozone_leave_sidebar(ozone_handle_t *ozone,
    else
       ozone->flags                 &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR_OLD;
    ozone->flags                    &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR;
+   /* As above: the thumbnail bar comes back, the list does not
+    * change, and the view should stay where the user left it. */
+   ozone->preserve_scroll_on_compute = true;
    /* If sublabels are enabled only for the currently selected entry,
     * recalculate geometry values to keep correct spacing and animation. */
    if (menu_show_sublabels && menu_current_sel_only)
@@ -5800,6 +5817,8 @@ static void ozone_compute_entries_position(ozone_handle_t *ozone,
    size_t i;
    /* Compute entries height and adjust scrolling if needed */
    settings_t *settings          = config_get_ptr();
+   size_t anchor_idx             = 0;
+   float anchor_offset           = 0.0f;
    unsigned video_info_width     = ozone->last_width;
    struct menu_state *menu_st    = menu_state_get_ptr();
    menu_list_t *menu_list        = menu_st->entries.list;
@@ -5832,6 +5851,31 @@ static void ozone_compute_entries_position(ozone_handle_t *ozone,
 
    if (menu_show_sublabels)
       sublabel_max_width         = ozone_get_sublabel_max_width(ozone, video_info_width, entry_padding);
+
+   /* Note which entry sits at the top of the view, and how far it
+    * is clipped, while the layout that produced it is still
+    * standing. Heights change across the recompute below - the
+    * thumbnail bar coming and going rewraps every sublabel - so a
+    * raw scroll_y would land somewhere else. */
+   if (ozone->preserve_scroll_on_compute)
+   {
+      float view_top = -ozone->animations.scroll_y;
+
+      for (i = 0; (i < entries_end) && (i < selection_buf->size); i++)
+      {
+         ozone_node_t *node = (ozone_node_t*)selection_buf->list[i].userdata;
+
+         if (!node)
+            continue;
+
+         if ((float)(node->position_y + node->height) > view_top)
+         {
+            anchor_idx    = i;
+            anchor_offset = view_top - (float)node->position_y;
+            break;
+         }
+      }
+   }
 
    ozone->entries_height         = 0;
 
@@ -5927,6 +5971,37 @@ compute_sublabel:
     * (issue #18797). size >= 1 is guaranteed by the early return above. */
    if (ozone->selection >= selection_buf->size)
       ozone->selection       = selection_buf->size - 1;
+
+   if (ozone->preserve_scroll_on_compute)
+   {
+      ozone_node_t *node = (anchor_idx < selection_buf->size)
+            ? (ozone_node_t*)selection_buf->list[anchor_idx].userdata
+            : NULL;
+
+      ozone->preserve_scroll_on_compute = false;
+
+      if (node)
+      {
+         uintptr_t tag         = (uintptr_t)selection_buf;
+         float bottom_boundary = (float)ozone->last_height
+               - ozone->dimensions.header_height
+               - ozone->dimensions.spacer_1px
+               - ozone->dimensions.footer_height;
+         float new_scroll      = -((float)node->position_y + anchor_offset);
+
+         if (new_scroll + ozone->entries_height < bottom_boundary)
+            new_scroll = bottom_boundary - ozone->entries_height
+                  - ozone->dimensions.entry_padding_vertical * 2;
+
+         if (new_scroll > 0.0f)
+            new_scroll = 0.0f;
+
+         gfx_animation_kill_by_tag(&tag);
+         ozone->animations.scroll_y = new_scroll;
+         return;
+      }
+   }
+
    if (!menu_show_sublabels || !menu_current_sel_only || !cursor_in_sidebar)
       ozone_update_scroll(ozone, animate_scroll, (ozone_node_t*)selection_buf->list[ozone->selection].userdata);
 }
@@ -10696,6 +10771,36 @@ static void ozone_list_free(file_list_t *list, size_t a, size_t b)
    ozone_list_clear(list);
 }
 
+/* Distance one wheel notch moves a list. Three rows is what
+ * desktops settled on, and it stays legible: a row of context is
+ * left behind on every notch. */
+static float ozone_get_wheel_step(ozone_handle_t *ozone)
+{
+   return 3.0f * (float)(ozone->dimensions.entry_height
+         + ozone->dimensions.spacer_1px);
+}
+
+static bool ozone_wheel_scroll(void *data, int notches)
+{
+   ozone_handle_t *ozone = (ozone_handle_t*)data;
+
+   if (!ozone)
+      return false;
+
+   /* The sidebar is a list too, and drag scrolls it the same way,
+    * but a collapsed one has nowhere to go. */
+   if (     (ozone->flags2 & OZONE_FLAG2_POINTER_IN_SIDEBAR)
+         && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)))
+      return false;
+
+   ozone->wheel_notches += notches;
+   /* Turning a wheel moves no pointer, so cursor mode would stay
+    * off and the block that reads wheel_notches would never run.
+    * It is mouse input all the same. */
+   ozone->flags         |= OZONE_FLAG_CURSOR_MODE;
+   return true;
+}
+
 static void ozone_render(void *data,
       unsigned width,
       unsigned height,
@@ -10992,6 +11097,16 @@ static void ozone_render(void *data,
 
          ozone->animations.scroll_y += ozone->pointer.y_accel;
 
+         if (ozone->wheel_notches)
+         {
+            /* A selection made before the wheel was touched may
+             * still be animating the list towards itself. */
+            gfx_animation_kill_by_tag(&animation_tag);
+            ozone->animations.scroll_y -= (float)ozone->wheel_notches
+                  * ozone_get_wheel_step(ozone);
+            ozone->wheel_notches        = 0;
+         }
+
          if (ozone->animations.scroll_y + ozone->entries_height < entry_bottom_boundary)
             ozone->animations.scroll_y = entry_bottom_boundary - ozone->entries_height;
 
@@ -11010,6 +11125,13 @@ static void ozone_render(void *data,
          float sidebar_height          = ozone_get_sidebar_height(ozone);
 
          ozone->animations.scroll_y_sidebar += ozone->pointer.y_accel;
+
+         if (ozone->wheel_notches)
+         {
+            ozone->animations.scroll_y_sidebar -=
+                  (float)ozone->wheel_notches * ozone_get_wheel_step(ozone);
+            ozone->wheel_notches                = 0;
+         }
 
          if (ozone->animations.scroll_y_sidebar + sidebar_height < sidebar_bottom_boundary)
             ozone->animations.scroll_y_sidebar = sidebar_bottom_boundary - sidebar_height;
@@ -13357,6 +13479,9 @@ static void ozone_populate_entries(
 
    ozone->flags               |=  OZONE_FLAG_NEED_COMPUTE;
    ozone->flags               &= ~OZONE_FLAG_SKIP_THUMBNAIL_RESET;
+   /* A different list needs its scroll derived from the selection,
+    * whatever an earlier transition asked for. */
+   ozone->preserve_scroll_on_compute = false;
 
    if (ozone->flags2 & OZONE_FLAG2_IS_QUICK_MENU)
       ozone->flags            |=  OZONE_FLAG_WAS_QUICK_MENU;
@@ -14083,5 +14208,6 @@ menu_ctx_driver_t menu_ctx_ozone = {
    ozone_update_savestate_thumbnail_image,
    NULL,                         /* pointer_down */
    ozone_pointer_up,
-   ozone_menu_entry_action
+   ozone_menu_entry_action,
+   ozone_wheel_scroll
 };

--- a/menu/drivers/ozone.c
+++ b/menu/drivers/ozone.c
@@ -4408,11 +4408,6 @@ static void ozone_go_to_sidebar(ozone_handle_t *ozone,
    else
       ozone->flags               &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR_OLD;
    ozone->flags                  |=  OZONE_FLAG_CURSOR_IN_SIDEBAR;
-   /* Focus moving here hides the thumbnail bar, which rewraps every
-    * entry and raises a compute. The list itself is unchanged, and
-    * a pointer leaves the selection wherever it was resting, so
-    * re-deriving the scroll from it would drag the list about. */
-   ozone->preserve_scroll_on_compute = true;
 
    /* If sublabels are enabled only for the currently selected entry,
     * recalculate geometry values to keep correct spacing and animation. */
@@ -4696,9 +4691,6 @@ static void ozone_leave_sidebar(ozone_handle_t *ozone,
    else
       ozone->flags                 &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR_OLD;
    ozone->flags                    &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR;
-   /* As above: the thumbnail bar comes back, the list does not
-    * change, and the view should stay where the user left it. */
-   ozone->preserve_scroll_on_compute = true;
    /* If sublabels are enabled only for the currently selected entry,
     * recalculate geometry values to keep correct spacing and animation. */
    if (menu_show_sublabels && menu_current_sel_only)
@@ -5983,15 +5975,16 @@ compute_sublabel:
       if (node)
       {
          uintptr_t tag         = (uintptr_t)selection_buf;
+         /* Same boundary ozone_render clamps drag and wheel to. */
          float bottom_boundary = (float)ozone->last_height
                - ozone->dimensions.header_height
                - ozone->dimensions.spacer_1px
-               - ozone->dimensions.footer_height;
+               - ozone->dimensions.footer_height
+               - ozone->dimensions.entry_padding_vertical * 2;
          float new_scroll      = -((float)node->position_y + anchor_offset);
 
          if (new_scroll + ozone->entries_height < bottom_boundary)
-            new_scroll = bottom_boundary - ozone->entries_height
-                  - ozone->dimensions.entry_padding_vertical * 2;
+            new_scroll = bottom_boundary - ozone->entries_height;
 
          if (new_scroll > 0.0f)
             new_scroll = 0.0f;
@@ -9792,6 +9785,10 @@ static int ozone_menu_entry_action(
     * (due to automatic on screen entry selection...) */
    size_t new_selection        = menu_st->selection_ptr;
 
+   /* An explicit action is about the selection again; a compute it
+    * raises must place the selection, not keep an old view. */
+   ozone->preserve_scroll_on_compute = false;
+
    if (new_selection != selection)
    {
       /* Selection has changed - must update
@@ -10774,8 +10771,11 @@ static void ozone_list_free(file_list_t *list, size_t a, size_t b)
 /* Distance one wheel notch moves a list. Three rows is what
  * desktops settled on, and it stays legible: a row of context is
  * left behind on every notch. */
-static float ozone_get_wheel_step(ozone_handle_t *ozone)
+static float ozone_get_wheel_step(ozone_handle_t *ozone, bool sidebar)
 {
+   if (sidebar)
+      return 3.0f * (float)(ozone->dimensions.sidebar_entry_height
+            + ozone->dimensions.sidebar_entry_padding_vertical);
    return 3.0f * (float)(ozone->dimensions.entry_height
          + ozone->dimensions.spacer_1px);
 }
@@ -10785,6 +10785,12 @@ static bool ozone_wheel_scroll(void *data, int notches)
    ozone_handle_t *ozone = (ozone_handle_t*)data;
 
    if (!ozone)
+      return false;
+
+   /* With a fullscreen thumbnail up, the wheel flips between
+    * entries behind it; that still wants MENU_ACTION_UP/DOWN. */
+   if (     (ozone->flags2 & OZONE_FLAG2_SHOW_FULLSCREEN_THUMBNAILS)
+         || (ozone->flags2 & OZONE_FLAG2_WANT_FULLSCREEN_THUMBNAILS))
       return false;
 
    /* The sidebar is a list too, and drag scrolls it the same way,
@@ -10903,6 +10909,11 @@ static void ozone_render(void *data,
       ozone->selection_old = ozone->selection;
       ozone->flags        |= OZONE_FLAG_NEED_COMPUTE;
       ozone->flags        &= ~OZONE_FLAG_CURSOR_IN_SIDEBAR_OLD;
+      /* A hover changed the selection. Only the hovered entry grows a
+       * sublabel; re-deriving the scroll from it would move the list
+       * under a pointer that did not move, and undo a wheel notch. */
+      if (ozone->flags & OZONE_FLAG_CURSOR_MODE)
+         ozone->preserve_scroll_on_compute = true;
    }
 
    if (ozone->flags & OZONE_FLAG_NEED_COMPUTE)
@@ -11066,16 +11077,29 @@ static void ozone_render(void *data,
        * mouse focus from entries to sidebar (and vice versa) */
       if (ozone->pointer.type == MENU_POINTER_MOUSE)
       {
+         /* Following the pointer moves focus, not the list: the
+          * thumbnail bar comes and goes and rewraps every entry, but
+          * the selection is wherever the pointer left it, so the
+          * compute keeps the view instead of re-deriving it from the
+          * selection. Pad/keyboard transitions still re-derive. */
          if (       (pointer_in_sidebar)
                && (!(last_pointer_in_sidebar))
                && (!(ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)))
+         {
             ozone_go_to_sidebar(ozone, ozone_collapse_sidebar, animation_tag);
+            ozone->preserve_scroll_on_compute = true;
+         }
          else if (   (!pointer_in_sidebar)
                   && (last_pointer_in_sidebar)
                   && (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR))
+         {
             if (!(ozone->flags & OZONE_FLAG_EMPTY_PLAYLIST))
+            {
                ozone_leave_sidebar(ozone, ozone_collapse_sidebar, animation_tag,
                      settings->uints.menu_remember_selection);
+               ozone->preserve_scroll_on_compute = true;
+            }
+         }
       }
       else if (ozone->pointer.type == MENU_POINTER_TOUCHSCREEN)
       {
@@ -11103,7 +11127,7 @@ static void ozone_render(void *data,
              * still be animating the list towards itself. */
             gfx_animation_kill_by_tag(&animation_tag);
             ozone->animations.scroll_y -= (float)ozone->wheel_notches
-                  * ozone_get_wheel_step(ozone);
+                  * ozone_get_wheel_step(ozone, false);
             ozone->wheel_notches        = 0;
          }
 
@@ -11129,7 +11153,7 @@ static void ozone_render(void *data,
          if (ozone->wheel_notches)
          {
             ozone->animations.scroll_y_sidebar -=
-                  (float)ozone->wheel_notches * ozone_get_wheel_step(ozone);
+                  (float)ozone->wheel_notches * ozone_get_wheel_step(ozone, true);
             ozone->wheel_notches                = 0;
          }
 
@@ -11257,8 +11281,11 @@ static void ozone_render(void *data,
                   if (ozone->flags & OZONE_FLAG_CURSOR_IN_SIDEBAR)
                   {
                      if (!(ozone->flags & OZONE_FLAG_EMPTY_PLAYLIST))
+                     {
                         ozone_leave_sidebar(ozone, ozone_collapse_sidebar, animation_tag,
                               settings->uints.menu_remember_selection);
+                        ozone->preserve_scroll_on_compute = true;
+                     }
                   }
                   /* If this is a playlist, must update thumbnails */
                   else if (ozone->flags & OZONE_FLAG_IS_PLAYLIST)

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -5707,8 +5707,9 @@ static bool gfx_thumbnail_get_label(
 /*
  * Moves the list by whole rows while keeping the selection the
  * same.
- * Returns true when the list was moved, false to let the notch
- * fall back to stepping the selection. */
+ * Returns true whenever the list is what the wheel drives, even
+ * where it has nowhere to go, so that a notch never steps the
+ * selection. False falls back to that step. */
 static bool rgui_wheel_scroll(void *data, int notches)
 {
    int start;
@@ -5728,14 +5729,7 @@ static bool rgui_wheel_scroll(void *data, int notches)
 
    entries_end = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
    bottom = (int)entries_end - (int)rgui->term_layout.height;
-
-   /* Everything is on screen already, so there is nothing to
-    * move. Switch the selection instead. */
-   if (bottom <= 0)
-      return false;
-
    start = (int)menu_st->entries.begin + (notches * RGUI_WHEEL_SCROLL_ROWS);
-
    if (start > bottom)
       start = bottom;
    if (start < 0)

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -353,6 +353,9 @@ typedef struct
    uint32_t thumbnail_queue_size;
    uint32_t left_thumbnail_queue_size;
    uint32_t flags;
+   /* Pixel offset of the list, term rows * font_height_stride;
+    * int16_t overflows on playlists past a few thousand entries. */
+   int32_t scroll_y;
    int8_t gfx_thumbnails_prev;
 
    rgui_particle_t particles[RGUI_NUM_PARTICLES]; /* float alignment */
@@ -362,7 +365,6 @@ typedef struct
    size_t playlist_selection_ptr;
    size_t playlist_selection[NAME_MAX_LENGTH];
    size_t playlist_mainmenu_selection[RGUI_MAINMENU_LAST]; /* History + Favorites */
-   int16_t scroll_y;
    rgui_colors_t colors;   /* int16_t alignment */
 
    struct scaler_ctx image_scaler;
@@ -5736,7 +5738,7 @@ static bool rgui_wheel_scroll(void *data, int notches)
       start = 0;
 
    menu_st->entries.begin = (size_t)start;
-   rgui->scroll_y = (int16_t)(start * (int)rgui->font_height_stride);
+   rgui->scroll_y = start * (int32_t)rgui->font_height_stride;
    rgui->flags |= RGUI_FLAG_FORCE_REDRAW;
    return true;
 }
@@ -5902,7 +5904,7 @@ static void rgui_render(void *data, unsigned width, unsigned height,
       if (     (rgui->pointer.flags & MENU_INP_PTR_FLG_DRAGGED)
             && (bottom > 0))
       {
-         int16_t scroll_y_max   = bottom * rgui->font_height_stride;
+         int32_t scroll_y_max   = bottom * (int32_t)rgui->font_height_stride;
          rgui->scroll_y        += -1 * rgui->pointer.dy;
          if (rgui->scroll_y < 0)
             rgui->scroll_y      = 0;

--- a/menu/drivers/rgui.c
+++ b/menu/drivers/rgui.c
@@ -132,6 +132,10 @@
 #define RGUI_SYMBOL_WIDTH_STRIDE  (RGUI_SYMBOL_WIDTH + 1)
 #define RGUI_SYMBOL_HEIGHT_STRIDE (RGUI_SYMBOL_HEIGHT + 1)
 
+/* When the mouse wheel moves, this is the number of rows that
+ * that will be scrolled. */
+#define RGUI_WHEEL_SCROLL_ROWS 3
+
 enum rgui_playlist_mainmenu_selection
 {
    RGUI_MAINMENU_HISTORY = 0,
@@ -5700,6 +5704,49 @@ static bool gfx_thumbnail_get_label(
    return true;
 }
 
+/*
+ * Moves the list by whole rows while keeping the selection the
+ * same.
+ * Returns true when the list was moved, false to let the notch
+ * fall back to stepping the selection. */
+static bool rgui_wheel_scroll(void *data, int notches)
+{
+   int start;
+   int bottom;
+   size_t entries_end;
+   rgui_t *rgui = (rgui_t*)data;
+   struct menu_state *menu_st = menu_state_get_ptr();
+   menu_list_t *menu_list = menu_st->entries.list;
+
+   if (!rgui || !menu_list)
+      return false;
+
+   /* A fullscreen thumbnail hides the list, and the wheel is
+    * better spent stepping through the playlist behind it. */
+   if (rgui->flags & RGUI_FLAG_SHOW_FULLSCREEN_THUMBNAIL)
+      return false;
+
+   entries_end = MENU_LIST_GET_SELECTION(menu_list, 0)->size;
+   bottom = (int)entries_end - (int)rgui->term_layout.height;
+
+   /* Everything is on screen already, so there is nothing to
+    * move. Switch the selection instead. */
+   if (bottom <= 0)
+      return false;
+
+   start = (int)menu_st->entries.begin + (notches * RGUI_WHEEL_SCROLL_ROWS);
+
+   if (start > bottom)
+      start = bottom;
+   if (start < 0)
+      start = 0;
+
+   menu_st->entries.begin = (size_t)start;
+   rgui->scroll_y = (int16_t)(start * (int)rgui->font_height_stride);
+   rgui->flags |= RGUI_FLAG_FORCE_REDRAW;
+   return true;
+}
+
 static void rgui_render(void *data, unsigned width, unsigned height,
       bool is_idle)
 {
@@ -9195,5 +9242,6 @@ menu_ctx_driver_t menu_ctx_rgui = {
    rgui_update_savestate_thumbnail_image,
    NULL,                               /* pointer_down */
    rgui_pointer_up,
-   rgui_menu_entry_action
+   rgui_menu_entry_action,
+   rgui_wheel_scroll
 };

--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -5990,6 +5990,27 @@ unsigned menu_event(
    return ret;
 }
 
+/**
+ * menu_input_wheel_scroll:
+ *
+ * Hands a mouse wheel notch to the menu driver as list movement.
+ * A wheel is not a d-pad, and a driver that can move its list
+ * under a resting pointer reads far better doing that than
+ * stepping the selection one entry per notch.
+ *
+ * Returns: true when the driver took it, false to fall back to
+ * MENU_ACTION_UP/MENU_ACTION_DOWN.
+ **/
+static bool menu_input_wheel_scroll(struct menu_state *menu_st,
+      int notches)
+{
+   if (     menu_st->driver_ctx
+         && menu_st->driver_ctx->wheel_scroll)
+      return menu_st->driver_ctx->wheel_scroll(
+            menu_st->userdata, notches);
+   return false;
+}
+
 MENU_NOINLINE static int menu_input_post_iterate(
       gfx_display_t *p_disp,
       struct menu_state *menu_st,
@@ -6556,17 +6577,23 @@ MENU_NOINLINE static int menu_input_post_iterate(
       /* > Up */
       if (pointer_hw_state->flags & MENU_INP_PTR_FLG_PRESS_UP)
       {
-         size_t selection = menu_st->selection_ptr;
-         ret              = menu_entry_action(
-               &entry, selection, MENU_ACTION_UP);
+         if (!menu_input_wheel_scroll(menu_st, -1))
+         {
+            size_t selection = menu_st->selection_ptr;
+            ret              = menu_entry_action(
+                  &entry, selection, MENU_ACTION_UP);
+         }
       }
 
       /* > Down */
       if (pointer_hw_state->flags & MENU_INP_PTR_FLG_PRESS_DOWN)
       {
-         size_t selection = menu_st->selection_ptr;
-         ret              = menu_entry_action(
-               &entry, selection, MENU_ACTION_DOWN);
+         if (!menu_input_wheel_scroll(menu_st, 1))
+         {
+            size_t selection = menu_st->selection_ptr;
+            ret              = menu_entry_action(
+                  &entry, selection, MENU_ACTION_DOWN);
+         }
       }
 
       /* Left/Right

--- a/menu/menu_driver.h
+++ b/menu/menu_driver.h
@@ -419,6 +419,12 @@ typedef struct menu_ctx_driver
    /* This will be invoked whenever a menu entry action
     * (menu_entry_action()) is performed */
    int (*entry_action)(void *userdata, menu_entry_t *entry, size_t i, enum menu_action action);
+   /* Move the list itself by the given number of mouse wheel
+    * notches, negative towards the top, leaving the selection
+    * where it is. Drivers whose list position *is* the selection
+    * leave this NULL and keep getting MENU_ACTION_UP/DOWN.
+    * Returns false when the driver cannot scroll right now. */
+   bool (*wheel_scroll)(void *userdata, int notches);
 } menu_ctx_driver_t;
 
 typedef struct


### PR DESCRIPTION
## menu: the mouse wheel moves the list, not the selection

Closes #9633.

The wheel has always been `MENU_ACTION_UP`/`DOWN` in `menu_driver.c`. Every driver stepped the selection, one entry per notch. That is what a d-pad does. It is a poor match for a wheel, and it is why Ozone and GLUI feel broken next to their own click-and-drag, which already moves the list.

A `wheel_scroll` hook on `menu_ctx_driver_t` lets a driver take the notch as list movement. Ozone and GLUI implement it. XMB and RGUI leave it NULL, so they keep the old step: their list position *is* the selection.

Ozone queues notches and spends them where drag scrolling already clamps, so the wheel obeys the same top and bottom. Three rows a notch. Pointer over the sidebar scrolls the sidebar. Cursor mode is turned on because a wheel moves no pointer, and without that the hover code never runs, so the entry under the pointer is selected once the list settles.

GLUI reuses the animated scroll it already had for swipes. It declines while fullscreen thumbnails or a scrollbar drag are active.

The last piece is Ozone going back to the sidebar. That hides the thumbnail bar, which rewraps every entry and used to re-center on the selection. A pointer leaves the selection wherever it was resting, so the list jumped. `preserve_scroll_on_compute` keeps the same top entry in view. Material UI already does this when geometry changes without the list changing.

Independent of #19493, which reworks the Ozone pointer highlight. Either can go in first. Together they read better, since that one stops a highlight showing while the pointer rests between rows.

### How to verify

Ozone (and GLUI, if you have a mouse):

- Wheel a long playlist. The list moves. Selection follows the pointer, not the wheel.
- Wheel with the pointer over the sidebar. The sidebar moves.
- Hover a game at the top or bottom of the view, move left. The list stays put.
- Open a playlist tab with the keyboard. It still scrolls to the remembered entry.
- D-pad still steps one entry.

Tested on an LG OLED65G5 (webOS 10.3.1) with the Magic Remote pointer and wheel, Ozone with thumbnails on.
