### PR TITLE
webOS: add sdl3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ apple/RetroArch_iOS.xcodeproj/project.xcworkspace/*
 /Cg/
 /GL/
 /SDL/
+/SDL3/
 /ffmpeg/
 /freetype2/
 /ft2build.h

--- a/Makefile.webos
+++ b/Makefile.webos
@@ -18,7 +18,9 @@ WEBOS_USR_LIB_DIR     ?= $(STAGING_DIR)/usr/lib
 WEBOS_LIB_DIR         ?= $(STAGING_DIR)/lib
 
 ADD_SDL2_LIB          ?= 0
-SDL2_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/download/release-2.30.12-webos.1/SDL2-2.30.12-webos-abi.tar.gz
+ADD_SDL3_LIB          ?= 0
+SDL2_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/download/release-2.30.12-webos.5/SDL2-2.30.12-webos-abi.tar.gz
+SDL3_PREBUILT_ARCHIVE ?= https://github.com/webosbrew/SDL-webOS/releases/download/release-3.4.16-webos.2/SDL3-3.4.16-webos.2.tar.gz
 64TO32_BRIDGE_DIR     ?= /media/developer/apps/usr/palm/applications/org.webosbrew.bridge-64to32
 ELF_INTERPRETER_BIN   ?= /lib/ld-linux-aarch64.so.1
 SET_ELF_INTERPRETER   ?= 0
@@ -121,6 +123,7 @@ HAVE_RDDS = 1
 HAVE_RUNAHEAD = 1
 HAVE_SDL = 0
 HAVE_SDL2 ?= 1
+HAVE_SDL3 ?= 0
 HAVE_SHADERPIPELINE = 1
 HAVE_STB_IMAGE = 1
 HAVE_RVORBIS = 1
@@ -239,6 +242,9 @@ ifeq ($(HAVE_PULSE),1)
 endif
 ifeq ($(HAVE_SDL2),1)
   DEFINES += -DHAVE_SDL2
+endif
+ifeq ($(HAVE_SDL3),1)
+  DEFINES += -DHAVE_SDL3
 endif
 ifeq ($(SET_ELF_INTERPRETER), 1)
   ELF_INTERPRETER ?= $(64TO32_BRIDGE_DIR)$(ELF_INTERPRETER_BIN)
@@ -375,6 +381,9 @@ clean:
 	$(Q)rm -rf SDL
 	$(Q)rm -rf SDL.tmp
 	$(Q)rm -f SDL2-prebuilt.tar.gz.tmp
+	$(Q)rm -rf SDL3
+	$(Q)rm -rf SDL3.tmp
+	$(Q)rm -f SDL3-prebuilt.tar.gz.tmp
 	$(Q)rm -rf webos/*.ipk
 	$(Q)rm -rf webos/dist
 
@@ -398,7 +407,27 @@ ifeq ($(ADD_SDL2_LIB), 1)
 	fi
 endif
 
-ipk: prebuild $(TARGET) sdl2
+sdl3: $(TARGET)
+ifeq ($(ADD_SDL3_LIB), 1)
+	@if [ ! -f SDL3/lib/libSDL3.so.0 ]; then \
+		echo "Downloading SDL3 prebuilt"; \
+		rm -rf SDL3.tmp SDL3-prebuilt.tar.gz.tmp; \
+		mkdir -p SDL3.tmp; \
+		curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+			-o SDL3-prebuilt.tar.gz.tmp $(SDL3_PREBUILT_ARCHIVE) \
+			|| { echo "error: SDL3 prebuilt download failed: $(SDL3_PREBUILT_ARCHIVE)"; \
+			     rm -rf SDL3.tmp SDL3-prebuilt.tar.gz.tmp; exit 1; }; \
+		tar -C SDL3.tmp -zxf SDL3-prebuilt.tar.gz.tmp \
+			|| { echo "error: SDL3 prebuilt archive is corrupt or truncated"; \
+			     rm -rf SDL3.tmp SDL3-prebuilt.tar.gz.tmp; exit 1; }; \
+		rm -f SDL3-prebuilt.tar.gz.tmp; \
+		mv SDL3.tmp SDL3; \
+	else \
+		echo "SDL3 prebuilt already exists, skipping download"; \
+	fi
+endif
+
+ipk: prebuild $(TARGET) sdl2 sdl3
 	rm -rf webos/dist
 	mkdir -p webos/dist/lib
 ifeq ($(SET_ELF_INTERPRETER), 1)
@@ -414,6 +443,9 @@ endif
 	cp -vf $(WEBOS_LIB_DIR)/libatomic.so.1 webos/dist/lib/
 ifeq ($(ADD_SDL2_LIB), 1)
 	cp -vf SDL/lib/libSDL2-2.0.so.0 webos/dist/lib/
+endif
+ifeq ($(ADD_SDL3_LIB), 1)
+	cp -vf SDL3/lib/libSDL3.so.0 webos/dist/lib/
 endif
 ifneq ($(DEBUG), 1)
 	$(STRIP) webos/dist/$(TARGET)

--- a/configuration.c
+++ b/configuration.c
@@ -656,6 +656,8 @@ static const enum input_driver_enum INPUT_DEFAULT_DRIVER = INPUT_ANDROID;
 static const enum input_driver_enum INPUT_DEFAULT_DRIVER = INPUT_SDL2;
 #elif defined(WEBOS) && defined(HAVE_SDL2)
 static const enum input_driver_enum INPUT_DEFAULT_DRIVER = INPUT_SDL2;
+#elif defined(WEBOS) && defined(HAVE_SDL3)
+static const enum input_driver_enum INPUT_DEFAULT_DRIVER = INPUT_SDL3;
 #elif defined(WEBOS) && defined(HAVE_WAYLAND)
 static const enum input_driver_enum INPUT_DEFAULT_DRIVER = INPUT_WAYLAND;
 #elif defined(__EMSCRIPTEN__)

--- a/gfx/common/sdl3_common.c
+++ b/gfx/common/sdl3_common.c
@@ -275,7 +275,8 @@ static SDL_Window *sdl3_window_create(unsigned width, unsigned height,
    /* SDL_EVENT_TEXT_INPUT is emitted for windows that opted in for
     * it. The SDL3 input driver handles those events for menu
     * text entry and core keyboard callbacks. */
-   SDL_StartTextInput(win);
+   if (!SDL_HasScreenKeyboardSupport())
+      SDL_StartTextInput(win);
 
    return win;
 }

--- a/gfx/drivers/sdl3_gfx.c
+++ b/gfx/drivers/sdl3_gfx.c
@@ -227,6 +227,12 @@ static void *sdl3_gfx_init(const video_info_t *video,
 
    sdl3_set_app_metadata();
 
+#ifdef WEBOS
+   SDL_SetHint(SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_BACK, "true");
+   SDL_SetHint(SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_EXIT, "true");
+   SDL_SetHint(SDL_HINT_WEBOS_CURSOR_SLEEP_TIME, "5000");
+#endif
+
    /* Initialize the video system. */
    if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
       return NULL;

--- a/gfx/video_driver.c
+++ b/gfx/video_driver.c
@@ -4748,7 +4748,7 @@ bool video_driver_init_internal(bool *video_is_threaded, bool verbosity_enabled)
       {
 #if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) ||  \
     (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) ||     \
-    defined(HAVE_SDL3)
+    defined(HAVE_SDL3) && !defined(WEBOS)
          bool window_custom_size_enable = settings->bools.video_window_save_positions;
 #else
          bool window_custom_size_enable = settings->bools.video_window_custom_size_enable;

--- a/input/drivers/sdl3_input.c
+++ b/input/drivers/sdl3_input.c
@@ -33,6 +33,11 @@
 
 #include "../../gfx/common/sdl3_common.h"
 
+#ifdef WEBOS
+#include <SDL3/SDL_webOS.h>
+#include <dlfcn.h>
+#endif
+
 /* OVERLAY_MAX_TOUCH */
 #define SDL3_MAX_TOUCH 16
 
@@ -77,6 +82,75 @@ typedef struct sdl3_input
    } touches[SDL3_MAX_TOUCH];
 } sdl3_input_t;
 
+#ifdef WEBOS
+enum sdl_webos_special_key
+{
+   sdl_webos_spkey_back,
+   sdl_webos_spkey_return,
+   sdl_webos_spkey_up,
+   sdl_webos_spkey_down,
+   sdl_webos_spkey_left,
+   sdl_webos_spkey_right,
+   sdl_webos_spkey_size,
+};
+
+static uint8_t sdl_webos_special_keymap[sdl_webos_spkey_size] = {0};
+
+/* Set after a real typing key while the OSK/line editor is open. Magic
+ * Remote arrows/OK/digits must leave this false so the OSK grid stays
+ * under remote control. */
+static bool sdl_webos_phys_kbd_typing = false;
+
+/* One-shot sticky keys: webOS often delivers KEYDOWN+KEYUP in the same
+ * poll, so SDL_GetKeyboardState is already clear when the menu reads input. */
+static bool sdl_webos_sticky_pressed(enum sdl_webos_special_key slot)
+{
+   if (sdl_webos_special_keymap[slot])
+   {
+      sdl_webos_special_keymap[slot] = 0;
+      return true;
+   }
+   return false;
+}
+
+static bool sdl_webos_is_remote_nav_scancode(SDL_Scancode scancode)
+{
+   switch ((int)scancode)
+   {
+      case SDL_SCANCODE_UP:
+      case SDL_SCANCODE_DOWN:
+      case SDL_SCANCODE_LEFT:
+      case SDL_SCANCODE_RIGHT:
+      case SDL_SCANCODE_RETURN:
+      case SDL_SCANCODE_ESCAPE:
+      case SDL_SCANCODE_PAGEUP:
+      case SDL_SCANCODE_PAGEDOWN:
+      case SDL_WEBOS_SCANCODE_BACK:
+      case SDL_WEBOS_SCANCODE_RED:
+      case SDL_WEBOS_SCANCODE_GREEN:
+      case SDL_WEBOS_SCANCODE_YELLOW:
+      case SDL_WEBOS_SCANCODE_BLUE:
+      case SDL_WEBOS_SCANCODE_EXIT:
+         return true;
+      default:
+         return false;
+   }
+}
+
+/* Keys that mean a physical BT keyboard is in use (not Magic Remote). */
+static bool sdl_webos_scancode_enables_phys_kbd(SDL_Scancode scancode)
+{
+   if (sdl_webos_is_remote_nav_scancode(scancode))
+      return false;
+
+   /* Remote digit row inserts text but must not switch to caret mode. */
+   if (scancode >= SDL_SCANCODE_1 && scancode <= SDL_SCANCODE_0)
+      return false;
+
+   return true;
+}
+#endif
+
 /* Rebuilt on SDL_EVENT_KEYMAP_CHANGED (e.g. system layout switch). */
 static void sdl3_build_scancode_lut(sdl3_input_t *sdl)
 {
@@ -117,10 +191,57 @@ static void *sdl3_input_init(const char *joypad_driver)
 
 static bool sdl3_key_pressed(sdl3_input_t *sdl, int key)
 {
+   SDL_Scancode sym = 0;
+
+   if (!key)
+      return false;
+
+#ifdef WEBOS
+   if (key == RETROK_BACKSPACE
+         && sdl_webos_sticky_pressed(sdl_webos_spkey_back))
+      return true;
+   /* Sticky pulse (Magic Remote) → OSK grid / OK. Held BT keys must not
+    * also report as menu joypad while the line editor owns them. */
+   if (key == RETROK_RETURN
+         || key == RETROK_UP
+         || key == RETROK_DOWN
+         || key == RETROK_LEFT
+         || key == RETROK_RIGHT)
+   {
+      enum sdl_webos_special_key slot = sdl_webos_spkey_return;
+
+      if (key == RETROK_UP)
+         slot = sdl_webos_spkey_up;
+      else if (key == RETROK_DOWN)
+         slot = sdl_webos_spkey_down;
+      else if (key == RETROK_LEFT)
+         slot = sdl_webos_spkey_left;
+      else if (key == RETROK_RIGHT)
+         slot = sdl_webos_spkey_right;
+
+      if (sdl_webos_sticky_pressed(slot))
+         return true;
+
+      if (input_state_get_ptr()
+            && (input_state_get_ptr()->flags & INP_FLAG_KB_MAPPING_BLOCKED))
+         return false;
+   }
+   if (key == RETROK_F1 && sdl->kb_state[SDL_WEBOS_SCANCODE_EXIT])
+      return true;
+   if (key == RETROK_x && sdl->kb_state[SDL_WEBOS_SCANCODE_RED])
+      return true;
+   if (key == RETROK_z && sdl->kb_state[SDL_WEBOS_SCANCODE_GREEN])
+      return true;
+   if (key == RETROK_s && sdl->kb_state[SDL_WEBOS_SCANCODE_YELLOW])
+      return true;
+   if (key == RETROK_a && sdl->kb_state[SDL_WEBOS_SCANCODE_BLUE])
+      return true;
+#endif
+
    /* The keyboard state array is refreshed by SDL while pumping
     * window events - it stays empty until a focused SDL3 window
     * exists (i.e. the SDL3 video driver is running). */
-   SDL_Scancode sym = sdl->key_scancode_lut[key];
+   sym = sdl->key_scancode_lut[key];
 
    if ((int)sym >= sdl->kb_num_keys)
       return false;
@@ -245,14 +366,35 @@ static int16_t sdl3_input_state(
                   return sdl->mouse_l;
                case RETRO_DEVICE_ID_MOUSE_RIGHT:
                   return sdl->mouse_r;
+#ifdef WEBOS
+               case RETRO_DEVICE_ID_MOUSE_WHEELUP:
+                  /* Note: webOS wheel is reversed */
+                  if (sdl->mouse_wd != 0)
+                  {
+                      sdl->mouse_wd = 0;
+                      return 1;
+                  }
+                  break;
+               case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
+                  if (sdl->mouse_wu != 0)
+                  {
+                      sdl->mouse_wu = 0;
+                      return 1;
+                  }
+                  break;
+               case RETRO_DEVICE_ID_MOUSE_X:
+                  /* MOUSE_SCREEN must be absolute (menu/OSK hit-test);
+                   * RETRO_DEVICE_MOUSE stays relative for cores. */
+                  return (device == RARCH_DEVICE_MOUSE_SCREEN)
+                        ? sdl->mouse_abs_x : sdl->mouse_x;
+               case RETRO_DEVICE_ID_MOUSE_Y:
+                  return (device == RARCH_DEVICE_MOUSE_SCREEN)
+                        ? sdl->mouse_abs_y : sdl->mouse_y;
+#else
                case RETRO_DEVICE_ID_MOUSE_WHEELUP:
                   return sdl->mouse_wu;
                case RETRO_DEVICE_ID_MOUSE_WHEELDOWN:
                   return sdl->mouse_wd;
-               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
-                  return sdl->mouse_wr;
-               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
-                  return sdl->mouse_wl;
                case RETRO_DEVICE_ID_MOUSE_X:
                   if (device == RARCH_DEVICE_MOUSE_SCREEN)
                      return (int16_t)sdl->mouse_abs_x;
@@ -261,6 +403,11 @@ static int16_t sdl3_input_state(
                   if (device == RARCH_DEVICE_MOUSE_SCREEN)
                      return (int16_t)sdl->mouse_abs_y;
                   return sdl->mouse_y;
+#endif
+               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP:
+                  return sdl->mouse_wr;
+               case RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN:
+                  return sdl->mouse_wl;
                case RETRO_DEVICE_ID_MOUSE_MIDDLE:
                   return sdl->mouse_m;
                case RETRO_DEVICE_ID_MOUSE_BUTTON_4:
@@ -667,6 +814,25 @@ static void sdl3_paste_clipboard(void)
    SDL_free(text);
 }
 
+#ifdef WEBOS
+bool SDL_webOSCursorVisibility(bool visible)
+{
+   static bool (*fn)(bool visible) = NULL;
+   static bool dlsym_called                = false;
+   if (!dlsym_called)
+   {
+      fn                                   = dlsym(RTLD_NEXT, "SDL_webOSCursorVisibility");
+      dlsym_called                         = true;
+   }
+   if (!fn)
+   {
+      SDL_ShowCursor();
+      return true;
+   }
+   return fn(visible);
+}
+#endif
+
 static void sdl3_input_poll(void *data)
 {
    SDL_Event event;
@@ -695,6 +861,83 @@ static void sdl3_input_poll(void *data)
          unsigned code = input_keymaps_translate_keysym_to_rk(
                event.key.key);
 
+#ifdef WEBOS
+         input_driver_state_t *input_st = input_state_get_ptr();
+         bool osk_active = input_st && (input_st->flags & INP_FLAG_KB_MAPPING_BLOCKED);
+
+         if (!osk_active)
+            sdl_webos_phys_kbd_typing = false;
+
+         switch ((int) event.key.scancode)
+         {
+            case SDL_WEBOS_SCANCODE_BACK:
+               /* Because webOS is sending DOWN/UP at the same time,
+                  we save this flag for later */
+               sdl_webos_special_keymap[sdl_webos_spkey_back] |= event.type == SDL_EVENT_KEY_DOWN;
+               code = RETROK_BACKSPACE;
+               break;
+            case SDL_WEBOS_SCANCODE_RED:
+               code = RETROK_x;
+               break;
+            case SDL_WEBOS_SCANCODE_GREEN:
+               code = RETROK_z;
+               break;
+            case SDL_WEBOS_SCANCODE_YELLOW:
+               code = RETROK_s;
+               break;
+            case SDL_WEBOS_SCANCODE_BLUE:
+               code = RETROK_a;
+               break;
+            case SDL_WEBOS_SCANCODE_EXIT:
+               code = RETROK_F1;
+               break;
+            case SDL_SCANCODE_UP:
+            case SDL_SCANCODE_DOWN:
+            case SDL_SCANCODE_LEFT:
+            case SDL_SCANCODE_RIGHT:
+               /* Default: Magic Remote → OSK grid. After BT typing keys,
+                * ←/→ move the caret and ↑/↓ act as home/end. */
+               if (osk_active && !sdl_webos_phys_kbd_typing)
+               {
+                  if (event.type == SDL_EVENT_KEY_DOWN)
+                  {
+                     if (event.key.scancode == SDL_SCANCODE_UP)
+                        sdl_webos_special_keymap[sdl_webos_spkey_up] = 1;
+                     else if (event.key.scancode == SDL_SCANCODE_DOWN)
+                        sdl_webos_special_keymap[sdl_webos_spkey_down] = 1;
+                     else if (event.key.scancode == SDL_SCANCODE_LEFT)
+                        sdl_webos_special_keymap[sdl_webos_spkey_left] = 1;
+                     else
+                        sdl_webos_special_keymap[sdl_webos_spkey_right] = 1;
+                  }
+                  continue;
+               }
+               break;
+            case SDL_SCANCODE_RETURN:
+               /* Default: remote OK → OSK select. After BT typing → save. */
+               if (osk_active && !sdl_webos_phys_kbd_typing)
+               {
+                  if (event.type == SDL_EVENT_KEY_DOWN)
+                     sdl_webos_special_keymap[sdl_webos_spkey_return] = 1;
+                  continue;
+               }
+               break;
+            default:
+               break;
+         }
+
+         /* Letters / numpad / backspace / punctuation ⇒ BT keyboard session.
+          * Remote digit row is excluded (see sdl_webos_scancode_enables_phys_kbd). */
+         if (osk_active
+               && event.type == SDL_EVENT_KEY_DOWN
+               && sdl_webos_scancode_enables_phys_kbd(event.key.scancode))
+            sdl_webos_phys_kbd_typing = true;
+
+         /* Disable cursor when using the buttons */
+         if (code && code != RETROK_RETURN)
+            SDL_webOSCursorVisibility(false);
+
+#endif
          /* Allow pasting the clipboard. */
          if (     event.type == SDL_EVENT_KEY_DOWN
                && event.key.key == SDLK_V
@@ -704,9 +947,18 @@ static void sdl3_input_poll(void *data)
             sdl3_paste_clipboard();
             continue;
          }
+            uint32_t character = sdl3_translate_control_key(code, mod);
+#ifdef WEBOS
+            if (code == RETROK_RETURN || code == RETROK_KP_ENTER)
+               character = '\r';
+
+            /* Numpad Enter is never sent by the Magic Remote; always save. */
+            if (code == RETROK_KP_ENTER)
+               sdl_webos_phys_kbd_typing = true;
+#endif
 
          input_keyboard_event(event.type == SDL_EVENT_KEY_DOWN,
-               code, sdl3_translate_control_key(code, mod), mod,
+               code, character, mod,
                RETRO_DEVICE_KEYBOARD);
       }
       else if (event.type == SDL_EVENT_TEXT_INPUT)

--- a/input/drivers_joypad/sdl3_joypad.c
+++ b/input/drivers_joypad/sdl3_joypad.c
@@ -184,6 +184,18 @@ static void sdl3_joypad_connect(SDL_JoystickID jid)
       vendor  = SDL_GetGamepadVendor(gamepad);
       product = SDL_GetGamepadProduct(gamepad);
 
+#ifdef WEBOS
+   if (vendor == 0x9999 && product == 0x9999)
+   {
+      RARCH_WARN("[SDL] Ignoring pad #%d (vendor: %d; product: %d).\n", jid, vendor, product);
+      if (pad->joypad)
+         SDL_CloseJoystick(pad->joypad);
+
+      pad->joypad = NULL;
+      return;
+   }
+#endif
+
       /* Ensure the player index matches the slot. */
       if (SDL_GetGamepadPlayerIndex(gamepad) != slot)
          SDL_SetGamepadPlayerIndex(gamepad, slot);

--- a/menu/menu_displaylist.c
+++ b/menu/menu_displaylist.c
@@ -11237,7 +11237,7 @@ unsigned menu_displaylist_build_list(
          {
 #if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) ||  \
     (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) ||     \
-    defined(HAVE_SDL3)
+    defined(HAVE_SDL3) && !defined(WEBOS)
             bool window_custom_size_enable = settings->bools.video_window_save_positions;
 #else
             bool window_custom_size_enable = settings->bools.video_window_custom_size_enable;
@@ -11245,7 +11245,7 @@ unsigned menu_displaylist_build_list(
             static menu_displaylist_build_info_selective_t build_list[] = {
 #if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) ||  \
     (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) ||     \
-    defined(HAVE_SDL3)
+    defined(HAVE_SDL3) && !defined(WEBOS)
                {MENU_ENUM_LABEL_VIDEO_WINDOW_SAVE_POSITION,      PARSE_ONLY_BOOL,  true },
 #else
                {MENU_ENUM_LABEL_VIDEO_WINDOW_CUSTOM_SIZE_ENABLE, PARSE_ONLY_BOOL,  true },

--- a/menu/menu_setting.c
+++ b/menu/menu_setting.c
@@ -11795,14 +11795,14 @@ static const setting_desc_t vid_desc_15[] = {
 };
 #endif
 
-#if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3)
+#if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3) && !defined(WEBOS)
 static const setting_desc_t vid_desc_16[] = {
 /* GENERATED: rows come from settings_def_video_window_save_position.h in order. */
 #include "../settings/settings_def_video_window_save_position.h"
 };
 #endif
 
-#if !((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3))
+#if !((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3) && !defined(WEBOS))
 static const setting_desc_t vid_desc_17[] = {
 /* GENERATED: rows come from settings_def_video_window_custom_size.h in order. */
 #include "../settings/settings_def_video_window_custom_size.h"
@@ -14667,7 +14667,7 @@ static void settings_build_video(
 #endif
 #if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) ||  \
     (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) ||     \
-    defined(HAVE_SDL3)
+    defined(HAVE_SDL3) && !defined(WEBOS)
             ADD_DESC(vid_desc_16);
 #else
             ADD_DESC(vid_desc_17);

--- a/settings/settings_def_video_window_custom_size.h
+++ b/settings/settings_def_video_window_custom_size.h
@@ -6,7 +6,7 @@
 
 /* Descriptor and configuration rows are #if !((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3)); the string
  * tables always carry this row via the strings pass. */
-#if (!((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3))) || defined(SETTINGS_DEF_STRINGS_PASS)
+#if (!((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3) && !defined(WEBOS))) || defined(SETTINGS_DEF_STRINGS_PASS)
 S_BOOL_EX(video_window_custom_size_enable, VIDEO_WINDOW_CUSTOM_SIZE_ENABLE,
       "video_window_custom_size_enable",
       DEFAULT_WINDOW_CUSTOM_SIZE_ENABLE, SD_FLAG_NONE, 0, CMD_EVENT_REINIT, setting_bool_action_left_with_refresh, NULL, NULL, NULL, setting_bool_action_left_with_refresh, setting_bool_action_right_with_refresh, 0,

--- a/settings/settings_def_video_window_save_position.h
+++ b/settings/settings_def_video_window_save_position.h
@@ -6,7 +6,7 @@
 
 /* Descriptor and configuration rows are #if (defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3); the string
  * tables always carry this row via the strings pass. */
-#if ((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3)) || defined(SETTINGS_DEF_STRINGS_PASS)
+#if ((defined(_WIN32) && !defined(_XBOX) && !defined(__WINRT__)) || (defined(HAVE_COCOA) && !defined(HAVE_COCOATOUCH)) || defined(HAVE_SDL3) && !defined(WEBOS)) || defined(SETTINGS_DEF_STRINGS_PASS)
 /* config key "video_window_save_positions" differs from the label string; the
  * configuration.c row stays literal for this setting. */
 #ifndef SETTINGS_DEF_CONFIG_PASS


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Adds SDL3 support to webOS.

Not enabled by default. Can be compiled with ADD_SDL3_LIB=1 and HAVE_SDL3=1 to enable.

## Related Issues

## Related Pull Requests

## Reviewers

