### PR TITLE
video_thread_wrapper: one user-side poster at a time

### DIFF
--- a/gfx/video_thread_wrapper.c
+++ b/gfx/video_thread_wrapper.c
@@ -186,6 +186,47 @@ static void video_thread_wait_reply(thread_video_t *thr, thread_packet_t *pkt)
    slock_unlock(thr->lock);
 }
 
+/* user -> thread: take the poster slot. Waits while another thread's
+ * command is in flight, until its reply has been consumed.
+ *
+ * A main-thread waiter pumps the cocoa trampoline here as it does in
+ * video_thread_wait_reply(): the slot holder's command may itself be
+ * blocked in cocoa_main_thread_sync() waiting on the main thread, so a
+ * plain wait here would close the cycle.
+ *
+ * The slot is counted rather than exclusive so that a re-entry from the
+ * owning thread does not deadlock on itself. That is the only thing the
+ * depth buys: a command posted from inside the trampoline while the
+ * worker is blocked in cocoa_main_thread_sync() has nobody to service
+ * it and overwrites the mailbox under the outstanding command, which is
+ * the same failure this slot exists to prevent. Nested posting is a bug
+ * in the caller, not a supported path. */
+static void video_thread_user_acquire(thread_video_t *thr)
+{
+   uintptr_t self = sthread_get_current_thread_id();
+
+   slock_lock(thr->lock);
+   while (thr->user_depth && thr->user_owner != self)
+   {
+      if (!video_thread_pump_wait(thr->cond_user, thr->lock))
+         scond_wait(thr->cond_user, thr->lock);
+   }
+   thr->user_owner = self;
+   thr->user_depth++;
+   slock_unlock(thr->lock);
+}
+
+static void video_thread_user_release(thread_video_t *thr)
+{
+   slock_lock(thr->lock);
+   if (--thr->user_depth == 0)
+   {
+      thr->user_owner = 0;
+      scond_broadcast(thr->cond_user);
+   }
+   slock_unlock(thr->lock);
+}
+
 /* user -> thread */
 static bool video_thread_handle_packet(thread_video_t *thr,
       const thread_packet_t *incoming);
@@ -205,8 +246,11 @@ static void video_thread_send_and_wait_user_to_thread(thread_video_t *thr, threa
       thr->inline_reply = NULL;
       return;
    }
+
+   video_thread_user_acquire(thr);
    video_thread_send_packet(thr, pkt);
    video_thread_wait_reply(thr, pkt);
+   video_thread_user_release(thr);
 }
 
 static void thread_update_driver_state(thread_video_t *thr)
@@ -1094,6 +1138,8 @@ static bool video_thread_init(thread_video_t *thr,
       return false;
    if (!(thr->cond_thread = scond_new()))
       return false;
+   if (!(thr->cond_user   = scond_new()))
+      return false;
 
    {
       unsigned i;
@@ -1280,6 +1326,7 @@ static void video_thread_free(void *data)
       scond_free(thr->cond_reply);
       scond_free(thr->cond_ring);
       scond_free(thr->cond_thread);
+      scond_free(thr->cond_user);
 
       RARCH_LOG(
          "Threaded video stats: Frames pushed: %u, Frames dropped: %u, Frames repeated: %llu.\n",
@@ -2022,10 +2069,15 @@ uintptr_t video_thread_texture_handle(void *data, custom_command_method_t func)
    /* Aliveness is tested inside the send, under the lock it already
     * takes.  Reading thr->alive here instead would race the worker's
     * write in video_thread_loop(). */
+   video_thread_user_acquire(thr);
    if (!video_thread_send_packet_if_alive(thr, &pkt))
+   {
+      video_thread_user_release(thr);
       return func(data);
+   }
 
    video_thread_wait_reply(thr, &pkt);
+   video_thread_user_release(thr);
 
    return pkt.data.custom_command.return_value;
 }

--- a/gfx/video_thread_wrapper.h
+++ b/gfx/video_thread_wrapper.h
@@ -215,8 +215,25 @@ typedef struct thread_video
     * counted rather than rejected because the cocoa trampoline drained
     * by video_thread_pump_wait() can re-enter the wrapper on the waiting
     * thread; a second distinct thread is the case that breaks, and
-    * cond_reply_waiters checks for it in debug builds. */
+    * cond_reply_waiters checks for it in debug builds. cond_user below
+    * is what keeps a second thread out. */
    scond_t *cond_reply;
+   /* cond_user: the poster slot. User-side commands come from more than
+    * one thread -- the main thread uploads an achievement badge while a
+    * task thread takes the screenshot the same unlock asked for -- and
+    * two of them in the single slot at once means one reply satisfies
+    * both waiters, and the video thread then runs a packet whose payload
+    * points into a stack frame that has already returned. So a poster
+    * holds the slot from send to reply; the wait pumps the cocoa
+    * trampoline like the reply wait does, because the holder's command
+    * may be blocked on the main thread. user_owner/user_depth only keep
+    * an owner from deadlocking on its own slot; a nested post is not
+    * serviceable (see video_thread_user_acquire()). The video thread
+    * never takes the slot: a wrapper entry reached from driver->frame()
+    * runs inline via inline_reply before the acquire. */
+   scond_t *cond_user;
+   uintptr_t user_owner;
+   unsigned user_depth;
    /* cond_ring: ring progress (frame.pending / frame.busy changing),
     * broadcast by the video thread when it claims or completes a slot.
     * Any number of waiters, each re-testing its own predicate. */


### PR DESCRIPTION
## Description

`video_thread_wrapper.c`'s command mailbox is a single slot (`cmd_data`), and `video_thread_wait_reply()` wakes on the command **type** alone. Two user-side threads posting at the same instant can therefore both leave with the first reply, and the video thread then runs the second packet after its poster has returned, with a payload pointing into a dead stack frame.

This is the crash in the linked issue: a RetroAchievements unlock uploads its badge from the main thread (`CMD_CUSTOM_COMMAND` through `video_thread_texture_handle`) while the automatic screenshot the same unlock asked for runs on a task thread and reaches the video thread for the cached frame, also `CMD_CUSTOM_COMMAND`. The core dump shows `gl3_texture_cmd_t` on a returned frame, and the segfault is in `video_texture_load_wrap_gl3_mipmap`.

The change holds a **poster slot** from send to reply: `cond_user` with an owner and a depth on `thread_video_t`.

- Re-entrant on its owner, because the cocoa trampoline that `video_thread_pump_wait()` drains can post again from the waiting thread (the case the `cond_reply` comment describes as counted rather than rejected).
- Its wait pumps like the reply wait, so a main-thread waiter keeps running work the worker marshals to it while another thread's command is outstanding.
- All user-side posters go through `video_thread_send_and_wait_user_to_thread()` or `video_thread_texture_handle()`, which take and release the slot; the `!alive` fallback in the latter releases before calling `func` directly.
- Nothing changes for a single poster: the acquire is one uncontended lock/unlock pair around the existing send.

Testing: compile-tested against master (release, `-DDEBUG`, and `-std=c89 -pedantic`) on Linux x86_64. A backport of the same change to the 1.22.2-based RetroArch on the ROCKNIX handhelds where the crash reproduces is being built now; I will report the result here. I do not have a macOS build to exercise the pump path, so a look from someone who does would be welcome.

## Related Issues

Fixes #19517

## Related Pull Requests

None.

## Reviewers

Whoever maintains `gfx/video_thread_wrapper.c` (the recent `cond_reply`/`cond_ring` rework touched the same code).
