### PR TITLE
content, webOS: a failed load returns to the menu instead of a dead screen

### DIFF
--- a/input/common/wayland_common_webos.c
+++ b/input/common/wayland_common_webos.c
@@ -404,6 +404,77 @@ static struct
    bool valid;
 } s_webos_keep;
 
+/* Destroy a stash nobody adopted. The cache owns these objects between
+ * the teardown that fills it and the init that empties it, so this is
+ * the only path that can free them once the live context has let go. */
+void gfx_ctx_wl_webos_release_kept_surface(void)
+{
+   if (!s_webos_keep.valid)
+      return;
+
+   RARCH_LOG("[Wayland/webOS] Releasing kept surface, no init claimed it.\n");
+
+   if (s_webos_keep.shell_surface)
+      wl_shell_surface_destroy(s_webos_keep.shell_surface);
+   if (s_webos_keep.webos_shell_surface)
+      wl_webos_shell_surface_destroy(s_webos_keep.webos_shell_surface);
+   if (s_webos_keep.surface)
+      wl_surface_destroy(s_webos_keep.surface);
+   if (s_webos_keep.cursor_surface)
+      wl_surface_destroy(s_webos_keep.cursor_surface);
+   if (s_webos_keep.seat)
+      wl_seat_destroy(s_webos_keep.seat);
+   if (s_webos_keep.webos_shell)
+      wl_webos_shell_destroy(s_webos_keep.webos_shell);
+   if (s_webos_keep.data_device_manager)
+      wl_data_device_manager_destroy(s_webos_keep.data_device_manager);
+   if (s_webos_keep.shm)
+      wl_shm_destroy(s_webos_keep.shm);
+   if (s_webos_keep.compositor)
+      wl_compositor_destroy(s_webos_keep.compositor);
+   if (s_webos_keep.registry)
+      wl_registry_destroy(s_webos_keep.registry);
+   if (s_webos_keep.dpy)
+   {
+      wl_display_flush(s_webos_keep.dpy);
+      wl_display_disconnect(s_webos_keep.dpy);
+   }
+
+   /* Disconnecting took the proxies with it, but the nodes tracking
+    * them are ours. Shutdown could leave them; a failed load cannot,
+    * since the session continues and may load again. */
+   while (!wl_list_empty(&s_webos_keep.current_outputs))
+   {
+      surface_output_t *os = wl_container_of(
+            s_webos_keep.current_outputs.next, os, link);
+      wl_list_remove(&os->link);
+      free(os);
+   }
+   while (!wl_list_empty(&s_webos_keep.all_outputs))
+   {
+      display_output_t *od = wl_container_of(
+            s_webos_keep.all_outputs.next, od, link);
+      output_info_t *oi    = od->output;
+      wl_list_remove(&od->link);
+      if (oi)
+      {
+         free(oi->make);
+         free(oi->model);
+         free(oi);
+      }
+      free(od);
+   }
+   while (!wl_list_empty(&s_webos_keep.all_seats))
+   {
+      seat_info_t *si = wl_container_of(
+            s_webos_keep.all_seats.next, si, link);
+      wl_list_remove(&si->link);
+      free(si);
+   }
+
+   memset(&s_webos_keep, 0, sizeof(s_webos_keep));
+}
+
 /* Move the live objects out of wl into the cache (reinit) or destroy
  * them (shutdown). Returns true when the objects were stashed and the
  * caller must skip its own teardown of them. */
@@ -415,6 +486,10 @@ static bool gfx_ctx_wl_webos_keep_or_destroy(gfx_ctx_wayland_data_t *wl,
 
    if (reinit)
    {
+      /* A stash still sitting here means the last teardown's init never
+       * came. Nothing else will collect it now. */
+      gfx_ctx_wl_webos_release_kept_surface();
+
       /* Stash. The seat/output lists are moved wholesale; their nodes
        * stay allocated and are re-adopted by the next context. */
       s_webos_keep.dpy                 = wl->input.dpy;
@@ -447,35 +522,7 @@ static bool gfx_ctx_wl_webos_keep_or_destroy(gfx_ctx_wayland_data_t *wl,
    }
 
    /* Shutdown: destroy any previously stashed objects for real. */
-   if (s_webos_keep.valid)
-   {
-      if (s_webos_keep.shell_surface)
-         wl_shell_surface_destroy(s_webos_keep.shell_surface);
-      if (s_webos_keep.webos_shell_surface)
-         wl_webos_shell_surface_destroy(s_webos_keep.webos_shell_surface);
-      if (s_webos_keep.surface)
-         wl_surface_destroy(s_webos_keep.surface);
-      if (s_webos_keep.cursor_surface)
-         wl_surface_destroy(s_webos_keep.cursor_surface);
-      if (s_webos_keep.seat)
-         wl_seat_destroy(s_webos_keep.seat);
-      if (s_webos_keep.webos_shell)
-         wl_webos_shell_destroy(s_webos_keep.webos_shell);
-      if (s_webos_keep.data_device_manager)
-         wl_data_device_manager_destroy(s_webos_keep.data_device_manager);
-      if (s_webos_keep.shm)
-         wl_shm_destroy(s_webos_keep.shm);
-      if (s_webos_keep.compositor)
-         wl_compositor_destroy(s_webos_keep.compositor);
-      if (s_webos_keep.registry)
-         wl_registry_destroy(s_webos_keep.registry);
-      if (s_webos_keep.dpy)
-      {
-         wl_display_flush(s_webos_keep.dpy);
-         wl_display_disconnect(s_webos_keep.dpy);
-      }
-      memset(&s_webos_keep, 0, sizeof(s_webos_keep));
-   }
+   gfx_ctx_wl_webos_release_kept_surface();
    return false;
 }
 

--- a/input/common/wayland_common_webos.h
+++ b/input/common/wayland_common_webos.h
@@ -37,4 +37,8 @@ enum webos_wl_special_keymap
 extern uint8_t webos_wl_special_keymap[webos_wl_key_size];
 extern void shutdown_webos_contexts();
 
+/* Destroy a surface kept across a video reinit that never completed.
+ * Safe to call when nothing is being kept. */
+extern void gfx_ctx_wl_webos_release_kept_surface(void);
+
 #endif

--- a/retroarch.c
+++ b/retroarch.c
@@ -8907,6 +8907,21 @@ error:
    runloop_is_inited_clear();
    global->flags &= ~GLOB_FLG_INIT_IN_PROGRESS;
 
+#if defined(HAVE_WAYLAND) && defined(WEBOS)
+   /* A content load deinits the drivers before coming back through
+    * here, and the webOS context driver holds its surface across that
+    * gap so the compositor never sees a surfaceless app.
+    *
+    * Normally the dummy core content_load() falls back to arrives next
+    * and its video init adopts that surface, which is why this does not
+    * fire on an ordinary failed load. Reaching here on the dummy core
+    * means the fallback itself is what failed, so nothing is coming to
+    * claim it, and the TV would sit on a window nothing can draw into.
+    * Hand it back: webOS returns to its dashboard. */
+   if (runloop_st->current_core_type == CORE_TYPE_DUMMY)
+      gfx_ctx_wl_webos_release_kept_surface();
+#endif
+
    return false;
 }
 

--- a/tasks/task_content.c
+++ b/tasks/task_content.c
@@ -1895,6 +1895,10 @@ static void content_load_init_wrap(
       argv[(*argc)++] = strldup("-v", sizeof("-v"));
 }
 
+/* Defined below, and needed by the dummy core fallback in content_load. */
+void menu_content_environment_get(int *argc, char *argv[],
+      void *args, void *params_data);
+
 /**
  * content_load:
  *
@@ -1958,7 +1962,49 @@ static bool content_load(content_ctx_info_t *info,
    free(wrap_args);
 
    if (!ret)
+   {
+      /* RARCH_CTL_MAIN_DEINIT above tore every driver down, and
+       * retroarch_main_init() left through its error path without
+       * building them again: no video, no audio, no input. Callers
+       * answer a false return by running the menu, which has nothing
+       * to run against, so the frontend keeps iterating blind until it
+       * dies. The dummy core is the state this file already treats as
+       * the floor - see the callers testing for it after a load that
+       * "failed and yet returned true" - so fall back to it here and
+       * let the failure end in the menu instead. */
+      static bool recovering      = false;
+      runloop_state_t *runloop_st = runloop_state_get_ptr();
+
+      if (     !recovering
+            && runloop_st->current_core_type != CORE_TYPE_DUMMY)
+      {
+         content_ctx_info_t dummy_info;
+
+         dummy_info.argc             = 0;
+         dummy_info.argv             = NULL;
+         dummy_info.args             = NULL;
+         dummy_info.environ_get      = menu_content_environment_get;
+
+         path_clear(RARCH_PATH_CONTENT);
+         runloop_set_current_core_type(CORE_TYPE_DUMMY, true);
+
+         /* A dummy core that cannot load either has nothing left to
+          * fall back to, so the flag stops the retry rather than
+          * letting it recurse. */
+         recovering = true;
+         if (content_load(&dummy_info, p_content))
+         {
+            /* The reload cleared the queue this failure would have
+             * been announced in, so the menu comes back with nothing
+             * said. Say it again on the far side. */
+            const char *_msg = msg_hash_to_str(MSG_FAILED_TO_LOAD_CONTENT);
+            runloop_msg_queue_push(_msg, strlen(_msg), 2, 90, true, NULL,
+                  MESSAGE_QUEUE_ICON_DEFAULT, MESSAGE_QUEUE_CATEGORY_ERROR);
+         }
+         recovering = false;
+      }
       return false;
+   }
 
    if (p_content->flags & CONTENT_ST_FLAG_PENDING_SUBSYSTEM_INIT)
       content_clear_subsystem();


### PR DESCRIPTION
Follow-up to #19492. The keep-surface commit from that PR is in master as 84106f01ce.

webOS hands the TV to the LG dashboard as soon as the app's only `wl_surface` is destroyed, and every content load tears the video context down. That commit stashes the surface across the gap so the next video init can adopt it. A load that fails never reaches that init. `retroarch_main_init()` returns through its error path with every driver still down, so nothing adopts the surface. The TV sits on a window nothing can draw into, and the remote does nothing. Before the surface was kept, the same failure dropped to the dashboard, which the user could leave.

The hole under that is generic: after a failed `content_load()`, the frontend keeps running with no drivers.

### A failed load leaves the frontend without drivers

`content_load()` deinits every driver, then asks `retroarch_main_init()` to build them again. The error path returns having built nothing. Paths such as `task_push_start_current_core()` answer a false return by running the menu:

```c
if (   !(ret = content_load(content_info, p_content))
    || !(ret = (runloop_st->current_core_type != CORE_TYPE_DUMMY)))
{
   retroarch_menu_running();
   goto end;
}
```

There is no video, audio or input for that menu to run against, so the frontend keeps iterating against dead drivers. What happens next depends on the platform. Windows crashes. webOS, once the surface is kept, hangs on a black window.

Those callers already treat the dummy core as the floor. The comment above them says a load can fail "and yet still return true", and then "the dummy core will be loaded". When init fails outright, that dummy load never runs.

So fall back to the dummy core inside `content_load()`. Drivers come back, the menu has something to run against, and the failure is visible. The dummy reload still returns false, which is what a failed content load should report. The reload also frees the message queue the failure was announced in, so the message is pushed again afterwards.

### Release the kept webOS surface only if that fallback fails too

With the fallback in place, an ordinary failure's reload adopts the kept surface. The case left is the dummy load failing as well. Then nothing is coming for it.

`retroarch_main_init()`'s error path releases the stash only when the current core is already `CORE_TYPE_DUMMY`. On an ordinary failure the core type is still the one that just failed, so the surface stays for the dummy reload instead of being destroyed and rebuilt, which flashes.

The output and seat tracking nodes are freed with it. Shutdown could leave those behind; this path returns to a session that may load again.

I did not have a repro that fails the dummy load too. The successful dummy fallback on webOS adopted the surface. It did not print the release log.

### Testing

The case used on both platforms: a playlist entry pointing at a real ROM and at a file that loads as a library but exports no `retro_init`. It has to come from a playlist. Picking the same file from the core list fails early against `retro_get_system_info` and never commits to a load.

Windows, master at cbbad49, Win64 nightly, Vulkan, dinput. I have not built this branch there, so the crash is the hole as it stands on master:

```
[ERROR] [Core] Failed to open libretro core: "...\cores/zz_broken_libretro.dll"
[INFO] [Core] Loading dynamic libretro core from: "...\cores/zz_broken_libretro.dll".
[ERROR] Failed to load symbol: "retro_init"
[ERROR] Fatal error received in: "runloop_init_libretro_symbols()"
[INFO] [Core] Unloading core symbols...
```

The log ends there. Windows then records an access violation in `retroarch.exe`:

```
Faulting application name: retroarch.exe
Exception code: 0xc0000005
Fault offset: 0x00000000002c60c1
```

A missing core file is refused cleanly on Windows and on webOS. The crash needs a core that loads and then turns out not to be one.

webOS, LG OLED65G5, webOS 10.3.1, Ozone, GL. Keep-surface is already in the tree, so the same hole is a stuck black window.

webOS only:

| | before (keep-surface, no dummy fallback) | after (this PR) |
|--|--|--|
| screen | black, stuck | brief black, then menu |
| remote | no response | works |
| message | none | "Failed to load content." |

Before, the keep has nothing to hand the surface to:

```
[INFO] [Wayland/webOS] Keeping surface across video reinit.
[ERROR] Failed to load symbol: "retro_init"
[ERROR] Fatal error received in: "runloop_init_libretro_symbols()"
```

After, the dummy reload adopts it:

```
[INFO] [Wayland/webOS] Keeping surface across video reinit.
[ERROR] Fatal error received in: "runloop_init_libretro_symbols()"
[INFO] [Core] No content, starting dummy core.
[INFO] [Wayland/webOS] Adopted cached surface after reinit.
```

Also checked that a missing content file still fails early at `playlist_entry_path_is_valid()` and never reaches this, and that normal loading, closing content and quitting still work.

Left the blank gap during the load itself. The surface outlives its buffer, so the screen is empty for that moment. That is the same class of gap as the frozen frame during a normal load. LibretroAdmin closed #19492 after taking the keep-surface commit and declined the loading-toast commit: he does not want a per-platform frame pump, and would rather make `task_content` a real task so the runloop keeps drawing during load. This PR does not add that.
