### PR TITLE
libretro-common: fix Emscripten mmap ABI mismatch

### DIFF
--- a/.github/workflows/Linux-libretro-common-samples.yml
+++ b/.github/workflows/Linux-libretro-common-samples.yml
@@ -74,6 +74,7 @@ jobs:
             snprintf
             unbase64_test
             crc32_test
+            emscripten_mmap_test
             archive_zip_test
             archive_zstd_test
             config_file_test

--- a/libretro-common/include/memmap.h
+++ b/libretro-common/include/memmap.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 #include <boolean.h>
 
-#if defined(PSP) || defined(PS2) || defined(GEKKO) || defined(VITA) || defined(_XBOX) || defined(_3DS) || defined(WIIU) || defined(SWITCH) || defined(HAVE_LIBNX) || defined(__PS3__) || defined(__PSL1GHT__) || defined(__EMSCRIPTEN__)
+#if defined(PSP) || defined(PS2) || defined(GEKKO) || defined(VITA) || defined(_XBOX) || defined(_3DS) || defined(WIIU) || defined(SWITCH) || defined(HAVE_LIBNX) || defined(__PS3__) || defined(__PSL1GHT__)
 /* No mman available */
 #elif defined(_WIN32) && !defined(_XBOX)
 #include <windows.h>

--- a/libretro-common/memmap/memmap.c
+++ b/libretro-common/memmap/memmap.c
@@ -199,7 +199,7 @@ int memsync(void *start, void *end)
     * webOS armv7 GCC rejects it as an implicit declaration. */
    __builtin___clear_cache((char*)start, (char*)end);
    return 0;
-#elif defined(HAVE_MMAN) && defined(MS_SYNC) && defined(MS_INVALIDATE)
+#elif defined(HAVE_MMAN) && !defined(__EMSCRIPTEN__) && defined(MS_SYNC) && defined(MS_INVALIDATE)
    /* Gate on the constants rather than on HAVE_MMAN alone: DJGPP falls
     * into the HAVE_MMAN branch of memmap.h and ships a <sys/mman.h>
     * that includes cleanly but declares neither msync nor the MS_
@@ -230,9 +230,10 @@ int memprotect(void *addr, size_t len)
  * Reserve/commit. See memmap.h for why this cannot go through mmap().
  * -------------------------------------------------------------------- */
 
+/* Emscripten mmap allocates backing memory; it cannot reserve address space. */
 #if defined(_WIN32)
 #define MEMMAP_HAVE_RESERVE 1
-#elif defined(HAVE_MMAN)
+#elif defined(HAVE_MMAN) && !defined(__EMSCRIPTEN__)
 /* memmap.h has already included <sys/mman.h> in this case; sysconf and
  * _SC_PAGESIZE need <unistd.h> as well. */
 #include <unistd.h>

--- a/libretro-common/samples/memmap/emscripten_mmap/Makefile
+++ b/libretro-common/samples/memmap/emscripten_mmap/Makefile
@@ -1,0 +1,32 @@
+LIBRETRO_COMM_DIR := ../../..
+TARGET := emscripten_mmap_test
+WASM_TARGET := emscripten_mmap.js
+EMCC ?= emcc
+NODE ?= node
+
+SOURCES := emscripten_mmap.c $(LIBRETRO_COMM_DIR)/memmap/memmap.c
+CFLAGS += -std=c89 -D_GNU_SOURCE -Wall -Wextra -Werror -I$(LIBRETRO_COMM_DIR)/include
+
+ifneq ($(SANITIZER),)
+   CFLAGS += -fsanitize=$(SANITIZER) -fno-omit-frame-pointer
+   LDFLAGS += -fsanitize=$(SANITIZER)
+endif
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES) $(LIBRETRO_COMM_DIR)/include/memmap.h
+	$(CC) $(CFLAGS) $(SOURCES) $(LDFLAGS) -o $@
+
+$(WASM_TARGET): $(SOURCES) $(LIBRETRO_COMM_DIR)/include/memmap.h
+	$(EMCC) $(CFLAGS) $(SOURCES) $(LDFLAGS) -sENVIRONMENT=node -o $@
+
+check: $(TARGET)
+	./$(TARGET)
+
+check-wasm: $(WASM_TARGET)
+	$(NODE) $(WASM_TARGET)
+
+clean:
+	rm -f $(TARGET) $(WASM_TARGET) emscripten_mmap.wasm
+
+.PHONY: all check check-wasm clean

--- a/libretro-common/samples/memmap/emscripten_mmap/emscripten_mmap.c
+++ b/libretro-common/samples/memmap/emscripten_mmap/emscripten_mmap.c
@@ -1,0 +1,52 @@
+/* Copyright (C) 2026 Gwendall Esnault
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (emscripten_mmap.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Both headers must agree on mmap's off_t argument. */
+#include <sys/types.h>
+#include <memmap.h>
+#include <sys/mman.h>
+#include <stdio.h>
+
+int main(void)
+{
+   void *(*map_fn)(void *, size_t, int, int, int, off_t) = mmap;
+   size_t size = 65536;
+   unsigned char *data = (unsigned char *)map_fn(NULL, size,
+         PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+   if (data == MAP_FAILED)
+      return 1;
+   data[0] = 0x12;
+   data[size - 1] = 0x34;
+   if (data[0] != 0x12 || data[size - 1] != 0x34)
+      return 1;
+   if (munmap(data, size) != 0)
+      return 1;
+#ifdef __EMSCRIPTEN__
+   if (mempagesize() != 0 || memreserve(size) != NULL ||
+       memcommit(NULL, 0) || memrearm(NULL, 0) ||
+       memsync(NULL, NULL) != 0)
+      return 1;
+#endif
+   puts("PASS: libc mmap signature and anonymous mapping");
+   return 0;
+}


### PR DESCRIPTION
## Guidelines

- One focused change, in one commit, rebased on current master.
- New C code uses C89 syntax; the standalone test was compiled with `-std=c89 -Wall -Wextra -Werror` and also checked as C++98 on macOS.

## Description

Emscripten provides `<sys/mman.h>`, but `memmap.h` currently selects the no-mman shim. That declares the final `mmap` argument as `size_t`; on Emscripten 5.0.1/wasm32 this is 32 bits, whereas libc uses 64-bit `off_t`. Including both headers produces conflicting declarations. A consumer that links against libc with only the shim declaration can instead fail WASM validation because the call's last argument is i32 rather than i64. This was encountered while building PicoDrive's libretro core.

Select the libc header and implementation for Emscripten. Keep the existing unsupported reserve/commit behavior and no-op instruction-cache synchronization: availability of emulated `mmap` does not provide virtual-memory reservation or page protection.

The standalone regression sample compiles both headers, assigns `mmap` to an `off_t`-typed function pointer, and checks anonymous mapping/write/unmap. On Emscripten it also checks the retained reservation and cache-sync fallbacks.

Validation:

```sh
# Emscripten 5.0.1, Node 22.22.3
make -C libretro-common/samples/memmap/emscripten_mmap check-wasm
```

Before: conflicting types for `mmap` and incompatible function pointer types (`size_t` versus `off_t`). After: `PASS: libc mmap signature and anonymous mapping`.

The sample defaults to a native build, so the existing libretro-common sample sweep does not require an Emscripten installation; `check-wasm` is explicit.

The same sources also compile and run with Apple Clang as C89 and C++98. This is a targeted library check; a full RetroArch application build was not run.

## Related Issues

No existing issue found for this signature mismatch.

## Related Pull Requests

None required. Consumers vendoring libretro-common will need their normal source synchronization to pick up the fix.

## Reviewers

Maintainer review requested.
