### PR TITLE
menu: show the start screen again when the setting is enabled

### DIFF
--- a/menu/menu_driver.c
+++ b/menu/menu_driver.c
@@ -3831,6 +3831,9 @@ static bool rarch_menu_init(
        * again after the first startup, so we save to config
        * file immediately. */
       p_dialog->current_type         = MENU_DIALOG_WELCOME;
+      /* generic_menu_iterate() only pushes the help entry
+       * for this dialog when pending_push is set. */
+      p_dialog->pending_push         = true;
 
       configuration_set_bool(settings,
             settings->bools.menu_show_start_screen, false);


### PR DESCRIPTION
"Display Start Screen" is a one-shot flag: rarch_menu_init() reads it, arms the welcome dialog and writes it back as false so the screen only shows once. The dialog itself is what broke. Since menu_dialog_push_pending() went away the init path only sets dialog_st.current_type and never pending_push, so generic_menu_iterate() never pushes the help entry and nothing is shown. Enabling the setting therefore looks like it silently resets to off on the next start.

Set pending_push together with current_type so the start screen appears on first boot and whenever the setting is re-enabled. The reset afterwards is unchanged and matches the sublabel; the configuration table default mismatch mentioned in the issue is unrelated to this.

Fixes #18972
