### PR TITLE
CLOUDSYNC: finish startup sync before loading CLI content

### DIFF
--- a/retroarch.c
+++ b/retroarch.c
@@ -6634,7 +6634,9 @@ int rarch_main(int argc, char *argv[], void *data)
          settings->bools.ui_companion_start_on_boot
          );
 #ifdef HAVE_CLOUDSYNC
-   if (settings->uints.cloud_sync_sync_mode == CLOUD_SYNC_MODE_AUTOMATIC)
+   if (   settings->uints.cloud_sync_sync_mode == CLOUD_SYNC_MODE_AUTOMATIC
+       && (   !(global_get_ptr()->flags & GLOB_FLG_LAUNCHED_FROM_CLI)
+           || path_is_empty(RARCH_PATH_CONTENT)))
       task_push_cloud_sync();
 #endif
 #ifdef HAVE_LAKKA
@@ -8705,6 +8707,18 @@ bool retroarch_main_init(int argc, char *argv[])
 #ifdef HAVE_CLOUDSYNC
    cloud_sync_find_driver(settings->arrays.cloud_sync_driver,
          "cloud sync driver", verbosity_enabled);
+
+   /* Directly launched content loads SaveRAM later in this function.
+    * Complete the automatic startup sync first so the core cannot retain
+    * stale SaveRAM and overwrite a newer downloaded file on content close. */
+   if (   settings->bools.cloud_sync_enable
+       && settings->uints.cloud_sync_sync_mode == CLOUD_SYNC_MODE_AUTOMATIC
+       && (global->flags & GLOB_FLG_LAUNCHED_FROM_CLI)
+       && !path_is_empty(RARCH_PATH_CONTENT))
+   {
+      task_push_cloud_sync();
+      task_wait_for_cloud_sync();
+   }
 #endif
    location_driver_find_driver(settings->arrays.location_driver,
          &location_driver_st,

--- a/tasks/task_cloudsync.c
+++ b/tasks/task_cloudsync.c
@@ -27,6 +27,7 @@
 #include <time/rtime.h>
 #include <retro_atomic.h>
 #include <retro_inline.h>
+#include <retro_timers.h>
 
 #include "../configuration.h"
 #include "../file_path_special.h"
@@ -1566,6 +1567,18 @@ static bool task_cloud_sync_task_finder(retro_task_t *task, void *user_data)
 
    /* there can be only one */
    return task->handler == task_cloud_sync_task_handler;
+}
+
+void task_wait_for_cloud_sync(void)
+{
+   task_finder_data_t find_data;
+
+   find_data.func = task_cloud_sync_task_finder;
+   while (task_queue_find(&find_data))
+   {
+      task_queue_check();
+      retro_sleep(1);
+   }
 }
 
 static void task_push_cloud_sync_with_mode(int conflict_resolution)

--- a/tasks/tasks_internal.h
+++ b/tasks/tasks_internal.h
@@ -418,6 +418,7 @@ extern const char* const input_builtin_autoconfs[];
 /* cloud sync tasks */
 void task_push_cloud_sync_update_driver(void);
 void task_push_cloud_sync(void);
+void task_wait_for_cloud_sync(void);
 void task_push_cloud_sync_resolve_keep_local(void);
 void task_push_cloud_sync_resolve_keep_server(void);
 


### PR DESCRIPTION
## Description

When content is supplied directly on the command line, `retroarch_main_init()` currently initializes the core and loads SaveRAM before `rarch_main()` queues automatic startup Cloud Sync. A newer save can therefore be downloaded only after the core has retained stale local SaveRAM; closing content then writes the stale data over the downloaded file and the next sync uploads it.

For direct CLI launches with content, queue automatic Cloud Sync immediately after configuration parsing and cloud driver selection, then drive the task queue until that sync has retired before continuing to core initialization. The normal no-content startup path remains asynchronous, and disabled/manual Cloud Sync behavior is unchanged. The later startup hook skips the sync already completed by the CLI path.

## Testing

- Built successfully on Steam Deck / SteamOS with GCC 14.3.0.
- Tested with the melonDS DS core and Koofr WebDAV.
- Prepared a newer server `.srm` and an older local `.srm`, then launched content directly through a Steam ROM Manager shortcut.
- Startup Cloud Sync downloaded the newer save and finished before `[Content] Loading content file`.
- The running game loaded the newer save.
- On exit, RetroArch reported the SRAM unchanged and skipped rewriting it.
- Repeated normal gameplay tests showed no regressions.
- The changed Cloud Sync sources compile on macOS with `HAVE_CLOUDSYNC=1`; the complete local link remains blocked by the unrelated SDK symbol `CAFrameRateRangeMake`.

## Related Issues

Fixes #19471.

Implementation developed and reviewed with OpenAI Codex.