### PR TITLE
menu: show Load Content > Downloads without installed cores

### DIFF
--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -8793,9 +8793,6 @@ unsigned menu_displaylist_build_list(
       case DISPLAYLIST_LOAD_CONTENT_LIST:
       case DISPLAYLIST_LOAD_CONTENT_SPECIAL:
       {
-         core_info_list_t *info_list = NULL;
-         core_info_get_list(&info_list);
-
          if (*settings->paths.directory_menu_content)
             if (menu_entries_append(list,
                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_FAVORITES),
@@ -8804,7 +8801,7 @@ unsigned menu_displaylist_build_list(
                      MENU_SETTING_ACTION_FAVORITES_DIR, 0, 0, NULL))
                count++;
 
-         if (info_list && info_list->info_count > 0)
+         if (*settings->paths.directory_core_assets)
             if (menu_entries_append(list,
                      msg_hash_to_str(
                         MENU_ENUM_LABEL_VALUE_DOWNLOADED_FILE_DETECT_CORE_LIST),


### PR DESCRIPTION
Load Content only listed the Downloads entry when at least one core info file was loaded, so with an empty or unreadable core directory the folder vanished from the menu even though its files were on disk. The check has been there since the entry was added next to Favorites in 2017 and survived the move out of the per-driver list_push functions in #17517. It is not needed for safety: picking a file with no cores installed already lands on the "No cores available" list with a Download Core entry.

This gates the entry on the Downloads directory being set instead, like the Favorites entry right above, and drops the core list lookup that only served the old check. menu_displaylist.o builds with the MSYS2 MinGW toolchain after a fresh ./configure.

Fixes #19405
