### PR TITLE
macOS: fix EXC_BAD_ACCESS in SLSFlushSurfaceWithOptionsAndIndex on first fullscreen frame

### DIFF
--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -550,7 +550,24 @@ static void cocoa_gl_gfx_ctx_set_video_mode_mainthread(void *userdata)
           * and both statics are already nil here; guard defensively so an
           * MRR build does not leak the previous +1 if that invariant ever
           * breaks (e.g. a future caller that re-inits without tearing
-          * down first).  Safe when already nil under both ARC and MRR. */
+          * down first).  Safe when already nil under both ARC and MRR.
+          *
+          * On macOS this guard is NOT always a no-op: gl2_init() calls
+          * -set_video_mode twice back-to-back as a deliberate workaround
+          * for a separate, poorly-understood issue (see the "very
+          * annoying issue" comment in gl2.c), so this can genuinely run
+          * with a live g_ctx/g_hw_ctx from the first call - one that was
+          * just -setView:'d onto the real, on-screen window and made the
+          * current context a moment ago. Releasing it with only a plain
+          * RELEASE (no -clearCurrentContext / -clearDrawable first, the
+          * teardown -destroy itself always does) can drop the last
+          * reference while WindowServer's surface bookkeeping for that
+          * view still considers it live, corrupting state the next
+          * context's first real frame then crashes on
+          * (EXC_BAD_ACCESS in SLSFlushSurfaceWithOptionsAndIndex). */
+         if ([NSOpenGLContext currentContext] == g_ctx)
+            [GLContextClass clearCurrentContext];
+         [g_ctx clearDrawable];
          RELEASE(g_ctx);
          RELEASE(g_hw_ctx);
          g_hw_ctx       = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext:nil];
@@ -558,6 +575,9 @@ static void cocoa_gl_gfx_ctx_set_video_mode_mainthread(void *userdata)
       }
       else
       {
+         if ([NSOpenGLContext currentContext] == g_ctx)
+            [GLContextClass clearCurrentContext];
+         [g_ctx clearDrawable];
          RELEASE(g_ctx);
          g_ctx          = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext:nil];
       }

--- a/gfx/drivers_context/cocoa_gl_ctx.m
+++ b/gfx/drivers_context/cocoa_gl_ctx.m
@@ -544,43 +544,29 @@ static void cocoa_gl_gfx_ctx_set_video_mode_mainthread(void *userdata)
          fmt            = [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
       }
 
+      /* A context must never be released while still attached to the
+       * view (or current on the render thread).  -destroy guarantees
+       * that on the normal reinit path, but on non-Metal macOS
+       * gl2_init() calls -set_video_mode twice back-to-back (see the
+       * "very annoying issue" comment in gl2.c), so g_ctx/g_hw_ctx can
+       * still be live here from the first call.  Detach them before
+       * RELEASE, exactly as -destroy_mainthread does; the caller has
+       * already cleared the render thread's current context.  Under
+       * ARC RELEASE() is an assignment of nil to a strong static, which
+       * still releases, so this applies to both memory models. */
+      [g_ctx clearDrawable];
+      if (g_hw_ctx)
+         [g_hw_ctx clearDrawable];
+      RELEASE(g_ctx);
+      RELEASE(g_hw_ctx);
+
       if (cocoa_ctx->flags & COCOA_CTX_FLAG_USE_HW_CTX)
       {
-         /* In the normal reinit flow -destroy runs before -set_video_mode
-          * and both statics are already nil here; guard defensively so an
-          * MRR build does not leak the previous +1 if that invariant ever
-          * breaks (e.g. a future caller that re-inits without tearing
-          * down first).  Safe when already nil under both ARC and MRR.
-          *
-          * On macOS this guard is NOT always a no-op: gl2_init() calls
-          * -set_video_mode twice back-to-back as a deliberate workaround
-          * for a separate, poorly-understood issue (see the "very
-          * annoying issue" comment in gl2.c), so this can genuinely run
-          * with a live g_ctx/g_hw_ctx from the first call - one that was
-          * just -setView:'d onto the real, on-screen window and made the
-          * current context a moment ago. Releasing it with only a plain
-          * RELEASE (no -clearCurrentContext / -clearDrawable first, the
-          * teardown -destroy itself always does) can drop the last
-          * reference while WindowServer's surface bookkeeping for that
-          * view still considers it live, corrupting state the next
-          * context's first real frame then crashes on
-          * (EXC_BAD_ACCESS in SLSFlushSurfaceWithOptionsAndIndex). */
-         if ([NSOpenGLContext currentContext] == g_ctx)
-            [GLContextClass clearCurrentContext];
-         [g_ctx clearDrawable];
-         RELEASE(g_ctx);
-         RELEASE(g_hw_ctx);
          g_hw_ctx       = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext:nil];
          g_ctx          = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext:g_hw_ctx];
       }
       else
-      {
-         if ([NSOpenGLContext currentContext] == g_ctx)
-            [GLContextClass clearCurrentContext];
-         [g_ctx clearDrawable];
-         RELEASE(g_ctx);
          g_ctx          = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext:nil];
-      }
 
       RELEASE(fmt);
    }
@@ -742,6 +728,14 @@ static bool cocoa_gl_gfx_ctx_set_video_mode(void *data,
    args.width      = width;
    args.height     = height;
    args.fullscreen = fullscreen;
+
+   /* Current-context state is per-thread, so this has to happen here
+    * on the render thread and not inside the main-thread body: with
+    * threaded video, +currentContext on the main thread would never
+    * report g_ctx, and the previous context (still live when gl2_init
+    * calls -set_video_mode twice) would be released while current.
+    * Harmless when nothing is current; g_ctx is re-bound below. */
+   [GLContextClass clearCurrentContext];
 
    cocoa_main_thread_sync(cocoa_gl_gfx_ctx_set_video_mode_mainthread, &args);
 


### PR DESCRIPTION
## Summary

Follow-up to #19491 / #19496, per @LibretroAdmin's request in #19491 to retest against current master rather than 1.22.2.

**Important scope correction after further testing (see "Trigger conditions" below): the standard/official macOS build (`xcodebuild -workspace pkg/apple/RetroArch.xcworkspace -scheme RetroArch -xcconfig pkg/apple/GitHubCI.xcconfig`, i.e. what CI actually produces and what `master`/nightly ships) does *not* reproduce this - I checked directly. So this is not "master crashes for everyone," and I don't want to overstate it. It's a real, deterministic memory-safety bug in `cocoa_gl_ctx.m` that I could still reliably reproduce and fix, but it's currently latent unless you build a specific non-default combination (below). Posting it as a correctness fix regardless, since the bug is real and the assumption the buggy commit relies on doesn't actually hold - it seems worth closing off rather than leaving as a landmine for whenever that build combination does get exercised (e.g. a future OpenGL-only or MRR target).**

`EXC_BAD_ACCESS` in `SLSFlushSurfaceWithOptionsAndIndex` (SkyLight), called from `AppleMetalOpenGLRenderer`'s `gldPresentFramebufferData`, called from our own `cocoa_gl_gfx_ctx_swap_buffers`'s `-flushBuffer` - on the very first frame after entering fullscreen. Reproduced **100% of the time** once the trigger conditions below are met.

## Root cause

Bisected (~5000 commits) against v1.22.2, which never hits this, down to bd450862 ("Normalise MRR safety in cocoa_gl_ctx.m"). That commit added a defensive `RELEASE(g_ctx)`/`RELEASE(g_hw_ctx)` in `-set_video_mode`'s mainthread work, reasoning that "the normal reinit flow has `-destroy` running first so both statics are already nil here."

That invariant does not hold on macOS: `gl2_init()` calls `-set_video_mode` **twice back-to-back** as a pre-existing, separate workaround (see the "very annoying issue" comment a few lines above in `gl2.c`). On the first call, a real `NSOpenGLContext` is created, `-setView:`'d onto the actual on-screen window, and made the current context. On the second call (milliseconds later, same synchronous call chain), the new defensive `RELEASE` drops that context's last reference - while it is still the current context and still attached to the live, on-screen view - before immediately creating a replacement and re-attaching *it* to the same view. Releasing a context that way (a plain release, not the `-clearCurrentContext` / `-clearDrawable` sequence `-destroy` itself always uses) leaves WindowServer's surface bookkeeping for that view briefly inconsistent; the replacement context's first real frame lands on that and crashes.

Confirmed this is a genuine, deterministic bug and not a timing race: pausing at a breakpoint anywhere in this path doesn't change the outcome, and adding an outright 2-second delay before the first frame (an earlier, wrong theory of mine) had no effect either - only fixing the actual release does.

## Fix

Before either defensive `RELEASE`, clear the context if it's still current and clear its drawable, mirroring what `-destroy` already does on the normal teardown path - so a context is never released while still current and attached, whether this code runs once or (as on macOS) twice.

## Trigger conditions (why this went unnoticed, and why the official build is unaffected)

I built this two different ways to check impact:

- **Official/CI recipe** (`xcodebuild -workspace pkg/apple/RetroArch.xcworkspace -scheme RetroArch -config Release -xcconfig pkg/apple/GitHubCI.xcconfig`, matching `.github/workflows/MacOS.yml` exactly): confirmed via the actual compiler invocation that this defines both `-DHAVE_COCOA_METAL` *and* `-fobjc-arc`. Both independently prevent this bug:
  - `HAVE_COCOA_METAL` routes fullscreen through `-[apple_platform setVideoMode:]` / native `-[NSWindow toggleFullScreen:]`, so the hand-rolled fullscreen path this bug lives in is never reached at all.
  - Even if it were reached, `RELEASE()` (`cocoa_common.h`) compiles to a plain `x = nil` under ARC, not an actual `-release` - so the premature release this PR fixes would be a no-op anyway under the official build's ARC setting.
- **What I originally built and reproduced the crash on**: plain `xcodebuild -project pkg/apple/RetroArch.xcodeproj -scheme RetroArch -configuration Release` with no `-xcconfig` at all (no workspace, no CI config) - which picks up neither of those, building the legacy OpenGL/MRR combination instead.

So concretely, it reproduces only when *all* of the following hold:
- built **without** `HAVE_COCOA_METAL` (no `-xcconfig` selecting Metal/GitHubCI/GitLabCI at all, as above),
- compiled **without ARC** (so `RELEASE()` is a real release, not a no-op),
- `video_driver` is the legacy `"gl"` driver rather than metal/vulkan/glcore,
- `video_fullscreen` is enabled, and
- running on **Apple Silicon** - the null-surface crash is specific to `AppleMetalOpenGLRenderer`'s OpenGL-over-Metal translation layer, which older Intel Macs with native OpenGL never go through.

That's a narrow enough combination - and different enough from how the project is actually built and shipped - that it plausibly never came up before.

## Test plan

- [x] Built via `xcodebuild -project pkg/apple/RetroArch.xcodeproj -scheme RetroArch -configuration Release`, arm64/macOS 11+.
- [x] Before the fix: crashed on **every single launch** attempted across dozens of trials (direct double-click, under lldb, launched by a frontend) - always the identical backtrace.
- [x] After the fix: **3 consecutive clean launches**, each independently confirmed, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
