### PR TITLE
populate swapcount while using threaded video

### DIFF
--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -4020,9 +4020,10 @@ void video_driver_build_info(video_frame_info_t *video_info)
    video_info->shader_subframes            = settings->uints.video_shader_subframes;
    video_info->current_subframe            = 0;
 #ifdef HAVE_THREADS
-   /* The video thread owns and stamps this under the wrapper. */
+   /* The video thread owns this under the wrapper; read it through the
+    * helper so callers still get a populated value. */
    if (video_st->thread_wrapper_active)
-      video_info->swap_count               = 0;
+      video_info->swap_count               = video_thread_swap_count();
    else
 #endif
       video_info->swap_count               = video_st->swap_count;
@@ -6020,10 +6021,15 @@ void video_driver_frame(const void *data, unsigned width,
    {
       video_info.current_subframe = 0;
 #ifdef HAVE_THREADS
-      /* The video thread owns and stamps this under the wrapper. */
+      /* The video thread owns this under the wrapper; read it through the
+       * helper so the wrapper callback always gets a current value. */
       if (!video_st->thread_wrapper_active)
-#endif
          video_info.swap_count    = video_st->swap_count;
+      else
+         video_info.swap_count    = video_thread_swap_count();
+#else
+      video_info.swap_count    = video_st->swap_count;
+#endif
       if (vid->frame(
                video_st->data, data, width, height,
                video_st->frame_count, (unsigned)pitch,


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

As part of the threaded video changes, we added a new shader uniform, SwapCount, to the slang shader backend that tracks how many times the present/swap function is called. (this should be the refresh rate)

Without this change, swapcount stays 0 with threaded video but increments on the non-threaded path.

## Related Issues

none

## Related Pull Requests

none

## Reviewers

@LibretroAdmin 