### PR TITLE
webOS: use SDL3 by default on aarch64 builds, disable popup keyboard on startup

### DIFF
--- a/.github/workflows/webOS.yml
+++ b/.github/workflows/webOS.yml
@@ -180,7 +180,8 @@ jobs:
           export SDK_PATH=/tmp/aarch64-webos-linux-gnu_sdk-buildroot
           make -f Makefile.webos clean
           bash gfx/common/wayland/generate_wayland_protos.sh
-          make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} ADD_SDL2_LIB=0 \
+          make -f Makefile.webos ipk PACKAGE_NAME=${PACKAGE_NAME} \
+          ADD_SDL2_LIB=0 HAVE_SDL2=0 HAVE_SDL3=1 \
           HAVE_XKBCOMMON=1 HAVE_USERLAND=1 HAVE_EGL=1 HAVE_WAYLAND=1 \
           HAVE_OPENGLES3=1 HAVE_OPENGLES3_1=1 HAVE_OPENGLES3_2=1 \
           HAVE_WAYLAND_BACKPORT=0 HAVE_64TO32BIT_BRIDGE=1 SET_ELF_INTERPRETER=1 HAVE_UDEV=1 \

--- a/gfx/common/sdl3_common.c
+++ b/gfx/common/sdl3_common.c
@@ -275,8 +275,10 @@ static SDL_Window *sdl3_window_create(unsigned width, unsigned height,
    /* SDL_EVENT_TEXT_INPUT is emitted for windows that opted in for
     * it. The SDL3 input driver handles those events for menu
     * text entry and core keyboard callbacks. */
+#ifndef WEBOS
    if (!sdl3_uses_screen_keyboard())
       SDL_StartTextInput(win);
+#endif
 
    return win;
 }


### PR DESCRIPTION
## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises
4. RetroArch codebase follows C89 coding rules for portability across many old platforms check using `C89_BUILD=1`

## Description

Enable SDL3 by default for webOS (aarch64) - mainly for testing the CI.
Also disable keyboard popup on opening up RA.

## Related Issues

## Related Pull Requests

## Reviewers
