### PR TITLE
macOS: fix EXC_BAD_ACCESS in SLSFlushSurfaceWithOptionsAndIndex on first fullscreen frame

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -672,6 +672,20 @@ static void cocoa_gl_gfx_ctx_set_video_mode_mainthread(void *userdata)
          [fullscreen_window makeFirstResponder:g_view];
 
          cocoa_show_mouse(data, false);
+
+         /* WindowServer registers this newly-created fullscreen window's
+          * backing surface asynchronously - makeKeyAndOrderFront returning
+          * does not mean that has finished. On some systems the very first
+          * -flushBuffer call (issued moments after this function returns)
+          * can land before that registration completes, crashing inside
+          * AppleMetalOpenGLRenderer/SkyLight with a null surface handle
+          * (EXC_BAD_ACCESS in SLSFlushSurfaceWithOptionsAndIndex). Pumping
+          * the run loop briefly here - actually processing the pending
+          * window-order/CATransaction work, not just sleeping - gives the
+          * WindowServer a real chance to catch up before the first frame.
+          * Only needed on this one-time transition into fullscreen. */
+         [[NSRunLoop currentRunLoop] runUntilDate:
+               [NSDate dateWithTimeIntervalSinceNow:0.2]];
       }
    }
    else


### PR DESCRIPTION
## Summary

Follow-up to #19491, per @LibretroAdmin's request there to retest against current master/nightly rather than 1.22.2.

On this setup (macOS 26.6.2, Apple M4, legacy `gl` video driver, `video_fullscreen = true`, `video_threaded = false`) current master crashes with `EXC_BAD_ACCESS` **100% of the time** on launch, in `SLSFlushSurfaceWithOptionsAndIndex` (SkyLight), called from `AppleMetalOpenGLRenderer`'s `gldPresentFramebufferData`, called from our own `cocoa_gl_gfx_ctx_swap_buffers`'s `-flushBuffer` - the very first buffer flush after entering fullscreen.

## Root cause

Bisected against v1.22.2 (which never crashes here) and confirmed live with lldb at the crash site. At the moment it crashes, every Cocoa-level object is completely valid: `g_ctx`/`g_hw_ctx` are real `NSOpenGLContext`s, `[g_ctx view]` is a real, visible `CocoaView`, and its window is our own hand-rolled borderless fullscreen `RAWindow` (`NSMainMenuWindowLevel + 1`), fully ordered front (`isVisible == 1`). The null pointer read (offset `0x78`) is inside SkyLight's own private surface-handle bookkeeping for that window - not anything reachable from application code.

`-[NSWindow makeKeyAndOrderFront:]` returning does not mean the WindowServer has finished registering this brand-new window's backing surface. The very first `-flushBuffer` call a moment later can lose that race.

This is a genuine timing margin, not app-observable state:
- Pausing execution at a breakpoint on the way to the first flush (adding tens of milliseconds of delay) makes the crash go away with identical code.
- Instrumenting both v1.22.2 and current master with lldb: v1.22.2 consistently leaves **~520ms** between the GL context being reattached to the new fullscreen window (`cocoa_gl_gfx_ctx_update`) and the first flush, vs. only **~390ms** on current master.
- That ~130ms margin loss traces back across 5186 commits between v1.22.2 and master without any single commit individually reproducing or fixing it once isolated - bisecting to a "first bad commit" and reverting just that commit's diff in isolation did not change the outcome, consistent with the margin having eroded gradually rather than from one regression.

## Fix

After ordering the new fullscreen window front (only on the one-time transition into fullscreen, not on every resize), actually pump the run loop for 200ms via `-[NSRunLoop runUntilDate:]` rather than sleeping - this processes whatever pending window-order/CATransaction work the WindowServer still has queued, instead of just letting wall-clock time pass. 200ms is comfortably above the ~130ms margin difference observed above.

## Test plan

- [x] Built via the same `xcodebuild -project pkg/apple/RetroArch.xcodeproj -scheme RetroArch -configuration Release` flow as before, targeting arm64/macOS 11+.
- [x] Before the fix: crashed on **every** launch attempted (double-click, launched under lldb, launched via a frontend/Pegasus) - many trials, always the same backtrace.
- [x] After the fix: **5 consecutive clean launches**, no crash, via direct double-click launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)