### PR TITLE
webdav: don't walk past a NULL when the URL has no path

### DIFF
--- a/network/cloud_sync/webdav.c
+++ b/network/cloud_sync/webdav.c
@@ -374,12 +374,16 @@ static char *webdav_create_digest_auth_header(const char *method, const char *ur
    int             count     = 0;
    size_t          total     = 0;
 
+   /* Skip scheme and host to get at the path.  strchr() returns NULL
+    * once the slashes run out, which happens for a URL that is only a
+    * scheme, so check before stepping past it again. */
    do
    {
       path++;
-      path = strchr(path, '/');
+      if (!(path = strchr(path, '/')))
+         return NULL;
       count++;
-   } while (count < 3 && *path != '\0');
+   } while (count < 3);
 
    response = webdav_create_digest_response(method, path);
    __len    = snprintf(nonceCount, sizeof(nonceCount),


### PR DESCRIPTION
### What

`webdav_create_digest_auth_header()` skips three slashes to find the path
portion of the request URL, but does not check the result of `strchr()`:

```c
do
{
   path++;
   path = strchr(path, '/');
   count++;
} while (count < 3 && *path != '\0');
```

When the slashes run out, `strchr()` returns `NULL`. The loop exits because
`count < 3` short-circuits, but `path` is left `NULL` and is then handed to
`webdav_create_digest_response()` and `strlen()`, both of which dereference it.

### When this happens

`webdav_start()` normalises the configured URL before it reaches here — it
prepends a scheme when `://` is missing and appends a trailing slash — so a
normal server address always ends up with three slashes and is unaffected:

| configured value | after normalisation | slashes |
| --- | --- | --- |
| `example.com` | `http://example.com/` | 3 |
| `https://example.com` | `https://example.com/` | 3 |

The gap is a value that already ends in a slash and so gets nothing appended.
Saving a scheme on its own does that:

| configured value | after normalisation | slashes |
| --- | --- | --- |
| `https://` | `https://` | 2 |

With that setting, connecting to a server that asks for Digest auth ends the
process. Basic auth is unaffected because it returns earlier.

### Repro

1. Settings → Services → Cloud Sync, set the WebDAV URL to `https://` and
   fill in a username/password
2. Start a sync against a server that responds with a Digest challenge

### Fix

Check `strchr()` inside the loop and fail the header instead of continuing.
The function already has `NULL` return paths, so callers are unaffected.
`*path != '\0'` is no longer needed: a slash was just found there, so it
cannot be the terminator.

This matches what the same file already does at line 1002:

```c
if (strchr(path, '/'))
```

### Note

Not a security issue — the trigger is the user's own configuration value and
the effect is a crash of their own process. This is a robustness fix.

While reading this function I also noticed `malloc()` results are not checked
here (line 404), but that is consistent with the rest of the file (lines 134,
180, 216, 226, 240, 288, 311, 334), so I left it alone rather than mixing an
unrelated cleanup into this change.
